### PR TITLE
bump spacetimedb sdk from 2.1.0 to 2.2.0

### DIFF
--- a/spacetimedb/package-lock.json
+++ b/spacetimedb/package-lock.json
@@ -8,7 +8,7 @@
       "name": "redemption-multiplayer",
       "version": "1.0.0",
       "dependencies": {
-        "spacetimedb": "^2.1.0"
+        "spacetimedb": "^2.2.0"
       },
       "devDependencies": {
         "typescript": "^5.9.3"
@@ -93,9 +93,9 @@
       }
     },
     "node_modules/spacetimedb": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/spacetimedb/-/spacetimedb-2.1.0.tgz",
-      "integrity": "sha512-Kzs+HXCRj15ryld03ztU4a2uQg0M8ivV/9Bk/gvMpb59lLc/A2/r7UkGCYBePsBL7Zwqgr8gE8FeufoZVXtPnA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spacetimedb/-/spacetimedb-2.2.0.tgz",
+      "integrity": "sha512-H/bCrIegtwrL5TYqRz0ljIiESWwhMRI8KShc8UQdmMXQGo/egfor8cUxK5yDf+wH2Aa4kNPr93v+wuZloqYP8Q==",
       "license": "ISC",
       "dependencies": {
         "base64-js": "^1.5.1",

--- a/spacetimedb/package.json
+++ b/spacetimedb/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "dependencies": {
-    "spacetimedb": "^2.1.0"
+    "spacetimedb": "^2.2.0"
   },
   "devDependencies": {
     "typescript": "^5.9.3"


### PR DESCRIPTION
## Summary
- Bumps the `spacetimedb` server module dependency in `spacetimedb/package.json` from `^2.1.0` to `^2.2.0` and refreshes `package-lock.json`.
- Minor version, additive only — no breaking changes called out in the v2.2.0 release notes.
- Notable additions: v3 WebSocket transport (new TS SDK default, batches messages), `useProcedure` hook + `enabled` option on `useTable`, direct table-clear APIs, bytes-key B-tree indices enabling multi-column range scans, V8 crash-resistance improvements.

## Test plan
- [x] `npm install` inside `spacetimedb/` succeeds (0 vulnerabilities)
- [ ] Republish module (`spacetime publish`) and regen client bindings — not included in this PR; run before deploy
- [ ] Smoke-test a multiplayer session locally (connect, subscribe, call a reducer)
