### PR TITLE
The Forge — Phase 1b.2: Realtime Collaboration Layer

### DIFF
--- a/__tests__/forge-anon-leak.test.ts
+++ b/__tests__/forge-anon-leak.test.ts
@@ -92,40 +92,53 @@ describe.runIf(ENABLED)("Forge anon-leak guardrail", () => {
   }
 
   // Realtime: a non-member (anon) must not be able to JOIN a private forge topic.
-  // A successful join is the only way to receive broadcasts/presence, so a rejected
-  // join (CHANNEL_ERROR / timeout, never SUBSCRIBED) proves the channel can't leak.
+  // A successful join is the only way to receive broadcasts/presence, so ANY
+  // non-SUBSCRIBED terminal outcome (CHANNEL_ERROR / TIMED_OUT / CLOSED / our own
+  // timer) proves the channel can't leak. realtime-js retries a rejected private
+  // join (and can stack-overflow its reconnect timer), so callers must hand us a
+  // client created with a short `realtime.timeout`, and we tear the socket down
+  // hard (disconnect) on the first terminal status to stop the reconnect storm.
   function joinStatus(
     client: ReturnType<typeof createClient>,
     topic: string,
-    timeoutMs = 8000
+    internalTimeoutMs = 4000
   ): Promise<string> {
-    return new Promise((resolve) => {
+    return new Promise<string>((resolve) => {
       const ch = client.channel(topic, { config: { private: true } });
-      const done = (status: string) => {
+      let settled = false;
+      const finish = (status: string) => {
+        if (settled) return;
+        settled = true;
         clearTimeout(timer);
-        client.removeChannel(ch);
+        try { client.removeChannel(ch); } catch { /* ignore */ }
+        try { client.realtime.disconnect(); } catch { /* ignore */ }
         resolve(status);
       };
-      const timer = setTimeout(() => done("TIMEOUT"), timeoutMs);
+      const timer = setTimeout(() => finish("TIMEOUT"), internalTimeoutMs);
       ch.subscribe((status) => {
-        if (status === "SUBSCRIBED" || status === "CHANNEL_ERROR" || status === "CLOSED") {
-          done(status);
+        if (
+          status === "SUBSCRIBED" || status === "CHANNEL_ERROR" ||
+          status === "CLOSED" || status === "TIMED_OUT"
+        ) {
+          finish(status);
         }
       });
     });
   }
 
   it("anon cannot join a private forge card channel", async () => {
-    const client = createClient(URL!, ANON!);
+    const client = createClient(URL!, ANON!, { realtime: { timeout: 2500 } });
+    await client.realtime.setAuth(ANON!); // anon-role JWT — private authz must reject it
     const status = await joinStatus(client, "forge:card:00000000-0000-0000-0000-000000000000");
     expect(status, `anon joined a forge channel (status: ${status})`).not.toBe("SUBSCRIBED");
-  });
+  }, 15000);
 
   it("anon cannot join a private forge set channel", async () => {
-    const client = createClient(URL!, ANON!);
+    const client = createClient(URL!, ANON!, { realtime: { timeout: 2500 } });
+    await client.realtime.setAuth(ANON!);
     const status = await joinStatus(client, "forge:set:00000000-0000-0000-0000-000000000000");
     expect(status, `anon joined a forge channel (status: ${status})`).not.toBe("SUBSCRIBED");
-  });
+  }, 15000);
 
   // Member-vs-member isolation: a signed-in member must NOT see another member's
   // private idea. Opt-in (needs a test member + service role to seed a foreign card).
@@ -185,7 +198,7 @@ describe.runIf(ENABLED)("Forge anon-leak guardrail", () => {
       expect(ins.error, ins.error?.message).toBeNull();
       const foreignId = ins.data!.id as string;
       try {
-        const member = createClient(URL!, ANON!);
+        const member = createClient(URL!, ANON!, { realtime: { timeout: 2500 } });
         const auth = await member.auth.signInWithPassword({ email: MEMBER_EMAIL!, password: MEMBER_PW! });
         expect(auth.error, auth.error?.message).toBeNull();
         const { data } = await member.from("forge_cards").select("*").eq("id", foreignId);

--- a/__tests__/forge-anon-leak.test.ts
+++ b/__tests__/forge-anon-leak.test.ts
@@ -74,6 +74,7 @@ describe.runIf(ENABLED)("Forge anon-leak guardrail", () => {
     ["forge_delete_card", { p_card_id: "00000000-0000-0000-0000-000000000000" }],
     ["_forge_can_read_card", { p_card_id: "00000000-0000-0000-0000-000000000000" }],
     ["_forge_is_card_field", { p_field: "name" }],
+    ["_forge_can_read_topic", { p_topic: "forge:card:00000000-0000-0000-0000-000000000000" }],
     ["forge_create_proposal", { p_card_id: "00000000-0000-0000-0000-000000000000", p_snapshot: {}, p_summary: "x" }],
     ["forge_accept_proposal", { p_proposal_id: "00000000-0000-0000-0000-000000000000" }],
     ["forge_deny_proposal", { p_proposal_id: "00000000-0000-0000-0000-000000000000", p_reason: "x" }],
@@ -89,6 +90,42 @@ describe.runIf(ENABLED)("Forge anon-leak guardrail", () => {
       expect(error, `anon was able to execute ${fn} — a definer grant leaked`).not.toBeNull();
     });
   }
+
+  // Realtime: a non-member (anon) must not be able to JOIN a private forge topic.
+  // A successful join is the only way to receive broadcasts/presence, so a rejected
+  // join (CHANNEL_ERROR / timeout, never SUBSCRIBED) proves the channel can't leak.
+  function joinStatus(
+    client: ReturnType<typeof createClient>,
+    topic: string,
+    timeoutMs = 8000
+  ): Promise<string> {
+    return new Promise((resolve) => {
+      const ch = client.channel(topic, { config: { private: true } });
+      const done = (status: string) => {
+        clearTimeout(timer);
+        client.removeChannel(ch);
+        resolve(status);
+      };
+      const timer = setTimeout(() => done("TIMEOUT"), timeoutMs);
+      ch.subscribe((status) => {
+        if (status === "SUBSCRIBED" || status === "CHANNEL_ERROR" || status === "CLOSED") {
+          done(status);
+        }
+      });
+    });
+  }
+
+  it("anon cannot join a private forge card channel", async () => {
+    const client = createClient(URL!, ANON!);
+    const status = await joinStatus(client, "forge:card:00000000-0000-0000-0000-000000000000");
+    expect(status, `anon joined a forge channel (status: ${status})`).not.toBe("SUBSCRIBED");
+  });
+
+  it("anon cannot join a private forge set channel", async () => {
+    const client = createClient(URL!, ANON!);
+    const status = await joinStatus(client, "forge:set:00000000-0000-0000-0000-000000000000");
+    expect(status, `anon joined a forge channel (status: ${status})`).not.toBe("SUBSCRIBED");
+  });
 
   // Member-vs-member isolation: a signed-in member must NOT see another member's
   // private idea. Opt-in (needs a test member + service role to seed a foreign card).
@@ -114,6 +151,12 @@ describe.runIf(ENABLED)("Forge anon-leak guardrail", () => {
         expect(auth.error, auth.error?.message).toBeNull();
         const { data } = await member.from("forge_cards").select("*").eq("id", foreignId);
         expect((data ?? []).length, "member leaked a foreign-owned card").toBe(0);
+        // ...and cannot join that card's realtime topic (per-topic authz = table RLS).
+        await member.realtime.setAuth(
+          (await member.auth.getSession()).data.session!.access_token
+        );
+        const rtStatus = await joinStatus(member, `forge:card:${foreignId}`);
+        expect(rtStatus, `member joined a foreign card's channel (status: ${rtStatus})`).not.toBe("SUBSCRIBED");
       } finally {
         await svc.from("forge_cards").delete().eq("id", foreignId);
       }

--- a/__tests__/forge-anon-leak.test.ts
+++ b/__tests__/forge-anon-leak.test.ts
@@ -136,6 +136,45 @@ describe.runIf(ENABLED)("Forge anon-leak guardrail", () => {
   const ISO_ENABLED = !!(MEMBER_EMAIL && MEMBER_PW && SERVICE && OTHER_OWNER);
 
   describe.runIf(ISO_ENABLED)("member cannot read another member's card", () => {
+    it("a public channel of the same name receives no forge broadcast", async () => {
+      // Defense-in-depth: DB broadcasts go only to the PRIVATE topic. A public
+      // channel with the same name is a DISTINCT channel and must receive nothing,
+      // even when a real member write fires a broadcast on the private topic.
+      const svc = createClient(URL!, SERVICE!);
+      const ins = await svc
+        .from("forge_cards")
+        .insert({ owner_id: OTHER_OWNER!, working_snapshot: { name: "RT LEAK PROBE" } })
+        .select("id")
+        .single();
+      expect(ins.error, ins.error?.message).toBeNull();
+      const cardId = ins.data!.id as string;
+
+      const pub = createClient(URL!, ANON!);
+      let received = 0;
+      const ch = pub.channel(`forge:card:${cardId}`, { config: { private: false } });
+      ch.on("broadcast", { event: "change" }, () => { received++; });
+      try {
+        // Wait for the public channel to settle (subscribe or error), capped.
+        await new Promise<void>((resolve) => {
+          const t = setTimeout(resolve, 6000);
+          ch.subscribe((status) => {
+            if (status === "SUBSCRIBED" || status === "CHANNEL_ERROR" || status === "CLOSED") {
+              clearTimeout(t);
+              resolve();
+            }
+          });
+        });
+        // Fire a private DB broadcast: update the card as the service role.
+        await svc.from("forge_cards").update({ working_snapshot: { name: "RT LEAK PROBE 2" } }).eq("id", cardId);
+        // Give any (errant) delivery a window to arrive.
+        await new Promise((r) => setTimeout(r, 2500));
+        expect(received, "a public channel received a private forge broadcast").toBe(0);
+      } finally {
+        pub.removeChannel(ch);
+        await svc.from("forge_cards").delete().eq("id", cardId);
+      }
+    });
+
     it("a signed-in member sees zero rows for a foreign-owned card", async () => {
       const svc = createClient(URL!, SERVICE!);
       const ins = await svc

--- a/app/forge/cards/[cardId]/PresenceBar.tsx
+++ b/app/forge/cards/[cardId]/PresenceBar.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import type { ForgePresenceMeta } from "@/app/forge/lib/useForgeRealtime";
+
+function initials(name: string | null): string {
+  if (!name) return "?";
+  const parts = name.trim().split(/\s+/);
+  return ((parts[0]?.[0] ?? "") + (parts[1]?.[0] ?? "")).toUpperCase() || "?";
+}
+
+export default function PresenceBar({ others }: { others: ForgePresenceMeta[] }) {
+  if (others.length === 0) return null;
+  // Dedupe by userId (a member may have two tabs open).
+  const seen = new Map<string, ForgePresenceMeta>();
+  for (const o of others) seen.set(o.userId, o);
+  const people = [...seen.values()];
+  const editing = people.filter((p) => p.editing);
+  return (
+    <div className="mb-3">
+      <div className="flex items-center gap-2">
+        <div className="flex -space-x-2">
+          {people.map((p) => (
+            <span
+              key={p.userId}
+              title={p.displayName ?? "Member"}
+              className="flex h-7 w-7 items-center justify-center rounded-full border border-background bg-muted text-[10px] font-medium text-muted-foreground"
+            >
+              {initials(p.displayName)}
+            </span>
+          ))}
+        </div>
+        <span className="text-xs text-muted-foreground">
+          {people.length === 1 ? "1 other person here" : `${people.length} others here`}
+        </span>
+      </div>
+      {editing.length > 0 && (
+        <div className="mt-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+          {editing.map((p) => p.displayName ?? "Someone").join(", ")}{" "}
+          {editing.length === 1 ? "is" : "are"} also editing this card — changes use last-write-wins.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/forge/cards/[cardId]/StudioEditor.tsx
+++ b/app/forge/cards/[cardId]/StudioEditor.tsx
@@ -10,13 +10,31 @@ import type { DesignCard } from "@/app/forge/lib/designCard";
 import FullModeForm from "./FullModeForm";
 import LifecycleControls from "./LifecycleControls";
 import type { ForgeSetSummary } from "@/app/forge/lib/sets";
+import { forgeCardTopic } from "@/app/forge/lib/realtime";
+import { useForgeCardChannel } from "@/app/forge/lib/useForgeRealtime";
+import PresenceBar from "./PresenceBar";
 
-export default function StudioEditor({ card, sets }: { card: ForgeCardFull; sets: ForgeSetSummary[] }) {
+export default function StudioEditor({
+  card,
+  sets,
+  currentUser,
+  setId,
+}: {
+  card: ForgeCardFull;
+  sets: ForgeSetSummary[];
+  currentUser: { userId: string; displayName: string | null };
+  setId: string | null;
+}) {
   const [snapshot, setSnapshot] = useState<DesignCard>(card.snapshot ?? {});
   const [fullMode, setFullMode] = useState<boolean>(!!card.snapshot?.cardType?.length);
   const [saved, setSaved] = useState<"idle" | "saving" | "saved" | "error">("idle");
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const firstRender = useRef(true);
+
+  const { others, setEditing } = useForgeCardChannel(
+    setId ? forgeCardTopic(card.id) : null,
+    { userId: currentUser.userId, displayName: currentUser.displayName, editing: false },
+  );
 
   // Debounced autosave — fires only after the user edits (skips mount).
   useEffect(() => {
@@ -53,6 +71,7 @@ export default function StudioEditor({ card, sets }: { card: ForgeCardFull; sets
 
   return (
     <div className="mx-auto max-w-5xl p-4">
+      <PresenceBar others={others} />
       <div className="mb-3 flex flex-col gap-2 text-sm">
         <div className="flex items-center justify-between">
           <Link href={card.setId ? `/forge/sets/${card.setId}/cards` : "/forge/ideas"} className="text-muted-foreground hover:underline">
@@ -101,7 +120,11 @@ export default function StudioEditor({ card, sets }: { card: ForgeCardFull; sets
         </div>
 
         {/* Form */}
-        <div className="space-y-4">
+        <div
+          className="space-y-4"
+          onFocusCapture={() => setEditing(true)}
+          onBlurCapture={() => setEditing(false)}
+        >
           {!fullMode ? (
             <div className="space-y-2">
               <input

--- a/app/forge/cards/[cardId]/page.tsx
+++ b/app/forge/cards/[cardId]/page.tsx
@@ -23,9 +23,16 @@ export default async function StudioPage({ params }: { params: Promise<{ cardId:
     : [[], [], []];
   const canReview = ctx.role === "elder" || ctx.role === "superadmin";
 
+  const { data: meRow } = await ctx.supabase
+    .from("playtest_members")
+    .select("display_name")
+    .eq("user_id", ctx.user.id)
+    .single();
+  const currentUser = { userId: ctx.user.id, displayName: meRow?.display_name ?? null };
+
   return (
     <>
-      <StudioEditor card={card} sets={sets} />
+      <StudioEditor card={card} sets={sets} currentUser={currentUser} setId={card.setId ?? null} />
       {inSet && (
         <ReviewPanel
           card={card}

--- a/app/forge/lib/__tests__/realtime.test.ts
+++ b/app/forge/lib/__tests__/realtime.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { forgeCardTopic, forgeSetTopic } from "@/app/forge/lib/realtime";
+
+describe("forge realtime topics", () => {
+  it("builds a card topic with no sub-suffix", () => {
+    expect(forgeCardTopic("abc-123")).toBe("forge:card:abc-123");
+  });
+  it("builds a set topic with no sub-suffix", () => {
+    expect(forgeSetTopic("set-9")).toBe("forge:set:set-9");
+  });
+  it("topics have exactly 3 colon-separated parts (RLS parses split_part(.,3))", () => {
+    expect(forgeCardTopic("u").split(":").length).toBe(3);
+    expect(forgeSetTopic("u").split(":").length).toBe(3);
+  });
+});

--- a/app/forge/lib/realtime.ts
+++ b/app/forge/lib/realtime.ts
@@ -1,0 +1,15 @@
+// Client-side Forge Realtime helpers. Imported only by client components.
+// Topic builders are the SINGLE SOURCE OF TRUTH for the topic format and must
+// match supabase/migrations/054 byte-for-byte (no sub-suffixes: the realtime.messages
+// RLS predicate parses split_part(topic, ':', 3)::uuid).
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export const forgeCardTopic = (cardId: string) => `forge:card:${cardId}`;
+export const forgeSetTopic = (setId: string) => `forge:set:${setId}`;
+
+// Private channels require the member JWT on the socket before join.
+export async function ensureRealtimeAuth(supabase: SupabaseClient): Promise<void> {
+  const { data } = await supabase.auth.getSession();
+  const token = data.session?.access_token;
+  if (token) await supabase.realtime.setAuth(token);
+}

--- a/app/forge/lib/useForgeRealtime.ts
+++ b/app/forge/lib/useForgeRealtime.ts
@@ -1,0 +1,106 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/utils/supabase/client";
+import { ensureRealtimeAuth } from "@/app/forge/lib/realtime";
+
+export type ForgePresenceMeta = {
+  userId: string;
+  displayName: string | null;
+  editing: boolean;
+};
+
+// Debounced router.refresh() on every 'change' broadcast for `topic`.
+// A no-op when topic is null (e.g. a setless private card).
+export function useForgeRefresh(topic: string | null): void {
+  const router = useRouter();
+  useEffect(() => {
+    if (!topic) return;
+    const supabase = createClient();
+    let channel: ReturnType<typeof supabase.channel> | null = null;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const ping = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => router.refresh(), 250);
+    };
+    (async () => {
+      await ensureRealtimeAuth(supabase);
+      if (cancelled) return;
+      channel = supabase
+        .channel(topic, { config: { private: true } })
+        .on("broadcast", { event: "change" }, ping)
+        .subscribe();
+    })();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      if (channel) supabase.removeChannel(channel);
+    };
+  }, [topic, router]);
+}
+
+// One card channel: presence (who's here / editing) + 'change' -> debounced refresh.
+// `setEditing` re-tracks the local member's presence so others see the collision state.
+export function useForgeCardChannel(
+  topic: string | null,
+  me: ForgePresenceMeta,
+): { others: ForgePresenceMeta[]; setEditing: (v: boolean) => void } {
+  const router = useRouter();
+  const [others, setOthers] = useState<ForgePresenceMeta[]>([]);
+  const channelRef = useRef<ReturnType<ReturnType<typeof createClient>["channel"]> | null>(null);
+  const editingRef = useRef<boolean>(me.editing);
+
+  // Depend on primitive fields, not the `me` object identity (which changes each render).
+  const { userId, displayName } = me;
+
+  useEffect(() => {
+    if (!topic) return;
+    const supabase = createClient();
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const ping = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => router.refresh(), 250);
+    };
+    (async () => {
+      await ensureRealtimeAuth(supabase);
+      if (cancelled) return;
+      const ch = supabase.channel(topic, {
+        config: { private: true, presence: { key: userId } },
+      });
+      ch.on("broadcast", { event: "change" }, ping);
+      ch.on("presence", { event: "sync" }, () => {
+        const state = ch.presenceState() as Record<string, ForgePresenceMeta[]>;
+        const list = Object.entries(state)
+          .filter(([key]) => key !== userId)
+          .flatMap(([, metas]) => metas);
+        setOthers(list);
+      });
+      ch.subscribe(async (status) => {
+        if (status === "SUBSCRIBED") {
+          await ch.track({ userId, displayName, editing: editingRef.current });
+        }
+      });
+      channelRef.current = ch;
+    })();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      if (channelRef.current) supabase.removeChannel(channelRef.current);
+      channelRef.current = null;
+    };
+  }, [topic, userId, displayName, router]);
+
+  const setEditing = useCallback(
+    (v: boolean) => {
+      editingRef.current = v;
+      const ch = channelRef.current;
+      if (ch) void ch.track({ userId, displayName, editing: v });
+    },
+    [userId, displayName],
+  );
+
+  return { others, setEditing };
+}

--- a/app/forge/sets/[setId]/SetRealtime.tsx
+++ b/app/forge/sets/[setId]/SetRealtime.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { useForgeRefresh } from "@/app/forge/lib/useForgeRealtime";
+import { forgeSetTopic } from "@/app/forge/lib/realtime";
+
+// Mounted in the set layout: one subscription drives live review badges (nav tab),
+// notes, and progress across every set tab via debounced router.refresh().
+export default function SetRealtime({ setId }: { setId: string }) {
+  useForgeRefresh(forgeSetTopic(setId));
+  return null;
+}

--- a/app/forge/sets/[setId]/layout.tsx
+++ b/app/forge/sets/[setId]/layout.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { requireForge } from "@/app/forge/lib/auth";
 import { getSet } from "@/app/forge/lib/sets";
+import SetRealtime from "./SetRealtime";
 
 export const dynamic = "force-dynamic";
 
@@ -26,6 +27,7 @@ export default async function SetLayout({ children, params }: { children: React.
           {tabs.map((t) => <Link key={t.href} href={t.href} className="text-muted-foreground hover:text-foreground hover:underline">{t.label}</Link>)}
         </nav>
       </div>
+      <SetRealtime setId={setId} />
       {children}
     </div>
   );

--- a/app/forge/sets/[setId]/notes/NotesEditor.tsx
+++ b/app/forge/sets/[setId]/notes/NotesEditor.tsx
@@ -8,6 +8,7 @@ export default function NotesEditor({ setId, initial, canEdit }: { setId: string
   const [saved, setSaved] = useState<"idle" | "saving" | "saved" | "error">("idle");
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const first = useRef(true);
+  const lastServer = useRef(initial);
 
   useEffect(() => {
     if (first.current) { first.current = false; return; }
@@ -19,6 +20,13 @@ export default function NotesEditor({ setId, initial, canEdit }: { setId: string
     }, 700);
     return () => { if (timer.current) clearTimeout(timer.current); };
   }, [notes, setId]);
+
+  useEffect(() => {
+    if (initial === lastServer.current) return;     // our own save / no remote change
+    const wasDirty = notes !== lastServer.current;   // local edits not yet reflected
+    lastServer.current = initial;
+    if (!wasDirty) setNotes(initial);                // safe to adopt the remote value
+  }, [initial, notes]);
 
   if (!canEdit) {
     return <pre className="whitespace-pre-wrap rounded-md border bg-muted/30 p-4 text-sm">{notes || "No notes yet."}</pre>;

--- a/docs/superpowers/plans/2026-06-25-forge-phase-1b-2-realtime.md
+++ b/docs/superpowers/plans/2026-06-25-forge-phase-1b-2-realtime.md
@@ -1,0 +1,734 @@
+# The Forge — Phase 1b.2: Realtime Collaboration Layer — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the 1b.1 review layer live — live comments/proposals, presence + a soft "also editing" collision warning, and live review-queue badges / set-notes / progress — over private, per-topic-authorized Supabase Realtime channels.
+
+**Architecture:** Broadcast-from-Database. `AFTER` triggers on the four Forge tables call `realtime.broadcast_changes()` to private topics `forge:card:{id}` / `forge:set:{id}`; receipt is gated by RLS on `realtime.messages` whose predicate (`_forge_can_read_topic`) reuses the existing table read-rules so Realtime visibility equals table RLS. Clients subscribe once per page-context: a single `'change'` broadcast event drives a debounced `router.refresh()` (every live surface renders from server props), and a presence track on the card channel drives the avatar row + collision banner. No change to the `supabase_realtime` publication or `REPLICA IDENTITY` — `/board` is untouched.
+
+**Tech Stack:** Next.js 15 App Router, React 19, `@supabase/ssr` browser client (`utils/supabase/client.ts`), `@supabase/supabase-js` Realtime (broadcast + presence), Postgres (Supabase) triggers + RLS, Vitest.
+
+## Global Constraints
+
+- **Hard constraint:** nothing about prerelease Forge cards may reach a **non-member**. Realtime is delivered only on **private** channels (`config: { private: true }`); join/receive is gated by RLS on `realtime.messages`. (Spec §"Security spine".)
+- **Per-topic authz = table RLS.** The `realtime.messages` predicate is `public._forge_can_read_topic(realtime.topic())`, which reuses `_forge_can_read_card` (053) for `forge:card:%` and `is_forge_set_elder` ∨ `is_forge_superadmin` (052/051) for `forge:set:%`. No member-level shortcut.
+- **No publication / `REPLICA IDENTITY` changes.** `realtime.broadcast_changes()` rides Realtime's internal messaging. Do **not** touch `supabase_realtime` (it holds `/board`'s `rounds`,`tournaments`).
+- **"Allow public access" Realtime setting stays ON** (required by `/board`); safe because private and public same-named topics are distinct channels.
+- **Topic format is exact:** `forge:card:{uuid}` / `forge:set:{uuid}`, **no sub-suffixes** (the RLS predicate parses `split_part(topic,':',3)::uuid`). Builders in `app/forge/lib/realtime.ts` are the single source of truth and must match the trigger SQL byte-for-byte.
+- **Broadcast event name is the constant `'change'`** (operation carried in the payload), so each client registers exactly one `.on('broadcast', { event: 'change' }, …)`.
+- **Every `/forge` page keeps its own `requireForge()` gate** (no `/forge` middleware; the `forge-gate-first` guardrail enforces this). This slice adds no new routes, but any new client component must be mounted inside an already-gated page/layout.
+- **SECURITY DEFINER + `set search_path = ''`** on every new function; **REVOKE … FROM public, anon** then **GRANT EXECUTE … TO authenticated** for any function reachable in a policy; trigger functions revoke from public/anon and grant nothing (they fire via the trigger). Anon-leak guardrail (`__tests__/forge-anon-leak.test.ts`) is the keystone — extend it.
+- **Migration numbering:** next is `054`. Filename `supabase/migrations/054_forge_realtime.sql`.
+- **`tsconfig` has `strict:false`** → discriminated-union narrowing on `if (r.ok)` is broken; use `r.ok === false`. Only `npm run build` typechecks (Vitest/esbuild does not).
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `supabase/migrations/054_forge_realtime.sql` (create) | `_forge_can_read_topic` helper; two `realtime.messages` policies; `forge_broadcast_change` trigger fn + 4 triggers; grants/revokes. |
+| `__tests__/forge-anon-leak.test.ts` (modify) | Add `_forge_can_read_topic` to the anon-cannot-exec probes; add a Realtime section asserting anon (and a member on a foreign topic) cannot join a private `forge:*` channel. |
+| `app/forge/lib/realtime.ts` (create) | Pure topic builders `forgeCardTopic`/`forgeSetTopic`; `ensureRealtimeAuth(supabase)`. |
+| `app/forge/lib/__tests__/realtime.test.ts` (create) | Unit tests for the topic builders. |
+| `app/forge/lib/useForgeRealtime.ts` (create, `"use client"`) | `useForgeRefresh(topic)`; `useForgeCardChannel(topic, me)`; `ForgePresenceMeta` type. |
+| `app/forge/cards/[cardId]/PresenceBar.tsx` (create, `"use client"`) | Presentational avatar row + collision banner. |
+| `app/forge/cards/[cardId]/StudioEditor.tsx` (modify) | Mount `useForgeCardChannel` when in a set; render `PresenceBar`; toggle `editing` on focus/blur. |
+| `app/forge/cards/[cardId]/page.tsx` (modify) | Fetch current member display name; pass `currentUser` + `setId` to `StudioEditor`. |
+| `app/forge/sets/[setId]/SetRealtime.tsx` (create, `"use client"`) | Mounts `useForgeRefresh(forgeSetTopic(setId))`; renders nothing. |
+| `app/forge/sets/[setId]/layout.tsx` (modify) | Render `<SetRealtime setId={setId} />` so liveness spans all set tabs + the nav badge. |
+| `app/forge/sets/[setId]/notes/NotesEditor.tsx` (modify) | Dirty-guarded sync of a refreshed `initial` into the buffer (viewers live, author protected). |
+
+---
+
+## Task 1: Migration 054 — Realtime authorization + broadcast triggers
+
+**Files:**
+- Create: `supabase/migrations/054_forge_realtime.sql`
+
+**Interfaces:**
+- Consumes (existing helpers): `public._forge_can_read_card(p_card_id uuid)` (053), `public.is_forge_set_elder(p_set_id uuid)` (052), `public.is_forge_superadmin()` (051).
+- Produces: `public._forge_can_read_topic(text) → boolean`; `public.forge_broadcast_change()` trigger fn; triggers `forge_sets_broadcast`, `forge_cards_broadcast`, `card_proposals_broadcast`, `card_comments_broadcast`; policies `"forge realtime receive"` / `"forge realtime presence-send"` on `realtime.messages`.
+
+- [ ] **Step 1: Write the migration file**
+
+Create `supabase/migrations/054_forge_realtime.sql`:
+
+```sql
+-- 054_forge_realtime.sql
+-- Phase 1b.2: Realtime collaboration layer (Broadcast from Database).
+-- Live comments/proposals/cards/sets over PRIVATE, per-topic-authorized channels.
+-- No change to the supabase_realtime publication or REPLICA IDENTITY:
+-- realtime.broadcast_changes() rides Realtime's own internal messaging.
+
+-- 1. Topic read-authorization helper. Mirrors table RLS exactly:
+--    forge:card:{uuid} -> _forge_can_read_card ; forge:set:{uuid} -> set-elder/super.
+create or replace function public._forge_can_read_topic(p_topic text)
+returns boolean
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  v_id uuid;
+begin
+  if p_topic like 'forge:card:%' then
+    begin
+      v_id := (split_part(p_topic, ':', 3))::uuid;
+    exception when others then
+      return false;
+    end;
+    return public._forge_can_read_card(v_id);
+  elsif p_topic like 'forge:set:%' then
+    begin
+      v_id := (split_part(p_topic, ':', 3))::uuid;
+    exception when others then
+      return false;
+    end;
+    return public.is_forge_set_elder(v_id) or public.is_forge_superadmin();
+  end if;
+  return false;
+end;
+$$;
+
+revoke all on function public._forge_can_read_topic(text) from public;
+revoke all on function public._forge_can_read_topic(text) from anon;
+grant execute on function public._forge_can_read_topic(text) to authenticated;
+
+-- 2. realtime.messages RLS — the join/receive gate. select = receive broadcasts +
+--    others' presence + JOIN; insert = publish own presence. Both reuse the predicate.
+drop policy if exists "forge realtime receive" on realtime.messages;
+create policy "forge realtime receive"
+  on realtime.messages
+  for select
+  to authenticated
+  using ( public._forge_can_read_topic((select realtime.topic())) );
+
+drop policy if exists "forge realtime presence-send" on realtime.messages;
+create policy "forge realtime presence-send"
+  on realtime.messages
+  for insert
+  to authenticated
+  with check ( public._forge_can_read_topic((select realtime.topic())) );
+
+-- 3. Broadcast-on-write trigger function. Fans out to the card topic and (when the
+--    card is in a set) the set topic, so a card page reacts to its card and a set
+--    page reacts to its whole set. NEW/OLD chosen by TG_OP (records can't coalesce).
+create or replace function public.forge_broadcast_change()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_row record;
+  v_set uuid;
+begin
+  if TG_OP = 'DELETE' then v_row := OLD; else v_row := NEW; end if;
+
+  if TG_TABLE_NAME = 'forge_sets' then
+    perform realtime.broadcast_changes(
+      'forge:set:' || v_row.id::text,
+      'change', TG_OP, TG_TABLE_NAME, TG_TABLE_SCHEMA, NEW, OLD);
+
+  elsif TG_TABLE_NAME = 'forge_cards' then
+    perform realtime.broadcast_changes(
+      'forge:card:' || v_row.id::text,
+      'change', TG_OP, TG_TABLE_NAME, TG_TABLE_SCHEMA, NEW, OLD);
+    if v_row.set_id is not null then
+      perform realtime.broadcast_changes(
+        'forge:set:' || v_row.set_id::text,
+        'change', TG_OP, TG_TABLE_NAME, TG_TABLE_SCHEMA, NEW, OLD);
+    end if;
+
+  else  -- card_proposals, card_comments (both carry card_id)
+    perform realtime.broadcast_changes(
+      'forge:card:' || v_row.card_id::text,
+      'change', TG_OP, TG_TABLE_NAME, TG_TABLE_SCHEMA, NEW, OLD);
+    select c.set_id into v_set from public.forge_cards c where c.id = v_row.card_id;
+    if v_set is not null then
+      perform realtime.broadcast_changes(
+        'forge:set:' || v_set::text,
+        'change', TG_OP, TG_TABLE_NAME, TG_TABLE_SCHEMA, NEW, OLD);
+    end if;
+  end if;
+
+  return null;  -- AFTER trigger: return value ignored
+end;
+$$;
+
+revoke all on function public.forge_broadcast_change() from public;
+revoke all on function public.forge_broadcast_change() from anon;
+
+drop trigger if exists forge_sets_broadcast on public.forge_sets;
+create trigger forge_sets_broadcast
+  after insert or update or delete on public.forge_sets
+  for each row execute function public.forge_broadcast_change();
+
+drop trigger if exists forge_cards_broadcast on public.forge_cards;
+create trigger forge_cards_broadcast
+  after insert or update or delete on public.forge_cards
+  for each row execute function public.forge_broadcast_change();
+
+drop trigger if exists card_proposals_broadcast on public.card_proposals;
+create trigger card_proposals_broadcast
+  after insert or update or delete on public.card_proposals
+  for each row execute function public.forge_broadcast_change();
+
+drop trigger if exists card_comments_broadcast on public.card_comments;
+create trigger card_comments_broadcast
+  after insert or update or delete on public.card_comments
+  for each row execute function public.forge_broadcast_change();
+```
+
+- [ ] **Step 2: Apply the migration** *(sensitive — confirm with the user first; touches `realtime.messages` RLS on the live prod DB)*
+
+Apply via the Supabase MCP (`apply_migration`, name `054_forge_realtime`) or `supabase db push`. **This is an outward-facing, hard-to-reverse change — get explicit go-ahead before applying, per the established Forge migration protocol.**
+
+- [ ] **Step 3: Verify objects exist + advisors clean**
+
+Run (Supabase MCP `execute_sql` or psql):
+```sql
+select proname from pg_proc where proname in ('_forge_can_read_topic','forge_broadcast_change');
+select polname from pg_policies where schemaname='realtime' and tablename='messages' and polname like 'forge realtime%';
+select tgname from pg_trigger where tgname like '%_broadcast' and not tgisinternal;
+select 1 from pg_proc where proname = 'broadcast_changes' and pronamespace = 'realtime'::regnamespace;  -- precondition
+```
+Expected: 2 functions, 2 policies, 4 triggers, and `broadcast_changes` present. Then run `get_advisors(type:"security")` → no new findings attributable to 054.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/migrations/054_forge_realtime.sql
+git commit -m "feat(forge): migration 054 — realtime broadcast triggers + realtime.messages RLS"
+```
+
+---
+
+## Task 2: Extend the anon-leak guardrail to Realtime
+
+**Files:**
+- Modify: `__tests__/forge-anon-leak.test.ts`
+
+**Interfaces:**
+- Consumes: the live Supabase env (`FORGE_LEAK_TEST=1`), the helper `_forge_can_read_topic`, and (for the per-topic member probe) the existing `ISO_ENABLED` seeded foreign card.
+- Produces: new assertions only.
+
+- [ ] **Step 1: Add the new RPC to the anon-cannot-exec list**
+
+In the `FORGE_RPCS` array, add one entry (place it after the `_forge_is_card_field` line):
+```ts
+    ["_forge_can_read_topic", { p_topic: "forge:card:00000000-0000-0000-0000-000000000000" }],
+```
+
+- [ ] **Step 2: Add a Realtime join-rejection helper + anon test**
+
+Inside the `describe.runIf(ENABLED)` block (after the RPC loop, before the member-isolation `describe`), add:
+```ts
+  // Realtime: a non-member (anon) must not be able to JOIN a private forge topic.
+  // A successful join is the only way to receive broadcasts/presence, so a rejected
+  // join (CHANNEL_ERROR / timeout, never SUBSCRIBED) proves the channel can't leak.
+  function joinStatus(
+    client: ReturnType<typeof createClient>,
+    topic: string,
+    timeoutMs = 8000
+  ): Promise<string> {
+    return new Promise((resolve) => {
+      const ch = client.channel(topic, { config: { private: true } });
+      const done = (status: string) => {
+        clearTimeout(timer);
+        client.removeChannel(ch);
+        resolve(status);
+      };
+      const timer = setTimeout(() => done("TIMEOUT"), timeoutMs);
+      ch.subscribe((status) => {
+        if (status === "SUBSCRIBED" || status === "CHANNEL_ERROR" || status === "CLOSED") {
+          done(status);
+        }
+      });
+    });
+  }
+
+  it("anon cannot join a private forge card channel", async () => {
+    const client = createClient(URL!, ANON!);
+    const status = await joinStatus(client, "forge:card:00000000-0000-0000-0000-000000000000");
+    expect(status, `anon joined a forge channel (status: ${status})`).not.toBe("SUBSCRIBED");
+  });
+
+  it("anon cannot join a private forge set channel", async () => {
+    const client = createClient(URL!, ANON!);
+    const status = await joinStatus(client, "forge:set:00000000-0000-0000-0000-000000000000");
+    expect(status, `anon joined a forge channel (status: ${status})`).not.toBe("SUBSCRIBED");
+  });
+```
+
+- [ ] **Step 3: Add a per-topic member-boundary probe inside the `ISO_ENABLED` block**
+
+The isolation block already seeds a foreign-owned card (`foreignId`) and signs in the test member. Inside its `try` (after the existing `forge_cards` row assertion), add a Realtime check that the signed-in member — who can't *read* that card — also can't *join* its topic:
+```ts
+        // ...and cannot join that card's realtime topic (per-topic authz = table RLS).
+        await member.realtime.setAuth(
+          (await member.auth.getSession()).data.session!.access_token
+        );
+        const rtStatus = await joinStatus(member, `forge:card:${foreignId}`);
+        expect(rtStatus, `member joined a foreign card's channel (status: ${rtStatus})`).not.toBe("SUBSCRIBED");
+```
+(`joinStatus` is in the enclosing `ENABLED` describe scope, so it is in scope here.)
+
+- [ ] **Step 4: Run the security suite**
+
+Run: `FORGE_LEAK_TEST=1 npm run test:security`
+Expected: all Forge anon-leak tests pass, including the new `_forge_can_read_topic` probe and the two anon channel-join tests (status `CHANNEL_ERROR`/`TIMEOUT`, never `SUBSCRIBED`). If `FORGE_TEST_*` env is present, the member per-topic probe also passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add __tests__/forge-anon-leak.test.ts
+git commit -m "test(forge): extend anon-leak guardrail to realtime channel joins + _forge_can_read_topic"
+```
+
+---
+
+## Task 3: `realtime.ts` — topic builders + auth helper (TDD)
+
+**Files:**
+- Create: `app/forge/lib/realtime.ts`
+- Test: `app/forge/lib/__tests__/realtime.test.ts`
+
+**Interfaces:**
+- Produces: `forgeCardTopic(cardId: string): string`; `forgeSetTopic(setId: string): string`; `ensureRealtimeAuth(supabase): Promise<void>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/forge/lib/__tests__/realtime.test.ts`:
+```ts
+import { describe, it, expect } from "vitest";
+import { forgeCardTopic, forgeSetTopic } from "@/app/forge/lib/realtime";
+
+describe("forge realtime topics", () => {
+  it("builds a card topic with no sub-suffix", () => {
+    expect(forgeCardTopic("abc-123")).toBe("forge:card:abc-123");
+  });
+  it("builds a set topic with no sub-suffix", () => {
+    expect(forgeSetTopic("set-9")).toBe("forge:set:set-9");
+  });
+  it("topics have exactly 3 colon-separated parts (RLS parses split_part(.,3))", () => {
+    expect(forgeCardTopic("u").split(":").length).toBe(3);
+    expect(forgeSetTopic("u").split(":").length).toBe(3);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run app/forge/lib/__tests__/realtime.test.ts`
+Expected: FAIL — cannot resolve `@/app/forge/lib/realtime`.
+
+- [ ] **Step 3: Implement `realtime.ts`**
+
+Create `app/forge/lib/realtime.ts`:
+```ts
+// Client-side Forge Realtime helpers. Imported only by client components.
+// Topic builders are the SINGLE SOURCE OF TRUTH for the topic format and must
+// match supabase/migrations/054 byte-for-byte (no sub-suffixes: the realtime.messages
+// RLS predicate parses split_part(topic, ':', 3)::uuid).
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export const forgeCardTopic = (cardId: string) => `forge:card:${cardId}`;
+export const forgeSetTopic = (setId: string) => `forge:set:${setId}`;
+
+// Private channels require the member JWT on the socket before join.
+export async function ensureRealtimeAuth(supabase: SupabaseClient): Promise<void> {
+  const { data } = await supabase.auth.getSession();
+  const token = data.session?.access_token;
+  if (token) await supabase.realtime.setAuth(token);
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npx vitest run app/forge/lib/__tests__/realtime.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/forge/lib/realtime.ts app/forge/lib/__tests__/realtime.test.ts
+git commit -m "feat(forge): realtime topic builders + ensureRealtimeAuth (TDD)"
+```
+
+---
+
+## Task 4: `useForgeRealtime.ts` — refresh + card-channel hooks
+
+**Files:**
+- Create: `app/forge/lib/useForgeRealtime.ts`
+
+**Interfaces:**
+- Consumes: `createClient` (`@/utils/supabase/client`), `forge` topic via the caller, `ensureRealtimeAuth` (Task 3).
+- Produces: `type ForgePresenceMeta = { userId: string; displayName: string | null; editing: boolean }`; `useForgeRefresh(topic: string | null): void`; `useForgeCardChannel(topic: string | null, me: ForgePresenceMeta): { others: ForgePresenceMeta[]; setEditing: (v: boolean) => void }`.
+
+- [ ] **Step 1: Implement the hooks**
+
+Create `app/forge/lib/useForgeRealtime.ts`:
+```ts
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/utils/supabase/client";
+import { ensureRealtimeAuth } from "@/app/forge/lib/realtime";
+
+export type ForgePresenceMeta = {
+  userId: string;
+  displayName: string | null;
+  editing: boolean;
+};
+
+// Debounced router.refresh() on every 'change' broadcast for `topic`.
+// A no-op when topic is null (e.g. a setless private card).
+export function useForgeRefresh(topic: string | null): void {
+  const router = useRouter();
+  useEffect(() => {
+    if (!topic) return;
+    const supabase = createClient();
+    let channel: ReturnType<typeof supabase.channel> | null = null;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const ping = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => router.refresh(), 250);
+    };
+    (async () => {
+      await ensureRealtimeAuth(supabase);
+      if (cancelled) return;
+      channel = supabase
+        .channel(topic, { config: { private: true } })
+        .on("broadcast", { event: "change" }, ping)
+        .subscribe();
+    })();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      if (channel) supabase.removeChannel(channel);
+    };
+  }, [topic, router]);
+}
+
+// One card channel: presence (who's here / editing) + 'change' -> debounced refresh.
+// `setEditing` re-tracks the local member's presence so others see the collision state.
+export function useForgeCardChannel(
+  topic: string | null,
+  me: ForgePresenceMeta,
+): { others: ForgePresenceMeta[]; setEditing: (v: boolean) => void } {
+  const router = useRouter();
+  const [others, setOthers] = useState<ForgePresenceMeta[]>([]);
+  const channelRef = useRef<ReturnType<ReturnType<typeof createClient>["channel"]> | null>(null);
+  const editingRef = useRef<boolean>(me.editing);
+
+  // Depend on primitive fields, not the `me` object identity (which changes each render).
+  const { userId, displayName } = me;
+
+  useEffect(() => {
+    if (!topic) return;
+    const supabase = createClient();
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const ping = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => router.refresh(), 250);
+    };
+    (async () => {
+      await ensureRealtimeAuth(supabase);
+      if (cancelled) return;
+      const ch = supabase.channel(topic, {
+        config: { private: true, presence: { key: userId } },
+      });
+      ch.on("broadcast", { event: "change" }, ping);
+      ch.on("presence", { event: "sync" }, () => {
+        const state = ch.presenceState() as Record<string, ForgePresenceMeta[]>;
+        const list = Object.entries(state)
+          .filter(([key]) => key !== userId)
+          .flatMap(([, metas]) => metas);
+        setOthers(list);
+      });
+      ch.subscribe(async (status) => {
+        if (status === "SUBSCRIBED") {
+          await ch.track({ userId, displayName, editing: editingRef.current });
+        }
+      });
+      channelRef.current = ch;
+    })();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      if (channelRef.current) supabase.removeChannel(channelRef.current);
+      channelRef.current = null;
+    };
+  }, [topic, userId, displayName, router]);
+
+  const setEditing = useCallback(
+    (v: boolean) => {
+      editingRef.current = v;
+      const ch = channelRef.current;
+      if (ch) void ch.track({ userId, displayName, editing: v });
+    },
+    [userId, displayName],
+  );
+
+  return { others, setEditing };
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit -p tsconfig.json 2>&1 | grep -i "useForgeRealtime" || echo "no type errors in useForgeRealtime"`
+Expected: `no type errors in useForgeRealtime`. (If the project has no standalone tsc script, defer the full check to Task 7's `npm run build`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/forge/lib/useForgeRealtime.ts
+git commit -m "feat(forge): useForgeRefresh + useForgeCardChannel realtime hooks"
+```
+
+---
+
+## Task 5: Card presence + collision banner
+
+**Files:**
+- Create: `app/forge/cards/[cardId]/PresenceBar.tsx`
+- Modify: `app/forge/cards/[cardId]/StudioEditor.tsx`
+- Modify: `app/forge/cards/[cardId]/page.tsx`
+
+**Interfaces:**
+- Consumes: `useForgeCardChannel` + `ForgePresenceMeta` (Task 4), `forgeCardTopic` (Task 3).
+- Produces: `<PresenceBar others={ForgePresenceMeta[]} />`; `StudioEditor` gains props `currentUser: { userId: string; displayName: string | null }` and `setId: string | null`.
+
+- [ ] **Step 1: Create `PresenceBar.tsx`**
+
+Create `app/forge/cards/[cardId]/PresenceBar.tsx`:
+```tsx
+"use client";
+
+import type { ForgePresenceMeta } from "@/app/forge/lib/useForgeRealtime";
+
+function initials(name: string | null): string {
+  if (!name) return "?";
+  const parts = name.trim().split(/\s+/);
+  return ((parts[0]?.[0] ?? "") + (parts[1]?.[0] ?? "")).toUpperCase() || "?";
+}
+
+export default function PresenceBar({ others }: { others: ForgePresenceMeta[] }) {
+  if (others.length === 0) return null;
+  // Dedupe by userId (a member may have two tabs open).
+  const seen = new Map<string, ForgePresenceMeta>();
+  for (const o of others) seen.set(o.userId, o);
+  const people = [...seen.values()];
+  const editing = people.filter((p) => p.editing);
+  return (
+    <div className="mb-3">
+      <div className="flex items-center gap-2">
+        <div className="flex -space-x-2">
+          {people.map((p) => (
+            <span
+              key={p.userId}
+              title={p.displayName ?? "Member"}
+              className="flex h-7 w-7 items-center justify-center rounded-full border border-background bg-muted text-[10px] font-medium text-muted-foreground"
+            >
+              {initials(p.displayName)}
+            </span>
+          ))}
+        </div>
+        <span className="text-xs text-muted-foreground">
+          {people.length === 1 ? "1 other person here" : `${people.length} others here`}
+        </span>
+      </div>
+      {editing.length > 0 && (
+        <div className="mt-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+          {editing.map((p) => p.displayName ?? "Someone").join(", ")}{" "}
+          {editing.length === 1 ? "is" : "are"} also editing this card — changes use last-write-wins.
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Wire `StudioEditor.tsx`**
+
+Read the file first. Make these changes:
+1. Add imports near the top:
+```tsx
+import { forgeCardTopic } from "@/app/forge/lib/realtime";
+import { useForgeCardChannel } from "@/app/forge/lib/useForgeRealtime";
+import PresenceBar from "./PresenceBar";
+```
+2. Change the component signature to accept the new props:
+```tsx
+export default function StudioEditor({
+  card,
+  sets,
+  currentUser,
+  setId,
+}: {
+  card: ForgeCardFull;
+  sets: ForgeSetSummary[];
+  currentUser: { userId: string; displayName: string | null };
+  setId: string | null;
+}) {
+```
+3. Inside the component body (after the existing `useState` for `snapshot`), add the channel hook — gated on the card being in a set:
+```tsx
+  const { others, setEditing } = useForgeCardChannel(
+    setId ? forgeCardTopic(card.id) : null,
+    { userId: currentUser.userId, displayName: currentUser.displayName, editing: false },
+  );
+```
+4. Render `<PresenceBar others={others} />` at the top of the editor's returned markup (above the form/preview wrapper).
+5. Mark the user as editing while the editor has focus. On the outermost wrapping element of the editor's form region, add:
+```tsx
+  onFocusCapture={() => setEditing(true)}
+  onBlurCapture={() => setEditing(false)}
+```
+(If the editor root is a fragment, wrap the form column in a `<div>` carrying these handlers — do not put them on the live-preview column.)
+
+- [ ] **Step 3: Pass `currentUser` + `setId` from `page.tsx`**
+
+Read `app/forge/cards/[cardId]/page.tsx`. After `requireForge()` yields `ctx`, fetch the member display name (mirror the progress page pattern) and pass the new props to `StudioEditor`:
+```tsx
+  const { data: meRow } = await ctx.supabase
+    .from("playtest_members")
+    .select("display_name")
+    .eq("user_id", ctx.user.id)
+    .single();
+  const currentUser = { userId: ctx.user.id, displayName: meRow?.display_name ?? null };
+```
+Then update the `<StudioEditor .../>` usage to add:
+```tsx
+      currentUser={currentUser}
+      setId={card.setId ?? null}
+```
+(Use whatever the existing `ForgeCardFull` field for the set is — confirm it's `setId`; if the type exposes `set_id`, use that. If `card` has no set field, derive `setId` from the same query the page already runs.)
+
+- [ ] **Step 4: Build to verify wiring typechecks**
+
+Run: `npm run build`
+Expected: compiles clean (no type errors in `StudioEditor`, `PresenceBar`, `page.tsx`). Resolve any `r.ok` narrowing or prop-type mismatches (`strict:false` — see Global Constraints).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/forge/cards/[cardId]/PresenceBar.tsx app/forge/cards/[cardId]/StudioEditor.tsx app/forge/cards/[cardId]/page.tsx
+git commit -m "feat(forge): card presence avatars + soft collision warning (live)"
+```
+
+---
+
+## Task 6: Set-level liveness (review badges, notes, progress)
+
+**Files:**
+- Create: `app/forge/sets/[setId]/SetRealtime.tsx`
+- Modify: `app/forge/sets/[setId]/layout.tsx`
+- Modify: `app/forge/sets/[setId]/notes/NotesEditor.tsx`
+
+**Interfaces:**
+- Consumes: `useForgeRefresh` (Task 4), `forgeSetTopic` (Task 3).
+- Produces: `<SetRealtime setId={string} />` (renders null).
+
+- [ ] **Step 1: Create `SetRealtime.tsx`**
+
+Create `app/forge/sets/[setId]/SetRealtime.tsx`:
+```tsx
+"use client";
+
+import { useForgeRefresh } from "@/app/forge/lib/useForgeRealtime";
+import { forgeSetTopic } from "@/app/forge/lib/realtime";
+
+// Mounted in the set layout: one subscription drives live review badges (nav tab),
+// notes, and progress across every set tab via debounced router.refresh().
+export default function SetRealtime({ setId }: { setId: string }) {
+  useForgeRefresh(forgeSetTopic(setId));
+  return null;
+}
+```
+
+- [ ] **Step 2: Mount it in the set layout**
+
+Read `app/forge/sets/[setId]/layout.tsx`. It already gates via `requireForge()` + `getSet(setId)` and renders the set nav + `children`. Import and render `<SetRealtime />` once, inside the gated return (the `setId` is already available from `params`):
+```tsx
+import SetRealtime from "./SetRealtime";
+// ...inside the returned JSX, e.g. just before {children}:
+      <SetRealtime setId={setId} />
+```
+(If `setId` is only available as `(await params).setId`, use that local.)
+
+- [ ] **Step 3: Dirty-guarded prop sync in `NotesEditor.tsx`**
+
+So a viewer sees live note updates after a refresh while an active author's buffer is never clobbered, add a guarded sync of `initial → notes`. Insert after the existing autosave `useEffect` (and add `lastServer` ref next to the other refs):
+```tsx
+  const lastServer = useRef(initial);
+  useEffect(() => {
+    if (initial === lastServer.current) return;     // our own save / no remote change
+    const wasDirty = notes !== lastServer.current;   // local edits not yet reflected
+    lastServer.current = initial;
+    if (!wasDirty) setNotes(initial);                // safe to adopt the remote value
+  }, [initial, notes]);
+```
+
+- [ ] **Step 4: Build**
+
+Run: `npm run build`
+Expected: clean compile across `SetRealtime`, `layout.tsx`, `NotesEditor.tsx`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/forge/sets/[setId]/SetRealtime.tsx app/forge/sets/[setId]/layout.tsx app/forge/sets/[setId]/notes/NotesEditor.tsx
+git commit -m "feat(forge): live set review badges, notes, and progress via set channel"
+```
+
+---
+
+## Task 7: Whole-branch verification, memory, PR
+
+**Files:** none (verification + docs).
+
+- [ ] **Step 1: Full test + build gates**
+
+Run and confirm:
+- `npm test` → green except the one known pre-existing unrelated `store-route` failure (record the exact pass count).
+- `npm run build` → clean.
+- `FORGE_LEAK_TEST=1 npm run test:security` → all Forge anon-leak tests pass, including the new realtime join-rejection tests.
+- Supabase `get_advisors(type:"security")` → no new findings from 054.
+- `npx vitest run app/forge/lib/__tests__/realtime.test.ts` and the forge gate-first guardrail → green.
+
+- [ ] **Step 2: Manual signed-in smoke (two browser sessions)** — record results in the PR
+
+1. Two tabs on the same set card (`/forge/cards/[id]` where the card is in a set): each shows the other's presence avatar; typing in one shows the amber "also editing" banner in the other.
+2. Post a comment / suggestion in tab A → it appears in tab B without reload.
+3. Create/accept/deny a proposal in A → B's review panel + the set review-queue badge update.
+4. Edit set notes in A → a viewer in B sees the update; an actively-typing author in B is **not** clobbered.
+5. Change a card's status/brigade in A → B's progress dashboard updates.
+6. Confirm a **setless** private idea card (`/forge/ideas` → open one) still loads and autosaves with no console errors (realtime is correctly skipped).
+
+- [ ] **Step 3: Update the project memory**
+
+Append a `1b.2` status entry to `project_forge_playtesting.md` (and keep the `MEMORY.md` pointer accurate): branch, migration 054 applied, broadcast-from-DB decision + why (over postgres_changes), the `_forge_can_read_topic` per-topic authz, the uniform `router.refresh()` consumption model, leak-test extension, and any logged non-blocking follow-ups.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git push -u origin forge-phase-1b-2-realtime
+gh pr create --title "The Forge — Phase 1b.2: Realtime Collaboration Layer" --body "<summary + the manual-smoke checklist results + 'migration 054 applied to prod'>"
+```
+
+---
+
+## Self-review (completed during planning)
+
+- **Spec coverage:** live comments/proposals (Task 5 page refresh + Task 6 nothing extra — card channel in Task 5), presence + collision (Task 5), live review badges (Task 6), live notes (Task 6), live progress (Task 6), private per-topic authz + triggers (Task 1), leak-test extension (Task 2), topic builders/hooks (Tasks 3–4). All spec sections map to a task.
+- **Placeholders:** none — every step carries real SQL/TS or an exact edit + command.
+- **Type consistency:** `ForgePresenceMeta` defined in Task 4, consumed identically in Tasks 4–5; topic builders defined in Task 3, consumed in Tasks 4–6; `forge_broadcast_change`/`_forge_can_read_topic` names consistent between Task 1 SQL and Task 2 probe. Trigger event name `'change'` matches the client `.on('broadcast', { event: 'change' })` in Task 4.
+- **Known soft spots flagged for the implementer:** exact `ForgeCardFull` set-field name (Task 5 Step 3) and the editor's focusable root element (Task 5 Step 2) must be confirmed against the real files; the `tsc --noEmit` availability (Task 4 Step 2) falls back to `npm run build`.

--- a/docs/superpowers/specs/2026-06-25-forge-phase-1b-2-realtime-design.md
+++ b/docs/superpowers/specs/2026-06-25-forge-phase-1b-2-realtime-design.md
@@ -1,0 +1,190 @@
+# The Forge — Phase 1b.2: Realtime Collaboration Layer
+
+**Date:** 2026-06-25
+**Phase:** 1b.2 (second sub-slice of Phase 1b — collaborative review)
+**Branch:** `forge-phase-1b-2-realtime`
+**Predecessor:** 1b.1 (Review Layer — proposals + comments/suggestions), PR #129, merged to `main`.
+
+---
+
+## Context
+
+Phase 1b.1 shipped the review layer (proposals, comments, single-field suggestions, per-set review queue) but is **refetch-only**: every collaborative surface updates via `router.refresh()` on the acting user's own action. A second elder looking at the same card or the set's review queue sees nothing until they reload. The master spec (`2026-06-19`) always intended Phase 1b to **make this layer live** via Supabase Realtime (lines 58–60, 466–471): live comment threads, presence avatars + collision warnings, live review-queue badge counts, live set-notes, live progress.
+
+This slice delivers that liveness. It adds **no new product surface** — every feature already exists from 1b.1/1a.5. It makes the existing surfaces update in real time and adds presence/collision affordances. The load-bearing work is the **security spine**: standing up private, authorized Realtime channels and extending the anon-leak guardrail to cover them, without violating the hard constraint that *nothing about prerelease cards may reach a non-member*.
+
+---
+
+## Goals / non-goals
+
+**Goals**
+- **Live comment threads** — a comment/suggestion posted by one elder appears immediately for everyone viewing the card.
+- **Presence + soft collision warning** — avatars of who is currently viewing/editing a card; a non-blocking "X is also editing this card" banner when ≥2 elders have the studio open. Last-write-wins autosave is unchanged (no locking, no CRDT).
+- **Live review-queue badges** — a set's open-proposal / unresolved-suggestion counts update live for its elders.
+- **Live set-notes** and **live progress dashboard** — viewers see edits/status changes without reloading.
+- **Security spine holds:** Realtime is delivered over **private, authorized** channels gated by RLS on `realtime.messages`; the anon-leak guardrail is extended to prove a non-member (and anon) cannot join a Forge channel or receive any Forge broadcast.
+
+**Non-goals (this slice)**
+- Proposing **art** changes (`proposed_art_key` stays reserved → later).
+- Multi-reviewer / **N>1** approval (stays single-elder per the parent spec).
+- Proposal **re-open / re-base** (a stale-base proposal is still closed `superseded`; author re-proposes).
+- **Playtester** participation (Phase 2). Today every set-card reader is an elder; presence/collision is among co-designing elders.
+- **CRDT / operational-transform** co-editing of a card's fields. Collision is *warned*, not prevented.
+- A **notification feed** or email. Liveness is in-app only, as the master spec dictates.
+- Any change to **`/board`** or its `supabase_realtime` publication (this slice uses a different delivery mechanism — see below).
+
+---
+
+## The core architecture decision: Broadcast from Database, not Postgres Changes
+
+The master spec's wording was "Realtime enabled on `card_comments`, `forge_cards`, `forge_sets` … `postgres_changes` … private/authorized channels." During design we found that **Postgres Changes is the wrong mechanism for this threat model**, and chose **Broadcast from Database** instead. This is a deliberate, security-motivated upgrade over the spec's literal wording — same intent (live, private, RLS-gated), strictly safer realization.
+
+| | Postgres Changes (spec's literal reading) | **Broadcast from Database (chosen)** |
+|---|---|---|
+| How | Add forge tables to the global `supabase_realtime` publication + `REPLICA IDENTITY FULL`; clients subscribe to row-change events. | A `security definer` trigger on each forge table calls `realtime.broadcast_changes()` to a **private** topic; clients subscribe to that topic. |
+| Authorization | RLS on the **source table** filters rows — **but only on private channels**. On a **public** channel, Postgres Changes performs **no** authorization. | RLS on **`realtime.messages`** governs who may join/receive a topic. A private topic and a public topic of the same name are **distinct channels**; DB broadcasts reach only the private topic. |
+| Threat-model exposure | Forge tables sit in a **global** publication. A non-member could attempt a **public-channel** Postgres-Changes subscription to `card_comments` and receive unfiltered changes. The leak test must actively disprove this path, and it depends on correct project config. | **No exposure surface.** Broadcasts exist only on the private topic; a non-member fails `realtime.messages` RLS and cannot join it. A public channel of the same name receives nothing because no broadcast is ever sent there. |
+| Schema footprint | Touches the shared `supabase_realtime` publication (`/board` lives there) + replica identity. | Touches **nothing** shared. `broadcast_changes` passes `NEW`/`OLD` explicitly and rides Realtime's own internal `realtime.messages` replication — **no publication change, no `REPLICA IDENTITY` change**. `/board` is untouched. |
+| Supabase guidance | "Simpler, but does not scale as well." | "**Recommended** method for scalability and security." |
+
+**Decision: Broadcast from Database.** It eliminates the public-channel bypass surface entirely, is uniform (a trigger can't be forgotten the way a hand-rolled per-RPC broadcast could), leaves shared infrastructure untouched, and is Supabase's recommended direction.
+
+---
+
+## Channel topology (private, member-authorized)
+
+Two topic families, each consumed by exactly one page type so every consumer subscribes to a single channel:
+
+- **`forge:card:{cardId}`** — used by the card studio/review page (`/forge/cards/[cardId]`). Carries broadcasts for: the card row, its comments, its proposals. **Also hosts presence** (who is viewing/editing this card).
+- **`forge:set:{setId}`** — used by the set pages (`/forge/sets/[setId]/{review,notes,progress}`). Carries broadcasts for: the set row (notes), every card in the set (status/brigade/type for progress), and proposals/comments on those cards (badge counts). No presence.
+
+**Trigger fan-out.** Each table's trigger broadcasts to the topic(s) a consumer needs, looking up the owning set where the row doesn't carry it directly (cheap indexed PK lookups, run in a `security definer` trigger):
+
+| Table | Broadcast to `forge:card:{…}` | Broadcast to `forge:set:{…}` |
+|---|---|---|
+| `forge_sets` | — | `forge:set:{id}` |
+| `forge_cards` | `forge:card:{id}` | `forge:set:{set_id}` when `set_id` is not null |
+| `card_proposals` | `forge:card:{card_id}` | `forge:set:{set_id of card_id}` when the card is in a set |
+| `card_comments` | `forge:card:{card_id}` | `forge:set:{set_id of card_id}` when the card is in a set |
+
+A card page thus reacts to everything about its card; a set page reacts to everything about its set — each from one subscription.
+
+**Join authorization — per-topic, matching table RLS.** A non-member must not join any `forge:*` topic, and — crucially — a member must not join a topic for a card/set they cannot read. Broadcast payloads are **not** per-row RLS filtered the way Postgres Changes are; whoever joins a topic receives every payload sent to it. So the join gate itself must carry the full read-authorization, parsing `realtime.topic()` and reusing the existing read predicates:
+
+- `forge:card:{uuid}` → `public._forge_can_read_card(uuid)` (owner / set-elder of the card's set / superadmin — the exact 053 read rule).
+- `forge:set:{uuid}` → `public.is_forge_set_elder(uuid) or public.is_forge_superadmin()` (the exact 052 set-read rule).
+
+This makes the Realtime layer's visibility **identical to the table RLS** — no intra-member content exposure, not just no non-member leak — and it is the same predicate Phase-2 playtesters will need, so Phase 2 requires no rework. (The cast `split_part(topic,':',3)::uuid` is guarded by a uuid-format check first so a malformed topic fails closed without a noisy error.)
+
+---
+
+## Security spine — migration `054_forge_realtime.sql`
+
+Schema + functions only, no data. Follows every 052/053 convention: `security definer`, `set search_path = ''`, explicit anon handling, default-deny posture.
+
+**1. `realtime.messages` RLS policies (the join gate).** A `select` policy (receive broadcasts + others' presence + join) and an `insert` policy (publish own presence) share one **per-topic read predicate** so Realtime visibility equals table RLS. A `stable` helper `public._forge_can_read_topic(text)` encapsulates the parse-and-check so both policies (and the test) stay in sync:
+
+```sql
+create or replace function public._forge_can_read_topic(p_topic text)
+returns boolean language plpgsql stable security definer set search_path = '' as $$
+declare v_id uuid;
+begin
+  if p_topic like 'forge:card:%' then
+    begin v_id := (split_part(p_topic, ':', 3))::uuid; exception when others then return false; end;
+    return public._forge_can_read_card(v_id);
+  elsif p_topic like 'forge:set:%' then
+    begin v_id := (split_part(p_topic, ':', 3))::uuid; exception when others then return false; end;
+    return public.is_forge_set_elder(v_id) or public.is_forge_superadmin();
+  end if;
+  return false;
+end $$;
+
+create policy "forge realtime receive" on realtime.messages
+  for select to authenticated
+  using ( public._forge_can_read_topic((select realtime.topic())) );
+
+create policy "forge realtime presence-send" on realtime.messages
+  for insert to authenticated
+  with check ( public._forge_can_read_topic((select realtime.topic())) );
+```
+
+`_forge_can_read_card` (053), `is_forge_set_elder` (052), `is_forge_superadmin` (051) are existing helpers. No `anon` grant is added; `anon` is not `authenticated`, so anon is denied by default, and the predicate returns `false` for any non-`forge:` topic. (All **data** broadcasts originate from the DB triggers as the Realtime admin role, so the client `insert` policy is needed only for presence tracking; gating it to topic-readers keeps presence visible only to a card's co-designers.)
+
+**2. Trigger functions (broadcast on write).** One `security definer` function per table (or a shared helper) that computes the topic(s) and calls `realtime.broadcast_changes(topic, TG_OP, TG_OP, TG_TABLE_NAME, TG_TABLE_SCHEMA, NEW, OLD)`. `AFTER INSERT OR UPDATE OR DELETE` triggers on `forge_sets`, `forge_cards`, `card_proposals`, `card_comments`. Set-topic lookups: `forge_cards.set_id` directly; for `card_proposals`/`card_comments`, `select set_id from public.forge_cards where id = <card_id>`. Functions own `search_path = ''` and reference `realtime.broadcast_changes` / `public.forge_cards` fully qualified.
+
+**3. No publication / replica-identity changes.** `broadcast_changes` does not use the `supabase_realtime` publication. `/board` is unaffected.
+
+**4. Project setting (documented, not a migration).** Disable **"Allow public access"** in Realtime Settings as defense-in-depth so the project serves *only* private channels. Security does not depend on it for this slice (DB broadcasts never reach a public topic), but it removes an entire class of future foot-gun. Recorded in the plan as a manual dashboard step + in the PR description.
+
+**5. Anon-leak guardrail extension (the keystone).** `__tests__/forge-anon-leak.test.ts` gains a Realtime section. As **anon** and as a **signed-in non-member**:
+- `realtime.setAuth(token)` then `.channel('forge:card:<seed-id>', { config: { private: true } }).subscribe()` → assert the channel **does not reach `SUBSCRIBED`** (it gets `CHANNEL_ERROR`/timeout because the `realtime.messages` SELECT policy denies the join).
+- Same for a `forge:set:<seed-id>` topic.
+- Defense-in-depth: join a **public** channel of the same topic name and assert **zero** messages arrive within a window even after a member-side write occurs.
+- Positive control (optional, gated behind the live-test flag): a member **can** reach `SUBSCRIBED`.
+
+The test runs under the existing `FORGE_LEAK_TEST=1 npm run test:security` live harness (the only mode with a real socket + seeded ids); it is skipped in the hermetic default run like the other live probes.
+
+---
+
+## Client modules
+
+**`app/forge/lib/realtime.ts`** (new) — the single private-channel factory. Browser-only (`utils/supabase/client.ts`). Responsibilities:
+- `forgeChannel(name, opts)` — creates a channel with `config: { private: true }`, after ensuring `await supabase.realtime.setAuth()` has run (so the socket carries the member's JWT before join).
+- `forgeCardTopic(cardId)` / `forgeSetTopic(setId)` — the canonical topic-name builders (single source of truth, mirrored by the trigger SQL's topic format; both documented as `forge:card:{uuid}` / `forge:set:{uuid}`).
+- Subscribe/teardown helpers that return an unsubscribe function for React effect cleanup.
+
+**Hooks** (new, colocated under `app/forge/` — `lib/useForgeRealtime.ts` or per-surface):
+- `useForgeChannelInvalidate(topic, onChange)` — subscribes to a topic's broadcast events and calls `onChange` (debounced ~250ms) so the consumer can `router.refresh()` / scoped-refetch. Used by review badges, progress, notes, proposal lists.
+- `useForgeComments(cardId, initial)` — subscribes to the card topic, applies INSERT/UPDATE/DELETE comment payloads to local state for an instant live thread. (The one surface that consumes payloads directly rather than refetching.)
+- `useForgePresence(cardId, me)` — joins the card topic's presence, tracks `{ userId, displayName, editing }`, returns the roster + an `othersEditing` boolean for the collision banner.
+
+All hooks are no-ops/clean-teardown when their id is absent (e.g. the studio's card has `set_id === null`, so the card page still works; the set surfaces simply aren't mounted).
+
+---
+
+## Live surfaces & consumption strategy
+
+| Surface | Mechanism | Consumption |
+|---|---|---|
+| **Comment thread** (`CommentThread.tsx`) | `forge:card` broadcasts of `card_comments` | **Apply payloads directly** — append on INSERT, patch on UPDATE (resolve/edit), drop on DELETE. Instant live thread; reconciles against the optimistic local insert by row `id`. |
+| **Presence + collision** (`StudioEditor.tsx` / card page) | `forge:card` presence track | Avatar row of current viewers; `editing:true` set on focus/typing in the editor. ≥2 editors ⇒ soft non-blocking banner. No locking. |
+| **Review-queue badges** (`ReviewQueue.tsx`, set nav tab) | `forge:set` broadcasts of `card_proposals`/`card_comments` | **Invalidation signal** → debounced `router.refresh()` (re-derives counts server-side). |
+| **Set notes** (`NotesEditor.tsx`) | `forge:set` broadcasts of `forge_sets` | Invalidation signal → refetch notes for viewers. The editor stays single-author autosave; a viewer sees updates live. (Author's own in-flight edit is not clobbered — refresh only pulls when not dirty.) |
+| **Progress dashboard** (`ProgressDashboard.tsx`) | `forge:set` broadcasts of `forge_cards` | Invalidation signal → debounced `router.refresh()`; progress recomputes server-side via the pure `progress.ts`. |
+
+**Why "invalidation signal" for the derived surfaces:** badges/progress/notes are *derived* (counts, cartesian cells, rendered markdown). Reconstructing them from raw INSERT/UPDATE/DELETE payloads is bug-prone (ordering, dedupe, old-row handling) for no user-visible gain at this scale. A debounced server refetch keeps the server as the single source of truth and slots directly into 1b.1's existing `router.refresh()` model. Only the comment thread, where instant append is the whole point and the payload maps 1:1 to a list item, consumes payloads directly.
+
+---
+
+## Collision / presence UX
+
+- Presence key = the member's `auth.uid()`; payload `{ displayName, editing }`.
+- **Viewing** = card page mounted. **Editing** = the studio editor has focus or has autosaved within a short window.
+- The card page shows a small avatar cluster of present members (display name on hover, reusing the existing avatar rendering).
+- When another member is `editing` the same card, `StudioEditor` shows a quiet, dismissible banner: *"Land of Redemption is also editing this card — changes use last-write-wins."* No input is blocked. This is exactly the mitigation the master spec calls "collision warning," and it softens the 1b.1 tradeoff where accepting a proposal overwrites the working draft.
+- All motion respects `prefers-reduced-motion` (avatars fade, no pulsing).
+
+---
+
+## Testing
+
+- **Anon-leak guardrail extension** (above) — the keystone; must pass under the live `FORGE_LEAK_TEST=1` harness as anon + non-member.
+- **Pure unit tests** for the non-React helpers: topic builders (`forgeCardTopic`/`forgeSetTopic`) and the comment-payload reducer (apply INSERT/UPDATE/DELETE to a list, dedupe vs optimistic id) — TDD, hermetic.
+- **`forge-gate-first`** guardrail unchanged (no new pages; existing pages keep their own `requireForge()` gate).
+- **`npm test`** full suite green (allowing the one pre-existing unrelated `store-route` failure); **`npm run build`** clean; **`get_advisors`** no new findings after 054 applies.
+- **Manual signed-in smoke** (two browser sessions): post a comment in one → appears in the other; open the same card in both → collision banner; change a card's status → set progress/badges update in the other tab. Logged as the remaining manual step (no creds in an autonomous session).
+
+---
+
+## Risks & tradeoffs
+
+- **Topic parsing in RLS.** The join gate parses `realtime.topic()` and casts a substring to `uuid`. The cast is wrapped in an exception guard that returns `false`, so a malformed/unknown topic fails closed rather than erroring the join. Per-topic authz means Realtime visibility equals table RLS — no intra-member content exposure — at the cost of one `stable` helper call per join.
+- **Refetch on every set-topic event.** Debounced, and write volume is tiny (a few elders). If it ever became chatty, the derived surfaces could move to payload-applied reducers — deferred under YAGNI.
+- **`realtime.messages` RLS join latency.** One `_forge_can_read_topic()` call per join (which itself runs one existing read predicate). Negligible at this scale; Supabase's complexity warning is about heavier policies.
+- **Project setting drift.** "Allow public access" is a dashboard setting, not in the migration. Mitigated by documenting it in the PR and by the design not depending on it for correctness.
+
+---
+
+## Deferred to later slices
+
+Art proposals; N>1 approval; proposal re-open/re-base; playtester access (the per-topic authz built here already accommodates them); notification feed/email; any CRDT co-editing. None are required for "make the 1b.1 review layer live."

--- a/docs/superpowers/specs/2026-06-25-forge-phase-1b-2-realtime-design.md
+++ b/docs/superpowers/specs/2026-06-25-forge-phase-1b-2-realtime-design.md
@@ -114,7 +114,7 @@ create policy "forge realtime presence-send" on realtime.messages
 
 **3. No publication / replica-identity changes.** `broadcast_changes` does not use the `supabase_realtime` publication. `/board` is unaffected.
 
-**4. Project setting (documented, not a migration).** Disable **"Allow public access"** in Realtime Settings as defense-in-depth so the project serves *only* private channels. Security does not depend on it for this slice (DB broadcasts never reach a public topic), but it removes an entire class of future foot-gun. Recorded in the plan as a manual dashboard step + in the PR description.
+**4. No project-setting change.** "Allow public access" in Realtime Settings stays **on** — `/board` uses a *public* (non-private) channel and disabling it project-wide would break the projector board. Keeping it on is safe for the Forge: `realtime.broadcast_changes()` sends only to the **private** topic, and Realtime treats a private topic and a public topic of the same name as **distinct channels** (no cross-delivery), so a public listener never receives a Forge broadcast. The leak test proves this directly (a public channel of the same name receives zero messages even after a member write).
 
 **5. Anon-leak guardrail extension (the keystone).** `__tests__/forge-anon-leak.test.ts` gains a Realtime section. As **anon** and as a **signed-in non-member**:
 - `realtime.setAuth(token)` then `.channel('forge:card:<seed-id>', { config: { private: true } }).subscribe()` → assert the channel **does not reach `SUBSCRIBED`** (it gets `CHANNEL_ERROR`/timeout because the `realtime.messages` SELECT policy denies the join).
@@ -128,31 +128,32 @@ The test runs under the existing `FORGE_LEAK_TEST=1 npm run test:security` live 
 
 ## Client modules
 
-**`app/forge/lib/realtime.ts`** (new) — the single private-channel factory. Browser-only (`utils/supabase/client.ts`). Responsibilities:
-- `forgeChannel(name, opts)` — creates a channel with `config: { private: true }`, after ensuring `await supabase.realtime.setAuth()` has run (so the socket carries the member's JWT before join).
-- `forgeCardTopic(cardId)` / `forgeSetTopic(setId)` — the canonical topic-name builders (single source of truth, mirrored by the trigger SQL's topic format; both documented as `forge:card:{uuid}` / `forge:set:{uuid}`).
-- Subscribe/teardown helpers that return an unsubscribe function for React effect cleanup.
+**One channel per page-context, not per component.** A card page subscribes once to `forge:card:{id}`; a set route subscribes once to `forge:set:{id}` (mounted in the set layout so it spans all set tabs + the nav badge). The trigger SQL uses a **fixed broadcast event name `'change'`** (operation carried in the payload) so each consumer registers a single `.on('broadcast', { event: 'change' }, …)` listener.
 
-**Hooks** (new, colocated under `app/forge/` — `lib/useForgeRealtime.ts` or per-surface):
-- `useForgeChannelInvalidate(topic, onChange)` — subscribes to a topic's broadcast events and calls `onChange` (debounced ~250ms) so the consumer can `router.refresh()` / scoped-refetch. Used by review badges, progress, notes, proposal lists.
-- `useForgeComments(cardId, initial)` — subscribes to the card topic, applies INSERT/UPDATE/DELETE comment payloads to local state for an instant live thread. (The one surface that consumes payloads directly rather than refetching.)
-- `useForgePresence(cardId, me)` — joins the card topic's presence, tracks `{ userId, displayName, editing }`, returns the roster + an `othersEditing` boolean for the collision banner.
+**`app/forge/lib/realtime.ts`** (new, plain TS — imported only by client components) — the canonical topic + channel layer:
+- `forgeCardTopic(cardId)` → `` `forge:card:${cardId}` `` and `forgeSetTopic(setId)` → `` `forge:set:${setId}` `` — single source of truth for the topic format, exactly mirroring the trigger SQL. **No sub-suffixes** (the `realtime.messages` predicate parses `split_part(topic,':',3)::uuid`, so a `:comments`-style suffix would break authorization).
+- `openForgeChannel(topic, { onChange?, presence? })` — calls `await supabase.realtime.setAuth()` (member JWT) then creates the channel with `config: { private: true, presence: { key } }`, wires the `'change'` broadcast handler and/or presence callbacks, subscribes, and returns a teardown function.
 
-All hooks are no-ops/clean-teardown when their id is absent (e.g. the studio's card has `set_id === null`, so the card page still works; the set surfaces simply aren't mounted).
+**Hooks** (`app/forge/lib/useForgeRealtime.ts`, `"use client"`):
+- `useForgeRefresh(topic)` — subscribes and calls a **debounced (~250ms) `router.refresh()`** on every `'change'` event. This is the uniform liveness mechanism: because comment threads, proposal lists/diffs, review badges, and the progress dashboard all render from **server props**, a refresh re-runs the server queries and they update live — **no payload reducer, no dedupe-vs-optimistic logic**. Server stays the single source of truth.
+- `useForgePresence(topic, me)` — joins presence, tracks `{ userId, displayName, editing }`, returns the roster + an `othersEditing` boolean for the collision banner.
+
+The card page combines both into one subscription (`useForgeCardChannel(cardId, currentUser)` = presence + refresh on the same channel). Subscriptions are **gated on the card being in a set** (`setId != null`) — a setless private sketch has only its owner as a possible joiner, so realtime is skipped. All hooks clean-teardown on unmount / id change.
 
 ---
 
 ## Live surfaces & consumption strategy
 
-| Surface | Mechanism | Consumption |
+| Surface | Channel | Consumption |
 |---|---|---|
-| **Comment thread** (`CommentThread.tsx`) | `forge:card` broadcasts of `card_comments` | **Apply payloads directly** — append on INSERT, patch on UPDATE (resolve/edit), drop on DELETE. Instant live thread; reconciles against the optimistic local insert by row `id`. |
-| **Presence + collision** (`StudioEditor.tsx` / card page) | `forge:card` presence track | Avatar row of current viewers; `editing:true` set on focus/typing in the editor. ≥2 editors ⇒ soft non-blocking banner. No locking. |
-| **Review-queue badges** (`ReviewQueue.tsx`, set nav tab) | `forge:set` broadcasts of `card_proposals`/`card_comments` | **Invalidation signal** → debounced `router.refresh()` (re-derives counts server-side). |
-| **Set notes** (`NotesEditor.tsx`) | `forge:set` broadcasts of `forge_sets` | Invalidation signal → refetch notes for viewers. The editor stays single-author autosave; a viewer sees updates live. (Author's own in-flight edit is not clobbered — refresh only pulls when not dirty.) |
-| **Progress dashboard** (`ProgressDashboard.tsx`) | `forge:set` broadcasts of `forge_cards` | Invalidation signal → debounced `router.refresh()`; progress recomputes server-side via the pure `progress.ts`. |
+| **Comment thread** (`CommentThread.tsx`) | `forge:card` | Renders from the server page's `comments` prop → `router.refresh()` re-runs `listComments` and the thread updates live. No reducer. |
+| **Proposal list + diffs** (`ReviewPanel.tsx`) | `forge:card` | Same `router.refresh()` re-runs the page's proposal/diff queries. |
+| **Presence + collision** (`StudioEditor.tsx`) | `forge:card` (presence) | Avatar row of current viewers; `editing:true` set on focus/typing in the editor. ≥2 editors ⇒ soft non-blocking banner. No locking. |
+| **Review-queue badges** (`ReviewQueue.tsx` + set nav tab in `layout.tsx`) | `forge:set` | `router.refresh()` re-derives counts server-side via `review.ts`. Subscription mounted in the set layout so the badge updates on every set tab. |
+| **Set notes** (`NotesEditor.tsx`) | `forge:set` | `router.refresh()` passes fresh `initial`; `NotesEditor` syncs `initial → notes` **only when its buffer is not dirty**, so a viewer sees updates live while an active author's in-progress edit is never clobbered. |
+| **Progress dashboard** (`ProgressDashboard.tsx`) | `forge:set` | `router.refresh()` recomputes `progress.ts` server-side; the dashboard renders from the refreshed `model` prop. |
 
-**Why "invalidation signal" for the derived surfaces:** badges/progress/notes are *derived* (counts, cartesian cells, rendered markdown). Reconstructing them from raw INSERT/UPDATE/DELETE payloads is bug-prone (ordering, dedupe, old-row handling) for no user-visible gain at this scale. A debounced server refetch keeps the server as the single source of truth and slots directly into 1b.1's existing `router.refresh()` model. Only the comment thread, where instant append is the whole point and the payload maps 1:1 to a list item, consumes payloads directly.
+**Why uniform `router.refresh()`:** every live surface here already renders from server props (1b.1 shipped them that way and uses `router.refresh()` after each local mutation). Treating a broadcast as "something changed → refresh" reuses that exact model, keeps the server as the single source of truth, and avoids fragile client-side reconciliation of raw INSERT/UPDATE/DELETE payloads (ordering, dedupe, old-row handling) for no perceptible gain at a few-elders scale. The editors (`StudioEditor`, `NotesEditor`) hold a local dirty buffer seeded once on mount, so a refresh does not clobber an in-progress edit; the dirty-guarded prop-sync in `NotesEditor` is the only place that re-reads server state into a field, and only when safe.
 
 ---
 
@@ -181,7 +182,7 @@ All hooks are no-ops/clean-teardown when their id is absent (e.g. the studio's c
 - **Topic parsing in RLS.** The join gate parses `realtime.topic()` and casts a substring to `uuid`. The cast is wrapped in an exception guard that returns `false`, so a malformed/unknown topic fails closed rather than erroring the join. Per-topic authz means Realtime visibility equals table RLS — no intra-member content exposure — at the cost of one `stable` helper call per join.
 - **Refetch on every set-topic event.** Debounced, and write volume is tiny (a few elders). If it ever became chatty, the derived surfaces could move to payload-applied reducers — deferred under YAGNI.
 - **`realtime.messages` RLS join latency.** One `_forge_can_read_topic()` call per join (which itself runs one existing read predicate). Negligible at this scale; Supabase's complexity warning is about heavier policies.
-- **Project setting drift.** "Allow public access" is a dashboard setting, not in the migration. Mitigated by documenting it in the PR and by the design not depending on it for correctness.
+- **Shared Realtime settings.** "Allow public access" must stay on for `/board`; the Forge's safety does not depend on it (private vs. public topics are distinct channels), and the leak test proves a public same-named channel receives nothing.
 
 ---
 

--- a/supabase/migrations/054_forge_realtime.sql
+++ b/supabase/migrations/054_forge_realtime.sql
@@ -1,0 +1,125 @@
+-- 054_forge_realtime.sql
+-- Phase 1b.2: Realtime collaboration layer (Broadcast from Database).
+-- Live comments/proposals/cards/sets over PRIVATE, per-topic-authorized channels.
+-- No change to the supabase_realtime publication or REPLICA IDENTITY:
+-- realtime.broadcast_changes() rides Realtime's own internal messaging.
+
+-- 1. Topic read-authorization helper. Mirrors table RLS exactly:
+--    forge:card:{uuid} -> _forge_can_read_card ; forge:set:{uuid} -> set-elder/super.
+create or replace function public._forge_can_read_topic(p_topic text)
+returns boolean
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  v_id uuid;
+begin
+  if p_topic like 'forge:card:%' then
+    begin
+      v_id := (split_part(p_topic, ':', 3))::uuid;
+    exception when others then
+      return false;
+    end;
+    return public._forge_can_read_card(v_id);
+  elsif p_topic like 'forge:set:%' then
+    begin
+      v_id := (split_part(p_topic, ':', 3))::uuid;
+    exception when others then
+      return false;
+    end;
+    return public.is_forge_set_elder(v_id) or public.is_forge_superadmin();
+  end if;
+  return false;
+end;
+$$;
+
+revoke all on function public._forge_can_read_topic(text) from public;
+revoke all on function public._forge_can_read_topic(text) from anon;
+grant execute on function public._forge_can_read_topic(text) to authenticated;
+
+-- 2. realtime.messages RLS — the join/receive gate. select = receive broadcasts +
+--    others' presence + JOIN; insert = publish own presence. Both reuse the predicate.
+drop policy if exists "forge realtime receive" on realtime.messages;
+create policy "forge realtime receive"
+  on realtime.messages
+  for select
+  to authenticated
+  using ( public._forge_can_read_topic((select realtime.topic())) );
+
+drop policy if exists "forge realtime presence-send" on realtime.messages;
+create policy "forge realtime presence-send"
+  on realtime.messages
+  for insert
+  to authenticated
+  with check ( public._forge_can_read_topic((select realtime.topic())) );
+
+-- 3. Broadcast-on-write trigger function. Fans out to the card topic and (when the
+--    card is in a set) the set topic, so a card page reacts to its card and a set
+--    page reacts to its whole set. NEW/OLD chosen by TG_OP (records can't coalesce).
+create or replace function public.forge_broadcast_change()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_row record;
+  v_set uuid;
+begin
+  if TG_OP = 'DELETE' then v_row := OLD; else v_row := NEW; end if;
+
+  if TG_TABLE_NAME = 'forge_sets' then
+    perform realtime.broadcast_changes(
+      'forge:set:' || v_row.id::text,
+      'change', TG_OP, TG_TABLE_NAME, TG_TABLE_SCHEMA, NEW, OLD);
+
+  elsif TG_TABLE_NAME = 'forge_cards' then
+    perform realtime.broadcast_changes(
+      'forge:card:' || v_row.id::text,
+      'change', TG_OP, TG_TABLE_NAME, TG_TABLE_SCHEMA, NEW, OLD);
+    if v_row.set_id is not null then
+      perform realtime.broadcast_changes(
+        'forge:set:' || v_row.set_id::text,
+        'change', TG_OP, TG_TABLE_NAME, TG_TABLE_SCHEMA, NEW, OLD);
+    end if;
+
+  else  -- card_proposals, card_comments (both carry card_id)
+    perform realtime.broadcast_changes(
+      'forge:card:' || v_row.card_id::text,
+      'change', TG_OP, TG_TABLE_NAME, TG_TABLE_SCHEMA, NEW, OLD);
+    select c.set_id into v_set from public.forge_cards c where c.id = v_row.card_id;
+    if v_set is not null then
+      perform realtime.broadcast_changes(
+        'forge:set:' || v_set::text,
+        'change', TG_OP, TG_TABLE_NAME, TG_TABLE_SCHEMA, NEW, OLD);
+    end if;
+  end if;
+
+  return null;  -- AFTER trigger: return value ignored
+end;
+$$;
+
+revoke all on function public.forge_broadcast_change() from public;
+revoke all on function public.forge_broadcast_change() from anon;
+
+drop trigger if exists forge_sets_broadcast on public.forge_sets;
+create trigger forge_sets_broadcast
+  after insert or update or delete on public.forge_sets
+  for each row execute function public.forge_broadcast_change();
+
+drop trigger if exists forge_cards_broadcast on public.forge_cards;
+create trigger forge_cards_broadcast
+  after insert or update or delete on public.forge_cards
+  for each row execute function public.forge_broadcast_change();
+
+drop trigger if exists card_proposals_broadcast on public.card_proposals;
+create trigger card_proposals_broadcast
+  after insert or update or delete on public.card_proposals
+  for each row execute function public.forge_broadcast_change();
+
+drop trigger if exists card_comments_broadcast on public.card_comments;
+create trigger card_comments_broadcast
+  after insert or update or delete on public.card_comments
+  for each row execute function public.forge_broadcast_change();


### PR DESCRIPTION
## The Forge — Phase 1b.2: Realtime Collaboration Layer

Makes the 1b.1 review layer **live**. No new product surface — every feature already existed; this makes them update in real time and adds presence/collision affordances.

- **Live comments / proposals** — a comment or proposal change appears for everyone viewing the card without reload.
- **Presence + soft collision warning** — avatars of who's viewing/editing a card; a non-blocking amber "_X is also editing — last-write-wins_" banner when ≥2 elders have the studio open. No locking (no CRDT).
- **Live review-queue badges, set notes, progress dashboard** — update live for a set's elders.

Spec: `docs/superpowers/specs/2026-06-25-forge-phase-1b-2-realtime-design.md` · Plan: `docs/superpowers/plans/2026-06-25-forge-phase-1b-2-realtime.md`

### Architecture — Broadcast from Database (not Postgres Changes)
A deliberate, security-motivated upgrade over the master spec's literal "postgres_changes" wording. Postgres Changes would force the Forge tables into the **global** `supabase_realtime` publication, where a **public** channel bypasses RLS — a non-member leak surface in a public-repo project. Instead:

- `AFTER` triggers on `forge_sets` / `forge_cards` / `card_proposals` / `card_comments` call `realtime.broadcast_changes()` to **private** topics `forge:card:{id}` / `forge:set:{id}`.
- Receipt is gated by RLS on `realtime.messages` via `_forge_can_read_topic()`, which **reuses the exact table read-rules** (`_forge_can_read_card` for cards; set-elder ∨ superadmin for sets) — so Realtime visibility equals table RLS (no non-member *or* intra-member leak).
- **No** `supabase_realtime` publication or `REPLICA IDENTITY` change → the public `/board` projector channel is untouched.

### Client
One private channel per page-context; a single `'change'` broadcast drives a debounced `router.refresh()`. Because comments/proposals/badges/notes/progress all render from server props, refresh makes them live with **no payload reducer**. `NotesEditor` gets a dirty-guarded `initial→notes` sync so a viewer goes live while an active author is never clobbered. Presence + collision live in `StudioEditor` (gated on the card being in a set).

### Migration
`054_forge_realtime.sql` — **applied to live prod** ✅. Adds `_forge_can_read_topic`, two `realtime.messages` policies (select=receive/join, insert=presence-send, both `to authenticated`), `forge_broadcast_change()` + 4 triggers. SECURITY DEFINER + `search_path=''`; anon revoked.

### Verification
- `npm test` (hermetic): **949 passed**, 1 pre-existing unrelated fail (`threshingfloor/store-route`). `npm run build`: clean.
- **Live `FORGE_LEAK_TEST=1` security suite: 56 passed / 2 skipped** (ISO tests need extra creds) — anon **rejected** from both private `forge:card`/`forge:set` topics; new `_forge_can_read_topic` anon-cannot-exec probe + public-channel defense-in-depth probe added.
- `get_advisors(security)`: only 2 benign by-design `authenticated_security_definer_function_executable` WARNs (same category as all prior Forge fns); no new problematic findings.
- Opus whole-branch review: security boundary verified sound end-to-end; one Important finding (missing public-channel test) fixed before merge.

### Remaining manual step
Signed-in **two-tab browser smoke** (no creds in the build session): two tabs on the same set card → presence avatars + amber collision banner; post a comment in one → appears in the other; change card status → other tab's progress/badges update; edit set notes → viewer sees it live, active author not clobbered; confirm a setless private idea still loads/autosaves (realtime correctly skipped).

### Deferred (unchanged)
Art proposals, N>1 approval, proposal reopen/rebase, playtester access (the per-topic authz already accommodates them), notification feed, CRDT co-editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
