### PR TITLE
fix(threshingfloor): include cards array in deck API response

### DIFF
--- a/app/threshingfloor/api/__tests__/data-route.test.ts
+++ b/app/threshingfloor/api/__tests__/data-route.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../auth", async (orig) => {
+  const real: any = await orig();
+  return { ...real, requireThreshingFloor: vi.fn() };
+});
+
+// Keep isUuid real; stub only the data loader.
+vi.mock("@/lib/api/cache", async (orig) => {
+  const real: any = await orig();
+  return { ...real, loadPublicDeckDetail: vi.fn() };
+});
+
+// The deck branch never touches these, but route.ts imports them at module load.
+vi.mock("@/app/tournaments/actions", () => ({ loadUpcomingListings: vi.fn() }));
+vi.mock("@/app/spoilers/actions", () => ({ loadPublicSpoilersAction: vi.fn() }));
+
+import { GET } from "../data/route";
+import * as auth from "../auth";
+import * as cache from "@/lib/api/cache";
+import { NextRequest } from "next/server";
+
+const req = (url: string) => new NextRequest(url);
+const UUID = "11111111-2222-3333-4444-555555555555";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (auth.requireThreshingFloor as any).mockResolvedValue({ supabase: {}, user: { id: "u1" } });
+});
+
+describe("GET /threshingfloor/api/data?kind=deck", () => {
+  it("404s when unauthorized", async () => {
+    (auth.requireThreshingFloor as any).mockResolvedValue(null);
+    const r = await GET(req(`http://x/threshingfloor/api/data?kind=deck&id=${UUID}`));
+    expect(r.status).toBe(404);
+  });
+
+  it("400s when id is not a uuid", async () => {
+    const r = await GET(req("http://x/threshingfloor/api/data?kind=deck&id=nope"));
+    expect(r.status).toBe(400);
+  });
+
+  it("404s when the deck is not found", async () => {
+    (cache.loadPublicDeckDetail as any).mockResolvedValue(null);
+    const r = await GET(req(`http://x/threshingfloor/api/data?kind=deck&id=${UUID}`));
+    expect(r.status).toBe(404);
+  });
+
+  it("returns the cards array alongside the metadata", async () => {
+    const cards = [
+      { name: "Abishai (Ki)", set: "Ki", quantity: 1, zone: "main" },
+      { name: "The Second Coming", set: "Wo", quantity: 1, zone: "reserve" },
+    ];
+    (cache.loadPublicDeckDetail as any).mockResolvedValue({
+      name: "My Deck",
+      username: "John",
+      format: "Type 2",
+      card_count: 2,
+      cards,
+    });
+
+    const r = await GET(req(`http://x/threshingfloor/api/data?kind=deck&id=${UUID}`));
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(body).toMatchObject({ name: "My Deck", creator: "John", format: "T2", card_count: 2 });
+    expect(body.cards).toEqual(cards);
+  });
+});

--- a/app/threshingfloor/api/data/route.ts
+++ b/app/threshingfloor/api/data/route.ts
@@ -35,6 +35,7 @@ export async function GET(request: NextRequest) {
       creator: deck.username,
       format,
       card_count: deck.card_count,
+      cards: deck.cards,
     });
   }
 


### PR DESCRIPTION
## What

Add `cards: deck.cards` to the `kind=deck` branch of `app/threshingfloor/api/data/route.ts`.

## Why

John (Threshing Floor outline tool) reported the inline deck viewer renders empty and asked for the cards array. He's right: the endpoint returned only `{ name, creator, format, card_count }`, but the outline tool's deck viewer reads `deck.cards` on **every** render path ([outline.html](app/threshingfloor/outline.html#L3979-L3980), 4076-4078, 4313-4315). With no `cards`, every `.filter()` returns `[]` and the viewer is an empty shell.

`loadPublicDeckDetail` already returns the full `DetailPayload` including the `cards` array ([cache.ts:57-58](lib/api/cache.ts#L57-L58)) — it just wasn't passed through. Each card is `{ name, set, quantity, zone }` (already-public deck data).

## Not in scope (verified, no change needed)

- **Image CORS / "403 host_not_allowed":** a misdiagnosis. The public Vercel Blob store already serves card images cross-origin (`200` + `access-control-allow-origin: *`, tested), and the viewer renders them via plain `<img src>`, which never triggers CORS. No proxy or dashboard change needed.
- **Profile-card preview thumbnails** (`deck.preview_card_1/2`) are still blank — those fields aren't on the payload type. Separate gap, left for a follow-up.

## Test plan

New `data-route.test.ts` covers the deck branch: unauthorized → 404, bad uuid → 400, not found → 404, and the cards array present in the 200 response. Written test-first (failed with `undefined` before the one-line fix, passes after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)