### PR TITLE
Lost Soul 'The First': draw 1 and topdeck self right-click ability

### DIFF
--- a/app/goldfish/state/gameReducer.ts
+++ b/app/goldfish/state/gameReducer.ts
@@ -435,6 +435,47 @@ function threeNailsResetInState(
   return { ...state, zones, history };
 }
 
+function drawAndTopdeckSelfInState(
+  state: GameState,
+  source: GameCard,
+  history: GameState[],
+): GameState {
+  // Phase 1 — validate.
+  const ABILITY_SOURCE_ZONES: ZoneId[] = ['territory', 'land-of-bondage', 'land-of-redemption'];
+  if (!ABILITY_SOURCE_ZONES.includes(source.zone)) return state;
+
+  // Phase 2 — build.
+  const zones = cloneZones(state.zones);
+
+  // Pull source out of its current zone and topdeck onto soul-deck (index 0 = top).
+  // Clear in-play state (counters, outline, notes, meek) since the card is leaving play.
+  zones[source.zone] = zones[source.zone].filter(c => c.instanceId !== source.instanceId);
+  const topdecked: GameCard = {
+    ...source,
+    zone: 'soul-deck',
+    isFlipped: true,
+    posX: undefined,
+    posY: undefined,
+    counters: [],
+    outlineColor: undefined,
+    notes: '',
+    isMeek: false,
+  };
+  zones['soul-deck'] = [topdecked, ...zones['soul-deck']];
+
+  // Draw 1 from top of deck → hand. No auto-route; matches other ability draws.
+  if (zones.deck.length > 0 && zones.hand.length < HAND_LIMIT) {
+    const drawn = zones.deck.shift()!;
+    drawn.zone = 'hand';
+    drawn.isFlipped = false;
+    drawn.posX = undefined;
+    drawn.posY = undefined;
+    zones.hand = [...zones.hand, drawn];
+  }
+
+  return { ...state, zones, history };
+}
+
 function underdeckTopOfDeckInState(
   state: GameState,
   _source: GameCard,
@@ -1273,6 +1314,8 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
           // Targeting variant — dispatched via the dedicated IMITATE_LOST_SOUL
           // action which carries a target. No-op here.
           return state;
+        case 'draw_and_topdeck_self':
+          return drawAndTopdeckSelfInState(state, source, history);
         default: {
           const _exhaustive: never = ability;
           return state;

--- a/app/play/components/ChatPanel.tsx
+++ b/app/play/components/ChatPanel.tsx
@@ -355,6 +355,29 @@ function formatActionType(actionType: string, payload?: string, playerNames?: Re
       );
     } catch { /* fall through */ }
   }
