### PR TITLE
The Forge — Phase 1a.1 + 1a.2: Access Foundation, Invites & Member Management

### DIFF
--- a/__tests__/forge-anon-leak.test.ts
+++ b/__tests__/forge-anon-leak.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { config } from "dotenv";
+import { createClient } from "@supabase/supabase-js";
+
+// Load local env (Next convention); CI provides these as secrets.
+config({ path: ".env.local" });
+
+const URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+// Opt-in: only runs under `npm run test:security` so the default unit run stays
+// hermetic (no network). Requires the Supabase env to be present.
+const ENABLED = process.env.FORGE_LEAK_TEST === "1" && !!URL && !!ANON;
+
+// Every table that holds Forge secret data. EXTEND THIS as new Forge tables are
+// added in later plans. The anon (public) role must see ZERO rows in each.
+const FORGE_TABLES = ["playtest_members"];
+
+describe.runIf(ENABLED)("Forge anon-leak guardrail", () => {
+  const anon = createClient(URL!, ANON!);
+
+  for (const table of FORGE_TABLES) {
+    it(`anon sees zero rows in ${table}`, async () => {
+      const { data, error } = await anon.from(table).select("*").limit(1000);
+      const rows = data ?? [];
+      // A permission error (REVOKE) or an empty result (RLS) is fine; a leak is not.
+      expect(
+        rows.length,
+        `anon leaked ${rows.length} row(s) from ${table} (error: ${error?.message ?? "none"})`
+      ).toBe(0);
+    });
+  }
+});

--- a/__tests__/forge-anon-leak.test.ts
+++ b/__tests__/forge-anon-leak.test.ts
@@ -13,7 +13,7 @@ const ENABLED = process.env.FORGE_LEAK_TEST === "1" && !!URL && !!ANON;
 
 // Every table that holds Forge secret data. EXTEND THIS as new Forge tables are
 // added in later plans. The anon (public) role must see ZERO rows in each.
-const FORGE_TABLES = ["playtest_members"];
+const FORGE_TABLES = ["playtest_members", "forge_invites", "forge_audit"];
 
 describe.runIf(ENABLED)("Forge anon-leak guardrail", () => {
   const anon = createClient(URL!, ANON!);
@@ -27,6 +27,31 @@ describe.runIf(ENABLED)("Forge anon-leak guardrail", () => {
         rows.length,
         `anon leaked ${rows.length} row(s) from ${table} (error: ${error?.message ?? "none"})`
       ).toBe(0);
+    });
+  }
+
+  // Spec leak-test step 3: no Forge SECURITY DEFINER function is callable by anon.
+  // (Calling with empty/placeholder args is fine — anon lacks EXECUTE, so PostgREST
+  // rejects before the body runs. A success here means a grant leaked.)
+  const FORGE_RPCS: Array<[string, Record<string, unknown>]> = [
+    ["my_forge_role", {}],
+    ["forge_role_of", { uid: "00000000-0000-0000-0000-000000000000" }],
+    ["is_forge_member", {}],
+    ["is_forge_elder_or_super", {}],
+    ["forge_role_outranks", { actor_role: "elder", target_role: "playtester" }],
+    ["forge_mint_invite", { p_token_hash: "x", p_role: "playtester", p_set_ids: [], p_email: null, p_expires_at: null }],
+    ["forge_redeem_invite", { p_token_hash: "x", p_nda_agreed: false }],
+    ["forge_add_member", { p_user_id: "00000000-0000-0000-0000-000000000000", p_role: "playtester" }],
+    ["forge_remove_member", { p_user_id: "00000000-0000-0000-0000-000000000000" }],
+    ["forge_change_role", { p_user_id: "00000000-0000-0000-0000-000000000000", p_new_role: "playtester" }],
+    ["forge_set_profile", { p_display_name: "x", p_avatar_url: null }],
+    ["forge_list_invites", {}],
+  ];
+
+  for (const [fn, args] of FORGE_RPCS) {
+    it(`anon cannot execute ${fn}`, async () => {
+      const { error } = await anon.rpc(fn, args);
+      expect(error, `anon was able to execute ${fn} — a definer grant leaked`).not.toBeNull();
     });
   }
 });

--- a/app/forge/admin/AdminConsole.tsx
+++ b/app/forge/admin/AdminConsole.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import type { ForgeRole } from "@/app/forge/lib/auth";
+import { mintInvite, changeRole, removeMember } from "@/app/forge/lib/members";
+
+type Member = { user_id: string; role: ForgeRole; display_name: string | null; created_at: string };
+type Invite = { id: string; role: ForgeRole; email: string | null; expires_at: string; used_at: string | null };
+
+// Roles this caller may grant/manage (mirrors forge_role_outranks server-side).
+function grantable(caller: ForgeRole): ForgeRole[] {
+  if (caller === "superadmin") return ["elder", "playtester"];
+  if (caller === "elder") return ["playtester"];
+  return [];
+}
+
+export default function AdminConsole({
+  callerRole,
+  members,
+  invites,
+}: {
+  callerRole: ForgeRole;
+  members: Member[];
+  invites: Invite[];
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [msg, setMsg] = useState<string | null>(null);
+  const [inviteRole, setInviteRole] = useState<ForgeRole>(grantable(callerRole)[0] ?? "playtester");
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteUrl, setInviteUrl] = useState<string | null>(null);
+  const canManage = new Set(grantable(callerRole));
+
+  function run(fn: () => Promise<{ ok: boolean; error?: string }>, okMsg: string) {
+    setMsg(null);
+    startTransition(async () => {
+      const r = await fn();
+      setMsg(r.ok ? okMsg : r.error ?? "Failed");
+      if (r.ok) router.refresh();
+    });
+  }
+
+  async function submitInvite(e: React.FormEvent) {
+    e.preventDefault();
+    setMsg(null);
+    setInviteUrl(null);
+    const r = await mintInvite({ role: inviteRole, email: inviteEmail || null });
+    if (r.ok === false) return setMsg(r.error);
+    setInviteUrl(r.url);
+    setMsg(inviteEmail ? "Invite emailed." : "Invite link created.");
+    router.refresh();
+  }
+
+  return (
+    <div className="mt-6 space-y-8">
+      <section>
+        <h2 className="text-lg font-medium">Invite a member</h2>
+        <form onSubmit={submitInvite} className="mt-2 flex flex-wrap items-end gap-3">
+          <label className="text-sm">
+            Role
+            <select
+              className="mt-1 block rounded-md border bg-background px-2 py-1.5 text-sm"
+              value={inviteRole}
+              onChange={(e) => setInviteRole(e.target.value as ForgeRole)}
+            >
+              {grantable(callerRole).map((r) => (
+                <option key={r} value={r}>{r}</option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm">
+            Email (optional)
+            <input
+              type="email"
+              className="mt-1 block rounded-md border bg-background px-2 py-1.5 text-sm"
+              value={inviteEmail}
+              onChange={(e) => setInviteEmail(e.target.value)}
+              placeholder="name@example.com"
+            />
+          </label>
+          <button className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground" disabled={pending}>
+            Mint invite
+          </button>
+        </form>
+        {inviteUrl && (
+          <p className="mt-2 break-all text-xs text-muted-foreground">
+            Link: <code>{inviteUrl}</code>
+          </p>
+        )}
+      </section>
+
+      <section>
+        <h2 className="text-lg font-medium">Members ({members.length})</h2>
+        <table className="mt-2 w-full text-sm">
+          <thead>
+            <tr className="text-left text-muted-foreground">
+              <th className="py-1">Name</th><th>Role</th><th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {members.map((m) => {
+              const editable = canManage.has(m.role);
+              return (
+                <tr key={m.user_id} className="border-t">
+                  <td className="py-2">{m.display_name ?? <span className="text-muted-foreground">—</span>}</td>
+                  <td>
+                    {editable ? (
+                      <select
+                        className="rounded border bg-background px-1.5 py-1 text-xs"
+                        defaultValue={m.role}
+                        onChange={(e) => run(() => changeRole(m.user_id, e.target.value as ForgeRole), "Role updated")}
+                        disabled={pending}
+                      >
+                        {grantable(callerRole).map((r) => (
+                          <option key={r} value={r}>{r}</option>
+                        ))}
+                      </select>
+                    ) : (
+                      m.role
+                    )}
+                  </td>
+                  <td className="text-right">
+                    {editable && (
+                      <button
+                        className="text-xs text-red-500 hover:underline"
+                        onClick={() => run(() => removeMember(m.user_id), "Member removed")}
+                        disabled={pending}
+                      >
+                        Remove
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-medium">Pending invites</h2>
+        <ul className="mt-2 space-y-1 text-sm">
+          {invites.filter((i) => !i.used_at).map((i) => (
+            <li key={i.id} className="text-muted-foreground">
+              {i.role} · {i.email ?? "link-only"} · expires {new Date(i.expires_at).toLocaleDateString()}
+            </li>
+          ))}
+          {invites.filter((i) => !i.used_at).length === 0 && (
+            <li className="text-muted-foreground">None.</li>
+          )}
+        </ul>
+      </section>
+
+      {msg && <p aria-live="polite" className="text-sm">{msg}</p>}
+    </div>
+  );
+}

--- a/app/forge/admin/AdminConsole.tsx
+++ b/app/forge/admin/AdminConsole.tsx
@@ -80,7 +80,7 @@ export default function AdminConsole({
             />
           </label>
           <button className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground" disabled={pending}>
-            Mint invite
+            Send invite
           </button>
         </form>
         {inviteUrl && (

--- a/app/forge/admin/page.tsx
+++ b/app/forge/admin/page.tsx
@@ -1,0 +1,21 @@
+import { notFound } from "next/navigation";
+import { requireElder } from "@/app/forge/lib/auth";
+import { listMembers, listInvites } from "@/app/forge/lib/members";
+import AdminConsole from "./AdminConsole";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function ForgeAdminPage() {
+  const ctx = await requireElder();
+  if (!ctx) notFound();
+  const [members, invites] = await Promise.all([listMembers(), listInvites()]);
+  return (
+    <main className="mx-auto max-w-3xl p-6">
+      <h1 className="text-2xl" style={{ fontFamily: "Cinzel, serif" }}>
+        Forge Members
+      </h1>
+      <AdminConsole callerRole={ctx.role} members={members} invites={invites} />
+    </main>
+  );
+}

--- a/app/forge/layout.tsx
+++ b/app/forge/layout.tsx
@@ -1,0 +1,15 @@
+import { notFound } from "next/navigation";
+import { requireForge } from "./lib/auth";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function ForgeLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const ctx = await requireForge();
+  if (!ctx) notFound();
+  return <div className="min-h-screen">{children}</div>;
+}

--- a/app/forge/lib/__tests__/auth.test.ts
+++ b/app/forge/lib/__tests__/auth.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/utils/supabase/server", () => ({ createClient: vi.fn() }));
+import { createClient } from "@/utils/supabase/server";
+import { requireForge, requireElder, requireForgeSuperadmin } from "../auth";
+
+function mockClient({ user, role }: { user: any; role: string | null }) {
+  (createClient as any).mockResolvedValue({
+    auth: {
+      getUser: vi.fn(async () => ({
+        data: { user },
+        error: user ? null : new Error("no session"),
+      })),
+    },
+    rpc: vi.fn(async (fn: string) =>
+      fn === "my_forge_role" ? { data: role, error: null } : { data: null, error: null }
+    ),
+  });
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("requireForge", () => {
+  it("returns null when not signed in", async () => {
+    mockClient({ user: null, role: null });
+    expect(await requireForge()).toBeNull();
+  });
+  it("returns null when signed in but not a member", async () => {
+    mockClient({ user: { id: "u1" }, role: null });
+    expect(await requireForge()).toBeNull();
+  });
+  it("returns ctx with role for a member", async () => {
+    mockClient({ user: { id: "u1" }, role: "playtester" });
+    const ctx = await requireForge();
+    expect(ctx?.role).toBe("playtester");
+    expect(ctx?.user.id).toBe("u1");
+  });
+});
+
+describe("requireElder", () => {
+  it("null for a playtester", async () => {
+    mockClient({ user: { id: "u1" }, role: "playtester" });
+    expect(await requireElder()).toBeNull();
+  });
+  it("ok for an elder", async () => {
+    mockClient({ user: { id: "u1" }, role: "elder" });
+    expect((await requireElder())?.role).toBe("elder");
+  });
+  it("ok for a superadmin", async () => {
+    mockClient({ user: { id: "u1" }, role: "superadmin" });
+    expect((await requireElder())?.role).toBe("superadmin");
+  });
+});
+
+describe("requireForgeSuperadmin", () => {
+  it("null for an elder", async () => {
+    mockClient({ user: { id: "u1" }, role: "elder" });
+    expect(await requireForgeSuperadmin()).toBeNull();
+  });
+  it("ok for a superadmin", async () => {
+    mockClient({ user: { id: "u1" }, role: "superadmin" });
+    expect((await requireForgeSuperadmin())?.role).toBe("superadmin");
+  });
+});

--- a/app/forge/lib/__tests__/members.test.ts
+++ b/app/forge/lib/__tests__/members.test.ts
@@ -12,9 +12,10 @@ vi.mock("@/utils/email", () => ({
 vi.mock("@/utils/supabase/server", () => ({ createClient: vi.fn() }));
 
 import { requireElder, requireForgeSuperadmin } from "@/app/forge/lib/auth";
+import { requireForge } from "@/app/forge/lib/auth";
 import { sendEmail } from "@/utils/email";
 import { createClient } from "@/utils/supabase/server";
-import { mintInvite, redeemInvite } from "../members";
+import { mintInvite, redeemInvite, setProfile } from "../members";
 
 function ctx(role: string, rpcImpl?: any) {
   return {
@@ -79,5 +80,26 @@ describe("redeemInvite", () => {
   it("returns {ok:false} when the RPC yields null (no oracle)", async () => {
     (createClient as any).mockResolvedValue({ rpc: vi.fn(async () => ({ data: null, error: null })) });
     expect(await redeemInvite("bad", "I agree")).toEqual({ ok: false });
+  });
+});
+
+describe("setProfile", () => {
+  it("rejects a non-member", async () => {
+    (requireForge as any).mockResolvedValue(null);
+    expect((await setProfile({ displayName: "X" })).ok).toBe(false);
+  });
+  it("rejects an empty display name", async () => {
+    (requireForge as any).mockResolvedValue({ supabase: { rpc: vi.fn() } });
+    expect((await setProfile({ displayName: "   " })).ok).toBe(false);
+  });
+  it("calls forge_set_profile for a member", async () => {
+    const rpc = vi.fn(async () => ({ error: null }));
+    (requireForge as any).mockResolvedValue({ supabase: { rpc } });
+    const r = await setProfile({ displayName: "Tim", avatarUrl: "https://x/y.png" });
+    expect(r.ok).toBe(true);
+    expect(rpc).toHaveBeenCalledWith("forge_set_profile", {
+      p_display_name: "Tim",
+      p_avatar_url: "https://x/y.png",
+    });
   });
 });

--- a/app/forge/lib/__tests__/members.test.ts
+++ b/app/forge/lib/__tests__/members.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 vi.mock("@/app/forge/lib/auth", () => ({
   requireElder: vi.fn(),
   requireForgeSuperadmin: vi.fn(),
@@ -15,7 +16,7 @@ import { requireElder, requireForgeSuperadmin } from "@/app/forge/lib/auth";
 import { requireForge } from "@/app/forge/lib/auth";
 import { sendEmail } from "@/utils/email";
 import { createClient } from "@/utils/supabase/server";
-import { mintInvite, redeemInvite, setProfile } from "../members";
+import { mintInvite, redeemInvite, setProfile, changeRole, removeMember, addMember } from "../members";
 
 function ctx(role: string, rpcImpl?: any) {
   return {
@@ -80,6 +81,33 @@ describe("redeemInvite", () => {
   it("returns {ok:false} when the RPC yields null (no oracle)", async () => {
     (createClient as any).mockResolvedValue({ rpc: vi.fn(async () => ({ data: null, error: null })) });
     expect(await redeemInvite("bad", "I agree")).toEqual({ ok: false });
+  });
+});
+
+describe("changeRole / removeMember / addMember", () => {
+  it("changeRole rejects non-elder", async () => {
+    (requireElder as any).mockResolvedValue(null);
+    expect((await changeRole("u", "playtester")).ok).toBe(false);
+  });
+  it("changeRole calls forge_change_role for an elder", async () => {
+    const rpc = vi.fn(async () => ({ error: null }));
+    (requireElder as any).mockResolvedValue({ supabase: { rpc } });
+    const r = await changeRole("u9", "playtester");
+    expect(r.ok).toBe(true);
+    expect(rpc).toHaveBeenCalledWith("forge_change_role", { p_user_id: "u9", p_new_role: "playtester" });
+  });
+  it("removeMember surfaces an RPC error", async () => {
+    const rpc = vi.fn(async () => ({ error: { message: "not authorized to remove a elder member" } }));
+    (requireElder as any).mockResolvedValue({ supabase: { rpc } });
+    const r = await removeMember("u9");
+    expect(r.ok).toBe(false);
+  });
+  it("addMember calls forge_add_member", async () => {
+    const rpc = vi.fn(async () => ({ error: null }));
+    (requireElder as any).mockResolvedValue({ supabase: { rpc } });
+    const r = await addMember("u2", "playtester");
+    expect(r.ok).toBe(true);
+    expect(rpc).toHaveBeenCalledWith("forge_add_member", { p_user_id: "u2", p_role: "playtester" });
   });
 });
 

--- a/app/forge/lib/__tests__/members.test.ts
+++ b/app/forge/lib/__tests__/members.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/app/forge/lib/auth", () => ({
+  requireElder: vi.fn(),
+  requireForgeSuperadmin: vi.fn(),
+  requireForge: vi.fn(),
+}));
+vi.mock("@/utils/email", () => ({
+  sendEmail: vi.fn(async () => ({ success: true })),
+  wrapEmailInTemplate: (s: string) => s,
+}));
+
+import { requireElder, requireForgeSuperadmin } from "@/app/forge/lib/auth";
+import { sendEmail } from "@/utils/email";
+import { mintInvite } from "../members";
+
+function ctx(role: string, rpcImpl?: any) {
+  return {
+    role,
+    user: { id: "caller", email: "c@x.com" },
+    supabase: { rpc: vi.fn(rpcImpl ?? (async () => ({ data: "invite-id", error: null }))) },
+  };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("mintInvite", () => {
+  it("rejects when caller is not an elder/superadmin", async () => {
+    (requireElder as any).mockResolvedValue(null);
+    const r = await mintInvite({ role: "playtester" });
+    expect(r.ok).toBe(false);
+  });
+
+  it("an elder cannot mint an elder invite (needs superadmin)", async () => {
+    (requireElder as any).mockResolvedValue(ctx("elder"));
+    (requireForgeSuperadmin as any).mockResolvedValue(null);
+    const r = await mintInvite({ role: "elder" });
+    expect(r.ok).toBe(false);
+  });
+
+  it("mints: hashes the token (raw never sent to RPC) and emails the URL", async () => {
+    const c = ctx("superadmin");
+    (requireElder as any).mockResolvedValue(c);
+    (requireForgeSuperadmin as any).mockResolvedValue(c);
+    const r = await mintInvite({ role: "elder", email: "new@x.com" });
+    expect(r.ok).toBe(true);
+    // RPC got a 64-hex hash, not a raw base64url token
+    const passedHash = (c.supabase.rpc as any).mock.calls[0][1].p_token_hash;
+    expect(passedHash).toMatch(/^[0-9a-f]{64}$/);
+    // email sent, and the raw token in the URL is NOT the stored hash
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    const html = (sendEmail as any).mock.calls[0][0].html as string;
+    const url = (r as any).url as string;
+    expect(html).toContain(url);
+    expect(url).toContain("/invite/");
+    expect(url).not.toContain(passedHash);
+  });
+});

--- a/app/forge/lib/__tests__/members.test.ts
+++ b/app/forge/lib/__tests__/members.test.ts
@@ -9,10 +9,12 @@ vi.mock("@/utils/email", () => ({
   sendEmail: vi.fn(async () => ({ success: true })),
   wrapEmailInTemplate: (s: string) => s,
 }));
+vi.mock("@/utils/supabase/server", () => ({ createClient: vi.fn() }));
 
 import { requireElder, requireForgeSuperadmin } from "@/app/forge/lib/auth";
 import { sendEmail } from "@/utils/email";
-import { mintInvite } from "../members";
+import { createClient } from "@/utils/supabase/server";
+import { mintInvite, redeemInvite } from "../members";
 
 function ctx(role: string, rpcImpl?: any) {
   return {
@@ -54,5 +56,28 @@ describe("mintInvite", () => {
     expect(html).toContain(url);
     expect(url).toContain("/invite/");
     expect(url).not.toContain(passedHash);
+  });
+});
+
+describe("redeemInvite", () => {
+  it("returns the role on success, hashes the token, and passes p_nda_agreed=true for 'I agree'", async () => {
+    const rpc = vi.fn(async () => ({ data: "playtester", error: null }));
+    (createClient as any).mockResolvedValue({ rpc });
+    const r = await redeemInvite("raw-token-123", "  I Agree ");
+    expect(r).toEqual({ ok: true, role: "playtester" });
+    expect((rpc as any).mock.calls[0][1].p_token_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect((rpc as any).mock.calls[0][1].p_token_hash).not.toBe("raw-token-123");
+    expect((rpc as any).mock.calls[0][1].p_nda_agreed).toBe(true);
+  });
+  it("passes p_nda_agreed=false when the text is not 'I agree'", async () => {
+    const rpc = vi.fn(async () => ({ data: null, error: null }));
+    (createClient as any).mockResolvedValue({ rpc });
+    const r = await redeemInvite("raw-token-123", "nope");
+    expect(r).toEqual({ ok: false });
+    expect((rpc as any).mock.calls[0][1].p_nda_agreed).toBe(false);
+  });
+  it("returns {ok:false} when the RPC yields null (no oracle)", async () => {
+    (createClient as any).mockResolvedValue({ rpc: vi.fn(async () => ({ data: null, error: null })) });
+    expect(await redeemInvite("bad", "I agree")).toEqual({ ok: false });
   });
 });

--- a/app/forge/lib/__tests__/token.test.ts
+++ b/app/forge/lib/__tests__/token.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { createHash } from "crypto";
+import { hashToken } from "../token";
+
+describe("hashToken", () => {
+  it("returns the sha256 hex of the input", () => {
+    expect(hashToken("abc")).toBe(createHash("sha256").update("abc").digest("hex"));
+  });
+  it("is deterministic and 64 hex chars", () => {
+    const h = hashToken("some-token");
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+    expect(hashToken("some-token")).toBe(h);
+  });
+});

--- a/app/forge/lib/auth.ts
+++ b/app/forge/lib/auth.ts
@@ -1,0 +1,44 @@
+import { createClient } from "@/utils/supabase/server";
+
+export type ForgeRole = "superadmin" | "elder" | "playtester";
+
+type ForgeContext = {
+  supabase: Awaited<ReturnType<typeof createClient>>;
+  user: { id: string; email?: string | null };
+  role: ForgeRole;
+};
+
+/**
+ * Gate for everything under /forge. Returns the Supabase client, user, and the
+ * caller's Forge role, or null when the caller is not a Forge member.
+ * Callers respond 404 (not 401/403) so the area stays secret.
+ */
+export async function requireForge(): Promise<ForgeContext | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+  if (error || !user) return null;
+
+  const { data: role } = await supabase.rpc("my_forge_role");
+  if (role !== "superadmin" && role !== "elder" && role !== "playtester") return null;
+
+  return { supabase, user, role: role as ForgeRole };
+}
+
+export async function requireElder(): Promise<ForgeContext | null> {
+  const ctx = await requireForge();
+  if (!ctx) return null;
+  return ctx.role === "elder" || ctx.role === "superadmin" ? ctx : null;
+}
+
+export async function requireForgeSuperadmin(): Promise<ForgeContext | null> {
+  const ctx = await requireForge();
+  if (!ctx) return null;
+  return ctx.role === "superadmin" ? ctx : null;
+}
+
+export function notFoundResponse() {
+  return new Response("Not Found", { status: 404 });
+}

--- a/app/forge/lib/members.ts
+++ b/app/forge/lib/members.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { randomBytes } from "crypto";
-import { requireElder, requireForgeSuperadmin, type ForgeRole } from "@/app/forge/lib/auth";
+import { requireElder, requireForgeSuperadmin, requireForge, type ForgeRole } from "@/app/forge/lib/auth";
 import { hashToken } from "@/app/forge/lib/token";
 import { sendEmail, wrapEmailInTemplate } from "@/utils/email";
 import { createClient } from "@/utils/supabase/server";
@@ -50,6 +50,23 @@ export async function mintInvite(input: {
     await sendEmail({ to: input.email, subject: "Your Forge invite", html: wrapEmailInTemplate(body) });
   }
   return { ok: true, url };
+}
+
+export async function setProfile(input: {
+  displayName: string;
+  avatarUrl?: string | null;
+}): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireForge();
+  if (!ctx) return { ok: false, error: "Not authorized" };
+  const name = input.displayName.trim();
+  if (!name) return { ok: false, error: "Display name is required" };
+  if (name.length > 60) return { ok: false, error: "Display name too long" };
+  const { error } = await ctx.supabase.rpc("forge_set_profile", {
+    p_display_name: name,
+    p_avatar_url: input.avatarUrl ?? null,
+  });
+  if (error) return { ok: false, error: "Could not save profile" };
+  return { ok: true };
 }
 
 export async function redeemInvite(

--- a/app/forge/lib/members.ts
+++ b/app/forge/lib/members.ts
@@ -1,0 +1,52 @@
+"use server";
+
+import { randomBytes } from "crypto";
+import { requireElder, requireForgeSuperadmin, type ForgeRole } from "@/app/forge/lib/auth";
+import { hashToken } from "@/app/forge/lib/token";
+import { sendEmail, wrapEmailInTemplate } from "@/utils/email";
+
+function siteUrl(): string {
+  const base = process.env.VERCEL_PROJECT_PRODUCTION_URL
+    ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+    : process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+  return base.replace(/\/$/, "");
+}
+
+export async function mintInvite(input: {
+  role: ForgeRole;
+  email?: string | null;
+  expiresInDays?: number;
+}): Promise<{ ok: true; url: string } | { ok: false; error: string }> {
+  // Elder gate first; an elder invite additionally needs superadmin.
+  const ctx = await requireElder();
+  if (!ctx) return { ok: false, error: "Not authorized" };
+  if (input.role === "elder" && !(await requireForgeSuperadmin())) {
+    return { ok: false, error: "Only a superadmin can invite an elder" };
+  }
+  if (input.role === "superadmin") return { ok: false, error: "Superadmin is not invitable" };
+
+  const raw = randomBytes(32).toString("base64url");
+  const days = input.expiresInDays && input.expiresInDays > 0 ? input.expiresInDays : 7;
+  const expiresAt = new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
+
+  const { error } = await ctx.supabase.rpc("forge_mint_invite", {
+    p_token_hash: hashToken(raw),
+    p_role: input.role,
+    p_set_ids: [],
+    p_email: input.email ?? null,
+    p_expires_at: expiresAt,
+  });
+  if (error) return { ok: false, error: "Could not mint invite" };
+
+  const url = `${siteUrl()}/invite/${raw}`;
+  const body = `
+    <h1 style="font-size:22px;margin:0 0 12px 0;">You're invited to The Forge</h1>
+    <p>You've been invited to join The Forge as a <strong>${input.role}</strong>.</p>
+    <p style="margin:24px 0;"><a href="${url}"
+       style="background:#10b981;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;">Accept invite</a></p>
+    <p style="color:#71717a;font-size:13px;">This link expires in ${days} day(s) and can be used once. If you didn't expect this, ignore it.</p>`;
+  if (input.email) {
+    await sendEmail({ to: input.email, subject: "Your Forge invite", html: wrapEmailInTemplate(body) });
+  }
+  return { ok: true, url };
+}

--- a/app/forge/lib/members.ts
+++ b/app/forge/lib/members.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { randomBytes } from "crypto";
+import { revalidatePath } from "next/cache";
 import { requireElder, requireForgeSuperadmin, requireForge, type ForgeRole } from "@/app/forge/lib/auth";
 import { hashToken } from "@/app/forge/lib/token";
 import { sendEmail, wrapEmailInTemplate } from "@/utils/email";
@@ -67,6 +68,59 @@ export async function setProfile(input: {
   });
   if (error) return { ok: false, error: "Could not save profile" };
   return { ok: true };
+}
+
+export async function addMember(
+  userId: string,
+  role: ForgeRole
+): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireElder();
+  if (!ctx) return { ok: false, error: "Not authorized" };
+  const { error } = await ctx.supabase.rpc("forge_add_member", { p_user_id: userId, p_role: role });
+  if (error) return { ok: false, error: error.message };
+  revalidatePath("/forge/admin");
+  return { ok: true };
+}
+
+export async function removeMember(userId: string): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireElder();
+  if (!ctx) return { ok: false, error: "Not authorized" };
+  const { error } = await ctx.supabase.rpc("forge_remove_member", { p_user_id: userId });
+  if (error) return { ok: false, error: error.message };
+  revalidatePath("/forge/admin");
+  return { ok: true };
+}
+
+export async function changeRole(
+  userId: string,
+  newRole: ForgeRole
+): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireElder();
+  if (!ctx) return { ok: false, error: "Not authorized" };
+  const { error } = await ctx.supabase.rpc("forge_change_role", {
+    p_user_id: userId,
+    p_new_role: newRole,
+  });
+  if (error) return { ok: false, error: error.message };
+  revalidatePath("/forge/admin");
+  return { ok: true };
+}
+
+export async function listMembers() {
+  const ctx = await requireElder();
+  if (!ctx) return [];
+  const { data } = await ctx.supabase
+    .from("playtest_members")
+    .select("user_id, role, display_name, created_at")
+    .order("created_at", { ascending: true });
+  return data ?? [];
+}
+
+export async function listInvites() {
+  const ctx = await requireElder();
+  if (!ctx) return [];
+  const { data } = await ctx.supabase.rpc("forge_list_invites");
+  return data ?? [];
 }
 
 export async function redeemInvite(

--- a/app/forge/lib/members.ts
+++ b/app/forge/lib/members.ts
@@ -4,6 +4,7 @@ import { randomBytes } from "crypto";
 import { requireElder, requireForgeSuperadmin, type ForgeRole } from "@/app/forge/lib/auth";
 import { hashToken } from "@/app/forge/lib/token";
 import { sendEmail, wrapEmailInTemplate } from "@/utils/email";
+import { createClient } from "@/utils/supabase/server";
 
 function siteUrl(): string {
   const base = process.env.VERCEL_PROJECT_PRODUCTION_URL
@@ -49,4 +50,20 @@ export async function mintInvite(input: {
     await sendEmail({ to: input.email, subject: "Your Forge invite", html: wrapEmailInTemplate(body) });
   }
   return { ok: true, url };
+}
+
+export async function redeemInvite(
+  rawToken: string,
+  agreement: string
+): Promise<{ ok: true; role: ForgeRole } | { ok: false }> {
+  const agreed = agreement.trim().toLowerCase() === "i agree";
+  const supabase = await createClient();
+  const { data, error } = await supabase.rpc("forge_redeem_invite", {
+    p_token_hash: hashToken(rawToken),
+    p_nda_agreed: agreed,
+  });
+  if (error || (data !== "superadmin" && data !== "elder" && data !== "playtester")) {
+    return { ok: false };
+  }
+  return { ok: true, role: data as ForgeRole };
 }

--- a/app/forge/lib/token.ts
+++ b/app/forge/lib/token.ts
@@ -1,0 +1,6 @@
+import { createHash } from "crypto";
+
+/** sha256 hex of a raw invite token. Only the hash is ever stored. */
+export function hashToken(raw: string): string {
+  return createHash("sha256").update(raw).digest("hex");
+}

--- a/app/forge/page.tsx
+++ b/app/forge/page.tsx
@@ -1,0 +1,20 @@
+import { notFound } from "next/navigation";
+import { requireForge } from "./lib/auth";
+
+export const dynamic = "force-dynamic";
+
+export default async function ForgeDeskPage() {
+  const ctx = await requireForge();
+  if (!ctx) notFound();
+  return (
+    <main className="mx-auto max-w-3xl p-6">
+      <h1 className="text-2xl" style={{ fontFamily: "Cinzel, serif" }}>
+        The Forge
+      </h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Signed in as {ctx.user.email ?? ctx.user.id} · role:{" "}
+        <span className="font-medium">{ctx.role}</span>
+      </p>
+    </main>
+  );
+}

--- a/app/forge/welcome/OnboardingForm.tsx
+++ b/app/forge/welcome/OnboardingForm.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/utils/supabase/client";
+import { setProfile } from "@/app/forge/lib/members";
+
+export default function OnboardingForm() {
+  const router = useRouter();
+  const [displayName, setDisplayName] = useState("");
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleAvatar(file: File) {
+    const supabase = createClient();
+    const fileName = `forge-${Date.now()}-${file.name}`;
+    const { error: upErr } = await supabase.storage.from("avatars").upload(fileName, file);
+    if (upErr) return setError("Avatar upload failed");
+    const {
+      data: { publicUrl },
+    } = supabase.storage.from("avatars").getPublicUrl(fileName);
+    setAvatarUrl(publicUrl);
+  }
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+    const r = await setProfile({ displayName, avatarUrl });
+    setBusy(false);
+    if (!r.ok) return setError(r.error ?? "Could not save");
+    router.push("/forge");
+  }
+
+  return (
+    <form onSubmit={submit} className="mt-6 space-y-4">
+      <label className="block text-sm font-medium">
+        Display name
+        <input
+          className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          maxLength={60}
+          required
+        />
+      </label>
+      <label className="block text-sm font-medium">
+        Avatar (optional)
+        <input
+          type="file"
+          accept="image/*"
+          className="mt-1 block w-full text-sm"
+          onChange={(e) => e.target.files?.[0] && handleAvatar(e.target.files[0])}
+        />
+      </label>
+      {avatarUrl && <img src={avatarUrl} alt="" className="h-16 w-16 rounded-full object-cover" />}
+      {error && <p className="text-sm text-red-500">{error}</p>}
+      <button
+        type="submit"
+        disabled={busy || !displayName.trim()}
+        className="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground disabled:opacity-50"
+      >
+        {busy ? "Saving…" : "Enter the Forge"}
+      </button>
+    </form>
+  );
+}

--- a/app/forge/welcome/page.tsx
+++ b/app/forge/welcome/page.tsx
@@ -1,0 +1,30 @@
+import { redirect } from "next/navigation";
+import { notFound } from "next/navigation";
+import { requireForge } from "@/app/forge/lib/auth";
+import OnboardingForm from "./OnboardingForm";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function ForgeWelcomePage() {
+  const ctx = await requireForge();
+  if (!ctx) notFound();
+  // Skip onboarding if the profile is already set.
+  const { data } = await ctx.supabase
+    .from("playtest_members")
+    .select("display_name")
+    .eq("user_id", ctx.user.id)
+    .single();
+  if (data?.display_name) redirect("/forge");
+  return (
+    <main className="mx-auto max-w-md p-6">
+      <h1 className="text-2xl" style={{ fontFamily: "Cinzel, serif" }}>
+        Welcome to The Forge
+      </h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        You're in as <span className="font-medium">{ctx.role}</span>. Set up your profile.
+      </p>
+      <OnboardingForm />
+    </main>
+  );
+}

--- a/app/invite/[token]/AcceptForm.tsx
+++ b/app/invite/[token]/AcceptForm.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { redeemInvite } from "@/app/forge/lib/members";
+
+export default function AcceptForm({ token }: { token: string }) {
+  const router = useRouter();
+  const [text, setText] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const agreed = text.trim().toLowerCase() === "i agree";
+
+  async function accept() {
+    setBusy(true);
+    setFailed(false);
+    const r = await redeemInvite(token, text);
+    setBusy(false);
+    if (r.ok) router.push("/forge/welcome");
+    else setFailed(true);
+  }
+
+  return (
+    <main className="mx-auto max-w-md p-6">
+      <h1 className="text-2xl" style={{ fontFamily: "Cinzel, serif" }}>
+        Accept your Forge invite
+      </h1>
+      <div className="mt-4 rounded-md border bg-muted/40 p-4 text-sm text-muted-foreground">
+        <p className="font-medium text-foreground">Before you enter — an unofficial NDA</p>
+        <p className="mt-2">
+          The Forge holds unreleased, confidential card designs. By accepting, you agree not to
+          share, screenshot, post, or otherwise disclose any unreleased card content — names, art,
+          abilities, anything — outside the Forge until it is officially published.
+        </p>
+      </div>
+      <label className="mt-4 block text-sm font-medium">
+        Type <span className="font-semibold">I agree</span> to continue
+        <input
+          className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="I agree"
+          autoComplete="off"
+        />
+      </label>
+      {failed && (
+        <p className="mt-3 text-sm text-muted-foreground">
+          This invite link is invalid, expired, or already used. Ask whoever invited you for a fresh link.
+        </p>
+      )}
+      <button
+        onClick={accept}
+        disabled={!agreed || busy}
+        className="mt-4 rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground disabled:opacity-50"
+      >
+        {busy ? "Entering…" : "Accept & enter the Forge"}
+      </button>
+    </main>
+  );
+}

--- a/app/invite/[token]/page.tsx
+++ b/app/invite/[token]/page.tsx
@@ -1,0 +1,27 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/utils/supabase/server";
+import AcceptForm from "./AcceptForm";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const metadata = { robots: { index: false, follow: false } };
+
+export default async function InviteRedemptionPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+
+  // Must be signed in to bind the invite to a real auth.users.id.
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect(`/sign-in?redirectTo=${encodeURIComponent(`/invite/${token}`)}`);
+  }
+
+  // Redemption happens only after the NDA is accepted, inside the form.
+  return <AcceptForm token={token} />;
+}

--- a/docs/superpowers/plans/2026-06-20-forge-phase-1a-1-access-foundation.md
+++ b/docs/superpowers/plans/2026-06-20-forge-phase-1a-1-access-foundation.md
@@ -1,0 +1,543 @@
+# The Forge — Phase 1a.1: Access & Security Foundation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up the secure, invite-only `/forge` shell — the roles data model, the `requireForge`/`requireElder`/`requireForgeSuperadmin` gate (404 to everyone else), a seeded superadmin, and the keystone anon-leak test — so every later Forge feature is built on a verified leak-proof foundation.
+
+**Architecture:** A dedicated `playtest_members` table with a `playtest_role` enum (not overloading `admin_users`). `SECURITY DEFINER STABLE` helpers (pinned `search_path`) read membership without tripping the caller's RLS. A route-level gate cloned from the existing `requireThreshingFloor` pattern returns 404 (not 403) to non-members. A default-deny RLS posture (no `anon` policy + `REVOKE ALL FROM anon`) plus an automated anon-leak test make "nothing leaks" verifiable.
+
+**Tech Stack:** Next.js 15 App Router (RSC + route handlers), TypeScript, Supabase (Postgres + Auth + RLS), `@supabase/ssr` server/client helpers, Vitest (unit + the env-gated security test), `@supabase/supabase-js` (anon client in the leak test).
+
+**Scope note:** This is plan **1 of the Phase 1a sequence**. It delivers the secure shell + the seeded superadmin only. Invites, member management, and onboarding UI are the next plan (1a.2) — see "Remaining Phase 1a plans" at the bottom. Reference spec: `docs/superpowers/specs/2026-06-19-forge-card-design-playtesting-design.md`.
+
+## Global Constraints
+
+- **Roles:** enum `playtest_role` = `('superadmin','elder','playtester')`; hierarchical (elder ⊇ playtester). One `playtest_members` row per member.
+- **Superadmin encoding:** a DB row keyed by `auth.users.id` (baboonytim = `6d30f6e3-838e-4f11-9416-95996da6e5b9`, from migration 044), seeded by migration resolving the UID — never a hardcoded username/email in policy/app code. A `BEFORE UPDATE/DELETE` trigger forbids removing/demoting the **last** superadmin.
+- **RLS posture:** every Forge table has RLS enabled, policies `TO authenticated` only, **no `anon` policy**, plus explicit `REVOKE ALL … FROM anon`. Helpers are `SECURITY DEFINER STABLE` with `SET search_path = ''` (avoid the circular-RLS trap from migration 009; do not copy migration 005's self-referential policies).
+- **Gate:** `requireForge()`/`requireElder()`/`requireForgeSuperadmin()` return `null` for unauthorized callers; callers respond **404, not 403** (keep the area secret). No reliance on Next.js middleware — `middleware.ts` excludes `api/` and only guards `/tracker`,`/admin`, so the in-route gate is the only defense.
+- **Routing:** all `/forge` routes set `export const dynamic = "force-dynamic"` and `export const revalidate = 0`; never statically generated.
+- **Migrations:** schema only, self-contained, **no real card data**. Next migration number is `048`.
+- **Keystone guardrail:** an automated test asserts the public/anon role sees **zero rows** in every Forge table; it is the gate on "nothing leaks."
+
+---
+
+## File Structure
+
+- `supabase/migrations/048_forge_access_foundation.sql` — **Create.** Role enum, `playtest_members`, SECURITY DEFINER helpers, last-superadmin trigger, RLS, grants/revokes, superadmin seed. One responsibility: the access data model + its security.
+- `app/forge/lib/auth.ts` — **Create.** The gate: `requireForge`, `requireElder`, `requireForgeSuperadmin`, `notFoundResponse`. One responsibility: turn a request into an authorized Forge context (or null).
+- `app/forge/lib/__tests__/auth.test.ts` — **Create.** Unit tests for the gate (mock the Supabase server client).
+- `app/forge/layout.tsx` — **Create.** Gates the whole route group (`force-dynamic`, `notFound()` if not a member).
+- `app/forge/page.tsx` — **Create.** Minimal role-aware landing ("desk").
+- `__tests__/forge-anon-leak.test.ts` — **Create.** The keystone anon-leak security test (env-gated integration test).
+- `package.json` — **Modify.** Add a `test:security` script.
+
+---
+
+## Task 1: Access-foundation migration (roles, members, helpers, seed, RLS)
+
+**Files:**
+- Create: `supabase/migrations/048_forge_access_foundation.sql`
+- Verify: Supabase MCP `execute_sql` / `get_advisors` (no new file)
+
+**Interfaces:**
+- Produces (consumed by Task 2 + later plans):
+  - SQL fn `public.my_forge_role() returns text` — current user's role or NULL.
+  - SQL fn `public.forge_role_of(uid uuid) returns text`.
+  - SQL fn `public.is_forge_member() returns boolean`.
+  - SQL fn `public.is_forge_elder_or_super() returns boolean`.
+  - Table `public.playtest_members(user_id uuid pk, role public.playtest_role, display_name text, avatar_url text, invited_by uuid, created_at timestamptz)`.
+  - Enum `public.playtest_role` = `('superadmin','elder','playtester')`.
+
+- [ ] **Step 1: Write the migration file**
+
+Create `supabase/migrations/048_forge_access_foundation.sql`:
+
+```sql
+-- Forge (private card design & playtesting) — access & security foundation.
+-- Role enum + membership table, SECURITY DEFINER helpers, superadmin seed,
+-- last-superadmin protection, default-deny RLS. SCHEMA ONLY — no card data.
+
+-- 1) Role enum
+do $$ begin
+  create type public.playtest_role as enum ('superadmin','elder','playtester');
+exception when duplicate_object then null; end $$;
+
+-- 2) Membership (one row per member; highest role)
+create table if not exists public.playtest_members (
+  user_id      uuid primary key references auth.users(id) on delete cascade,
+  role         public.playtest_role not null,
+  display_name text,
+  avatar_url   text,
+  invited_by   uuid references auth.users(id),
+  created_at   timestamptz not null default now()
+);
+
+alter table public.playtest_members enable row level security;
+
+-- 3) SECURITY DEFINER helpers. search_path pinned; reads the table outside the
+--    caller's RLS so policies that call them don't recurse (cf. migration 009).
+create or replace function public.my_forge_role()
+returns text language sql security definer stable set search_path = '' as $$
+  select role::text from public.playtest_members where user_id = auth.uid();
+$$;
+
+create or replace function public.forge_role_of(uid uuid)
+returns text language sql security definer stable set search_path = '' as $$
+  select role::text from public.playtest_members where user_id = uid;
+$$;
+
+create or replace function public.is_forge_member()
+returns boolean language sql security definer stable set search_path = '' as $$
+  select exists(select 1 from public.playtest_members where user_id = auth.uid());
+$$;
+
+create or replace function public.is_forge_elder_or_super()
+returns boolean language sql security definer stable set search_path = '' as $$
+  select coalesce(
+    (select role from public.playtest_members where user_id = auth.uid())
+      in ('elder','superadmin'), false);
+$$;
+
+grant execute on function public.my_forge_role() to authenticated;
+grant execute on function public.forge_role_of(uuid) to authenticated;
+grant execute on function public.is_forge_member() to authenticated;
+grant execute on function public.is_forge_elder_or_super() to authenticated;
+
+-- 4) Last-superadmin protection
+create or replace function public.forge_protect_last_superadmin()
+returns trigger language plpgsql security definer set search_path = '' as $$
+declare remaining int;
+begin
+  select count(*) into remaining
+  from public.playtest_members
+  where role = 'superadmin'
+    and user_id <> coalesce(old.user_id, '00000000-0000-0000-0000-000000000000'::uuid);
+
+  if tg_op = 'DELETE' then
+    if old.role = 'superadmin' and remaining = 0 then
+      raise exception 'cannot remove the last superadmin';
+    end if;
+    return old;
+  elsif tg_op = 'UPDATE' then
+    if old.role = 'superadmin' and new.role <> 'superadmin' and remaining = 0 then
+      raise exception 'cannot demote the last superadmin';
+    end if;
+    return new;
+  end if;
+  return null;
+end;
+$$;
+
+drop trigger if exists forge_protect_last_superadmin on public.playtest_members;
+create trigger forge_protect_last_superadmin
+  before update or delete on public.playtest_members
+  for each row execute function public.forge_protect_last_superadmin();
+
+-- 5) RLS: members may read the membership list. No direct write policy — writes
+--    land in plan 1a.2 via SECURITY DEFINER RPCs. anon gets nothing.
+create policy "forge_members_select" on public.playtest_members
+  for select to authenticated
+  using (public.is_forge_member());
+
+-- 6) Default-deny hardening for the public/anon role
+revoke all on public.playtest_members from anon;
+grant select on public.playtest_members to authenticated;
+
+-- 7) Seed the superadmin (baboonytim). UID from migration 044. Fail loudly if
+--    the auth.users row is missing. CONFIRM this UID is baboonytim before apply.
+do $$
+declare super uuid := '6d30f6e3-838e-4f11-9416-95996da6e5b9';
+begin
+  if not exists (select 1 from auth.users where id = super) then
+    raise exception 'superadmin seed failed: no auth.users row for %', super;
+  end if;
+  insert into public.playtest_members (user_id, role, display_name)
+  values (super, 'superadmin', 'baboonytim')
+  on conflict (user_id) do update set role = 'superadmin';
+end $$;
+```
+
+- [ ] **Step 2: Apply the migration**
+
+Apply via Supabase MCP `apply_migration` (name: `forge_access_foundation`, the SQL above) or `supabase db push`.
+Expected: success, no errors. If the seed raises `superadmin seed failed: no auth.users row for …`, stop and confirm baboonytim's real UID (query `select id, email from auth.users where email ilike '%baboony%' or email = 'landofredemption@gmail.com';`), correct the seed, and re-apply.
+
+- [ ] **Step 3: Verify schema + seed via SQL**
+
+Run via Supabase MCP `execute_sql`:
+```sql
+select public.forge_role_of('6d30f6e3-838e-4f11-9416-95996da6e5b9') as super_role,
+       (select count(*) from public.playtest_members) as member_count;
+```
+Expected: `super_role = 'superadmin'`, `member_count = 1`.
+
+- [ ] **Step 4: Verify the last-superadmin guard fires**
+
+Run via Supabase MCP `execute_sql`:
+```sql
+do $$ begin
+  begin
+    delete from public.playtest_members where role = 'superadmin';
+    raise exception 'GUARD FAILED: delete succeeded';
+  exception when others then
+    raise notice 'guard ok: %', sqlerrm;
+  end;
+end $$;
+```
+Expected: a notice `guard ok: cannot remove the last superadmin`; the row still exists (re-run Step 3 → `member_count = 1`).
+
+- [ ] **Step 5: Run Supabase security advisors**
+
+Run Supabase MCP `get_advisors` (type: `security`).
+Expected: no new ERROR-level findings referencing `playtest_members` or the new functions (e.g., no "function search_path mutable", no "RLS disabled"). Fix any that appear before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/048_forge_access_foundation.sql
+git commit -m "feat(forge): access-foundation migration — roles, members, helpers, superadmin seed, RLS"
+```
+
+---
+
+## Task 2: The Forge gate (`requireForge` / `requireElder` / `requireForgeSuperadmin`)
+
+**Files:**
+- Create: `app/forge/lib/auth.ts`
+- Test: `app/forge/lib/__tests__/auth.test.ts`
+
+**Interfaces:**
+- Consumes: `createClient` from `@/utils/supabase/server`; RPC `my_forge_role` (Task 1).
+- Produces (consumed by Tasks 3–4 + later plans):
+  - `type ForgeRole = "superadmin" | "elder" | "playtester"`
+  - `requireForge(): Promise<{ supabase: SupabaseClient; user: User; role: ForgeRole } | null>`
+  - `requireElder(): Promise<…same… | null>` (null unless elder/superadmin)
+  - `requireForgeSuperadmin(): Promise<…same… | null>` (null unless superadmin)
+  - `notFoundResponse(): Response` (404)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/forge/lib/__tests__/auth.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/utils/supabase/server", () => ({ createClient: vi.fn() }));
+import { createClient } from "@/utils/supabase/server";
+import { requireForge, requireElder, requireForgeSuperadmin } from "../auth";
+
+function mockClient({ user, role }: { user: any; role: string | null }) {
+  (createClient as any).mockResolvedValue({
+    auth: {
+      getUser: vi.fn(async () => ({
+        data: { user },
+        error: user ? null : new Error("no session"),
+      })),
+    },
+    rpc: vi.fn(async (fn: string) =>
+      fn === "my_forge_role" ? { data: role, error: null } : { data: null, error: null }
+    ),
+  });
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("requireForge", () => {
+  it("returns null when not signed in", async () => {
+    mockClient({ user: null, role: null });
+    expect(await requireForge()).toBeNull();
+  });
+  it("returns null when signed in but not a member", async () => {
+    mockClient({ user: { id: "u1" }, role: null });
+    expect(await requireForge()).toBeNull();
+  });
+  it("returns ctx with role for a member", async () => {
+    mockClient({ user: { id: "u1" }, role: "playtester" });
+    const ctx = await requireForge();
+    expect(ctx?.role).toBe("playtester");
+    expect(ctx?.user.id).toBe("u1");
+  });
+});
+
+describe("requireElder", () => {
+  it("null for a playtester", async () => {
+    mockClient({ user: { id: "u1" }, role: "playtester" });
+    expect(await requireElder()).toBeNull();
+  });
+  it("ok for an elder", async () => {
+    mockClient({ user: { id: "u1" }, role: "elder" });
+    expect((await requireElder())?.role).toBe("elder");
+  });
+  it("ok for a superadmin", async () => {
+    mockClient({ user: { id: "u1" }, role: "superadmin" });
+    expect((await requireElder())?.role).toBe("superadmin");
+  });
+});
+
+describe("requireForgeSuperadmin", () => {
+  it("null for an elder", async () => {
+    mockClient({ user: { id: "u1" }, role: "elder" });
+    expect(await requireForgeSuperadmin()).toBeNull();
+  });
+  it("ok for a superadmin", async () => {
+    mockClient({ user: { id: "u1" }, role: "superadmin" });
+    expect((await requireForgeSuperadmin())?.role).toBe("superadmin");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- app/forge/lib/__tests__/auth.test.ts`
+Expected: FAIL — cannot resolve `../auth` (module does not exist yet).
+
+- [ ] **Step 3: Write the gate**
+
+Create `app/forge/lib/auth.ts`:
+
+```ts
+import { createClient } from "@/utils/supabase/server";
+
+export type ForgeRole = "superadmin" | "elder" | "playtester";
+
+type ForgeContext = {
+  supabase: Awaited<ReturnType<typeof createClient>>;
+  user: { id: string; email?: string | null };
+  role: ForgeRole;
+};
+
+/**
+ * Gate for everything under /forge. Returns the Supabase client, user, and the
+ * caller's Forge role, or null when the caller is not a Forge member.
+ * Callers respond 404 (not 401/403) so the area stays secret.
+ */
+export async function requireForge(): Promise<ForgeContext | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+  if (error || !user) return null;
+
+  const { data: role } = await supabase.rpc("my_forge_role");
+  if (role !== "superadmin" && role !== "elder" && role !== "playtester") return null;
+
+  return { supabase, user, role: role as ForgeRole };
+}
+
+export async function requireElder(): Promise<ForgeContext | null> {
+  const ctx = await requireForge();
+  if (!ctx) return null;
+  return ctx.role === "elder" || ctx.role === "superadmin" ? ctx : null;
+}
+
+export async function requireForgeSuperadmin(): Promise<ForgeContext | null> {
+  const ctx = await requireForge();
+  if (!ctx) return null;
+  return ctx.role === "superadmin" ? ctx : null;
+}
+
+export function notFoundResponse() {
+  return new Response("Not Found", { status: 404 });
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- app/forge/lib/__tests__/auth.test.ts`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/forge/lib/auth.ts app/forge/lib/__tests__/auth.test.ts
+git commit -m "feat(forge): requireForge/requireElder/requireForgeSuperadmin gate (404-not-403)"
+```
+
+---
+
+## Task 3: Gated `/forge` route group (layout + landing)
+
+**Files:**
+- Create: `app/forge/layout.tsx`
+- Create: `app/forge/page.tsx`
+
+**Interfaces:**
+- Consumes: `requireForge` from `./lib/auth` (Task 2); `notFound` from `next/navigation`.
+- Produces: the `/forge` route group shell that all later Forge pages nest under.
+
+- [ ] **Step 1: Write the gated layout**
+
+Create `app/forge/layout.tsx`:
+
+```tsx
+import { notFound } from "next/navigation";
+import { requireForge } from "./lib/auth";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function ForgeLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const ctx = await requireForge();
+  if (!ctx) notFound();
+  return <div className="min-h-screen">{children}</div>;
+}
+```
+
+- [ ] **Step 2: Write the landing page**
+
+Create `app/forge/page.tsx`:
+
+```tsx
+import { notFound } from "next/navigation";
+import { requireForge } from "./lib/auth";
+
+export const dynamic = "force-dynamic";
+
+export default async function ForgeDeskPage() {
+  const ctx = await requireForge();
+  if (!ctx) notFound();
+  return (
+    <main className="mx-auto max-w-3xl p-6">
+      <h1 className="text-2xl" style={{ fontFamily: "Cinzel, serif" }}>
+        The Forge
+      </h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Signed in as {ctx.user.email ?? ctx.user.id} · role:{" "}
+        <span className="font-medium">{ctx.role}</span>
+      </p>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 3: Typecheck the new files**
+
+Run: `npx tsc --noEmit`
+Expected: no new errors referencing `app/forge/layout.tsx` or `app/forge/page.tsx`. (Pre-existing errors elsewhere, if any, are out of scope — confirm none are in `app/forge/**`.)
+
+- [ ] **Step 4: Manual verification in the running app**
+
+Run `npm run dev`. Then:
+1. **As the seeded superadmin** (sign in as baboonytim), visit `http://localhost:3000/forge` → the page renders with `role: superadmin`.
+2. **As a signed-in non-member** (any other account), visit `/forge` → Next.js 404 page.
+3. **Signed out**, visit `/forge` → 404.
+
+Expected: only the superadmin sees the page; everyone else gets 404 (not a redirect or 403).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/forge/layout.tsx app/forge/page.tsx
+git commit -m "feat(forge): gated /forge route group shell + landing"
+```
+
+---
+
+## Task 4: Keystone anon-leak security test
+
+**Files:**
+- Create: `__tests__/forge-anon-leak.test.ts`
+- Modify: `package.json` (add `test:security` script)
+
+**Interfaces:**
+- Consumes: `NEXT_PUBLIC_SUPABASE_URL` + `NEXT_PUBLIC_SUPABASE_ANON_KEY` from `.env.local`; the `playtest_members` table (Task 1).
+- Produces: `npm run test:security` — fails the build if the public/anon role can read any Forge table. The `FORGE_TABLES` array is the extension point as later plans add tables.
+
+- [ ] **Step 1: Write the test**
+
+Create `__tests__/forge-anon-leak.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { config } from "dotenv";
+import { createClient } from "@supabase/supabase-js";
+
+// Load local env (Next convention); CI provides these as secrets.
+config({ path: ".env.local" });
+
+const URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+// Opt-in: only runs under `npm run test:security` so the default unit run stays
+// hermetic (no network). Requires the Supabase env to be present.
+const ENABLED = process.env.FORGE_LEAK_TEST === "1" && !!URL && !!ANON;
+
+// Every table that holds Forge secret data. EXTEND THIS as new Forge tables are
+// added in later plans. The anon (public) role must see ZERO rows in each.
+const FORGE_TABLES = ["playtest_members"];
+
+describe.runIf(ENABLED)("Forge anon-leak guardrail", () => {
+  const anon = createClient(URL!, ANON!);
+
+  for (const table of FORGE_TABLES) {
+    it(`anon sees zero rows in ${table}`, async () => {
+      const { data, error } = await anon.from(table).select("*").limit(1000);
+      const rows = data ?? [];
+      // A permission error (REVOKE) or an empty result (RLS) is fine; a leak is not.
+      expect(
+        rows.length,
+        `anon leaked ${rows.length} row(s) from ${table} (error: ${error?.message ?? "none"})`
+      ).toBe(0);
+    });
+  }
+});
+```
+
+- [ ] **Step 2: Add the `test:security` script**
+
+Modify `package.json` — add to `"scripts"` (after `"test:e2e"`):
+
+```json
+    "test:security": "FORGE_LEAK_TEST=1 vitest run forge-anon-leak"
+```
+
+- [ ] **Step 3: Verify the default unit run still skips it (hermetic)**
+
+Run: `npm test -- forge-anon-leak`
+Expected: the suite is **skipped** (no `FORGE_LEAK_TEST=1`), so it does not hit the network. 0 failures.
+
+- [ ] **Step 4: Run the security test against the real DB**
+
+Run: `npm run test:security`
+Expected: PASS — `anon sees zero rows in playtest_members` (the seeded superadmin row is NOT visible to anon). If it FAILS reporting leaked rows, the migration's `REVOKE`/RLS is wrong — fix Task 1 before proceeding.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add __tests__/forge-anon-leak.test.ts package.json
+git commit -m "test(forge): keystone anon-leak guardrail + test:security script"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (for this plan's slice — the security/access foundation):**
+- Dedicated `playtest_members` + role enum, not overloading `admin_users` → Task 1. ✅
+- Superadmin = seeded UID row + last-superadmin trigger → Task 1 (Steps 1, 4). ✅
+- SECURITY DEFINER helpers, pinned `search_path`, no circular RLS → Task 1. ✅
+- Default-deny RLS (`TO authenticated` only, no anon policy, `REVOKE ALL FROM anon`) → Task 1. ✅
+- 404-not-403 gate, no middleware reliance, role hierarchy → Task 2. ✅
+- `force-dynamic`/`revalidate = 0` route group → Task 3. ✅
+- Keystone anon-leak test (table surface) → Task 4. ✅
+- **Deferred to later plans (not gaps):** invites/onboarding/member-management RPCs + UI (1a.2); the broadened leak-test surfaces (definer-grant assertion, route 404 checks, Realtime) wired in as those surfaces are built; art proxy, studio, ideas, sets, lifecycle, dashboard, print (1a.3+).
+
+**Placeholder scan:** none — every step has runnable SQL/TS/commands.
+
+**Type consistency:** `ForgeRole` and the `{ supabase, user, role }` context shape are defined in Task 2 and consumed unchanged in Tasks 3–4. RPC name `my_forge_role` matches between Task 1 (defined) and Task 2 (called). `FORGE_TABLES` references `playtest_members` from Task 1.
+
+---
+
+## Remaining Phase 1a plans (roadmap — written next, not in this plan)
+
+1. **1a.2 — Invites, onboarding & member management:** `forge_invites` + `forge_audit` tables; `SECURITY DEFINER` mint/redeem/add-member/remove-member(+ownership reassignment)/change-role RPCs (role-capped); Resend invite emails; `/forge/invite/[token]` redemption + onboarding; `/forge/admin` roles UI. Extends the leak test with the new tables + definer-grant assertions.
+2. **1a.3 — Private art pipeline:** private Vercel Blob (`access:'private'`) upload + UUID keys; the authed `/forge/api/art/[cardId]` proxy + `?download=1`; lint rule forbidding `<Image>` under `app/forge/**`; "download original."
+3. **1a.4 — Card studio + ideas library:** `forge_cards` (+ `working_snapshot`), the DesignCard schema, quick-draft/full studio with live preview + placeholder art, `/forge/ideas`.
+4. **1a.5 — Sets, lifecycle, dashboard, print:** `forge_sets`/`forge_set_elders`/`forge_set_grants`, set notes + 2-D targets, share-move/publish/approve/archive/delete/send-back lifecycle + `card_versions`, the Brigade×Type progress dashboard, "download all for printer."
+
+Then Phase 1b (collaborative review) and Phase 2 (playtester play) as separate plan sets.

--- a/docs/superpowers/plans/2026-06-20-forge-phase-1a-2-invites-members.md
+++ b/docs/superpowers/plans/2026-06-20-forge-phase-1a-2-invites-members.md
@@ -1,0 +1,1373 @@
+# The Forge — Phase 1a.2: Invites, Onboarding & Member Management — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up invite-only membership management on top of the 1a.1 access foundation — hash-only invite tokens minted/redeemed through `SECURITY DEFINER` RPCs, an NDA-gated top-level `/invite/[token]` redemption flow, profile onboarding (display name + avatar), and a `/forge/admin` roles UI — so authorized members can grow and manage the Forge roster without anything leaking.
+
+**Architecture:** A `forge_invites` table that is a pure secret store (no `authenticated` RLS policy at all; reachable only via definer RPCs, mirroring `api_keys`/migration 030). Raw tokens are `crypto.randomBytes(32)` base64url generated in Node; only their sha256 hash touches Postgres. All membership mutations (mint/redeem/add/remove/change-role/profile) go through role-capped `SECURITY DEFINER` RPCs that read the caller's role server-side via `my_forge_role()` (1a.1). Redemption lives at top-level `/invite/[token]` (outside the `/forge` membership gate, since the redeemer isn't a member yet) and requires only an authenticated session.
+
+**Tech Stack:** Next.js 15 App Router (RSC + server actions + a dynamic route), TypeScript, Supabase (Postgres + Auth + RLS + RPC), `@supabase/ssr` server/client helpers, Node `crypto` (token + sha256), Resend via the existing `utils/email.ts` helper, the existing public `avatars` Storage bucket, Vitest (unit + the env-gated security test).
+
+**Scope note:** This is plan **2 of the Phase 1a sequence**, building directly on 1a.1 (PR #119: `playtest_members`, `playtest_role`, `my_forge_role`/`forge_role_of`/`is_forge_member`/`is_forge_elder_or_super`, the last-superadmin trigger, and the `requireForge`/`requireElder`/`requireForgeSuperadmin` gate). Reference spec: `docs/superpowers/specs/2026-06-19-forge-card-design-playtesting-design.md` (Roles & Access Model; Invites & onboarding; Data Model `forge_invites`/`forge_audit`; the keystone guardrail).
+
+**Forced deferrals (tables don't exist until later plans — not gaps):**
+- `forge_remove_member` deletes the membership row + audits it (which revokes all access via RLS — the security-critical effect). **Card/set ownership reassignment** and **sole-elder reassignment** wait for `forge_cards` (1a.4) / `forge_sets`+`forge_set_elders` (1a.5).
+- The invite's `set_ids` column is stored for forward-compat but **not consumed** — redemption does not create set grants until `forge_set_grants` exists (1a.5).
+- Onboarding captures **display name + avatar** and lands on the desk. The spec's "jot an idea / open a set" choices + 3-step checklist wait for the studio (1a.4) / sets (1a.5).
+
+## Global Constraints
+
+- **Next migration number is `049`.** Schema + functions only; **no real card data**; obvious fakes only in tests.
+- **Roles & cap (verbatim):** `superadmin > elder > playtester`. Grant/manage cap: **superadmin → {elder, playtester}; elder → {playtester}; others → nobody.** `superadmin` is **never** grantable via RPC (seed-only; the last-superadmin trigger from 048 backstops removal/demotion).
+- **Token:** raw = `crypto.randomBytes(32).toString("base64url")`, generated in Node. Store **only** `sha256(raw)` hex (`token_hash`). Raw token never touches the DB; it travels only in the emailed URL.
+- **No oracle on redeem:** bad / expired / used / email-mismatched tokens all return the **same** NULL/not-found result. Redemption requires an authenticated session.
+- **NDA gate (applies to every invite acceptance):** accepting an invite requires acknowledging a short confidentiality notice by typing **"I agree"** (case-insensitive, trimmed). Enforced in three places: the Accept button is disabled until it matches (UX), the `redeemInvite` server action re-validates the typed text (defense in depth), and `forge_redeem_invite` refuses (`p_nda_agreed` must be true) and stamps `playtest_members.nda_agreed_at` (DB boundary + record). A non-agreeing call returns the same NULL as a bad token (no oracle).
+- **RLS posture:** every Forge table has RLS enabled; policies `TO authenticated` only; **no `anon` policy**; explicit `REVOKE ALL … FROM anon`. `forge_invites` has **no `authenticated` policy at all** (definer-RPC-only access).
+- **Definer hardening (the 1a.1 lesson):** every Forge function is `SECURITY DEFINER` (helpers `STABLE`) with `SET search_path = ''`, and must `REVOKE EXECUTE … FROM public, anon` then `GRANT … TO authenticated`. Supabase default-grants EXECUTE to `anon` directly, so a `REVOKE FROM public` alone is insufficient — `REVOKE FROM anon` explicitly. (See `reference_supabase_revoke_anon_not_public`.)
+- **Routing:** `/forge/**` routes set `export const dynamic = "force-dynamic"` and `revalidate = 0`. The redemption page `/invite/[token]` also sets `force-dynamic` (no static generation of token pages). 404 (not 403) for unauthorized Forge access.
+- **Gate reuse:** server actions/pages reuse `requireForge`/`requireElder`/`requireForgeSuperadmin` from `app/forge/lib/auth.ts` (1a.1) — never re-implement auth.
+
+---
+
+## File Structure
+
+- `supabase/migrations/049_forge_invites_members.sql` — **Create.** `forge_invites` + `forge_audit` tables, the role-cap helper, and the membership-management RPCs (mint/redeem/add/remove/change-role/profile/list-invites). One responsibility: the invite + membership-mutation data layer and its security.
+- `app/forge/lib/token.ts` — **Create.** `hashToken(raw)` (sha256 hex) shared by mint + redeem. One responsibility: token hashing.
+- `app/forge/lib/__tests__/token.test.ts` — **Create.** Unit test for `hashToken`.
+- `app/forge/lib/members.ts` — **Create.** Server actions: `mintInvite`, `redeemInvite`, `addMember`, `removeMember`, `changeRole`, `setProfile`, `listMembers`, `listInvites`. One responsibility: the typed server-action surface over the RPCs (+ the invite email).
+- `app/forge/lib/__tests__/members.test.ts` — **Create.** Unit tests for the server actions (mock the Supabase client + `sendEmail`).
+- `app/invite/[token]/page.tsx` — **Create.** Top-level redemption route (NOT under the `/forge` gate). Requires a session, then renders the NDA acceptance form.
+- `app/invite/[token]/AcceptForm.tsx` — **Create.** Client form: confidentiality notice + "type I agree" field → `redeemInvite` → onboarding, or a generic failure message.
+- `app/forge/welcome/page.tsx` — **Create.** Gated onboarding host (member-only). Skips itself if `display_name` is already set.
+- `app/forge/welcome/OnboardingForm.tsx` — **Create.** Client form: display name + avatar upload → `setProfile` → `/forge`.
+- `app/forge/admin/page.tsx` — **Create.** Gated (`requireElder`) roles/invites console (server-fetches members + invites).
+- `app/forge/admin/AdminConsole.tsx` — **Create.** Client UI: invite form, members table with capped row actions, pending-invites list.
+- `__tests__/forge-anon-leak.test.ts` — **Modify.** Add `forge_invites`/`forge_audit` to `FORGE_TABLES`; add an "anon cannot execute any Forge definer RPC" block (closes spec leak-test step 3 and the 1a.1 gap).
+
+---
+
+## Task 1: Invites + audit + membership-management RPCs (migration 049)
+
+**Files:**
+- Create: `supabase/migrations/049_forge_invites_members.sql`
+- Verify: Supabase MCP `apply_migration` / `execute_sql` / `get_advisors` (no new file)
+
+**Interfaces:**
+- Consumes (from 048): `public.playtest_members`, enum `public.playtest_role`, `public.my_forge_role()`, `public.is_forge_elder_or_super()`, the last-superadmin trigger.
+- Produces (consumed by Tasks 2–6):
+  - `public.forge_role_outranks(actor_role text, target_role text) returns boolean`
+  - `public.forge_mint_invite(p_token_hash text, p_role public.playtest_role, p_set_ids uuid[], p_email text, p_expires_at timestamptz) returns uuid`
+  - `public.forge_redeem_invite(p_token_hash text, p_nda_agreed boolean) returns text` (granted role, or NULL on any failure incl. NDA not agreed)
+  - `public.forge_add_member(p_user_id uuid, p_role public.playtest_role) returns void`
+  - `public.forge_remove_member(p_user_id uuid) returns void`
+  - `public.forge_change_role(p_user_id uuid, p_new_role public.playtest_role) returns void`
+  - `public.forge_set_profile(p_display_name text, p_avatar_url text) returns void`
+  - `public.forge_list_invites() returns table(id uuid, role public.playtest_role, email text, set_ids uuid[], invited_by uuid, expires_at timestamptz, used_at timestamptz, created_at timestamptz)`
+  - Tables `public.forge_invites`, `public.forge_audit`.
+
+- [ ] **Step 1: Write the migration file**
+
+Create `supabase/migrations/049_forge_invites_members.sql`:
+
+```sql
+-- Forge access layer, part 2: invites, audit, and the membership-management RPCs.
+-- Builds on 048 (playtest_members, playtest_role, my_forge_role / is_forge_* helpers,
+-- last-superadmin trigger). SCHEMA + FUNCTIONS ONLY — no card data.
+
+-- 0) Record the NDA acknowledgment on the membership row (stamped at redeem).
+alter table public.playtest_members add column if not exists nda_agreed_at timestamptz;
+
+-- 1) Invites. Hash-only token. This table has NO authenticated RLS policy: it is a
+--    secret store reachable only through the SECURITY DEFINER RPCs below (mirrors
+--    api_keys / migration 030). anon is default-denied + explicit revoke.
+create table if not exists public.forge_invites (
+  id         uuid primary key default gen_random_uuid(),
+  token_hash text not null unique,
+  role       public.playtest_role not null,
+  set_ids    uuid[] not null default '{}',   -- stored for 1a.5; not consumed yet
+  email      text,                            -- optional bind to a specific address
+  invited_by uuid not null references auth.users(id),
+  expires_at timestamptz not null default now() + interval '7 days',
+  used_at    timestamptz,
+  created_at timestamptz not null default now()
+);
+alter table public.forge_invites enable row level security;
+revoke all on public.forge_invites from anon;
+
+-- 2) Minimal audit. Write-only via definer RPCs; elders+ may read.
+create table if not exists public.forge_audit (
+  id     bigserial primary key,
+  actor  uuid not null references auth.users(id),
+  action text not null,
+  target text,
+  at     timestamptz not null default now()
+);
+alter table public.forge_audit enable row level security;
+drop policy if exists "forge_audit_select" on public.forge_audit;
+create policy "forge_audit_select" on public.forge_audit
+  for select to authenticated
+  using (public.is_forge_elder_or_super());
+revoke all on public.forge_audit from anon;
+grant select on public.forge_audit to authenticated;
+
+-- 3) Role-cap helper (pure logic, no table access).
+create or replace function public.forge_role_outranks(actor_role text, target_role text)
+returns boolean language sql immutable set search_path = '' as $$
+  select case actor_role
+    when 'superadmin' then target_role in ('elder','playtester')
+    when 'elder'      then target_role = 'playtester'
+    else false
+  end;
+$$;
+
+-- 4) Mint an invite. Caller's role caps the grantable role. Stores hash only.
+create or replace function public.forge_mint_invite(
+  p_token_hash text, p_role public.playtest_role, p_set_ids uuid[],
+  p_email text, p_expires_at timestamptz
+) returns uuid language plpgsql security definer set search_path = '' as $$
+declare v_id uuid;
+begin
+  if not public.forge_role_outranks(public.my_forge_role(), p_role::text) then
+    raise exception 'not authorized to mint a % invite', p_role;
+  end if;
+  insert into public.forge_invites (token_hash, role, set_ids, email, invited_by, expires_at)
+  values (p_token_hash, p_role, coalesce(p_set_ids, '{}'), p_email, auth.uid(),
+          coalesce(p_expires_at, now() + interval '7 days'))
+  returning id into v_id;
+  insert into public.forge_audit (actor, action, target)
+  values (auth.uid(), 'invite_minted', v_id::text);
+  return v_id;
+end; $$;
+
+-- 5) Redeem an invite. Authenticated caller becomes a member after acknowledging
+--    the NDA (p_nda_agreed). NO ORACLE: every failure path returns NULL
+--    (no-agreement/bad/expired/used/email-mismatch are indistinguishable).
+create or replace function public.forge_redeem_invite(p_token_hash text, p_nda_agreed boolean)
+returns text language plpgsql security definer set search_path = '' as $$
+declare v_invite public.forge_invites;
+begin
+  if not coalesce(p_nda_agreed, false) then return null; end if;  -- must accept the NDA
+  select * into v_invite from public.forge_invites
+   where token_hash = p_token_hash and used_at is null and expires_at > now()
+   for update;
+  if not found then return null; end if;
+  if v_invite.email is not null and v_invite.email is distinct from auth.email() then
+    return null;  -- email-bound to someone else; same not-found result
+  end if;
+  insert into public.playtest_members (user_id, role, invited_by, nda_agreed_at)
+  values (auth.uid(), v_invite.role, v_invite.invited_by, now())
+  on conflict (user_id) do nothing;
+  update public.forge_invites set used_at = now() where id = v_invite.id;
+  insert into public.forge_audit (actor, action, target)
+  values (auth.uid(), 'member_added', v_invite.id::text);
+  return v_invite.role::text;
+end; $$;
+
+-- 6) Direct membership management (no invite). All role-capped against the caller.
+--    add_member is INSERT-only (use change_role to modify an existing member —
+--    otherwise an elder could downgrade an elder via add_member, bypassing the cap).
+create or replace function public.forge_add_member(p_user_id uuid, p_role public.playtest_role)
+returns void language plpgsql security definer set search_path = '' as $$
+begin
+  if not public.forge_role_outranks(public.my_forge_role(), p_role::text) then
+    raise exception 'not authorized to add a % member', p_role;
+  end if;
+  if exists (select 1 from public.playtest_members where user_id = p_user_id) then
+    raise exception 'already a member; use change_role';
+  end if;
+  insert into public.playtest_members (user_id, role, invited_by)
+  values (p_user_id, p_role, auth.uid());
+  insert into public.forge_audit (actor, action, target)
+  values (auth.uid(), 'member_added', p_user_id::text);
+end; $$;
+
+create or replace function public.forge_remove_member(p_user_id uuid)
+returns void language plpgsql security definer set search_path = '' as $$
+declare v_target_role text;
+begin
+  select role::text into v_target_role from public.playtest_members where user_id = p_user_id;
+  if v_target_role is null then raise exception 'not a member'; end if;
+  if not public.forge_role_outranks(public.my_forge_role(), v_target_role) then
+    raise exception 'not authorized to remove a % member', v_target_role;
+  end if;
+  -- FORWARD DEPENDENCY: card/set ownership reassignment lands when forge_cards/
+  -- forge_sets exist (plans 1a.4/1a.5). Deleting the membership row already revokes
+  -- all access via RLS — the security-critical effect. The last-superadmin trigger
+  -- (048) backstops removal of the final superadmin.
+  delete from public.playtest_members where user_id = p_user_id;
+  insert into public.forge_audit (actor, action, target)
+  values (auth.uid(), 'member_removed', p_user_id::text);
+end; $$;
+
+create or replace function public.forge_change_role(p_user_id uuid, p_new_role public.playtest_role)
+returns void language plpgsql security definer set search_path = '' as $$
+declare v_caller text := public.my_forge_role(); v_current text;
+begin
+  select role::text into v_current from public.playtest_members where user_id = p_user_id;
+  if v_current is null then raise exception 'not a member'; end if;
+  if not public.forge_role_outranks(v_caller, v_current)
+     or not public.forge_role_outranks(v_caller, p_new_role::text) then
+    raise exception 'not authorized to change this member''s role';
+  end if;
+  -- last-superadmin demotion is backstopped by the 048 trigger.
+  update public.playtest_members set role = p_new_role where user_id = p_user_id;
+  insert into public.forge_audit (actor, action, target)
+  values (auth.uid(), 'role_changed', p_user_id::text || ' -> ' || p_new_role::text);
+end; $$;
+
+-- 7) Self-service profile (display_name + avatar only; never role).
+create or replace function public.forge_set_profile(p_display_name text, p_avatar_url text)
+returns void language plpgsql security definer set search_path = '' as $$
+begin
+  update public.playtest_members
+     set display_name = p_display_name, avatar_url = p_avatar_url
+   where user_id = auth.uid();
+  if not found then raise exception 'not a member'; end if;
+end; $$;
+
+-- 8) Admin read: invites WITHOUT token_hash (elders+ only; empty for everyone else).
+create or replace function public.forge_list_invites()
+returns table(id uuid, role public.playtest_role, email text, set_ids uuid[],
+              invited_by uuid, expires_at timestamptz, used_at timestamptz, created_at timestamptz)
+language sql security definer stable set search_path = '' as $$
+  select id, role, email, set_ids, invited_by, expires_at, used_at, created_at
+  from public.forge_invites
+  where public.is_forge_elder_or_super()
+  order by created_at desc;
+$$;
+
+-- 9) Lock down execute: strip anon (Supabase default-grants it directly), grant authenticated.
+revoke execute on function public.forge_role_outranks(text, text) from public, anon;
+revoke execute on function public.forge_mint_invite(text, public.playtest_role, uuid[], text, timestamptz) from public, anon;
+revoke execute on function public.forge_redeem_invite(text, boolean) from public, anon;
+revoke execute on function public.forge_add_member(uuid, public.playtest_role) from public, anon;
+revoke execute on function public.forge_remove_member(uuid) from public, anon;
+revoke execute on function public.forge_change_role(uuid, public.playtest_role) from public, anon;
+revoke execute on function public.forge_set_profile(text, text) from public, anon;
+revoke execute on function public.forge_list_invites() from public, anon;
+
+grant execute on function public.forge_role_outranks(text, text) to authenticated;
+grant execute on function public.forge_mint_invite(text, public.playtest_role, uuid[], text, timestamptz) to authenticated;
+grant execute on function public.forge_redeem_invite(text, boolean) to authenticated;
+grant execute on function public.forge_add_member(uuid, public.playtest_role) to authenticated;
+grant execute on function public.forge_remove_member(uuid) to authenticated;
+grant execute on function public.forge_change_role(uuid, public.playtest_role) to authenticated;
+grant execute on function public.forge_set_profile(text, text) to authenticated;
+grant execute on function public.forge_list_invites() to authenticated;
+```
+
+- [ ] **Step 2: Apply the migration**
+
+Apply via Supabase MCP `apply_migration` (name: `forge_invites_members`, the SQL above).
+Expected: `{"success": true}`. If it errors on a missing 048 object (e.g. `my_forge_role`), stop — 048 must be applied first (it is, per PR #119).
+
+- [ ] **Step 3: Verify schema + anon has zero execute on the new functions**
+
+Run via Supabase MCP `execute_sql`:
+```sql
+select
+  to_regclass('public.forge_invites')                                         as invites_tbl,
+  to_regclass('public.forge_audit')                                           as audit_tbl,
+  has_function_privilege('anon','public.forge_mint_invite(text,public.playtest_role,uuid[],text,timestamptz)','execute') as anon_mint,
+  has_function_privilege('anon','public.forge_redeem_invite(text,boolean)','execute')  as anon_redeem,
+  has_function_privilege('anon','public.forge_change_role(uuid,public.playtest_role)','execute') as anon_change,
+  has_function_privilege('authenticated','public.forge_redeem_invite(text,boolean)','execute') as auth_redeem;
+```
+Expected: both tables non-null; `anon_mint`, `anon_redeem`, `anon_change` = **false**; `auth_redeem` = **true**.
+
+- [ ] **Step 4: Verify the role-cap (privilege-escalation guard) via JWT-claim impersonation**
+
+Run via Supabase MCP `execute_sql` (sets `auth.uid()`/`my_forge_role()` for the elder seeded… there is none yet, so test the pure cap helper + a mint attempt against a simulated elder by inserting a throwaway elder, then cleaning up):
+```sql
+do $$
+declare elder_uid uuid := '00000000-0000-0000-0000-0000000000e1';
+begin
+  -- pure cap logic
+  assert public.forge_role_outranks('superadmin','elder');
+  assert public.forge_role_outranks('elder','playtester');
+  assert not public.forge_role_outranks('elder','elder');       -- elder cannot grant elder
+  assert not public.forge_role_outranks('superadmin','superadmin'); -- nobody mints superadmin
+  assert not public.forge_role_outranks('playtester','playtester');
+
+  -- simulate an elder caller and assert mint of an elder invite is rejected
+  insert into auth.users (id, email) values (elder_uid, 'elder-test@example.com')
+    on conflict (id) do nothing;
+  insert into public.playtest_members (user_id, role) values (elder_uid, 'elder')
+    on conflict (user_id) do update set role = 'elder';
+  perform set_config('request.jwt.claims', json_build_object('sub', elder_uid)::text, true);
+  begin
+    perform public.forge_mint_invite('hash-x','elder','{}'::uuid[], null, null);
+    raise exception 'CAP FAILED: elder minted an elder invite';
+  exception when others then
+    if sqlerrm like 'CAP FAILED%' then raise; end if;
+    raise notice 'cap ok: %', sqlerrm;
+  end;
+  -- elder CAN mint a playtester invite
+  perform public.forge_mint_invite('hash-pt','playtester','{}'::uuid[], null, null);
+  raise notice 'elder minted playtester invite ok';
+
+  -- cleanup
+  delete from public.forge_invites where token_hash in ('hash-x','hash-pt');
+  delete from public.playtest_members where user_id = elder_uid;
+  delete from public.forge_audit where actor = elder_uid;
+  delete from auth.users where id = elder_uid;
+end $$;
+```
+Expected: notices `cap ok: not authorized to mint a elder invite` and `elder minted playtester invite ok`; no `CAP FAILED`. (All test rows cleaned up.)
+
+- [ ] **Step 5: Verify redeem has no oracle (expired/used/email-mismatch all → NULL)**
+
+Run via Supabase MCP `execute_sql`:
+```sql
+do $$
+declare u uuid := '00000000-0000-0000-0000-0000000000d2';
+begin
+  insert into auth.users (id, email) values (u, 'redeemer@example.com') on conflict (id) do nothing;
+  -- expired invite
+  insert into public.forge_invites (token_hash, role, invited_by, expires_at)
+  values ('expired-hash','playtester', u, now() - interval '1 day');
+  -- email-bound to someone else
+  insert into public.forge_invites (token_hash, role, invited_by, email)
+  values ('bound-hash','playtester', u, 'someone-else@example.com');
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', u, 'email', 'redeemer@example.com')::text, true);
+  assert public.forge_redeem_invite('expired-hash', true) is null, 'expired should be null';
+  assert public.forge_redeem_invite('bound-hash',   true) is null, 'email-mismatch should be null';
+  assert public.forge_redeem_invite('nonexistent',  true) is null, 'unknown should be null';
+  assert public.forge_redeem_invite('expired-hash', false) is null, 'no-NDA should be null';
+  raise notice 'redeem no-oracle ok';
+  -- cleanup
+  delete from public.forge_invites where token_hash in ('expired-hash','bound-hash');
+  delete from public.playtest_members where user_id = u;
+  delete from public.forge_audit where actor = u;
+  delete from auth.users where id = u;
+end $$;
+```
+Expected: notice `redeem no-oracle ok`; no assertion failure.
+
+- [ ] **Step 6: Run Supabase security advisors**
+
+Run Supabase MCP `get_advisors` (type: `security`).
+Expected: **no** `function_search_path_mutable` or `anon_security_definer_function_executable` finding referencing any new `forge_*` function, and no RLS-disabled finding on `forge_invites`/`forge_audit`. (Pre-existing findings on unrelated objects are out of scope.) Fix any new finding before continuing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add supabase/migrations/049_forge_invites_members.sql
+git commit -m "feat(forge): invites + audit + membership-management RPCs (049)"
+```
+
+---
+
+## Task 2: Token hashing + the invite mint server action (with email)
+
+**Files:**
+- Create: `app/forge/lib/token.ts`
+- Test: `app/forge/lib/__tests__/token.test.ts`
+- Create: `app/forge/lib/members.ts` (this task adds `mintInvite`; later tasks extend the same file)
+- Test: `app/forge/lib/__tests__/members.test.ts` (this task adds the `mintInvite` describe block)
+
+**Interfaces:**
+- Consumes: `requireElder`/`requireForgeSuperadmin` from `@/app/forge/lib/auth` (1a.1); RPC `forge_mint_invite` (Task 1); `sendEmail` + `wrapEmailInTemplate` from `@/utils/email`.
+- Produces (consumed by Tasks 3, 5):
+  - `hashToken(raw: string): string` (sha256 hex)
+  - `mintInvite(input: { role: ForgeRole; email?: string | null; expiresInDays?: number }): Promise<{ ok: true; url: string } | { ok: false; error: string }>`
+
+- [ ] **Step 1: Write the failing test for `hashToken`**
+
+Create `app/forge/lib/__tests__/token.test.ts`:
+```ts
+import { describe, it, expect } from "vitest";
+import { createHash } from "crypto";
+import { hashToken } from "../token";
+
+describe("hashToken", () => {
+  it("returns the sha256 hex of the input", () => {
+    expect(hashToken("abc")).toBe(createHash("sha256").update("abc").digest("hex"));
+  });
+  it("is deterministic and 64 hex chars", () => {
+    const h = hashToken("some-token");
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+    expect(hashToken("some-token")).toBe(h);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npm test -- app/forge/lib/__tests__/token.test.ts`
+Expected: FAIL — cannot resolve `../token`.
+
+- [ ] **Step 3: Implement `hashToken`**
+
+Create `app/forge/lib/token.ts`:
+```ts
+import { createHash } from "crypto";
+
+/** sha256 hex of a raw invite token. Only the hash is ever stored. */
+export function hashToken(raw: string): string {
+  return createHash("sha256").update(raw).digest("hex");
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `npm test -- app/forge/lib/__tests__/token.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Write the failing test for `mintInvite`**
+
+Create `app/forge/lib/__tests__/members.test.ts`:
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/app/forge/lib/auth", () => ({
+  requireElder: vi.fn(),
+  requireForgeSuperadmin: vi.fn(),
+  requireForge: vi.fn(),
+}));
+vi.mock("@/utils/email", () => ({
+  sendEmail: vi.fn(async () => ({ success: true })),
+  wrapEmailInTemplate: (s: string) => s,
+}));
+
+import { requireElder, requireForgeSuperadmin } from "@/app/forge/lib/auth";
+import { sendEmail } from "@/utils/email";
+import { mintInvite } from "../members";
+
+function ctx(role: string, rpcImpl?: any) {
+  return {
+    role,
+    user: { id: "caller", email: "c@x.com" },
+    supabase: { rpc: vi.fn(rpcImpl ?? (async () => ({ data: "invite-id", error: null }))) },
+  };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("mintInvite", () => {
+  it("rejects when caller is not an elder/superadmin", async () => {
+    (requireElder as any).mockResolvedValue(null);
+    const r = await mintInvite({ role: "playtester" });
+    expect(r.ok).toBe(false);
+  });
+
+  it("an elder cannot mint an elder invite (needs superadmin)", async () => {
+    (requireElder as any).mockResolvedValue(ctx("elder"));
+    (requireForgeSuperadmin as any).mockResolvedValue(null);
+    const r = await mintInvite({ role: "elder" });
+    expect(r.ok).toBe(false);
+  });
+
+  it("mints: hashes the token (raw never sent to RPC) and emails the URL", async () => {
+    const c = ctx("superadmin");
+    (requireElder as any).mockResolvedValue(c);
+    (requireForgeSuperadmin as any).mockResolvedValue(c);
+    const r = await mintInvite({ role: "elder", email: "new@x.com" });
+    expect(r.ok).toBe(true);
+    // RPC got a 64-hex hash, not a raw base64url token
+    const passedHash = (c.supabase.rpc as any).mock.calls[0][1].p_token_hash;
+    expect(passedHash).toMatch(/^[0-9a-f]{64}$/);
+    // email sent, and the raw token in the URL is NOT the stored hash
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    const html = (sendEmail as any).mock.calls[0][0].html as string;
+    const url = (r as any).url as string;
+    expect(html).toContain(url);
+    expect(url).toContain("/invite/");
+    expect(url).not.toContain(passedHash);
+  });
+});
+```
+
+- [ ] **Step 6: Run it to verify it fails**
+
+Run: `npm test -- app/forge/lib/__tests__/members.test.ts`
+Expected: FAIL — cannot resolve `../members` / `mintInvite` not exported.
+
+- [ ] **Step 7: Implement `mintInvite` in `app/forge/lib/members.ts`**
+
+Create `app/forge/lib/members.ts`:
+```ts
+"use server";
+
+import { randomBytes } from "crypto";
+import { requireElder, requireForgeSuperadmin, type ForgeRole } from "@/app/forge/lib/auth";
+import { hashToken } from "@/app/forge/lib/token";
+import { sendEmail, wrapEmailInTemplate } from "@/utils/email";
+
+function siteUrl(): string {
+  const base = process.env.VERCEL_PROJECT_PRODUCTION_URL
+    ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+    : process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+  return base.replace(/\/$/, "");
+}
+
+export async function mintInvite(input: {
+  role: ForgeRole;
+  email?: string | null;
+  expiresInDays?: number;
+}): Promise<{ ok: true; url: string } | { ok: false; error: string }> {
+  // Elder gate first; an elder invite additionally needs superadmin.
+  const ctx = await requireElder();
+  if (!ctx) return { ok: false, error: "Not authorized" };
+  if (input.role === "elder" && !(await requireForgeSuperadmin())) {
+    return { ok: false, error: "Only a superadmin can invite an elder" };
+  }
+  if (input.role === "superadmin") return { ok: false, error: "Superadmin is not invitable" };
+
+  const raw = randomBytes(32).toString("base64url");
+  const days = input.expiresInDays && input.expiresInDays > 0 ? input.expiresInDays : 7;
+  const expiresAt = new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
+
+  const { error } = await ctx.supabase.rpc("forge_mint_invite", {
+    p_token_hash: hashToken(raw),
+    p_role: input.role,
+    p_set_ids: [],
+    p_email: input.email ?? null,
+    p_expires_at: expiresAt,
+  });
+  if (error) return { ok: false, error: "Could not mint invite" };
+
+  const url = `${siteUrl()}/invite/${raw}`;
+  const body = `
+    <h1 style="font-size:22px;margin:0 0 12px 0;">You're invited to The Forge</h1>
+    <p>You've been invited to join The Forge as a <strong>${input.role}</strong>.</p>
+    <p style="margin:24px 0;"><a href="${url}"
+       style="background:#10b981;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;">Accept invite</a></p>
+    <p style="color:#71717a;font-size:13px;">This link expires in ${days} day(s) and can be used once. If you didn't expect this, ignore it.</p>`;
+  if (input.email) {
+    await sendEmail({ to: input.email, subject: "Your Forge invite", html: wrapEmailInTemplate(body) });
+  }
+  return { ok: true, url };
+}
+```
+(Note: when `email` is omitted the inviter shares the returned `url` manually; the email send is skipped.)
+
+- [ ] **Step 8: Run both test files to verify they pass**
+
+Run: `npm test -- app/forge/lib/__tests__/token.test.ts app/forge/lib/__tests__/members.test.ts`
+Expected: PASS (2 + 3 tests).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/forge/lib/token.ts app/forge/lib/__tests__/token.test.ts app/forge/lib/members.ts app/forge/lib/__tests__/members.test.ts
+git commit -m "feat(forge): hashToken + mintInvite server action (hash-only token, Resend email)"
+```
+
+---
+
+## Task 3: NDA-gated redemption flow — `redeemInvite` action + `/invite/[token]` acceptance form
+
+**Files:**
+- Modify: `app/forge/lib/members.ts` (add `redeemInvite`)
+- Modify: `app/forge/lib/__tests__/members.test.ts` (add the `redeemInvite` describe block)
+- Create: `app/invite/[token]/page.tsx`
+- Create: `app/invite/[token]/AcceptForm.tsx`
+
+**Interfaces:**
+- Consumes: RPC `forge_redeem_invite` (Task 1); `hashToken` (Task 2); `createClient` from `@/utils/supabase/server`.
+- Produces (consumed by the page + form):
+  - `redeemInvite(rawToken: string, agreement: string): Promise<{ ok: true; role: ForgeRole } | { ok: false }>` — `agreement` must normalize to `"i agree"` (trimmed, lowercased) or redemption is refused.
+
+- [ ] **Step 1: Write the failing test for `redeemInvite`**
+
+Add to `app/forge/lib/__tests__/members.test.ts` (append; reuse the existing mocks). First extend the server mock to include `createClient`:
+```ts
+vi.mock("@/utils/supabase/server", () => ({ createClient: vi.fn() }));
+import { createClient } from "@/utils/supabase/server";
+import { redeemInvite } from "../members";
+
+describe("redeemInvite", () => {
+  it("returns the role on success, hashes the token, and passes p_nda_agreed=true for 'I agree'", async () => {
+    const rpc = vi.fn(async () => ({ data: "playtester", error: null }));
+    (createClient as any).mockResolvedValue({ rpc });
+    const r = await redeemInvite("raw-token-123", "  I Agree ");
+    expect(r).toEqual({ ok: true, role: "playtester" });
+    expect(rpc.mock.calls[0][1].p_token_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(rpc.mock.calls[0][1].p_token_hash).not.toBe("raw-token-123");
+    expect(rpc.mock.calls[0][1].p_nda_agreed).toBe(true);
+  });
+  it("passes p_nda_agreed=false when the text is not 'I agree'", async () => {
+    const rpc = vi.fn(async () => ({ data: null, error: null }));
+    (createClient as any).mockResolvedValue({ rpc });
+    const r = await redeemInvite("raw-token-123", "nope");
+    expect(r).toEqual({ ok: false });
+    expect(rpc.mock.calls[0][1].p_nda_agreed).toBe(false);
+  });
+  it("returns {ok:false} when the RPC yields null (no oracle)", async () => {
+    (createClient as any).mockResolvedValue({ rpc: vi.fn(async () => ({ data: null, error: null })) });
+    expect(await redeemInvite("bad", "I agree")).toEqual({ ok: false });
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npm test -- app/forge/lib/__tests__/members.test.ts`
+Expected: FAIL — `redeemInvite` not exported.
+
+- [ ] **Step 3: Implement `redeemInvite`**
+
+Add to `app/forge/lib/members.ts`:
+```ts
+import { createClient } from "@/utils/supabase/server";
+
+export async function redeemInvite(
+  rawToken: string,
+  agreement: string
+): Promise<{ ok: true; role: ForgeRole } | { ok: false }> {
+  const agreed = agreement.trim().toLowerCase() === "i agree";
+  const supabase = await createClient();
+  const { data, error } = await supabase.rpc("forge_redeem_invite", {
+    p_token_hash: hashToken(rawToken),
+    p_nda_agreed: agreed,
+  });
+  if (error || (data !== "superadmin" && data !== "elder" && data !== "playtester")) {
+    return { ok: false };
+  }
+  return { ok: true, role: data as ForgeRole };
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `npm test -- app/forge/lib/__tests__/members.test.ts`
+Expected: PASS (mint 3 + redeem 2).
+
+- [ ] **Step 5: Write the redemption page (auth gate → render the acceptance form)**
+
+Create `app/invite/[token]/page.tsx`:
+```tsx
+import { redirect } from "next/navigation";
+import { createClient } from "@/utils/supabase/server";
+import AcceptForm from "./AcceptForm";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const metadata = { robots: { index: false, follow: false } };
+
+export default async function InviteRedemptionPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+
+  // Must be signed in to bind the invite to a real auth.users.id.
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect(`/sign-in?redirectTo=${encodeURIComponent(`/invite/${token}`)}`);
+  }
+
+  // Redemption happens only after the NDA is accepted, inside the form.
+  return <AcceptForm token={token} />;
+}
+```
+
+- [ ] **Step 6: Write the NDA acceptance form (client)**
+
+Create `app/invite/[token]/AcceptForm.tsx`:
+```tsx
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { redeemInvite } from "@/app/forge/lib/members";
+
+export default function AcceptForm({ token }: { token: string }) {
+  const router = useRouter();
+  const [text, setText] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const agreed = text.trim().toLowerCase() === "i agree";
+
+  async function accept() {
+    setBusy(true);
+    setFailed(false);
+    const r = await redeemInvite(token, text);
+    setBusy(false);
+    if (r.ok) router.push("/forge/welcome");
+    else setFailed(true);
+  }
+
+  return (
+    <main className="mx-auto max-w-md p-6">
+      <h1 className="text-2xl" style={{ fontFamily: "Cinzel, serif" }}>
+        Accept your Forge invite
+      </h1>
+      <div className="mt-4 rounded-md border bg-muted/40 p-4 text-sm text-muted-foreground">
+        <p className="font-medium text-foreground">Before you enter — an unofficial NDA</p>
+        <p className="mt-2">
+          The Forge holds unreleased, confidential card designs. By accepting, you agree not to
+          share, screenshot, post, or otherwise disclose any unreleased card content — names, art,
+          abilities, anything — outside the Forge until it is officially published.
+        </p>
+      </div>
+      <label className="mt-4 block text-sm font-medium">
+        Type <span className="font-semibold">I agree</span> to continue
+        <input
+          className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="I agree"
+          autoComplete="off"
+        />
+      </label>
+      {failed && (
+        <p className="mt-3 text-sm text-muted-foreground">
+          This invite link is invalid, expired, or already used. Ask whoever invited you for a fresh link.
+        </p>
+      )}
+      <button
+        onClick={accept}
+        disabled={!agreed || busy}
+        className="mt-4 rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground disabled:opacity-50"
+      >
+        {busy ? "Entering…" : "Accept & enter the Forge"}
+      </button>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 7: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no new errors referencing `app/invite/**` or `app/forge/lib/members.ts`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/forge/lib/members.ts app/forge/lib/__tests__/members.test.ts "app/invite/[token]/page.tsx" "app/invite/[token]/AcceptForm.tsx"
+git commit -m "feat(forge): NDA-gated /invite/[token] acceptance flow (type 'I agree', no-oracle)"
+```
+
+---
+
+## Task 4: Onboarding — `setProfile` action + `/forge/welcome` (display name + avatar)
+
+**Files:**
+- Modify: `app/forge/lib/members.ts` (add `setProfile`)
+- Modify: `app/forge/lib/__tests__/members.test.ts` (add the `setProfile` block)
+- Create: `app/forge/welcome/page.tsx`
+- Create: `app/forge/welcome/OnboardingForm.tsx`
+
+**Interfaces:**
+- Consumes: `requireForge` (1a.1); RPC `forge_set_profile` (Task 1); the public `avatars` storage bucket; `createClient` from `@/utils/supabase/client` (client upload).
+- Produces:
+  - `setProfile(input: { displayName: string; avatarUrl?: string | null }): Promise<{ ok: boolean; error?: string }>`
+
+- [ ] **Step 1: Write the failing test for `setProfile`**
+
+Add to `app/forge/lib/__tests__/members.test.ts` (the `requireForge` mock already exists from Task 2):
+```ts
+import { requireForge } from "@/app/forge/lib/auth";
+import { setProfile } from "../members";
+
+describe("setProfile", () => {
+  it("rejects a non-member", async () => {
+    (requireForge as any).mockResolvedValue(null);
+    expect((await setProfile({ displayName: "X" })).ok).toBe(false);
+  });
+  it("rejects an empty display name", async () => {
+    (requireForge as any).mockResolvedValue({ supabase: { rpc: vi.fn() } });
+    expect((await setProfile({ displayName: "   " })).ok).toBe(false);
+  });
+  it("calls forge_set_profile for a member", async () => {
+    const rpc = vi.fn(async () => ({ error: null }));
+    (requireForge as any).mockResolvedValue({ supabase: { rpc } });
+    const r = await setProfile({ displayName: "Tim", avatarUrl: "https://x/y.png" });
+    expect(r.ok).toBe(true);
+    expect(rpc).toHaveBeenCalledWith("forge_set_profile", {
+      p_display_name: "Tim",
+      p_avatar_url: "https://x/y.png",
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npm test -- app/forge/lib/__tests__/members.test.ts`
+Expected: FAIL — `setProfile` not exported.
+
+- [ ] **Step 3: Implement `setProfile`**
+
+Add to `app/forge/lib/members.ts` (import `requireForge` alongside the existing auth imports):
+```ts
+export async function setProfile(input: {
+  displayName: string;
+  avatarUrl?: string | null;
+}): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireForge();
+  if (!ctx) return { ok: false, error: "Not authorized" };
+  const name = input.displayName.trim();
+  if (!name) return { ok: false, error: "Display name is required" };
+  if (name.length > 60) return { ok: false, error: "Display name too long" };
+  const { error } = await ctx.supabase.rpc("forge_set_profile", {
+    p_display_name: name,
+    p_avatar_url: input.avatarUrl ?? null,
+  });
+  if (error) return { ok: false, error: "Could not save profile" };
+  return { ok: true };
+}
+```
+(Update the `import { requireElder, requireForgeSuperadmin, type ForgeRole }` line in `members.ts` to also import `requireForge`.)
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `npm test -- app/forge/lib/__tests__/members.test.ts`
+Expected: PASS (mint 3 + redeem 2 + setProfile 3).
+
+- [ ] **Step 5: Write the gated onboarding host page**
+
+Create `app/forge/welcome/page.tsx`:
+```tsx
+import { redirect } from "next/navigation";
+import { notFound } from "next/navigation";
+import { requireForge } from "@/app/forge/lib/auth";
+import OnboardingForm from "./OnboardingForm";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function ForgeWelcomePage() {
+  const ctx = await requireForge();
+  if (!ctx) notFound();
+  // Skip onboarding if the profile is already set.
+  const { data } = await ctx.supabase
+    .from("playtest_members")
+    .select("display_name")
+    .eq("user_id", ctx.user.id)
+    .single();
+  if (data?.display_name) redirect("/forge");
+  return (
+    <main className="mx-auto max-w-md p-6">
+      <h1 className="text-2xl" style={{ fontFamily: "Cinzel, serif" }}>
+        Welcome to The Forge
+      </h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        You're in as <span className="font-medium">{ctx.role}</span>. Set up your profile.
+      </p>
+      <OnboardingForm />
+    </main>
+  );
+}
+```
+
+- [ ] **Step 6: Write the client onboarding form (display name + avatar upload)**
+
+Create `app/forge/welcome/OnboardingForm.tsx`:
+```tsx
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/utils/supabase/client";
+import { setProfile } from "@/app/forge/lib/members";
+
+export default function OnboardingForm() {
+  const router = useRouter();
+  const [displayName, setDisplayName] = useState("");
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleAvatar(file: File) {
+    const supabase = createClient();
+    const fileName = `forge-${Date.now()}-${file.name}`;
+    const { error: upErr } = await supabase.storage.from("avatars").upload(fileName, file);
+    if (upErr) return setError("Avatar upload failed");
+    const {
+      data: { publicUrl },
+    } = supabase.storage.from("avatars").getPublicUrl(fileName);
+    setAvatarUrl(publicUrl);
+  }
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+    const r = await setProfile({ displayName, avatarUrl });
+    setBusy(false);
+    if (!r.ok) return setError(r.error ?? "Could not save");
+    router.push("/forge");
+  }
+
+  return (
+    <form onSubmit={submit} className="mt-6 space-y-4">
+      <label className="block text-sm font-medium">
+        Display name
+        <input
+          className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          maxLength={60}
+          required
+        />
+      </label>
+      <label className="block text-sm font-medium">
+        Avatar (optional)
+        <input
+          type="file"
+          accept="image/*"
+          className="mt-1 block w-full text-sm"
+          onChange={(e) => e.target.files?.[0] && handleAvatar(e.target.files[0])}
+        />
+      </label>
+      {avatarUrl && <img src={avatarUrl} alt="" className="h-16 w-16 rounded-full object-cover" />}
+      {error && <p className="text-sm text-red-500">{error}</p>}
+      <button
+        type="submit"
+        disabled={busy || !displayName.trim()}
+        className="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground disabled:opacity-50"
+      >
+        {busy ? "Saving…" : "Enter the Forge"}
+      </button>
+    </form>
+  );
+}
+```
+(Per the spec, Forge art uses plain `<img>`, never `next/image` — applied here for the avatar preview too.)
+
+- [ ] **Step 7: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no new errors referencing `app/forge/welcome/**` or `members.ts`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/forge/lib/members.ts app/forge/lib/__tests__/members.test.ts app/forge/welcome/page.tsx app/forge/welcome/OnboardingForm.tsx
+git commit -m "feat(forge): onboarding — setProfile RPC action + /forge/welcome (name + avatar)"
+```
+
+---
+
+## Task 5: `/forge/admin` — roles + invites console
+
+**Files:**
+- Modify: `app/forge/lib/members.ts` (add `addMember`, `removeMember`, `changeRole`, `listMembers`, `listInvites`)
+- Modify: `app/forge/lib/__tests__/members.test.ts` (add blocks for the new actions)
+- Create: `app/forge/admin/page.tsx`
+- Create: `app/forge/admin/AdminConsole.tsx`
+
+**Interfaces:**
+- Consumes: `requireElder`, `requireForgeSuperadmin`, `requireForge` (1a.1); RPCs `forge_add_member`, `forge_remove_member`, `forge_change_role`, `forge_list_invites` (Task 1); `mintInvite` (Task 2); the `playtest_members` SELECT policy (1a.1).
+- Produces (consumed by the console):
+  - `changeRole(userId: string, newRole: ForgeRole): Promise<{ ok: boolean; error?: string }>`
+  - `removeMember(userId: string): Promise<{ ok: boolean; error?: string }>`
+  - `listMembers(): Promise<Array<{ user_id: string; role: ForgeRole; display_name: string | null; created_at: string }>>`
+  - `listInvites(): Promise<Array<{ id: string; role: ForgeRole; email: string | null; expires_at: string; used_at: string | null }>>`
+  - `addMember(userId: string, role: ForgeRole): Promise<{ ok: boolean; error?: string }>`
+
+- [ ] **Step 1: Write the failing tests for the management actions**
+
+Add to `app/forge/lib/__tests__/members.test.ts`:
+```ts
+import { changeRole, removeMember, addMember } from "../members";
+
+describe("changeRole / removeMember / addMember", () => {
+  it("changeRole rejects non-elder", async () => {
+    (requireElder as any).mockResolvedValue(null);
+    expect((await changeRole("u", "playtester")).ok).toBe(false);
+  });
+  it("changeRole calls forge_change_role for an elder", async () => {
+    const rpc = vi.fn(async () => ({ error: null }));
+    (requireElder as any).mockResolvedValue({ supabase: { rpc } });
+    const r = await changeRole("u9", "playtester");
+    expect(r.ok).toBe(true);
+    expect(rpc).toHaveBeenCalledWith("forge_change_role", { p_user_id: "u9", p_new_role: "playtester" });
+  });
+  it("removeMember surfaces an RPC error", async () => {
+    const rpc = vi.fn(async () => ({ error: { message: "not authorized to remove a elder member" } }));
+    (requireElder as any).mockResolvedValue({ supabase: { rpc } });
+    const r = await removeMember("u9");
+    expect(r.ok).toBe(false);
+  });
+  it("addMember calls forge_add_member", async () => {
+    const rpc = vi.fn(async () => ({ error: null }));
+    (requireElder as any).mockResolvedValue({ supabase: { rpc } });
+    const r = await addMember("u2", "playtester");
+    expect(r.ok).toBe(true);
+    expect(rpc).toHaveBeenCalledWith("forge_add_member", { p_user_id: "u2", p_role: "playtester" });
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npm test -- app/forge/lib/__tests__/members.test.ts`
+Expected: FAIL — the new actions aren't exported.
+
+- [ ] **Step 3: Implement the management + list actions**
+
+Add to `app/forge/lib/members.ts` (add `revalidatePath` import from `next/cache`):
+```ts
+import { revalidatePath } from "next/cache";
+
+export async function addMember(
+  userId: string,
+  role: ForgeRole
+): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireElder();
+  if (!ctx) return { ok: false, error: "Not authorized" };
+  const { error } = await ctx.supabase.rpc("forge_add_member", { p_user_id: userId, p_role: role });
+  if (error) return { ok: false, error: error.message };
+  revalidatePath("/forge/admin");
+  return { ok: true };
+}
+
+export async function removeMember(userId: string): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireElder();
+  if (!ctx) return { ok: false, error: "Not authorized" };
+  const { error } = await ctx.supabase.rpc("forge_remove_member", { p_user_id: userId });
+  if (error) return { ok: false, error: error.message };
+  revalidatePath("/forge/admin");
+  return { ok: true };
+}
+
+export async function changeRole(
+  userId: string,
+  newRole: ForgeRole
+): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireElder();
+  if (!ctx) return { ok: false, error: "Not authorized" };
+  const { error } = await ctx.supabase.rpc("forge_change_role", {
+    p_user_id: userId,
+    p_new_role: newRole,
+  });
+  if (error) return { ok: false, error: error.message };
+  revalidatePath("/forge/admin");
+  return { ok: true };
+}
+
+export async function listMembers() {
+  const ctx = await requireElder();
+  if (!ctx) return [];
+  const { data } = await ctx.supabase
+    .from("playtest_members")
+    .select("user_id, role, display_name, created_at")
+    .order("created_at", { ascending: true });
+  return data ?? [];
+}
+
+export async function listInvites() {
+  const ctx = await requireElder();
+  if (!ctx) return [];
+  const { data } = await ctx.supabase.rpc("forge_list_invites");
+  return data ?? [];
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `npm test -- app/forge/lib/__tests__/members.test.ts`
+Expected: PASS (all prior + 4 new).
+
+- [ ] **Step 5: Write the gated admin page (server)**
+
+Create `app/forge/admin/page.tsx`:
+```tsx
+import { notFound } from "next/navigation";
+import { requireElder } from "@/app/forge/lib/auth";
+import { listMembers, listInvites } from "@/app/forge/lib/members";
+import AdminConsole from "./AdminConsole";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function ForgeAdminPage() {
+  const ctx = await requireElder();
+  if (!ctx) notFound();
+  const [members, invites] = await Promise.all([listMembers(), listInvites()]);
+  return (
+    <main className="mx-auto max-w-3xl p-6">
+      <h1 className="text-2xl" style={{ fontFamily: "Cinzel, serif" }}>
+        Forge Members
+      </h1>
+      <AdminConsole callerRole={ctx.role} members={members} invites={invites} />
+    </main>
+  );
+}
+```
+
+- [ ] **Step 6: Write the admin console (client)**
+
+Create `app/forge/admin/AdminConsole.tsx`:
+```tsx
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import type { ForgeRole } from "@/app/forge/lib/auth";
+import { mintInvite, changeRole, removeMember } from "@/app/forge/lib/members";
+
+type Member = { user_id: string; role: ForgeRole; display_name: string | null; created_at: string };
+type Invite = { id: string; role: ForgeRole; email: string | null; expires_at: string; used_at: string | null };
+
+// Roles this caller may grant/manage (mirrors forge_role_outranks server-side).
+function grantable(caller: ForgeRole): ForgeRole[] {
+  if (caller === "superadmin") return ["elder", "playtester"];
+  if (caller === "elder") return ["playtester"];
+  return [];
+}
+
+export default function AdminConsole({
+  callerRole,
+  members,
+  invites,
+}: {
+  callerRole: ForgeRole;
+  members: Member[];
+  invites: Invite[];
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [msg, setMsg] = useState<string | null>(null);
+  const [inviteRole, setInviteRole] = useState<ForgeRole>(grantable(callerRole)[0] ?? "playtester");
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteUrl, setInviteUrl] = useState<string | null>(null);
+  const canManage = new Set(grantable(callerRole));
+
+  function run(fn: () => Promise<{ ok: boolean; error?: string }>, okMsg: string) {
+    setMsg(null);
+    startTransition(async () => {
+      const r = await fn();
+      setMsg(r.ok ? okMsg : r.error ?? "Failed");
+      if (r.ok) router.refresh();
+    });
+  }
+
+  async function submitInvite(e: React.FormEvent) {
+    e.preventDefault();
+    setMsg(null);
+    setInviteUrl(null);
+    const r = await mintInvite({ role: inviteRole, email: inviteEmail || null });
+    if (!r.ok) return setMsg(r.error);
+    setInviteUrl(r.url);
+    setMsg(inviteEmail ? "Invite emailed." : "Invite link created.");
+    router.refresh();
+  }
+
+  return (
+    <div className="mt-6 space-y-8">
+      <section>
+        <h2 className="text-lg font-medium">Invite a member</h2>
+        <form onSubmit={submitInvite} className="mt-2 flex flex-wrap items-end gap-3">
+          <label className="text-sm">
+            Role
+            <select
+              className="mt-1 block rounded-md border bg-background px-2 py-1.5 text-sm"
+              value={inviteRole}
+              onChange={(e) => setInviteRole(e.target.value as ForgeRole)}
+            >
+              {grantable(callerRole).map((r) => (
+                <option key={r} value={r}>{r}</option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm">
+            Email (optional)
+            <input
+              type="email"
+              className="mt-1 block rounded-md border bg-background px-2 py-1.5 text-sm"
+              value={inviteEmail}
+              onChange={(e) => setInviteEmail(e.target.value)}
+              placeholder="name@example.com"
+            />
+          </label>
+          <button className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground" disabled={pending}>
+            Mint invite
+          </button>
+        </form>
+        {inviteUrl && (
+          <p className="mt-2 break-all text-xs text-muted-foreground">
+            Link: <code>{inviteUrl}</code>
+          </p>
+        )}
+      </section>
+
+      <section>
+        <h2 className="text-lg font-medium">Members ({members.length})</h2>
+        <table className="mt-2 w-full text-sm">
+          <thead>
+            <tr className="text-left text-muted-foreground">
+              <th className="py-1">Name</th><th>Role</th><th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {members.map((m) => {
+              const editable = canManage.has(m.role);
+              return (
+                <tr key={m.user_id} className="border-t">
+                  <td className="py-2">{m.display_name ?? <span className="text-muted-foreground">—</span>}</td>
+                  <td>
+                    {editable ? (
+                      <select
+                        className="rounded border bg-background px-1.5 py-1 text-xs"
+                        defaultValue={m.role}
+                        onChange={(e) => run(() => changeRole(m.user_id, e.target.value as ForgeRole), "Role updated")}
+                        disabled={pending}
+                      >
+                        {grantable(callerRole).map((r) => (
+                          <option key={r} value={r}>{r}</option>
+                        ))}
+                      </select>
+                    ) : (
+                      m.role
+                    )}
+                  </td>
+                  <td className="text-right">
+                    {editable && (
+                      <button
+                        className="text-xs text-red-500 hover:underline"
+                        onClick={() => run(() => removeMember(m.user_id), "Member removed")}
+                        disabled={pending}
+                      >
+                        Remove
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-medium">Pending invites</h2>
+        <ul className="mt-2 space-y-1 text-sm">
+          {invites.filter((i) => !i.used_at).map((i) => (
+            <li key={i.id} className="text-muted-foreground">
+              {i.role} · {i.email ?? "link-only"} · expires {new Date(i.expires_at).toLocaleDateString()}
+            </li>
+          ))}
+          {invites.filter((i) => !i.used_at).length === 0 && (
+            <li className="text-muted-foreground">None.</li>
+          )}
+        </ul>
+      </section>
+
+      {msg && <p aria-live="polite" className="text-sm">{msg}</p>}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 7: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no new errors referencing `app/forge/admin/**` or `members.ts`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/forge/lib/members.ts app/forge/lib/__tests__/members.test.ts app/forge/admin/page.tsx app/forge/admin/AdminConsole.tsx
+git commit -m "feat(forge): /forge/admin roles + invites console (capped row actions)"
+```
+
+---
+
+## Task 6: Extend the keystone anon-leak guardrail (tables + RPC grants)
+
+**Files:**
+- Modify: `__tests__/forge-anon-leak.test.ts`
+
+**Interfaces:**
+- Consumes: anon Supabase client; the new `forge_invites`/`forge_audit` tables (Task 1); all Forge `SECURITY DEFINER` RPCs (1a.1 + Task 1).
+- Produces: `npm run test:security` now also fails if anon can read the new tables OR execute any Forge definer RPC (spec leak-test step 3; also closes the 1a.1 `forge_role_of` gap).
+
+- [ ] **Step 1: Add the new tables to `FORGE_TABLES`**
+
+In `__tests__/forge-anon-leak.test.ts`, change:
+```ts
+const FORGE_TABLES = ["playtest_members"];
+```
+to:
+```ts
+const FORGE_TABLES = ["playtest_members", "forge_invites", "forge_audit"];
+```
+
+- [ ] **Step 2: Add the "anon cannot execute any Forge definer RPC" block**
+
+Append inside the `describe.runIf(ENABLED)(...)` body (after the table loop), using the same `anon` client:
+```ts
+  // Spec leak-test step 3: no Forge SECURITY DEFINER function is callable by anon.
+  // (Calling with empty/placeholder args is fine — anon lacks EXECUTE, so PostgREST
+  // rejects before the body runs. A success here means a grant leaked.)
+  const FORGE_RPCS: Array<[string, Record<string, unknown>]> = [
+    ["my_forge_role", {}],
+    ["forge_role_of", { uid: "00000000-0000-0000-0000-000000000000" }],
+    ["is_forge_member", {}],
+    ["is_forge_elder_or_super", {}],
+    ["forge_role_outranks", { actor_role: "elder", target_role: "playtester" }],
+    ["forge_mint_invite", { p_token_hash: "x", p_role: "playtester", p_set_ids: [], p_email: null, p_expires_at: null }],
+    ["forge_redeem_invite", { p_token_hash: "x", p_nda_agreed: false }],
+    ["forge_add_member", { p_user_id: "00000000-0000-0000-0000-000000000000", p_role: "playtester" }],
+    ["forge_remove_member", { p_user_id: "00000000-0000-0000-0000-000000000000" }],
+    ["forge_change_role", { p_user_id: "00000000-0000-0000-0000-000000000000", p_new_role: "playtester" }],
+    ["forge_set_profile", { p_display_name: "x", p_avatar_url: null }],
+    ["forge_list_invites", {}],
+  ];
+
+  for (const [fn, args] of FORGE_RPCS) {
+    it(`anon cannot execute ${fn}`, async () => {
+      const { error } = await anon.rpc(fn, args);
+      expect(error, `anon was able to execute ${fn} — a definer grant leaked`).not.toBeNull();
+    });
+  }
+```
+
+- [ ] **Step 3: Confirm the default unit run still skips it (hermetic)**
+
+Run: `npm test -- forge-anon-leak`
+Expected: suite **skipped** (no `FORGE_LEAK_TEST=1`).
+
+- [ ] **Step 4: Run the security test against the real DB**
+
+Run: `npm run test:security`
+Expected: **PASS** — anon sees zero rows in `playtest_members`/`forge_invites`/`forge_audit`, and every `anon cannot execute <fn>` test passes. If any RPC test fails, that function still has an anon grant — add `revoke execute on function … from anon;` to migration 049 and re-apply before continuing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add __tests__/forge-anon-leak.test.ts
+git commit -m "test(forge): extend anon-leak guardrail to invites/audit tables + definer-RPC grants"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Invites, onboarding & member management slice):**
+- Hash-only invite token (`randomBytes(32)` base64url, sha256 stored, raw never in DB) → Task 1 (`forge_invites`, no token in body) + Task 2 (`hashToken`, mint). ✅
+- Mint role-capped by inviter's role; stored role authoritative → Task 1 (`forge_mint_invite` + `forge_role_outranks`); Task 2 (elder-needs-superadmin for elder invites). ✅
+- Single-use + expiry + optional email-bind; redeem in one transaction; no oracle → Task 1 (`forge_redeem_invite`, `FOR UPDATE`, NULL on every failure) + Task 3 (generic failure message). ✅
+- **NDA gate on acceptance (type "I agree"):** UX (disabled button) + server action re-validation + DB-boundary refusal (`p_nda_agreed`) + `nda_agreed_at` record → Task 1 (column + RPC) + Task 3 (AcceptForm + `redeemInvite`). Applies to every invite (elders + playtesters). ✅
+- Invites reachable only via definer RPCs (no authenticated table policy) → Task 1 (no policy on `forge_invites`) + Task 5 (`forge_list_invites` for the admin read). ✅
+- `add_member`/`remove_member`/`change_role` role-capped server-side; removal keeps work (forward-deferred) → Task 1 (RPCs; removal documented forward dependency) + Task 5 (actions/UI). ✅
+- Redemption requires auth; binds to `auth.users.id`; bad tokens 404-ish → Task 3 (`/invite/[token]` redirects to sign-in, generic failure). ✅
+- Onboarding (elder/superadmin): welcome + display name + optional avatar, land on desk → Task 4 (`/forge/welcome`, `forge_set_profile`, avatar via `avatars` bucket). ✅
+- `/forge/admin`: invites + roles → Task 5 (gated `requireElder`, capped UI). ✅
+- Keystone broadened: new tables + "no definer fn granted to anon" → Task 6. ✅
+- **Deferred to later plans (forced, not gaps):** card/set ownership reassignment in `remove_member` + sole-elder reassignment (1a.4/1a.5); invite `set_ids`→set-grant wiring (1a.5); onboarding "jot idea / open set" + checklist (1a.4/1a.5); Realtime channel leak-test rows + route-404 + art-proxy leak checks (1a.3+). Each listed in the "Forced deferrals" note and in-code comments.
+
+**Placeholder scan:** none — every step has runnable SQL/TS/commands. The two in-code "FORWARD DEPENDENCY" comments mark intentional, dependency-blocked deferrals, not unfinished steps.
+
+**Type consistency:** `ForgeRole` (from 1a.1 `app/forge/lib/auth.ts`) is reused everywhere. RPC names match between Task 1 (defined) and Tasks 2–6 (called): `forge_mint_invite`, `forge_redeem_invite`, `forge_add_member`, `forge_remove_member`, `forge_change_role`, `forge_set_profile`, `forge_list_invites`, `forge_role_outranks`. RPC param names (`p_token_hash`, `p_nda_agreed`, `p_role`, `p_set_ids`, `p_email`, `p_expires_at`, `p_user_id`, `p_new_role`, `p_display_name`, `p_avatar_url`) match between the SQL signatures and the `.rpc(...)` call sites. The `grantable()` cap in `AdminConsole.tsx` mirrors `forge_role_outranks` server-side (UI convenience only; the RPC is authoritative).
+
+---
+
+## Remaining Phase 1a plans (roadmap — written after this one)
+
+3. **1a.3 — Private art pipeline:** private Vercel Blob (`access:'private'`) + UUID keys; authed `/forge/api/art/[cardId]` proxy + `?download=1`; lint forbidding `<Image>` under `app/forge/**`; broadens the leak test with the route-404 + art-proxy checks.
+4. **1a.4 — Card studio + ideas library:** `forge_cards` (+ `working_snapshot`), DesignCard schema, quick-draft/full studio with live preview + placeholder art, `/forge/ideas`. Wires `forge_remove_member` card-ownership reassignment and the onboarding "jot an idea" path.
+5. **1a.5 — Sets, lifecycle, dashboard, print:** `forge_sets`/`forge_set_elders`/`forge_set_grants`, set notes + 2-D targets, share-move/publish/approve/archive/delete/send-back lifecycle + `card_versions`, Brigade×Type dashboard, "download all for printer." Wires invite `set_ids`→grants, sole-elder reassignment, and the onboarding "open a set" path.
+
+Then Phase 1b (collaborative review) and Phase 2 (playtester play) as separate plan sets.

--- a/docs/superpowers/specs/2026-06-19-forge-card-design-playtesting-design.md
+++ b/docs/superpowers/specs/2026-06-19-forge-card-design-playtesting-design.md
@@ -1,0 +1,582 @@
+# The Forge — Private Card Design & Playtesting Area
+
+**Date:** 2026-06-19 (rev. 2026-06-20 after two-reviewer pass)
+**Status:** Draft
+**Branch:** forge-card-design-playtesting
+**Working name:** "The Forge" (route `/forge`) — renameable.
+
+## Overview
+
+A private, invite-only area of the Redemption Tournament Tracker where a small trusted group designs new Redemption CCG cards, iterates on them collaboratively, playtests them in real games, and eventually promotes a finished set toward print and (later) the public card pool.
+
+Three roles operate here: **superadmin** (the user `baboonytim`, can do anything), **elders** (designers — create/iterate cards, run sets, review, manage members), and **playtesters** (build decks with approved cards and play games against other playtesters). Elders are playtesters by default.
+
+The hard constraint that shapes the whole architecture: **nothing about unreleased playtest cards may leak to the public, even though the repo is open source.** The UI code (`.tsx`) being public is fine; all secret data (card names, abilities, art, set contents) lives only in the backend (Postgres behind RLS + private blob storage) and is served only to authorized users.
+
+## Goals
+
+- Elders can design new cards — both 10-second rough text drafts and fully-specified cards with art.
+- Each elder has a private personal library ("ideas") that no one else can see until they choose to share an idea into a set.
+- Cards iterate through multiple versions with a review/approval workflow that feels like code review, but for cards.
+- Elders collaborate on a set in real time (presence, live comments, live progress).
+- Each set has an at-a-glance progress dashboard broken down by brigade and card type against declared targets.
+- Elders can write holistic, set-level design notes.
+- A finished set can be exported for the printer ("download all"), with a path designed for later promotion into the public app card pool.
+- Playtesters (Phase 2) build decks mixing approved playtest cards with the real card pool and play online games — only against other playtesters.
+- Publishing a new version of a card updates what playtesters are testing.
+- **No unreleased card data is ever reachable by the public**, and that property is verifiable by an automated test.
+
+## Non-Goals (Out of Scope)
+
+- Google-Docs-style real-time co-editing of a single card (CRDT/OT). The proposal/review workflow already prevents lost work.
+- A full rules engine for playtest cards (reuses existing deck validation + multiplayer engine).
+- Branching/merging version history. History is strictly linear.
+- Public discovery of the Forge's existence (routes return 404, not 403, to unauthorized users).
+- Multi-elder approval quorums (ships at single-elder approval; the column exists for later).
+- Automatic public-pool promotion in Phase 1 (the print export ships; the public-pool merge is designed now, wired up in Phase 2).
+- Email notifications in Phase 1 (review state surfaces as in-app badges; email is deferred).
+
+---
+
+## Phasing
+
+The full vision is captured in this document. Implementation is split so the independent, lower-risk creation side ships first, and so the single largest sub-feature (the collaborative review engine) is its own plan.
+
+**Phase 1a — Single-author design tool + security foundation (first implementation plan):**
+- Access foundation: `playtest_members` roles, invites, elder/superadmin onboarding, the security spine, and the anon-leak CI test (the keystone guardrail). This proves the leak-proofing before any rich features are built on it.
+- Private art upload/serving (private Blob + authed proxy) + placeholder/original handling + "download original."
+- Card design studio (quick-draft + full mode, live preview, placeholder art) — single-author editing with last-write-wins autosave (no presence yet).
+- Private "ideas" library.
+- Sets: card library, set-level holistic notes, declared targets.
+- Card lifecycle managed by elders: share-to-set (move), publish, approve, archive, delete, send-back-to-private (with confirmation on the destructive ones).
+- Set progress dashboard.
+- "Download all for printer."
+
+**Phase 1b — Collaborative review layer (second implementation plan):**
+- Proposals ("code review for cards"): submit a candidate change, before/after card diff, single-elder accept/deny.
+- Single-field suggestions (comment + one-click apply).
+- Threaded comments, live via Supabase Realtime.
+- Presence avatars (who's viewing/editing a card) + collision warnings.
+- Per-set review queue with live badge counts.
+
+**Phase 2 — Playtester play (separate spec/plan, designed here):**
+- Playtester role, invites, and onboarding.
+- Deckbuilder over a mixed pool (approved playtest cards + real cards); reuses existing deck-legality rules unchanged, since playtest cards conform to current deck-building rules.
+- SpacetimeDB-isolated games restricted to playtesters (UUID-only card references; see below).
+- "Updated card available" diff/swap when a card is republished, plus republish notifications.
+- Public-pool promotion via reviewable PR into a committed `forge-promoted.json` that the card-data generator merges.
+
+`forge_set_grants` and `published_version_id`/`approved_version_id` ship in Phase 1 (cheap forward-compat) but are only *consumed* in Phase 2. There is no hidden Phase-1-depends-on-Phase-2 coupling.
+
+---
+
+## Roles & Access Model
+
+### Role hierarchy
+
+`superadmin > elder > playtester`. Roles are hierarchical — **an elder automatically has playtester capabilities**, and superadmin has everything. Permission checks for playtester features accept `role IN ('playtester','elder','superadmin')`.
+
+A single `playtest_members` table holds one row per member with their highest role. Set-level relationships (which elders run a set, which playtesters are granted a set) live in join tables.
+
+### Capabilities by role
+
+| Capability | Superadmin | Elder | Playtester |
+|---|---|---|---|
+| Create/edit cards, sets | ✅ | ✅ (sets they're on) | ❌ |
+| Review / accept / deny proposals | ✅ | ✅ (sets they're on) | ❌ |
+| Write set-level notes | ✅ | ✅ (sets they're on) | ❌ |
+| Send card back to private / archive / delete | ✅ | ✅ (sets they're on) | ❌ |
+| Declare set targets, create sets | ✅ | ✅ | ❌ |
+| Invite/remove **playtesters** | ✅ | ✅ | ❌ |
+| Invite/remove **elders** | ✅ | ❌ | ❌ |
+| Build decks + play with approved cards | ✅ | ✅ | ✅ (granted sets) |
+| Promote set / export for printer | ✅ | ✅ (sets they're on) | ❌ |
+| Manage everything, override | ✅ | ❌ | ❌ |
+
+### Superadmin encoding
+
+The superadmin is **not** hardcoded by username or email anywhere (emails are mutable; string checks in public code are brittle). It is a row `playtest_members(user_id = <baboonytim's auth.users.id>, role = 'superadmin')`, seeded by a migration that resolves the UID from `auth.users` at apply time (same approach migration 016 uses for `rharbold`). A `BEFORE UPDATE/DELETE` trigger on `playtest_members` forbids removing or demoting the **last** superadmin, so the role can't be locked out.
+
+### Member management & removal
+
+Membership rows are managed only through `SECURITY DEFINER` RPCs (`add_member`, `remove_member`, `change_role`) that enforce the role-cap (elders manage only playtesters; superadmin manages elders) against the caller's own role server-side.
+
+**Removing a member** deletes their `playtest_members` row (never their `auth.users` row). The `remove_member` RPC handles their artifacts so nothing is silently lost (decision: keep work, reassign ownership):
+- **Cards they own that are shared into a set** (`set_id IS NOT NULL`) → `owner_id` reassigned to a superadmin; the cards stay in the set. The team keeps the work; the removed member simply loses access (RLS denies them once their membership row is gone).
+- **Their purely-private ideas** (`set_id IS NULL`) → untouched; they remain owned by the now-removed user and are inaccessible to other members (superadmin retains visibility via the superadmin SELECT policy and can clean up).
+- **Sets where they were the sole elder** → the RPC reassigns the set to a superadmin (or requires the caller to name a replacement elder) so no set is left without an elder.
+- **Proposals/comments they authored** → retained as historical record (authorship preserved).
+
+`forge_cards.owner_id` is `NOT NULL`; ownership reassignment happens inside the RPC. Deletion of the underlying `auth.users` account is out of scope (handled by superadmin reassignment first).
+
+### Invites & onboarding
+
+No self-serve path. Membership is granted only via an invite minted by an authorized member.
+
+- **Token**: `crypto.randomBytes(32)` base64url, emailed via Resend. Only the **sha256 hash** is stored (reuse migration 030's `api_keys` hash pattern). Raw token never touches the DB.
+- **Single-use + expiry + optional email-bind**: a `SECURITY DEFINER` redemption RPC checks `used_at IS NULL AND expires_at > now()` (and, if the invite is email-bound, `email = auth.email()`), then in one transaction inserts the membership + any set grants and stamps `used_at`. If an email-bound invite is redeemed by a session with a different email, the RPC returns the same not-found result as a bad token (no oracle).
+- **Role-capping enforced at mint**: the mint RPC caps `forge_invites.role` against the caller's role; the stored row is authoritative at redeem time. (An invite minted by an elder can never grant `elder`.)
+- **Table access**: `forge_invites` has **no** direct INSERT/SELECT policy for `authenticated`; it is reachable only through the SECURITY DEFINER mint/redeem RPCs (mirroring how `api_keys` restricts access). No member can read another's `token_hash`.
+- Redemption requires an authenticated session, so the invite binds to a real `auth.users.id`. Bad/expired/used/mismatched tokens return 404.
+
+**Onboarding (Phase 1a covers elder/superadmin):** a newly-invited elder gets a short welcome (set display name + optional avatar) then a choice — "jot a private idea" (drops into the quick-draft studio) or "open a set" (lands on its progress dashboard). A light, dismissible 3-step checklist appears on the desk and fades when complete. Playtester onboarding (card-back reveal of granted cards → "build a deck" / "find a game") ships in Phase 2.
+
+---
+
+## Security Architecture
+
+**Core principle:** keep the secret in exactly one place — Postgres behind RLS — and make every other surface (Blob, SpacetimeDB, RSC, API, CDN, Realtime) carry only opaque references or stream bytes after a server-side gate. If a leak surface ever holds only a UUID, leaking it is harmless.
+
+### Threat model
+
+An adversary who (a) reads the public GitHub repo, (b) has the public Supabase anon key (it ships in the bundle — assume known), (c) can sign up for a normal account, and (d) pokes the deployed app, its API/RSC payloads, the Blob CDN, the Realtime websocket, and (Phase 2) the SpacetimeDB websocket. The asset is prerelease card data. "Leak" = any of that reaching a non-member.
+
+### RLS posture
+
+- Every Forge table has RLS enabled, with policies scoped `TO authenticated` only. The `anon` role gets **no policy** (Postgres RLS default-denies) plus an explicit `REVOKE ALL ... FROM anon` belt-and-suspenders.
+- Helper functions (`is_playtest_member()`, `is_elder_or_super()`, `playtest_role_of(uid)`) are `SECURITY DEFINER STABLE` with **`SET search_path = ''`** (the hardened pattern from migration 046's `get_published_outline`, stricter than the unset `check_admin_role()` in migration 005). This reads membership without tripping the caller's RLS and avoids the recursive-policy loop documented in migration 009. **Do not copy migration 005's self-referential policies** — use the definer-helper shape from migrations 010/044.
+- Migrations are **self-contained**: they create their own enums/columns and do not assume parity with the out-of-band `admin_users.permissions` column (which has no migration of record).
+- Visibility rules enforced by SELECT policy on `forge_cards`: superadmin sees all; an owner always sees their own private idea; an elder on a set sees everything in that set; a playtester granted a set sees only `approved` cards in it.
+- Writes gated by INSERT/UPDATE policies checking both authorship and set-elder membership (an elder can't move a card into a set they aren't on). Mutations that need cross-row invariants (publish, approve, accept-proposal, member removal) go through `SECURITY DEFINER` RPCs, not raw table writes.
+
+### Image isolation
+
+The existing card-art scheme (public bucket, guessable filename URLs in `app/shared/utils/cardImageUrl.ts`) is **disqualified** here.
+
+- Playtest art lives in a **private** Vercel Blob store (`access: 'private'` — a real, current Blob feature) with **UUID keys** (not card names), so paths are unguessable even if the scheme leaks. The existing upload routes use `access: 'public'`; Forge upload code must not copy that.
+- Served only through an **authenticated proxy route** `GET /forge/api/art/[cardId]` → `requireForge()` (404 if unauthorized) → RLS-checked lookup → server-side fetch of the private blob (server-only token) → stream bytes with `Cache-Control: private, no-store`. The browser only ever sees the proxy URL on the app's own domain — never the blob host or key.
+- **`next/image` is forbidden for Forge art.** `next.config.js` already wildcards `*.public.blob.vercel-storage.com` in `remotePatterns`, and private Blob shares the storage domain family, so an `<Image>` could "just work" and CDN-cache a public optimized variant. Forge art uses plain `<img src="/forge/api/art/...">`; a lint rule forbids `<Image>` under `app/forge/**`.
+- **"Download original"**: same proxy with `?download=1` → `Content-Disposition: attachment`. Logged in `forge_audit`.
+- **Print export** streams the same gated private-blob fetch path; it never generates a public URL.
+
+### Middleware reality & the in-route gate
+
+`middleware.ts` **excludes any path containing `api/`**, and `utils/supabase/middleware.ts` only force-auths `/tracker` and `/admin`. So there is **no middleware-level protection for Forge routes** — the in-route gate is the *only* defense. Therefore:
+- A shared `requireForge()` / `requireElder()` helper (cloning `app/threshingfloor/api/auth.ts`, returning 404 not 403) is the **literal first statement** of every Forge route handler, layout, and API route, before any data access.
+- A CI test greps every `app/forge/**/page.tsx`, `app/forge/**/route.ts`, and `app/forge/api/**` and fails if the gate is not the first call.
+- All Forge routes set `export const dynamic = 'force-dynamic'` and `revalidate = 0`; none use `generateStaticParams` over card data; responses set `Cache-Control: private, no-store`. (This is net-new convention, not reuse.)
+
+### Realtime authorization
+
+Realtime is enabled only on `card_comments`, `forge_cards`, `forge_sets` — tables whose RLS already gates rows. Supabase enforces RLS on `postgres_changes` **only when the channel is configured private/authorized**, so Forge Realtime channels must be set to private (authorized) — an explicit setting, not a default. The CI leak test subscribes to these channels as anon and as a non-member and asserts zero rows broadcast.
+
+### SpacetimeDB isolation (Phase 2 — larger than a rule)
+
+This is a **significant engine change, not a config flag.** The existing `spacetimedb/src/schema.ts` defines `CardInstance` as `public: true` storing full card text (`cardName`, `specialAbility`, `brigade`, `strength`, `toughness`, etc.), and `Player`/`Game` carry JSON deck payloads. `spacetimedb/CLAUDE.md` also states **RLS is deprecated in this SDK; visibility is via private tables + views.** Therefore Phase 2 commits to, as the **baseline** (not a fallback):
+- A **UUID-only card representation in STDB** — game/instance rows carry `cardId` (UUID) + game state only; **no unreleased name/ability/art string is ever written to any STDB column.** Human-readable definitions resolve client-side from the RLS-gated Postgres set the player already has access to. This requires a client-side resolver touching every renderer that currently reads `card.cardName`/`specialAbility`/etc. off the STDB row — scope this explicitly.
+- **Entry gating**: a server action verifies playtester membership and mints a short-lived, single-use join token bound to a specific game; playtest games are excluded from the public lobby. STDB reducers bind seats to `ctx.sender` and reject joins from identities not on the pre-authorized player list.
+- Whether this lives in a separate STDB module or a UUID-only variant of the existing one is a Phase-2 implementation decision; either way the no-secret-data rule is what makes it safe even though STDB tables are broadly readable.
+
+### Leakage-vector checklist
+
+| # | Vector | Mitigation |
+|---|---|---|
+| 1 | anon key + permissive RLS | No anon policy; `REVOKE ALL FROM anon`; CI anon-leak test. |
+| 2 | RSC renders before auth | `requireForge()`/`requireElder()` as first statement of every route/layout; 404 not 403; no middleware reliance. |
+| 3 | API route returns data without auth | Same gate first in every API handler; CI grep enforces it. |
+| 4 | Build-time/static generation/ISR | All Forge routes `force-dynamic`, `revalidate = 0`; no `generateStaticParams` over card data. |
+| 5 | CDN caching | `Cache-Control: private, no-store`; no `s-maxage`. |
+| 6 | Migrations/seeds/fixtures in repo | Schema-only migrations; never commit real card data; superadmin seeded by resolving UID; test data = obvious fakes. |
+| 7 | Env vars | Service-role key + private `BLOB_READ_WRITE_TOKEN` stay server-only, never `NEXT_PUBLIC_*`, never in `.env.example`. |
+| 8 | Predictable Blob URLs | Private store (`access:'private'`) + UUID keys + authed proxy on app domain. |
+| 9 | `next/image` cache leak | `<Image>` forbidden under `app/forge/**` (lint); plain `<img>` to the proxy only. |
+| 10 | Source maps | Card data never imported into client code; only `.tsx` structure is public, which is fine by design. |
+| 11 | STDB public tables (Phase 2) | UUID-only rows + entry gating (above). |
+| 12 | Realtime broadcast | Private/authorized channels only, on RLS-gated tables; covered by the leak test. |
+| 13 | SECURITY DEFINER functions | No Forge definer function granted to `anon`; leak test asserts grants; `get_advisors` in CI. |
+| 14 | RSC prefetch | Per-request server gate returns the 404 payload to unauthorized prefetch. |
+
+### The keystone guardrail (broadened)
+
+A **CI test** that asserts the "nothing leaks" property across surfaces, not just PostgREST tables:
+1. With the bare public **anon key**, query every Forge table → 0 rows.
+2. As a logged-in **non-member**, query every Forge table → 0 rows.
+3. Assert **no Forge `SECURITY DEFINER` function is granted to `anon`** (the shape of an accidental bypass, cf. migration 046's intentionally-anon `get_published_outline`).
+4. Hit every `/forge/**` route and `/forge/api/art/<known-id>` **unauthenticated** → 404/empty.
+5. Subscribe to each Forge **Realtime** channel as anon and non-member → 0 rows.
+6. Run Supabase `get_advisors` (security lints) and fail on new findings.
+7. (Phase 2) Subscribe to the playtest STDB module as a non-member → no playtest rows.
+
+This is what makes "nothing leaks" verifiable in an open-source repo rather than hoped-for. Steps 3–7 close the surfaces a table-only test would miss.
+
+---
+
+## Data Model
+
+All tables: `uuid` PKs (`gen_random_uuid()`), `auth.users` FKs, `timestamptz` defaults `now()`, RLS enabled. Migrations are self-contained.
+
+```sql
+create type playtest_role  as enum ('superadmin','elder','playtester');
+create type forge_card_status as enum
+  ('private_idea','draft','playtesting','approved','promoted','archived');
+create type version_status  as enum ('published','approved','superseded');
+create type proposal_status as enum ('open','accepted','denied','superseded');
+
+-- Membership (one row per member; highest role)
+create table playtest_members (
+  user_id      uuid primary key references auth.users(id) on delete cascade,
+  role         playtest_role not null,
+  display_name text,
+  avatar_url   text,
+  invited_by   uuid references auth.users(id),
+  created_at   timestamptz not null default now()
+);
+
+-- Sets
+create table forge_sets (
+  id            uuid primary key default gen_random_uuid(),
+  name          text not null,
+  slug          text unique not null,         -- slugify(name) + numeric suffix on collision
+  notes         text,                          -- holistic set-level design notes (markdown), elder-editable
+  target_counts jsonb not null default '{}',   -- 2-D targets; see "Set progress dashboard"
+  status        text not null default 'open',  -- open | frozen | promoted (computed gate, not auto-cascade)
+  created_by    uuid not null references auth.users(id),
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now()
+);
+
+create table forge_set_elders (        -- who designs a set
+  set_id  uuid references forge_sets(id) on delete cascade,
+  user_id uuid references auth.users(id) on delete cascade,
+  primary key (set_id, user_id)
+);
+
+create table forge_set_grants (        -- who playtests a set (consumed in Phase 2)
+  set_id     uuid references forge_sets(id) on delete cascade,
+  user_id    uuid references auth.users(id) on delete cascade,
+  granted_by uuid references auth.users(id),
+  primary key (set_id, user_id)
+);
+
+-- Card identity (stable). set_id NULL = private idea (in owner's sketchbook).
+-- A card is in AT MOST ONE set (single FK) — sharing MOVES it in, send-back MOVES it out.
+create table forge_cards (
+  id                   uuid primary key default gen_random_uuid(),
+  set_id               uuid references forge_sets(id) on delete set null,
+  owner_id             uuid not null references auth.users(id),  -- reassigned on member removal
+  status               forge_card_status not null default 'private_idea',
+  -- The live, MUTABLE draft being edited (autosave writes here). Immutable snapshots
+  -- are frozen into card_versions only at publish.
+  working_snapshot     jsonb not null default '{}',     -- DesignCard game fields
+  working_art_key      text,                            -- private blob key (UUID) for the draft
+  working_art_is_placeholder boolean not null default false,
+  working_art_original_key   text,
+  -- Pointers into immutable history. Enforced same-card via composite FK below.
+  published_version_id uuid,
+  approved_version_id  uuid,
+  promoted_version_id  uuid,
+  created_at           timestamptz not null default now(),
+  updated_at           timestamptz not null default now()
+);
+
+-- Immutable, append-only published snapshots (linear history). Created at publish.
+create table card_versions (
+  id              uuid primary key default gen_random_uuid(),
+  card_id         uuid not null references forge_cards(id) on delete cascade,
+  version_number  int not null,
+  status          version_status not null default 'published',
+  data            jsonb not null,        -- frozen DesignCard payload (validated vs schema at publish)
+  art_key         text,                  -- private blob key (UUID), never a public URL
+  art_is_placeholder boolean not null default false,
+  art_original_key text,                 -- full-res asset for printer download
+  created_by      uuid not null references auth.users(id),
+  created_at      timestamptz not null default now(),
+  unique (card_id, version_number),
+  unique (card_id, id)                    -- enables composite-FK same-card enforcement
+);
+
+-- Same-card integrity for the pointers (a published_version_id must belong to this card):
+alter table forge_cards
+  add constraint fk_published  foreign key (id, published_version_id) references card_versions(card_id, id),
+  add constraint fk_approved   foreign key (id, approved_version_id)  references card_versions(card_id, id),
+  add constraint fk_promoted   foreign key (id, promoted_version_id)  references card_versions(card_id, id);
+-- (Pointers are nullable; the two-step insert — card row first, then version, then UPDATE the
+--  pointer — is required and documented in the publish RPC.)
+
+-- "Pull request": a proposed change for review (Phase 1b)
+create table card_proposals (
+  id                uuid primary key default gen_random_uuid(),
+  card_id           uuid not null references forge_cards(id) on delete cascade,
+  base_version_id   uuid references card_versions(id),  -- the published base it was branched from
+  proposed_snapshot jsonb not null,      -- validated vs the DesignCard schema, same shape as data
+  proposed_art_key  text,
+  status            proposal_status not null default 'open',
+  resulting_version_id uuid references card_versions(id),
+  created_by        uuid not null references auth.users(id),
+  created_at        timestamptz not null default now(),
+  closed_at         timestamptz,
+  closed_by         uuid references auth.users(id)
+);
+
+-- Threaded comments; field-anchored (single-field suggestions) or proposal/card-level (Phase 1b)
+create table card_comments (
+  id                uuid primary key default gen_random_uuid(),
+  card_id           uuid not null references forge_cards(id) on delete cascade,
+  proposal_id       uuid references card_proposals(id) on delete cascade,
+  field             text,                 -- nullable; which DesignCard field a suggestion targets
+  suggested_value   jsonb,                -- nullable; one-click "apply" writes this into working_snapshot
+  parent_comment_id uuid references card_comments(id),
+  body              text not null,
+  resolved          boolean not null default false,
+  created_by        uuid not null references auth.users(id),
+  created_at        timestamptz not null default now()
+);
+
+-- Invites (hash-only token storage; access only via SECURITY DEFINER RPCs)
+create table forge_invites (
+  id         uuid primary key default gen_random_uuid(),
+  token_hash text not null unique,
+  role       playtest_role not null,     -- capped at mint by inviter's role
+  set_ids    uuid[] not null default '{}',
+  email      text,                        -- optional bind
+  invited_by uuid not null references auth.users(id),
+  expires_at timestamptz not null default now() + interval '7 days',
+  used_at    timestamptz,
+  created_at timestamptz not null default now()
+);
+
+-- Minimal audit (membership changes, deletes, art downloads). Write-only via definer RPCs.
+create table forge_audit (
+  id     bigserial primary key,
+  actor  uuid not null references auth.users(id),
+  action text not null,  -- 'art_download' | 'member_added' | 'member_removed' | 'card_deleted' | 'card_approved'
+  target text,
+  at     timestamptz not null default now()
+);
+```
+
+Notes:
+- `working_snapshot`/`working_art_*` on `forge_cards` is the **mutable** draft (autosave target). `card_versions` rows are **immutable** and created only at publish — this reconciles "edit with autosave" against "versions are immutable." `proposed_snapshot`/`data`/`working_snapshot` all share the validated DesignCard shape.
+- Publishing a new version sets the prior published version `superseded`, the new one `published`, and `forge_cards.published_version_id`. Only one `published` version exists per card at a time.
+- Realtime publication added for `card_comments`, `forge_cards`, `forge_sets` (private channels). Presence uses a Realtime presence channel (no DB writes).
+
+---
+
+## DesignCard Field Schema
+
+Grounded in the repo's existing `CardData` (`lib/cards/lookup.ts`) and the real Redemption model. Stored as the `working_snapshot`/`data` jsonb. Multi-value fields are arrays; a `toCardData()` adapter collapses them to the legacy delimited-string shape **only where needed** — for the deck-validation reuse and the promotion export, both of which are Phase 2. Phase 1 stores and renders the array shape natively.
+
+### Fields
+
+| Field | Type | Applies to | Required | Notes |
+|---|---|---|---|---|
+| `name` | text | all | ✅ | Working/card title |
+| `cardType` | enum[] | all | ✅ | Array supports dual-types (e.g., Hero/EvilCharacter) |
+| `alignment` | enum | all | ✅ | Good / Evil / Neutral / Good_Evil |
+| `brigades` | enum[] | characters, enhancements, some Sites/Cities/Fortresses, Curses/Covenants | type-dependent | Designer chooses the resolved brigade up front (Good/Evil Gold, Good/Evil Multi explicit); the tool never stores ambiguous raw "Gold"/"Multi". Empty for Artifact/Dominant/Lost Soul |
+| `strength` | int? | Hero, Evil Character, stat-bearing GE/EE | type-dependent | Might (top number) |
+| `toughness` | int? | same | type-dependent | Defense (bottom number) |
+| `strengthModifier`/`toughnessModifier` | text? | enhancements | opt | Signed `+N` for enhancement modifiers |
+| `class` | enum[] | characters | opt | Warrior / Weapon |
+| `icons` | enum[] | characters, sites | opt | Territory / Star / Cloud (separated from class) |
+| `identifiers` | text[] | mostly characters/dominants/artifacts | opt | Open vocab (Prophet, Demon, Egyptian, X=…) |
+| `specialAbility` | text? | all (esp. enhancements; Lost Souls legality-relevant) | type-dependent | Rules text box |
+| `reference` | text? | all printed cards | opt (usually req) | Bible verse |
+| `legality` | enum? | all | opt | Rotation / Classic / Scrolls / Paragon / Banned |
+| `rarity` | text? | all | opt | Distribution/rarity |
+| `flavorText` | text? | all | opt | Distinct from specialAbility |
+| `artistCredit` | text? | all | opt | |
+| `cardFrame` | text? | all | opt | Template choice |
+
+Art refs (`*_art_key`, `*_art_is_placeholder`, `*_art_original_key`) live as columns (on `forge_cards` for the draft, on `card_versions` for frozen snapshots), not in the jsonb. Identity/meta (status, version, owner, set, timestamps) live on the rows, not in the jsonb.
+
+### Enums
+
+```
+CARD_TYPE: Hero | EvilCharacter | GE | EE | LostSoul | Artifact | Dominant
+           | Fortress | Site | City | Curse | Covenant
+           (+ HeroToken | EvilCharacterToken | LostSoulToken)
+ALIGNMENT: Good | Evil | Neutral | Good_Evil
+BRIGADE (good):  Blue | Clay | GoodGold | Green | Purple | Red | Silver | Teal | White | GoodMulti
+BRIGADE (evil):  Black | Brown | Crimson | EvilGold | Gray | Orange | PaleGreen | EvilMulti
+CLASS: Warrior | Weapon          ICON: Territory | Star | Cloud
+LEGALITY: Rotation | Classic | Scrolls | Paragon | Banned
+```
+
+### Type/field applicability (summary)
+
+- **Lost Soul**: ability optional but legality-relevant (souls with an ability are unique/T1 or max-2/T2; plain souls duplicate freely); no brigade/might/toughness.
+- **Hero / Evil Character**: require brigade + might + toughness; optional class/icons/identifiers.
+- **Artifact / Dominant**: ability + identifiers, no brigade/might/toughness. Dominant max-1 unique, capped by Lost Soul count.
+- **GE / EE**: brigade + ability; strength/toughness as modifiers.
+- Full matrix carried from research into the implementation plan.
+
+---
+
+## Card Lifecycle
+
+### States (`forge_cards.status` is authoritative)
+
+`private_idea → draft → playtesting → approved → promoted`, plus `archived`. **There is no separate `in_review` status** — "in review" is a *derived* condition (the card has ≥1 open proposal) shown as a badge, so a `draft` or `playtesting` card can be under review without an ambiguous state flip.
+
+| State | Meaning | Entered by |
+|---|---|---|
+| `private_idea` | In an owner's personal library; `set_id IS NULL`; only owner (+superadmin) sees it | Owner creates a card outside any set |
+| `draft` | In a set; iterating; nothing published yet | A card is shared (moved) into a set, or an elder creates directly in a set |
+| `playtesting` | Has a `published` version | An elder publishes the working draft |
+| `approved` | Elders signed off; the published version is locked from casual edits | An elder approves the published version |
+| `promoted` | Frozen; exported (printer / public pool) | Elder/superadmin promotes |
+| `archived` | Cut from the set; hidden, recoverable | Elder archives |
+
+### Transitions
+
+- **Share** (`private_idea → draft`): **moves** the card into a set — one row, `set_id` set, `status = draft`. The card leaves the owner's private sketchbook and appears under the set. No duplication, no `source_card_id`, and (single FK) a card belongs to at most one set, so "shared twice / divergence" cannot occur. Owner is retained; set-elders gain edit rights via RLS.
+- **Send back to private** (`draft/playtesting/approved → private_idea`): **moves** the same card back out — `set_id = NULL`, `status = private_idea`, returned to the owner's sketchbook (carrying its version history). Elder on the set (or owner/superadmin). **Requires manual confirmation.**
+- **Publish** (`draft → playtesting`, or re-publish while `playtesting`): freezes `working_snapshot` into a new immutable `card_versions` row, supersedes the prior published version, sets `published_version_id`. Re-publishing is intentionally live for playtesters (Phase 2).
+- **Approve** (`playtesting → approved`): marks the published version `approved`, sets `approved_version_id`, `status = approved`. Reversible (`approved → playtesting`) before promotion.
+- **Promote** (`approved → promoted`): freezes `promoted_version_id`; `status = promoted`. Reopening requires a deliberate superadmin action.
+- **Archive** (`{draft,playtesting,approved} → archived`): soft, reversible (`archived → draft`). Any open proposals on the card are closed `superseded` at archive time.
+- **Delete from set**: hard delete of the `forge_cards` row and its versions (cascade). Elder/superadmin, **manual confirmation**, logged to `forge_audit`. Archive is presented in the UI as the safer default next to delete.
+
+### Version-status sync (single source of truth)
+
+`forge_cards.status` is authoritative for the card. `card_versions.status` tracks each frozen snapshot (`published` → `approved` on approval, `superseded` when a newer one is published). Invariant: exactly one non-superseded version per card may be `published` or `approved`, and `forge_cards.published_version_id`/`approved_version_id` point at it. Enforced inside the publish/approve RPCs (with the row lock below), not by client writes.
+
+---
+
+## Review Workflow — "Code Review, but for Cards" (Phase 1b)
+
+There are three distinct edit paths, deliberately separated so it's unambiguous which edits need sign-off:
+
+1. **Direct edit** (no review) — elders on the set (and the card's owner) edit the **working draft** directly via autosave. This is the default for people with write access in a small trusted group; presence warns of collisions.
+2. **Proposal** (the "pull request") — any member who can see the card can submit a `card_proposals` row: a candidate full snapshot against the current published `base_version_id`, for sign-off. Used when you want review rather than just editing. Reviewed via the card diff; an elder accepts or denies.
+3. **Single-field suggestion** — a `card_comments` row anchored to one field with an optional `suggested_value`. An elder **applies** it in one click, which writes the value into the **working draft** (it does *not* itself create a published version or a proposal). Most lightweight iteration lives here.
+
+**Diff visualization**: never a text diff. Two card previews side-by-side — **Current** (published, left) and **Proposed** (right) — with changed fields highlighted on the card itself (added text in accent, removed struck-through, changed brigade as ghosted→solid pill), plus a one-line plain-language summary. On mobile they stack.
+
+**Accept/deny (proposals)**: only elders/superadmin. **Single-elder approval (N=1).** The accept RPC:
+1. `SELECT ... FOR UPDATE` on the `forge_cards` row (closes the TOCTOU window).
+2. Verifies `base_version_id` still equals the card's `published_version_id`; if not, the proposal is marked `superseded` and the author is asked to re-base (no auto-re-diff in Phase 1b — manual reopen).
+3. Validates `proposed_snapshot` against the DesignCard schema.
+4. Allocates the next `version_number` under the lock, inserts the new immutable `card_versions` row (`published`), supersedes the prior published version, updates `published_version_id`.
+5. Closes the proposal `accepted` (records `resulting_version_id`), and marks sibling open proposals `superseded`.
+
+Denying closes `denied` with a required reason comment.
+
+**History**: a per-card timeline of published versions + accepted/denied proposals with before/after thumbnails.
+
+---
+
+## Real-Time Collaboration
+
+Supabase Realtime only (private/authorized channels) — no SpacetimeDB on the design side, no CRDT.
+
+| Spot | Real-time? | Mechanism | Phase |
+|---|---|---|---|
+| Comment threads on a proposal | Yes | Realtime changes on `card_comments` filtered by `proposal_id` | 1b |
+| "Who's viewing/editing this card" presence | Yes | Realtime presence channel (no DB writes) | 1b |
+| Review-queue badge counts per set | Yes | Realtime on `card_proposals`/`forge_cards` (or refetch-on-focus) | 1b |
+| Set-progress dashboard | Yes (coarse) | Realtime on `forge_cards` / refetch-on-focus | 1a (refetch) → 1b (live) |
+| Set-level notes | Yes (coarse) | Realtime on `forge_sets`; single-author autosave | 1a (refetch) → 1b (live) |
+| Card field editing | No | Single-author autosave; last-write-wins in 1a, presence-warned in 1b | — |
+
+---
+
+## Notifications
+
+Phase 1 is **in-app only, derived, no table, no email**: review state surfaces as badge counts (a set's open-proposal + unresolved-suggestion count for its elders), computed by query and live-updated via Realtime in 1b. There is no separate notification feed.
+
+Phase 2 introduces a `forge_notifications` table when persistent, cross-session notifications are actually needed — specifically the **republish notice** to playtesters whose decks contain a changed card ("Updated card available" + diff/swap). Email via Resend is deferred and optional even then.
+
+---
+
+## Information Architecture & UX
+
+Gated root `/forge`, mobile-first, reusing the existing glassmorphic floating dock (contextual: top-level vs in-set sub-tabs).
+
+```
+/forge
+├── /                      → role-aware desk / landing
+├── /ideas                 → private sketchbook (cards with set_id = NULL)
+│   └── /[cardId]          → studio editor (private context)
+├── /sets                  → sets index
+│   └── /[setId]
+│       ├── /cards         → set card library (grid)
+│       ├── /notes         → holistic set-level design notes (elder-editable)
+│       ├── /progress      → progress dashboard
+│       ├── /review        → review queue (Phase 1b)
+│       ├── /print         → download-all / printer export
+│       └── /card/[cardId] → studio editor (set context)
+├── /forge/api/art/[cardId] → authed private-art proxy (not a page)
+├── /play                  → Phase 2: deckbuilder + lobby + game
+└── /admin                 → superadmin: invites, roles, set creation/targets
+```
+
+### Card design studio
+
+Live card preview (the hero) + form. **Quick-draft "napkin" mode** is the default on "+": a single free-text field (ghost prompt, zero required fields) that renders as a real card frame immediately; smart chips light up structure (type/brigade) as recognized, never demanded. **Full mode** reveals the typed fields (segmented type control, multi-select brigade color pills, ability textarea with keyword formatting, stat inputs). **Status stepper** (`Draft → Finalized → Ready for printer`) in the header. Art control surfaces three states (No art → Placeholder → Final); placeholder shows an unmistakable diagonal "PLACEHOLDER" stamp; replacing art retains the previous file as downloadable. All editing autosaves to `working_snapshot` (Phase 1a single-author; Phase 1b adds presence + proposal authoring as the explicit "Propose changes" action for non-direct-editors).
+
+### Ideas library & sets
+
+`/ideas` is the private sketchbook — a dense card-preview grid (cards with `set_id = NULL`) with tag/type/brigade/status filters and free-text search; tags over folders. "Send to a set" **moves** an idea in with a gentle confirm (it leaves the sketchbook). `/sets/[id]/cards` is the same grid framed as collective work (owner/recent-editor info, status badges; review-count badges in 1b; "needs review" facet in 1b).
+
+### Set notes
+
+`/sets/[id]/notes` holds holistic, set-level design notes (markdown) — direction, themes, open questions, decisions. Elder-editable, single-author autosave, live-updated for viewers (refetch in 1a, Realtime in 1b).
+
+### Set progress dashboard
+
+One honest headline number (`73/120 · 61%`) + a **status breakdown bar** (draft/finalized/ready, so "%" never lies) + the hero **Brigade × Card-Type completion heatmap** + a "what's left" checklist auto-generated from targets vs actuals. Tap a gap cell → filtered library with a pre-filled "new [Brown Lost Soul]" CTA. Mobile: matrix scrolls horizontally with sticky row labels; headline/status/checklist stack above.
+
+**`target_counts` shape** (must back the 2-D matrix — two 1-D vectors can't):
+```jsonc
+{
+  "total": 120,
+  "cells": {                       // per (cardType → brigade) target; source of truth for the heatmap
+    "Hero":     { "Red": 4, "Blue": 3, "Green": 3 },
+    "LostSoul": { "none": 12 },    // brigade-less types use the "none" bucket / a single column
+    "Artifact": { "none": 8 },
+    "Dominant": { "none": 6 }
+  }
+}
+```
+`byType`/`byBrigade` roll-ups are derived from `cells`; a set that declares only a `total` still renders actual distribution with per-cell targets omitted (graceful degrade).
+
+### Onboarding & empty states
+
+Invite-only first-run is a welcome, not a tutorial wall (above). Empty states are a card-shaped dashed cut-out slot + one CTA + one sentence — no mascots.
+
+### Delight touches (sparing, on-brand)
+
+The signature **napkin→card live render** and the **placeholder stamp** are core (Phase 1a). Lower-priority touches — accept-suggestion morph, progress-cell saturation pulse, set-complete sweep, presence avatars — ride with Phase 1b and are cuttable under time pressure. All respect `prefers-reduced-motion`.
+
+---
+
+## Promotion & Print Export
+
+- **Gate**: a set is promotable when every non-archived card is `approved` (or an elder explicitly excludes stragglers). The progress dashboard is the gate's UI. `forge_sets.status` (`open/frozen/promoted`) is a computed/elder-set marker; it does **not** auto-cascade per-card status. Freezing a set gates further edits.
+- **Phase 1 — "Download all for printer"**: a button that zips approved versions' **original** art (full-res, streamed via the gated private-blob path) + a print-layout sheet/PDF. Pure read of `card_versions` where `status='approved'`. **Sizing note:** the data read is trivial, but generating a print-ready sheet/PDF (layout, bleed) is non-trivial engineering — size it as its own task, not a freebie. Independent of the public-pool merge.
+- **Phase 2 — Public-pool promotion (corrected pipeline)**: `cardData.json` is **regenerated wholesale** by `scripts/parse-carddata.js` from an external upstream `carddata.txt` on every `make update-cards` — so appending promoted cards to that output would be **silently wiped**. Instead, promotion writes/updates a separate **committed `forge-promoted.json`** (the serialized `CardData`-shaped rows for approved cards) via a reviewable GitHub PR, and `parse-carddata.js` is extended to **concatenate `forge-promoted.json` onto the upstream-parsed array** during generation. This makes promoted cards survive regeneration, keeps the public pool a type-checked generated artifact, and goes through the normal build/deploy. A dry-run previews the `forge-promoted.json` delta first. We avoid any runtime-merged "virtual pool" (it would fork `lib/cards/lookup.ts`'s synchronous global `CARDS` array and risk leaking unfinished cards). On promotion, `status='promoted'` and `promoted_version_id` is stamped.
+
+---
+
+## Top Risks & Mitigations
+
+1. **Reusing the public Blob bucket / predictable URLs / `next/image` for playtest art** → private store (`access:'private'`) + UUID keys + authed proxy on app domain; `<Image>` forbidden under `app/forge/**`.
+2. **A Forge table/route/function/channel reachable by anon or a non-member** → default-deny RLS + in-route gate as first statement + the broadened CI leak test (tables, definer grants, routes, Realtime) + `get_advisors`.
+3. **Promotion silently wiped by `make update-cards`** → separate committed `forge-promoted.json` concatenated by the generator, not an append to the regenerated output.
+4. **STDB leaking card text (Phase 2)** → UUID-only rows + client-side resolver + entry gating; scoped as a real engine change, not a flag.
+5. **Concurrent proposal accept / version-pointer corruption** → `SELECT … FOR UPDATE` in the accept/publish RPCs, `version_number` allocated under the lock, composite-FK same-card enforcement on the pointers.
+6. **Republish silently breaking playtesters' decks (Phase 2)** → live resolution to current published version + visible notification/diff, never silent mutation, never version-pinning.
+
+## Design Decisions (resolved)
+
+1. **No gender field.** Dropped entirely — not part of the model.
+2. **Brigade chosen up front.** Designers explicitly pick the resolved brigade (Good/Evil Gold, Good/Evil Multi) at creation; the tool never stores ambiguous raw "Gold"/"Multi".
+3. **No printed-vs-functional brigade override** (`brigadeCountsAs` removed). Not needed.
+4. **Playtest cards conform to existing deck-building rules.** No novel brigades, card types, or anything that breaks current deck design rules. The Phase 2 mixed-pool deckbuilder therefore reuses `deckValidation.ts` as-is, with no rule changes.
+
+---
+
+## Appendix — Files this builds on
+
+- Auth/roles to mirror: `supabase/migrations/005_refactor_to_table_based_admins.sql` (table-based admin — but **use the helper pattern, not its self-referential policies**), `010_add_get_my_permissions_function.sql`, `016_add_permissions_and_rharbold_admin.sql` (UID-resolution seed), `046` (`get_published_outline` — the `SET search_path=''` definer pattern to copy).
+- Recursive-policy trap to avoid: `supabase/migrations/009`.
+- Hash-only token pattern: `supabase/migrations/030_create_api_keys.sql`.
+- Secret-area gate (404-not-403): `app/threshingfloor/api/auth.ts`; upload-route auth precedent: `app/api/spoilers/upload/route.ts`.
+- Realtime publication pattern: `supabase/migrations/040_enable_realtime_for_board.sql`.
+- Three-state visibility precedent: `supabase/migrations/041_add_deck_visibility.sql`.
+- Current (public) card-art URL scheme to avoid copying: `app/shared/utils/cardImageUrl.ts`; public upload pattern to avoid: `app/api/spoilers/upload/route.ts`, `app/api/sync-card-images/route.ts`.
+- Existing card model + the generated-artifact promotion target: `lib/cards/lookup.ts`, `lib/cards/generated/cardData.ts`, `scripts/parse-carddata.js`, `Makefile` (`update-cards`), `app/decklist/card-search/constants.ts`, `app/decklist/card-search/utils/deckValidation.ts`.
+- Middleware reality (no `api/` coverage): `middleware.ts`, `utils/supabase/middleware.ts`; image config: `next.config.js`.
+- STDB schema (Phase 2 isolation) + SDK rules: `spacetimedb/src/schema.ts`, `spacetimedb/CLAUDE.md`.

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "start": "next start",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:security": "FORGE_LEAK_TEST=1 vitest run forge-anon-leak"
   },
   "keywords": [],
   "author": "",

--- a/supabase/migrations/048_forge_access_foundation.sql
+++ b/supabase/migrations/048_forge_access_foundation.sql
@@ -1,0 +1,115 @@
+-- Forge (private card design & playtesting) — access & security foundation.
+-- Role enum + membership table, SECURITY DEFINER helpers, superadmin seed,
+-- last-superadmin protection, default-deny RLS. SCHEMA ONLY — no card data.
+
+-- 1) Role enum
+do $$ begin
+  create type public.playtest_role as enum ('superadmin','elder','playtester');
+exception when duplicate_object then null; end $$;
+
+-- 2) Membership (one row per member; highest role)
+create table if not exists public.playtest_members (
+  user_id      uuid primary key references auth.users(id) on delete cascade,
+  role         public.playtest_role not null,
+  display_name text,
+  avatar_url   text,
+  invited_by   uuid references auth.users(id),
+  created_at   timestamptz not null default now()
+);
+
+alter table public.playtest_members enable row level security;
+
+-- 3) SECURITY DEFINER helpers. search_path pinned; reads the table outside the
+--    caller's RLS so policies that call them don't recurse (cf. migration 009).
+create or replace function public.my_forge_role()
+returns text language sql security definer stable set search_path = '' as $$
+  select role::text from public.playtest_members where user_id = auth.uid();
+$$;
+
+create or replace function public.forge_role_of(uid uuid)
+returns text language sql security definer stable set search_path = '' as $$
+  select role::text from public.playtest_members where user_id = uid;
+$$;
+
+create or replace function public.is_forge_member()
+returns boolean language sql security definer stable set search_path = '' as $$
+  select exists(select 1 from public.playtest_members where user_id = auth.uid());
+$$;
+
+create or replace function public.is_forge_elder_or_super()
+returns boolean language sql security definer stable set search_path = '' as $$
+  select coalesce(
+    (select role from public.playtest_members where user_id = auth.uid())
+      in ('elder','superadmin'), false);
+$$;
+
+-- Supabase's ALTER DEFAULT PRIVILEGES grants EXECUTE directly to anon (and
+-- authenticated) on new public functions, so a REVOKE FROM PUBLIC is not enough.
+-- Strip anon explicitly so it cannot call these over REST (e.g. forge_role_of(uid)
+-- would otherwise leak any member's role). authenticated keeps the grant below.
+revoke execute on function public.my_forge_role() from public, anon;
+revoke execute on function public.forge_role_of(uuid) from public, anon;
+revoke execute on function public.is_forge_member() from public, anon;
+revoke execute on function public.is_forge_elder_or_super() from public, anon;
+
+grant execute on function public.my_forge_role() to authenticated;
+grant execute on function public.forge_role_of(uuid) to authenticated;
+grant execute on function public.is_forge_member() to authenticated;
+grant execute on function public.is_forge_elder_or_super() to authenticated;
+
+-- 4) Last-superadmin protection
+create or replace function public.forge_protect_last_superadmin()
+returns trigger language plpgsql security definer set search_path = '' as $$
+declare remaining int;
+begin
+  select count(*) into remaining
+  from public.playtest_members
+  where role = 'superadmin'
+    and user_id <> coalesce(old.user_id, '00000000-0000-0000-0000-000000000000'::uuid);
+
+  if tg_op = 'DELETE' then
+    if old.role = 'superadmin' and remaining = 0 then
+      raise exception 'cannot remove the last superadmin';
+    end if;
+    return old;
+  elsif tg_op = 'UPDATE' then
+    if old.role = 'superadmin' and new.role <> 'superadmin' and remaining = 0 then
+      raise exception 'cannot demote the last superadmin';
+    end if;
+    return new;
+  end if;
+  return null;
+end;
+$$;
+
+-- Trigger function should never be callable as an RPC (revoke from both roles).
+revoke execute on function public.forge_protect_last_superadmin() from public, anon, authenticated;
+
+drop trigger if exists forge_protect_last_superadmin on public.playtest_members;
+create trigger forge_protect_last_superadmin
+  before update or delete on public.playtest_members
+  for each row execute function public.forge_protect_last_superadmin();
+
+-- 5) RLS: members may read the membership list. No direct write policy — writes
+--    land in plan 1a.2 via SECURITY DEFINER RPCs. anon gets nothing.
+drop policy if exists "forge_members_select" on public.playtest_members;
+create policy "forge_members_select" on public.playtest_members
+  for select to authenticated
+  using (public.is_forge_member());
+
+-- 6) Default-deny hardening for the public/anon role
+revoke all on public.playtest_members from anon;
+grant select on public.playtest_members to authenticated;
+
+-- 7) Seed the superadmin (baboonytim). UID from migration 044. Fail loudly if
+--    the auth.users row is missing. CONFIRM this UID is baboonytim before apply.
+do $$
+declare super uuid := '6d30f6e3-838e-4f11-9416-95996da6e5b9';
+begin
+  if not exists (select 1 from auth.users where id = super) then
+    raise exception 'superadmin seed failed: no auth.users row for %', super;
+  end if;
+  insert into public.playtest_members (user_id, role, display_name)
+  values (super, 'superadmin', 'baboonytim')
+  on conflict (user_id) do update set role = 'superadmin';
+end $$;

--- a/supabase/migrations/049_forge_invites_members.sql
+++ b/supabase/migrations/049_forge_invites_members.sql
@@ -1,0 +1,184 @@
+-- Forge access layer, part 2: invites, audit, and the membership-management RPCs.
+-- Builds on 048 (playtest_members, playtest_role, my_forge_role / is_forge_* helpers,
+-- last-superadmin trigger). SCHEMA + FUNCTIONS ONLY — no card data.
+
+-- 0) Record the NDA acknowledgment on the membership row (stamped at redeem).
+alter table public.playtest_members add column if not exists nda_agreed_at timestamptz;
+
+-- 1) Invites. Hash-only token. This table has NO authenticated RLS policy: it is a
+--    secret store reachable only through the SECURITY DEFINER RPCs below (mirrors
+--    api_keys / migration 030). anon is default-denied + explicit revoke.
+create table if not exists public.forge_invites (
+  id         uuid primary key default gen_random_uuid(),
+  token_hash text not null unique,
+  role       public.playtest_role not null,
+  set_ids    uuid[] not null default '{}',   -- stored for 1a.5; not consumed yet
+  email      text,                            -- optional bind to a specific address
+  invited_by uuid not null references auth.users(id),
+  expires_at timestamptz not null default now() + interval '7 days',
+  used_at    timestamptz,
+  created_at timestamptz not null default now()
+);
+alter table public.forge_invites enable row level security;
+revoke all on public.forge_invites from anon;
+
+-- 2) Minimal audit. Write-only via definer RPCs; elders+ may read.
+create table if not exists public.forge_audit (
+  id     bigserial primary key,
+  actor  uuid not null references auth.users(id),
+  action text not null,
+  target text,
+  at     timestamptz not null default now()
+);
+alter table public.forge_audit enable row level security;
+drop policy if exists "forge_audit_select" on public.forge_audit;
+create policy "forge_audit_select" on public.forge_audit
+  for select to authenticated
+  using (public.is_forge_elder_or_super());
+revoke all on public.forge_audit from anon;
+grant select on public.forge_audit to authenticated;
+
+-- 3) Role-cap helper (pure logic, no table access).
+create or replace function public.forge_role_outranks(actor_role text, target_role text)
+returns boolean language sql immutable set search_path = '' as $$
+  select case actor_role
+    when 'superadmin' then target_role in ('elder','playtester')
+    when 'elder'      then target_role = 'playtester'
+    else false
+  end;
+$$;
+
+-- 4) Mint an invite. Caller's role caps the grantable role. Stores hash only.
+create or replace function public.forge_mint_invite(
+  p_token_hash text, p_role public.playtest_role, p_set_ids uuid[],
+  p_email text, p_expires_at timestamptz
+) returns uuid language plpgsql security definer set search_path = '' as $$
+declare v_id uuid;
+begin
+  if not public.forge_role_outranks(public.my_forge_role(), p_role::text) then
+    raise exception 'not authorized to mint a % invite', p_role;
+  end if;
+  insert into public.forge_invites (token_hash, role, set_ids, email, invited_by, expires_at)
+  values (p_token_hash, p_role, coalesce(p_set_ids, '{}'), p_email, auth.uid(),
+          coalesce(p_expires_at, now() + interval '7 days'))
+  returning id into v_id;
+  insert into public.forge_audit (actor, action, target)
+  values (auth.uid(), 'invite_minted', v_id::text);
+  return v_id;
+end; $$;
+
+-- 5) Redeem an invite. Authenticated caller becomes a member after acknowledging
+--    the NDA (p_nda_agreed). NO ORACLE: every failure path returns NULL
+--    (no-agreement/bad/expired/used/email-mismatch are indistinguishable).
+create or replace function public.forge_redeem_invite(p_token_hash text, p_nda_agreed boolean)
+returns text language plpgsql security definer set search_path = '' as $$
+declare v_invite public.forge_invites;
+begin
+  if not coalesce(p_nda_agreed, false) then return null; end if;  -- must accept the NDA
+  select * into v_invite from public.forge_invites
+   where token_hash = p_token_hash and used_at is null and expires_at > now()
+   for update;
+  if not found then return null; end if;
+  if v_invite.email is not null and v_invite.email is distinct from auth.email() then
+    return null;  -- email-bound to someone else; same not-found result
+  end if;
+  insert into public.playtest_members (user_id, role, invited_by, nda_agreed_at)
+  values (auth.uid(), v_invite.role, v_invite.invited_by, now())
+  on conflict (user_id) do nothing;
+  update public.forge_invites set used_at = now() where id = v_invite.id;
+  insert into public.forge_audit (actor, action, target)
+  values (auth.uid(), 'member_added', v_invite.id::text);
+  return v_invite.role::text;
+end; $$;
+
+-- 6) Direct membership management (no invite). All role-capped against the caller.
+--    add_member is INSERT-only (use change_role to modify an existing member —
+--    otherwise an elder could downgrade an elder via add_member, bypassing the cap).
+create or replace function public.forge_add_member(p_user_id uuid, p_role public.playtest_role)
+returns void language plpgsql security definer set search_path = '' as $$
+begin
+  if not public.forge_role_outranks(public.my_forge_role(), p_role::text) then
+    raise exception 'not authorized to add a % member', p_role;
+  end if;
+  if exists (select 1 from public.playtest_members where user_id = p_user_id) then
+    raise exception 'already a member; use change_role';
+  end if;
+  insert into public.playtest_members (user_id, role, invited_by)
+  values (p_user_id, p_role, auth.uid());
+  insert into public.forge_audit (actor, action, target)
+  values (auth.uid(), 'member_added', p_user_id::text);
+end; $$;
+
+create or replace function public.forge_remove_member(p_user_id uuid)
+returns void language plpgsql security definer set search_path = '' as $$
+declare v_target_role text;
+begin
+  select role::text into v_target_role from public.playtest_members where user_id = p_user_id;
+  if v_target_role is null then raise exception 'not a member'; end if;
+  if not public.forge_role_outranks(public.my_forge_role(), v_target_role) then
+    raise exception 'not authorized to remove a % member', v_target_role;
+  end if;
+  -- FORWARD DEPENDENCY: card/set ownership reassignment lands when forge_cards/
+  -- forge_sets exist (plans 1a.4/1a.5). Deleting the membership row already revokes
+  -- all access via RLS — the security-critical effect. The last-superadmin trigger
+  -- (048) backstops removal of the final superadmin.
+  delete from public.playtest_members where user_id = p_user_id;
+  insert into public.forge_audit (actor, action, target)
+  values (auth.uid(), 'member_removed', p_user_id::text);
+end; $$;
+
+create or replace function public.forge_change_role(p_user_id uuid, p_new_role public.playtest_role)
+returns void language plpgsql security definer set search_path = '' as $$
+declare v_caller text := public.my_forge_role(); v_current text;
+begin
+  select role::text into v_current from public.playtest_members where user_id = p_user_id;
+  if v_current is null then raise exception 'not a member'; end if;
+  if not public.forge_role_outranks(v_caller, v_current)
+     or not public.forge_role_outranks(v_caller, p_new_role::text) then
+    raise exception 'not authorized to change this member''s role';
+  end if;
+  -- last-superadmin demotion is backstopped by the 048 trigger.
+  update public.playtest_members set role = p_new_role where user_id = p_user_id;
+  insert into public.forge_audit (actor, action, target)
+  values (auth.uid(), 'role_changed', p_user_id::text || ' -> ' || p_new_role::text);
+end; $$;
+
+-- 7) Self-service profile (display_name + avatar only; never role).
+create or replace function public.forge_set_profile(p_display_name text, p_avatar_url text)
+returns void language plpgsql security definer set search_path = '' as $$
+begin
+  update public.playtest_members
+     set display_name = p_display_name, avatar_url = p_avatar_url
+   where user_id = auth.uid();
+  if not found then raise exception 'not a member'; end if;
+end; $$;
+
+-- 8) Admin read: invites WITHOUT token_hash (elders+ only; empty for everyone else).
+create or replace function public.forge_list_invites()
+returns table(id uuid, role public.playtest_role, email text, set_ids uuid[],
+              invited_by uuid, expires_at timestamptz, used_at timestamptz, created_at timestamptz)
+language sql security definer stable set search_path = '' as $$
+  select id, role, email, set_ids, invited_by, expires_at, used_at, created_at
+  from public.forge_invites
+  where public.is_forge_elder_or_super()
+  order by created_at desc;
+$$;
+
+-- 9) Lock down execute: strip anon (Supabase default-grants it directly), grant authenticated.
+revoke execute on function public.forge_role_outranks(text, text) from public, anon;
+revoke execute on function public.forge_mint_invite(text, public.playtest_role, uuid[], text, timestamptz) from public, anon;
+revoke execute on function public.forge_redeem_invite(text, boolean) from public, anon;
+revoke execute on function public.forge_add_member(uuid, public.playtest_role) from public, anon;
+revoke execute on function public.forge_remove_member(uuid) from public, anon;
+revoke execute on function public.forge_change_role(uuid, public.playtest_role) from public, anon;
+revoke execute on function public.forge_set_profile(text, text) from public, anon;
+revoke execute on function public.forge_list_invites() from public, anon;
+
+grant execute on function public.forge_role_outranks(text, text) to authenticated;
+grant execute on function public.forge_mint_invite(text, public.playtest_role, uuid[], text, timestamptz) to authenticated;
+grant execute on function public.forge_redeem_invite(text, boolean) to authenticated;
+grant execute on function public.forge_add_member(uuid, public.playtest_role) to authenticated;
+grant execute on function public.forge_remove_member(uuid) to authenticated;
+grant execute on function public.forge_change_role(uuid, public.playtest_role) to authenticated;
+grant execute on function public.forge_set_profile(text, text) to authenticated;
+grant execute on function public.forge_list_invites() to authenticated;


### PR DESCRIPTION
Combined PR for the first two slices of **The Forge** (private, invite-only card-design area). Supersedes #119 (1a.1 alone) — this branch contains all of 1a.1 plus 1a.2.

Plans: [1a.1](docs/superpowers/plans/2026-06-20-forge-phase-1a-1-access-foundation.md) · [1a.2](docs/superpowers/plans/2026-06-20-forge-phase-1a-2-invites-members.md). Spec: `docs/superpowers/specs/2026-06-19-forge-card-design-playtesting-design.md`.

## Phase 1a.1 — Access & security foundation
- **Migration 048**: `playtest_role` enum + `playtest_members`, `SECURITY DEFINER STABLE` helpers (pinned `search_path=''`), last-superadmin trigger, default-deny RLS, baboonytim superadmin seed (UID-resolved).
- **Gate** `app/forge/lib/auth.ts`: `requireForge`/`requireElder`/`requireForgeSuperadmin`, **404-not-403** (area stays secret; no middleware reliance). 8 unit tests.
- Gated `/forge` route group (`force-dynamic`, `revalidate=0`).
- **Keystone anon-leak test** `__tests__/forge-anon-leak.test.ts` + `test:security` script.

## Phase 1a.2 — Invites, onboarding & member management
- **Migration 049**: `forge_invites` (hash-only token, **no authenticated policy** — definer-RPC-only access) + `forge_audit` + role-capped `SECURITY DEFINER` RPCs (mint/redeem/add/remove/change-role/profile/list-invites) + `playtest_members.nda_agreed_at`.
- **Hash-only tokens**: `randomBytes(32)` base64url generated in Node; only sha256 hex stored; raw travels only in the emailed URL (Resend).
- **NDA gate on every acceptance**: top-level `/invite/[token]` requires typing **"I agree"** — enforced in the UI (disabled button), the server action (re-validates), and the RPC (`p_nda_agreed` refusal + `nda_agreed_at` stamp). No-oracle: bad/expired/used/email-mismatch/NDA-not-agreed all return the same failure.
- **Onboarding** `/forge/welcome`: display name + avatar (existing `avatars` bucket).
- **`/forge/admin`**: role-capped invites + members console.
- **Leak test broadened**: 3 tables + 12 "anon cannot execute" definer-RPC probes (spec leak-test step 3; also guards the 1a.1 surface).

## Security spine
Role grant cap (superadmin → {elder, playtester}; elder → {playtester}; superadmin never grantable via RPC), enforced server-side in every RPC. Anon `EXECUTE` explicitly revoked on all functions (Supabase default-grants anon directly, so `REVOKE FROM public` is insufficient). RLS-only write paths close self-promotion.

## Verification
- Migrations 048 + 049 applied to prod; schema/seed/role-cap/no-oracle/last-superadmin-guard verified via SQL.
- `npx tsc --noEmit`: 0 errors. Unit tests for gate + all server actions pass.
- `npm run test:security` (opt-in, real DB): **15/15** — anon sees zero rows in all 3 Forge tables and cannot execute any of the 12 Forge definer RPCs.
- Built via subagent-driven development with per-task spec/quality reviews + a final whole-branch review (verified against prod DB) — cleared as merge-ready.
- Pre-existing unrelated `threshingfloor/store-route` test failure also fails on `main`; not touched here.

### Needs a human with credentials (manual)
- [ ] Sign in **as baboonytim** → `/forge` renders (`role: superadmin`); `/forge/admin` reachable.
- [ ] Sign in **as a non-member** → `/forge` returns 404.
- [ ] Mint an invite, accept it (type "I agree") as a second account → lands in onboarding → desk.

### Known non-blocking follow-ups (for later plans)
- Email-bind is case-sensitive (fails *closed* — no leak); normalize with `lower()` later.
- Double-redeem of a 2nd valid invite returns a misleading role (rare; not escalatable).
- `addMember` (not yet wired to UI) should get a `requireForgeSuperadmin` pre-check for elder grants when surfaced.

Next: 1a.3 (private art pipeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)