+  if (actionType === 'DRAW_AND_TOPDECK_SELF' && payload) {
+    try {
+      const data = JSON.parse(payload);
+      const sourceName: string = data.sourceCardName ?? '';
+      const sourceImg: string = data.sourceCardImgFile ?? '';
+      const drew = data.drewCard;
+      return (
+        <>
+          drew 1 and topdecked
+          {sourceName ? (
+            <>
+              {' '}<HoverableCard name={sourceName} img={sourceImg} />
+            </>
+          ) : null}
+          {drew ? (
+            <>
+              {' '}— drew <HoverableCard name={drew.name} img={drew.img} />
+            </>
+          ) : null}
+        </>
+      );
+    } catch { /* fall through */ }
+  }
   if (actionType === 'SET_CARD_OUTLINE' && payload) {
     try {
       const data = JSON.parse(payload);

--- a/lib/cards/cardAbilities.ts
+++ b/lib/cards/cardAbilities.ts
@@ -36,6 +36,7 @@ export type CardAbility = AbilityBase & (
   | { type: 'play_all_lost_souls' }
   | { type: 'three_nails_reset' }
   | { type: 'imitate_lost_soul' }
+  | { type: 'draw_and_topdeck_self' }
   | { type: 'custom'; reducerName: string; label: string }
 );
 
@@ -59,6 +60,7 @@ export const CARD_ABILITIES: Record<string, CardAbility[]> = {
   'Lost Soul "Harvest" [John 4:35] [2023 - 2nd Place]':  [{ type: 'spawn_token', tokenName: 'Harvest Soul Token' }],
   'Lost Soul "Imitate" [III John 1:11]':                 [{ type: 'imitate_lost_soul' }],
   'Lost Soul "Imitate" [III John 1:11]  [AB - RoJ]':     [{ type: 'imitate_lost_soul' }],
+  'Lost Soul "The First" [Luke 13:30]':                  [{ type: 'draw_and_topdeck_self' }],
   'Lost Soul "Lost Souls" [Proverbs 2:16-17]':           [{ type: 'spawn_token', tokenName: 'Lost Souls Token' }],
   'Mayhem':                                              [{ type: 'all_players_shuffle_and_draw', shuffleCount: 6, drawCount: 6 }],
   'Mayhem (2020 Promo)':                                 [{ type: 'all_players_shuffle_and_draw', shuffleCount: 6, drawCount: 6 }],
@@ -379,6 +381,8 @@ export function abilityLabel(a: CardAbility): string {
       return 'Reset (banishes Nails, both players draw 8)';
     case 'imitate_lost_soul':
       return 'Imitate...';
+    case 'draw_and_topdeck_self':
+      return 'Draw 1 and topdeck this Lost Soul';
     case 'custom':
       return a.label;
   }

--- a/spacetimedb/src/cardAbilities.ts
+++ b/spacetimedb/src/cardAbilities.ts
@@ -41,6 +41,7 @@ export type CardAbility = AbilityBase & (
   | { type: 'play_all_lost_souls' }
   | { type: 'three_nails_reset' }
   | { type: 'imitate_lost_soul' }
+  | { type: 'draw_and_topdeck_self' }
   | { type: 'custom'; reducerName: string; label: string }
 );
 
@@ -57,6 +58,7 @@ export const CARD_ABILITIES: Record<string, CardAbility[]> = {
   'Lost Soul "Harvest" [John 4:35] [2023 - 2nd Place]':  [{ type: 'spawn_token', tokenName: 'Harvest Soul Token' }],
   'Lost Soul "Imitate" [III John 1:11]':                 [{ type: 'imitate_lost_soul' }],
   'Lost Soul "Imitate" [III John 1:11]  [AB - RoJ]':     [{ type: 'imitate_lost_soul' }],
+  'Lost Soul "The First" [Luke 13:30]':                  [{ type: 'draw_and_topdeck_self' }],
   'Lost Soul "Lost Souls" [Proverbs 2:16-17]':           [{ type: 'spawn_token', tokenName: 'Lost Souls Token' }],
   'Mayhem':                                              [{ type: 'all_players_shuffle_and_draw', shuffleCount: 6, drawCount: 6 }],
   'Mayhem (2020 Promo)':                                 [{ type: 'all_players_shuffle_and_draw', shuffleCount: 6, drawCount: 6 }],

--- a/spacetimedb/src/index.ts
+++ b/spacetimedb/src/index.ts
@@ -3106,6 +3106,80 @@ function underdeckTopOfDeckImpl(
 }
 
 // ---------------------------------------------------------------------------
+// Helper: drawAndTopdeckSelfImpl
+// Topdecks the source Lost Soul onto its owner's Soul Deck (zoneIndex 0,
+// shifting existing soul-deck cards up by 1) and draws 1 from the top of the
+// owner's main deck into their hand.
+// ---------------------------------------------------------------------------
+function drawAndTopdeckSelfImpl(
+  ctx: any,
+  source: any,
+  player: any,
+  gameId: bigint,
+) {
+  const game = ctx.db.Game.id.find(gameId);
+  if (!game) throw new SenderError('Game not found');
+
+  const fromZone = source.zone;
+  const gameCards = [...ctx.db.CardInstance.card_instance_game_id.filter(gameId)];
+
+  // Shift this player's existing soul-deck cards up by 1 so the source can
+  // land at index 0 (top). Excludes the source itself defensively.
+  const soulCards = gameCards.filter(
+    (c: any) => c.ownerId === player.id && c.zone === 'soul-deck' && c.id !== source.id
+  );
+  for (const sc of soulCards) {
+    ctx.db.CardInstance.id.update({ ...sc, zoneIndex: sc.zoneIndex + 1n });
+  }
+
+  // Move source to top of soul-deck, clearing in-play state.
+  ctx.db.CardInstance.id.update({
+    ...source,
+    ...leavePlayFieldOverrides(source, fromZone, 'soul-deck'),
+    zone: 'soul-deck',
+    zoneIndex: 0n,
+    posX: '',
+    posY: '',
+    isFlipped: true,
+  });
+  clearCountersIfLeavingPlay(ctx, source.id, fromZone, 'soul-deck');
+  if (fromZone === 'land-of-bondage') {
+    compactLobIndices(ctx, gameId, source.ownerId, gameCards, source.id);
+  }
+
+  // Draw 1 from top of own main deck into hand, respecting HAND_LIMIT.
+  const handCards = gameCards.filter((c: any) => c.ownerId === player.id && c.zone === 'hand');
+  let drawnCard: { name: string; img: string } | null = null;
+  if (handCards.length < HAND_LIMIT) {
+    const deckCards = gameCards
+      .filter((c: any) => c.ownerId === player.id && c.zone === 'deck')
+      .sort((a: any, b: any) => (a.zoneIndex < b.zoneIndex ? -1 : a.zoneIndex > b.zoneIndex ? 1 : 0));
+    if (deckCards.length > 0) {
+      const top = deckCards[0];
+      ctx.db.CardInstance.id.update({
+        ...top,
+        zone: 'hand',
+        zoneIndex: BigInt(handCards.length),
+        posX: '',
+        posY: '',
+        isFlipped: false,
+      });
+      drawnCard = { name: top.cardName, img: top.cardImgFile };
+    }
+  }
+
+  logAction(
+    ctx, gameId, player.id, 'DRAW_AND_TOPDECK_SELF',
+    JSON.stringify({
+      sourceCardName: source.cardName,
+      sourceCardImgFile: source.cardImgFile,
+      drewCard: drawnCard,
+    }),
+    game.turnNumber, game.currentPhase,
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Helper: reserveTopOfDeckImpl
 // Moves the top `count` cards of the acting player's deck into their reserve.
 // "Top" is defined by ascending zoneIndex (same convention as drawCardsForPlayer).
@@ -3453,6 +3527,8 @@ export const execute_card_ability = spacetimedb.reducer(
         return setCardOutlineImpl(ctx, source, ability, player, gameId);
       case 'play_all_lost_souls':
         return playAllLostSoulsImpl(ctx, source, player, gameId);
+      case 'draw_and_topdeck_self':
+        return drawAndTopdeckSelfImpl(ctx, source, player, gameId);
       case 'custom':
         throw new SenderError('Custom abilities are dispatched by the client, not this reducer');
     }


### PR DESCRIPTION
## Summary

Adds a new right-click ability for `Lost Soul "The First" [Luke 13:30]` that mirrors its printed text: **draw 1 and topdeck this card**.

- New `CardAbility` variant `draw_and_topdeck_self` (added to both registry copies; parity tests stay green).
- Goldfish reducer helper `drawAndTopdeckSelfInState`: pulls source from territory / LoB / LoR, clears in-play state (counters, outline, notes, meek), unshifts onto `soul-deck`, then shifts top of `deck` into `hand` respecting `HAND_LIMIT`.
- Server reducer helper `drawAndTopdeckSelfImpl`: same effect server-side — shifts existing soul-deck `zoneIndex` up by 1, places source at index 0 face-down, uses `leavePlayFieldOverrides` + `clearCountersIfLeavingPlay`, compacts LoB indices, then draws top of main deck into hand.
- `ChatPanel` `DRAW_AND_TOPDECK_SELF` log renderer with hover cards for source and drawn card.

## Why

This is a Mode B change (new ability type, not just a registry row). The existing union has no "topdeck this Lost Soul" mechanic, so the variant had to be added end-to-end. SpacetimeDB module has been republished to both `redemption-multiplayer-dev` and `redemption-multiplayer` (in-place, no `--clear`). Client bindings regenerated with no diff (no new reducer signature).

## Test plan

- [ ] Goldfish: load a deck containing `Lost Soul "The First" [Luke 13:30]`, get it into LoB / LoR / territory, right-click → "Draw 1 and topdeck this Lost Soul". Verify the LS moves to top of Soul Deck and 1 card moves from main deck to hand.
- [ ] Goldfish edge: empty main deck → only the topdeck half fires (no hand draw).
- [ ] Goldfish edge: hand at `HAND_LIMIT` → topdeck still happens, draw skipped.
- [ ] Multiplayer (two browsers): same flow syncs to both clients; ChatPanel shows "drew 1 and topdecked … — drew \<card\>" with hover cards.
- [ ] Source card with counters / outline / meek state: ability strips those when the LS leaves play.
- [ ] Parity tests `npx vitest run lib/cards/__tests__/cardAbilities.test.ts` (34 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)