### PR TITLE
The Forge — Set artwork download (ZIP)

### DIFF
--- a/app/forge/api/sets/[setId]/artwork/route.ts
+++ b/app/forge/api/sets/[setId]/artwork/route.ts
@@ -1,0 +1,52 @@
+import { requireForge, notFoundResponse } from "@/app/forge/lib/auth";
+import { getSet } from "@/app/forge/lib/sets";
+import { listSetApprovedArt, artExt, artFileName } from "@/app/forge/lib/setArtwork";
+import { readForgeArt } from "@/app/forge/lib/art";
+import { zipSync } from "fflate";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ setId: string }> }
+): Promise<Response> {
+  const ctx = await requireForge();
+  if (!ctx) return notFoundResponse(); // 404, never 401/403 — the area stays secret
+
+  const { setId } = await params;
+  const set = await getSet(setId);
+  if (!set) return notFoundResponse(); // not readable under RLS ⇒ not a set-elder/super
+
+  const arts = await listSetApprovedArt(setId);
+  if (arts.length === 0) return notFoundResponse(); // nothing to export (indistinguishable 404)
+
+  // Stable order: version number, then name.
+  arts.sort((a, b) => a.versionNumber - b.versionNumber || a.name.localeCompare(b.name));
+
+  const files: Record<string, Uint8Array> = {};
+  let seq = 0;
+  for (const art of arts) {
+    let result;
+    try {
+      result = await readForgeArt(art.key);
+    } catch {
+      continue; // skip a missing/failed blob rather than failing the whole export
+    }
+    if (!result || result.statusCode !== 200) continue;
+    const bytes = new Uint8Array(await new Response(result.stream).arrayBuffer());
+    seq += 1;
+    files[artFileName(seq, art.name, artExt(result.blob.contentType))] = bytes;
+  }
+  if (Object.keys(files).length === 0) return notFoundResponse();
+
+  // Images are already compressed → store (level 0), don't waste CPU recompressing.
+  const zip = zipSync(files, { level: 0 });
+
+  return new Response(zip, {
+    headers: {
+      "Content-Type": "application/zip",
+      "Content-Disposition": `attachment; filename="${set.slug}-artwork.zip"`,
+      "Cache-Control": "private, no-store",
+    },
+  });
+}

--- a/app/forge/lib/__tests__/setArtwork.test.ts
+++ b/app/forge/lib/__tests__/setArtwork.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { artExt, artFileName } from "@/app/forge/lib/setArtwork";
+
+describe("artExt", () => {
+  it("maps known image content types", () => {
+    expect(artExt("image/png")).toBe("png");
+    expect(artExt("image/webp")).toBe("webp");
+    expect(artExt("image/jpeg")).toBe("jpg");
+  });
+  it("falls back to 'img' for unknown types", () => {
+    expect(artExt("application/octet-stream")).toBe("img");
+    expect(artExt("")).toBe("img");
+  });
+});
+
+describe("artFileName", () => {
+  it("builds {NN}_{slug}.{ext} with a zero-padded sequence", () => {
+    expect(artFileName(1, "Angel of the Lord", "png")).toBe("01_angel-of-the-lord.png");
+    expect(artFileName(12, "Goliath!", "webp")).toBe("12_goliath.webp");
+  });
+  it("pads sequences beyond 99 without truncating", () => {
+    expect(artFileName(100, "X", "png")).toBe("100_x.png");
+  });
+  it("falls back to 'card' when the name has no slug characters", () => {
+    expect(artFileName(3, "   ", "png")).toBe("03_card.png");
+    expect(artFileName(4, "!!!", "png")).toBe("04_card.png");
+  });
+});

--- a/app/forge/lib/setArtwork.ts
+++ b/app/forge/lib/setArtwork.ts
@@ -53,6 +53,7 @@ export async function listSetApprovedArt(setId: string): Promise<ApprovedArt[]> 
   const { data: versions } = await ctx.supabase
     .from("card_versions")
     .select("id, card_id, version_number, data, art_key, art_original_key, art_is_placeholder")
+    .eq("status", "approved") // self-defend: don't lean solely on the approve RPC keeping these in lockstep
     .in("id", versionIds);
 
   return (versions ?? [])

--- a/app/forge/lib/setArtwork.ts
+++ b/app/forge/lib/setArtwork.ts
@@ -1,0 +1,67 @@
+// Set artwork export helpers. The pure helpers (artExt/artFileName) are unit-tested;
+// listSetApprovedArt is SERVER-ONLY (it reads private blob keys — never serialize its
+// result to a client component).
+import { requireForge } from "@/app/forge/lib/auth";
+
+const EXT_BY_TYPE: Record<string, string> = {
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/jpeg": "jpg",
+};
+
+/** Map a blob content-type to a file extension; 'img' for anything unknown. Pure. */
+export function artExt(contentType: string): string {
+  return EXT_BY_TYPE[contentType] ?? "img";
+}
+
+/** `{NN}_{slug}.{ext}` — zero-padded sequence, slugified name (fallback 'card'). Pure. */
+export function artFileName(seq: number, name: string, ext: string): string {
+  const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "card";
+  return `${String(seq).padStart(2, "0")}_${slug}.${ext}`;
+}
+
+export type ApprovedArt = {
+  cardId: string;
+  name: string;
+  key: string;
+  isPlaceholder: boolean;
+  versionNumber: number;
+};
+
+/**
+ * SERVER-ONLY. The approved cards of a set with exportable art, read under the
+ * caller's RLS (set-elder/superadmin can read the set's approved card_versions).
+ * Returns only entries with real, non-placeholder art. Carries blob keys — never
+ * pass the result to a client component; derive a boolean/count instead.
+ */
+export async function listSetApprovedArt(setId: string): Promise<ApprovedArt[]> {
+  const ctx = await requireForge();
+  if (!ctx) return [];
+
+  const { data: cards } = await ctx.supabase
+    .from("forge_cards")
+    .select("approved_version_id")
+    .eq("set_id", setId)
+    .eq("status", "approved")
+    .not("approved_version_id", "is", null);
+
+  const versionIds = (cards ?? [])
+    .map((c: any) => c.approved_version_id)
+    .filter((id: any): id is string => !!id);
+  if (versionIds.length === 0) return [];
+
+  const { data: versions } = await ctx.supabase
+    .from("card_versions")
+    .select("id, card_id, version_number, data, art_key, art_original_key, art_is_placeholder")
+    .in("id", versionIds);
+
+  return (versions ?? [])
+    .map((v: any) => ({
+      cardId: v.card_id as string,
+      name: (v.data?.name ?? "").toString(),
+      key: (v.art_original_key ?? v.art_key ?? "") as string,
+      isPlaceholder: !!v.art_is_placeholder,
+      versionNumber: (v.version_number ?? 0) as number,
+    }))
+    .filter((a: ApprovedArt) => a.key !== "" && !a.isPlaceholder);
+}

--- a/app/forge/sets/[setId]/progress/ProgressDashboard.tsx
+++ b/app/forge/sets/[setId]/progress/ProgressDashboard.tsx
@@ -17,10 +17,10 @@ function cellTone(actual: number, target: number): string {
 }
 
 export default function ProgressDashboard({
-  setId, model, targets, elders, addable, canEdit,
+  setId, model, targets, elders, addable, canEdit, hasApprovedArt,
 }: {
   setId: string; model: ProgressModel; targets: TargetCounts; elders: SetElder[];
-  addable: { userId: string; displayName: string | null }[]; canEdit: boolean;
+  addable: { userId: string; displayName: string | null }[]; canEdit: boolean; hasApprovedArt: boolean;
 }) {
   const live = model.headline.actual;
   return (
@@ -33,7 +33,25 @@ export default function ProgressDashboard({
           </div>
           <p className="text-xs text-muted-foreground">cards in set</p>
         </div>
-        {canEdit && <TargetsEditor setId={setId} initial={targets} />}
+        <div className="flex flex-wrap items-end gap-2">
+          {hasApprovedArt ? (
+            <a
+              href={`/forge/api/sets/${setId}/artwork`}
+              className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+            >
+              Download artwork (ZIP)
+            </a>
+          ) : (
+            <span
+              className="cursor-not-allowed rounded-md border px-3 py-1.5 text-sm text-muted-foreground opacity-50"
+              title="Approve cards with art to enable"
+              aria-disabled="true"
+            >
+              Download artwork (ZIP)
+            </span>
+          )}
+          {canEdit && <TargetsEditor setId={setId} initial={targets} />}
+        </div>
       </div>
 
       {/* status breakdown bar */}

--- a/app/forge/sets/[setId]/progress/page.tsx
+++ b/app/forge/sets/[setId]/progress/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { requireForge } from "@/app/forge/lib/auth";
 import { getSet, listSetCards, listSetElders } from "@/app/forge/lib/sets";
+import { listSetApprovedArt } from "@/app/forge/lib/setArtwork";
 import { computeProgress } from "@/app/forge/lib/progress";
 import ProgressDashboard from "./ProgressDashboard";
 
@@ -15,6 +16,8 @@ export default async function SetProgressPage({ params }: { params: Promise<{ se
   const cards = await listSetCards(setId);
   const model = computeProgress(cards.map((c) => ({ snapshot: c.snapshot, status: c.status })), set.targetCounts);
   const canEdit = ctx.role === "elder" || ctx.role === "superadmin";
+  // Server-side boolean only — the art list carries blob keys and must not reach the client.
+  const hasApprovedArt = (await listSetApprovedArt(setId)).length > 0;
 
   const elders = await listSetElders(setId);
   let addable: { userId: string; displayName: string | null }[] = [];
@@ -24,5 +27,5 @@ export default async function SetProgressPage({ params }: { params: Promise<{ se
     addable = (members ?? []).filter((m: any) => !onSet.has(m.user_id)).map((m: any) => ({ userId: m.user_id, displayName: m.display_name ?? null }));
   }
 
-  return <ProgressDashboard setId={setId} model={model} targets={set.targetCounts} elders={elders} addable={addable} canEdit={canEdit} />;
+  return <ProgressDashboard setId={setId} model={model} targets={set.targetCounts} elders={elders} addable={addable} canEdit={canEdit} hasApprovedArt={hasApprovedArt} />;
 }

--- a/docs/superpowers/plans/2026-06-25-forge-set-artwork-download.md
+++ b/docs/superpowers/plans/2026-06-25-forge-set-artwork-download.md
@@ -1,0 +1,357 @@
+# Forge Set Artwork Download (ZIP) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a set-level "Download artwork (ZIP)" action that streams the set's **approved** cards' full-res original illustrations as a ZIP, through the existing gated private-blob path.
+
+**Architecture:** A new gated GET route (`app/forge/api/sets/[setId]/artwork/route.ts`) mirrors the per-card art proxy: `requireForge()` → `getSet()` (null ⇒ 404) → read the approved cards' frozen `card_versions` art keys server-side under RLS → `readForgeArt()` each → in-memory `fflate` `zipSync` → stream as an attachment. A boolean `hasApprovedArt` (computed server-side) gates the button on the progress page. No migration (set-elder RLS already permits reading the set's approved versions). Art keys never cross to the client.
+
+**Tech Stack:** Next.js 15 App Router route handler, `@vercel/blob` private `get` (via `app/forge/lib/art.ts`), `fflate` (new dep), Supabase RLS-scoped reads, Vitest.
+
+## Global Constraints
+
+- **Leak boundary:** the route streams prerelease art. It must call `requireForge()` as its **first statement** and return **404** (`notFoundResponse()`), never 401/403, for non-members and non-set-elders. (`forge-gate-first` auto-scans every `app/forge/**/route.ts` for a `require(Forge|Elder|ForgeSuperadmin)(` call — the route passes that guardrail only by gating itself.)
+- **Set authorization = set-read:** reuse `getSet(setId)` — a non-null return means the caller can read the set under RLS (set-elder or superadmin); `null ⇒ notFoundResponse()`. Mirrors the progress page's `getSet → notFound` gate.
+- **Private-blob path only:** all bytes via `readForgeArt(key)` (`@/app/forge/lib/art`, `get(..., {access:'private'})`). **No public URL ever generated.** Response headers include `Cache-Control: private, no-store`. Route sets `export const dynamic = "force-dynamic"`.
+- **Art keys never reach the client.** `listSetApprovedArt()` is SERVER-ONLY and returns blob keys; the progress page passes only the derived boolean `hasApprovedArt` to the client component. (Consistent with 1a.3's `hasArt:boolean`-not-key rule.)
+- **Approved only:** include a card iff `forge_cards.status='approved'` with `approved_version_id` set, and the approved version's art is non-placeholder and present.
+- **No migration, no status change, no manifest, no PDF.** Pure read; raw illustration files only.
+- **strict:false tsconfig** — discriminated-union narrowing on `if (r.ok)` is broken; use `r.ok === false`. Only `npm run build` typechecks.
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `package.json` (modify) | Add `fflate` dependency. |
+| `app/forge/lib/setArtwork.ts` (create) | Pure `artExt(contentType)` + `artFileName(seq, name, ext)`; SERVER-ONLY `listSetApprovedArt(setId)` reader + `ApprovedArt` type. |
+| `app/forge/lib/__tests__/setArtwork.test.ts` (create) | Unit tests for the two pure helpers. |
+| `app/forge/api/sets/[setId]/artwork/route.ts` (create) | Gated GET → ZIP stream. |
+| `app/forge/sets/[setId]/progress/page.tsx` (modify) | Compute `hasApprovedArt`, pass to `ProgressDashboard`. |
+| `app/forge/sets/[setId]/progress/ProgressDashboard.tsx` (modify) | Render the "Download artwork (ZIP)" button (disabled when `!hasApprovedArt`). |
+
+---
+
+## Task 1: `fflate` dep + pure filename helpers (TDD)
+
+**Files:**
+- Modify: `package.json`
+- Create: `app/forge/lib/setArtwork.ts`
+- Test: `app/forge/lib/__tests__/setArtwork.test.ts`
+
+**Interfaces:**
+- Produces: `artExt(contentType: string): string`; `artFileName(seq: number, name: string, ext: string): string`.
+
+- [ ] **Step 1: Add the dependency**
+
+Run: `npm install fflate`
+Expected: `fflate` appears in `package.json` dependencies; `package-lock.json` updated.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `app/forge/lib/__tests__/setArtwork.test.ts`:
+```ts
+import { describe, it, expect } from "vitest";
+import { artExt, artFileName } from "@/app/forge/lib/setArtwork";
+
+describe("artExt", () => {
+  it("maps known image content types", () => {
+    expect(artExt("image/png")).toBe("png");
+    expect(artExt("image/webp")).toBe("webp");
+    expect(artExt("image/jpeg")).toBe("jpg");
+  });
+  it("falls back to 'img' for unknown types", () => {
+    expect(artExt("application/octet-stream")).toBe("img");
+    expect(artExt("")).toBe("img");
+  });
+});
+
+describe("artFileName", () => {
+  it("builds {NN}_{slug}.{ext} with a zero-padded sequence", () => {
+    expect(artFileName(1, "Angel of the Lord", "png")).toBe("01_angel-of-the-lord.png");
+    expect(artFileName(12, "Goliath!", "webp")).toBe("12_goliath.webp");
+  });
+  it("pads sequences beyond 99 without truncating", () => {
+    expect(artFileName(100, "X", "png")).toBe("100_x.png");
+  });
+  it("falls back to 'card' when the name has no slug characters", () => {
+    expect(artFileName(3, "   ", "png")).toBe("03_card.png");
+    expect(artFileName(4, "!!!", "png")).toBe("04_card.png");
+  });
+});
+```
+
+- [ ] **Step 3: Run RED**
+
+Run: `npx vitest run app/forge/lib/__tests__/setArtwork.test.ts`
+Expected: FAIL — cannot resolve `@/app/forge/lib/setArtwork`.
+
+- [ ] **Step 4: Implement the pure helpers**
+
+Create `app/forge/lib/setArtwork.ts`:
+```ts
+// Set artwork export helpers. The pure helpers (artExt/artFileName) are unit-tested;
+// listSetApprovedArt is SERVER-ONLY (it reads private blob keys — never serialize its
+// result to a client component).
+import { requireForge } from "@/app/forge/lib/auth";
+
+const EXT_BY_TYPE: Record<string, string> = {
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/jpeg": "jpg",
+};
+
+/** Map a blob content-type to a file extension; 'img' for anything unknown. Pure. */
+export function artExt(contentType: string): string {
+  return EXT_BY_TYPE[contentType] ?? "img";
+}
+
+/** `{NN}_{slug}.{ext}` — zero-padded sequence, slugified name (fallback 'card'). Pure. */
+export function artFileName(seq: number, name: string, ext: string): string {
+  const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "card";
+  return `${String(seq).padStart(2, "0")}_${slug}.${ext}`;
+}
+```
+
+- [ ] **Step 5: Run GREEN**
+
+Run: `npx vitest run app/forge/lib/__tests__/setArtwork.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json package-lock.json app/forge/lib/setArtwork.ts app/forge/lib/__tests__/setArtwork.test.ts
+git commit -m "feat(forge): fflate dep + artExt/artFileName helpers for set artwork export (TDD)"
+```
+
+---
+
+## Task 2: Approved-art reader + ZIP route
+
+**Files:**
+- Modify: `app/forge/lib/setArtwork.ts`
+- Create: `app/forge/api/sets/[setId]/artwork/route.ts`
+
+**Interfaces:**
+- Consumes: `artExt`, `artFileName` (Task 1); `requireForge`, `notFoundResponse` (`@/app/forge/lib/auth`); `getSet` (`@/app/forge/lib/sets`); `readForgeArt` (`@/app/forge/lib/art`); `zipSync` (`fflate`).
+- Produces: `type ApprovedArt = { cardId: string; name: string; key: string; isPlaceholder: boolean; versionNumber: number }`; `listSetApprovedArt(setId: string): Promise<ApprovedArt[]>` (returns only **exportable** entries — non-empty `key`, not placeholder).
+
+- [ ] **Step 1: Add the server reader to `setArtwork.ts`**
+
+Append to `app/forge/lib/setArtwork.ts`:
+```ts
+export type ApprovedArt = {
+  cardId: string;
+  name: string;
+  key: string;
+  isPlaceholder: boolean;
+  versionNumber: number;
+};
+
+/**
+ * SERVER-ONLY. The approved cards of a set with exportable art, read under the
+ * caller's RLS (set-elder/superadmin can read the set's approved card_versions).
+ * Returns only entries with real, non-placeholder art. Carries blob keys — never
+ * pass the result to a client component; derive a boolean/count instead.
+ */
+export async function listSetApprovedArt(setId: string): Promise<ApprovedArt[]> {
+  const ctx = await requireForge();
+  if (!ctx) return [];
+
+  const { data: cards } = await ctx.supabase
+    .from("forge_cards")
+    .select("approved_version_id")
+    .eq("set_id", setId)
+    .eq("status", "approved")
+    .not("approved_version_id", "is", null);
+
+  const versionIds = (cards ?? [])
+    .map((c: any) => c.approved_version_id)
+    .filter((id: any): id is string => !!id);
+  if (versionIds.length === 0) return [];
+
+  const { data: versions } = await ctx.supabase
+    .from("card_versions")
+    .select("id, card_id, version_number, data, art_key, art_original_key, art_is_placeholder")
+    .in("id", versionIds);
+
+  return (versions ?? [])
+    .map((v: any) => ({
+      cardId: v.card_id as string,
+      name: (v.data?.name ?? "").toString(),
+      key: (v.art_original_key ?? v.art_key ?? "") as string,
+      isPlaceholder: !!v.art_is_placeholder,
+      versionNumber: (v.version_number ?? 0) as number,
+    }))
+    .filter((a: ApprovedArt) => a.key !== "" && !a.isPlaceholder);
+}
+```
+
+- [ ] **Step 2: Create the route**
+
+Create `app/forge/api/sets/[setId]/artwork/route.ts`:
+```ts
+import { requireForge, notFoundResponse } from "@/app/forge/lib/auth";
+import { getSet } from "@/app/forge/lib/sets";
+import { listSetApprovedArt, artExt, artFileName } from "@/app/forge/lib/setArtwork";
+import { readForgeArt } from "@/app/forge/lib/art";
+import { zipSync } from "fflate";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ setId: string }> }
+): Promise<Response> {
+  const ctx = await requireForge();
+  if (!ctx) return notFoundResponse(); // 404, never 401/403 — the area stays secret
+
+  const { setId } = await params;
+  const set = await getSet(setId);
+  if (!set) return notFoundResponse(); // not readable under RLS ⇒ not a set-elder/super
+
+  const arts = await listSetApprovedArt(setId);
+  if (arts.length === 0) return notFoundResponse(); // nothing to export (indistinguishable 404)
+
+  // Stable order: version number, then name.
+  arts.sort((a, b) => a.versionNumber - b.versionNumber || a.name.localeCompare(b.name));
+
+  const files: Record<string, Uint8Array> = {};
+  let seq = 0;
+  for (const art of arts) {
+    let result;
+    try {
+      result = await readForgeArt(art.key);
+    } catch {
+      continue; // skip a missing/failed blob rather than failing the whole export
+    }
+    if (!result || result.statusCode !== 200) continue;
+    const bytes = new Uint8Array(await new Response(result.stream).arrayBuffer());
+    seq += 1;
+    files[artFileName(seq, art.name, artExt(result.blob.contentType))] = bytes;
+  }
+  if (Object.keys(files).length === 0) return notFoundResponse();
+
+  // Images are already compressed → store (level 0), don't waste CPU recompressing.
+  const zip = zipSync(files, { level: 0 });
+
+  return new Response(zip, {
+    headers: {
+      "Content-Type": "application/zip",
+      "Content-Disposition": `attachment; filename="${set.slug}-artwork.zip"`,
+      "Cache-Control": "private, no-store",
+    },
+  });
+}
+```
+(The `{NN}_` sequence prefix makes every filename unique, so no collision handling is needed.)
+
+- [ ] **Step 3: Build**
+
+Run: `npm run build`
+Expected: clean compile; the new route appears in the route manifest. Fix any type errors (e.g. `result` narrowing — `strict:false`, so guard with `if (!result || result.statusCode !== 200)` as written).
+
+- [ ] **Step 4: Confirm the gate-first guardrail still passes (route auto-covered)**
+
+Run: `npx vitest run __tests__/forge-gate-first.test.ts`
+Expected: PASS — the new `app/forge/api/sets/[setId]/artwork/route.ts` is auto-scanned and recognized as gated (it calls `requireForge`). If it FAILS naming the new route, the gate call is missing — add it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/forge/lib/setArtwork.ts app/forge/api/sets/[setId]/artwork/route.ts
+git commit -m "feat(forge): gated set-artwork ZIP route + approved-art reader"
+```
+
+---
+
+## Task 3: "Download artwork" button on the progress page
+
+**Files:**
+- Modify: `app/forge/sets/[setId]/progress/page.tsx`
+- Modify: `app/forge/sets/[setId]/progress/ProgressDashboard.tsx`
+
+**Interfaces:**
+- Consumes: `listSetApprovedArt` (Task 2).
+- Produces: `ProgressDashboard` gains a `hasApprovedArt: boolean` prop.
+
+- [ ] **Step 1: Compute `hasApprovedArt` in the page (server-side) and pass it down**
+
+In `app/forge/sets/[setId]/progress/page.tsx`, add the import and the computation, then pass the boolean to `<ProgressDashboard>`:
+```ts
+import { listSetApprovedArt } from "@/app/forge/lib/setArtwork";
+// ...after `const cards = await listSetCards(setId);`
+const hasApprovedArt = (await listSetApprovedArt(setId)).length > 0;
+```
+Add `hasApprovedArt={hasApprovedArt}` to the `<ProgressDashboard ... />` props. **Do not** pass the art list itself — only the boolean (it must not carry blob keys to the client).
+
+- [ ] **Step 2: Render the button in `ProgressDashboard.tsx`**
+
+Add `hasApprovedArt: boolean` to the component's props type. Render a download control in the dashboard header area (near the set title / actions). Use the existing button styling in that file; do **not** add `focus:ring-*`. When enabled it's a plain anchor to the route (browser handles the download); when disabled it's a non-interactive, muted element with a hint:
+```tsx
+{hasApprovedArt ? (
+  <a
+    href={`/forge/api/sets/${setId}/artwork`}
+    className="<match the file's existing button/secondary-action classes>"
+  >
+    Download artwork (ZIP)
+  </a>
+) : (
+  <span
+    className="<same classes + an opacity-50/cursor-not-allowed muted variant>"
+    title="Approve cards with art to enable"
+    aria-disabled="true"
+  >
+    Download artwork (ZIP)
+  </span>
+)}
+```
+(`setId` is already a prop of `ProgressDashboard`.)
+
+- [ ] **Step 3: Build**
+
+Run: `npm run build`
+Expected: clean compile across `page.tsx` and `ProgressDashboard.tsx`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "app/forge/sets/[setId]/progress/page.tsx" "app/forge/sets/[setId]/progress/ProgressDashboard.tsx"
+git commit -m "feat(forge): Download artwork (ZIP) button on set progress page"
+```
+
+---
+
+## Task 4: Whole-feature verification + PR
+
+**Files:** none (verification + docs).
+
+- [ ] **Step 1: Gates**
+
+Run and confirm:
+- `npx vitest run app/forge/lib/__tests__/setArtwork.test.ts __tests__/forge-gate-first.test.ts` → green (helpers + gate-first incl. the new route).
+- `npm test` → green except the one known pre-existing unrelated `store-route` failure (record the pass count).
+- `npm run build` → clean.
+
+- [ ] **Step 2: Manual smoke** (record in the PR)
+
+As a set-elder: a set with ≥1 approved card with real art → the button is enabled → clicking downloads `{set-slug}-artwork.zip` containing `{NN}_{slug}.{ext}` files that open as the correct images. A set with only drafts/placeholders → the button is disabled with the hint. Confirm a non-member / non-set-elder GET of `/forge/api/sets/{id}/artwork` returns 404.
+
+- [ ] **Step 3: Update memory + open PR**
+
+Add a short note to `project_forge_playtesting.md` (set artwork download shipped: branch, the route + `setArtwork.ts`, approved-only, no migration, fflate). Then:
+```bash
+git push -u origin forge-set-artwork-download
+gh pr create --title "The Forge — Set artwork download (ZIP)" --body "<summary + manual-smoke results>"
+```
+
+---
+
+## Self-review (completed during planning)
+
+- **Spec coverage:** approved-only filter (Task 2 reader), gated route + 404 + private-blob path (Task 2), `{NN}_{slug}.{ext}` naming + ext-from-contentType (Tasks 1–2), disabled-when-empty button (Task 3), no migration / no status change / art-only (whole plan), guardrail coverage (Task 2 Step 4 + Task 4). All spec sections map to a task.
+- **Placeholders:** none — real code/commands in every step. The one intentional "match existing classes" note in Task 3 is a styling instruction, not a logic placeholder (the file's own button styles are the source).
+- **Type consistency:** `ApprovedArt` defined in Task 2 and consumed by the Task 2 route + Task 3 page; `artExt`/`artFileName` signatures identical across Tasks 1–2; `hasApprovedArt: boolean` defined in Task 3 page → ProgressDashboard prop.
+- **Soft spot flagged:** the implementer must read `ProgressDashboard.tsx` for its existing button classes and a sensible header placement (Task 3 Step 2).

--- a/docs/superpowers/specs/2026-06-25-forge-set-artwork-download-design.md
+++ b/docs/superpowers/specs/2026-06-25-forge-set-artwork-download-design.md
@@ -1,0 +1,85 @@
+# The Forge — Set Artwork Download (ZIP)
+
+**Date:** 2026-06-25
+**Branch:** `forge-set-artwork-download`
+**Scope:** A standalone Phase-1 capstone (the slimmed-down survivor of the deferred "download all for printer" idea). Not a numbered 1a/1b slice.
+
+---
+
+## Context
+
+The Forge design toolset is complete through Phase 1b (studio, sets, lifecycle/versions, private art, review layer, realtime). The master spec's "Promotion & Print Export" called for a "Download all for printer" feature; after brainstorming we **dropped the print-ready PDF / card-face compositing entirely** (non-trivial, low near-term value) and kept only the genuinely useful core: **let a set's elders bulk-download the finished artwork.**
+
+Per-card art download already exists (the art proxy `app/forge/api/art/[cardId]/route.ts` supports `?download=1` → attachment + audit, built in 1a.3). The gap is a **set-level bulk download**.
+
+---
+
+## Goal / non-goals
+
+**Goal:** A "Download artwork (ZIP)" action on a set that streams a ZIP of the **approved** cards' full-res original illustrations, via the existing gated private-blob path. Art keys never reach the client.
+
+**Non-goals:**
+- No print-ready PDF, no tiled imposition, no bleed/crop marks, no card-face compositing (frame+text). **Raw illustrations only.**
+- No manifest/CSV (just the art files).
+- No status change — pure read. The `promoted` status + public-pool promotion remain Phase 2.
+- No draft/playtesting art — **approved cards only.**
+
+---
+
+## Behaviour
+
+**Which art.** For every card in the set whose `status='approved'` (i.e. `approved_version_id` is set), read that frozen `card_versions` row and take `art_original_key` (full-res original), falling back to `art_key` when `art_original_key` is null. **Skip** any approved card whose chosen art is a placeholder (`art_is_placeholder`) or missing (both keys null) — those simply don't appear in the ZIP.
+
+**ZIP contents.** One file per included card, named `{NN}_{card-slug}.{ext}`:
+- `NN` = a 2+-digit sequence (by `version_number` then name) for stable ordering.
+- `card-slug` = slugified card name (from the version's `data.name`).
+- `ext` = derived from the blob's `contentType` (`image/png`→`png`, `image/webp`→`webp`, `image/jpeg`→`jpg`) — fixes the 1a.3 "Content-Disposition has no extension" follow-up.
+- Collisions (same slug) get the `NN` prefix to stay unique.
+
+**Empty case.** A set with zero qualifying cards: the UI button is **disabled** with a hint ("No approved card art yet"); if the route is hit directly with nothing to export it returns **404** (indistinguishable from the not-authorized 404 — no information about set contents leaks).
+
+---
+
+## Architecture
+
+**Route** — `GET app/forge/api/sets/[setId]/artwork/route.ts` (mirrors the per-card art proxy):
+1. `requireForge()` first statement → if not a member, **404**.
+2. Authorize: the caller must be a **set-elder of this set or superadmin** (the set-read rule). Otherwise **404**. (Reuse the existing set-read check / `getSet` → notFound pattern, or `is_forge_set_elder` ∨ `is_forge_superadmin`.)
+3. `export const dynamic = 'force-dynamic'`; response headers `Cache-Control: private, no-store`.
+4. Read the approved cards' art keys **server-side** (RLS-scoped query on the caller's `ctx.supabase`, or a small definer helper if RLS blocks reading a set's approved `card_versions` — confirmed during planning). Keys stay in the route; never serialized to the client.
+5. For each key, `get(key, { access: 'private' })` (the `app/forge/lib/art.ts` helper) → bytes + contentType. Tolerate a missing/failed blob by skipping that card (don't fail the whole export); if the result is indistinguishable-404 like the proxy, skip.
+6. Assemble an **in-memory ZIP** with **`fflate`** (`zipSync`) — card counts are small (tens), so in-memory is fine and simplest.
+7. Respond `200` with the ZIP bytes, `Content-Type: application/zip`, `Content-Disposition: attachment; filename="{set-slug}-artwork.zip"`, `Cache-Control: private, no-store`.
+
+**UI** — on `app/forge/sets/[setId]/progress/` (the gate's UI): a "Download artwork (ZIP)" control. It's a plain link/anchor to the route (`<a href="/forge/api/sets/{id}/artwork">`), so the browser performs the download; **no art keys or blob bytes pass through any client prop.** The server page computes a boolean `hasApprovedArt` (count of approved cards with non-placeholder art > 0) and disables the control with a hint when false.
+
+**Audit (optional, lightweight).** One `forge_audit` entry per bulk download (reuse `forge_log_art_download` per included card, or a single set-level event). Non-blocking; include if cheap.
+
+**Dependency.** Add `fflate` (tiny, zero-dependency). No other new deps.
+
+---
+
+## Security
+
+This is a leak-sensitive surface (it streams prerelease art bytes), handled exactly like the per-card proxy:
+- The route **gates first** (`requireForge` as the first statement, then the set-elder check) — satisfies the `forge-gate-first` guardrail (every `/forge` surface gates itself; there is no `/forge` middleware).
+- Non-member / non-set-elder → **404**, indistinguishable from "set has no exportable art."
+- All bytes flow through the **private-blob `get(..., {access:'private'})`** path; **no public URL is ever generated**; `Cache-Control: private, no-store`.
+- **Art keys never cross to the client** (consistent with 1a.3's `hasArt:boolean`-not-key rule).
+- **Guardrail coverage:** extend the Forge test guardrails so the new route is asserted to 404 for anon / non-member (and `forge-gate-first` recognizes the route gates itself).
+
+---
+
+## Testing
+
+- **Pure unit tests** for the two pure helpers: the filename builder (`{NN}_{slug}.{ext}` from name + contentType, collision-safe) and the content-type→extension map. TDD, hermetic.
+- **Guardrail:** anon / non-member `GET /forge/api/sets/{id}/artwork` → 404 (extend `forge-anon-leak` live probes and/or `forge-gate-first`).
+- `npm run build` clean; `npm test` green (allowing the one pre-existing unrelated `store-route` failure).
+- **Manual smoke:** as a set-elder, approve ≥1 card with real art, click "Download artwork" → a ZIP with correctly-named files downloads; a set with only placeholders/drafts shows the disabled button.
+
+---
+
+## Open items resolved during planning
+
+- Exact set-read predicate to reuse for the route gate (`getSet`/`is_forge_set_elder`) and whether a definer helper is needed to read approved `card_versions` art keys under RLS.
+- Whether `get()` returns `contentType` reliably for ext derivation (the proxy already relies on it).

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "canvas-confetti": "^1.9.4",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "fflate": "^0.8.3",
         "flowbite-react": "^0.10.2",
         "framer-motion": "^12.34.3",
         "geist": "^1.2.1",
@@ -6168,6 +6169,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "fflate": "^0.8.3",
     "flowbite-react": "^0.10.2",
     "framer-motion": "^12.34.3",
     "geist": "^1.2.1",


### PR DESCRIPTION
## The Forge — Set artwork download (ZIP)

A "Download artwork (ZIP)" action on a set's progress page that streams the set's **approved** cards' full-res original illustrations as a ZIP, through the existing gated private-blob path.

This is the slimmed-down survivor of the old "download all for printer" idea — the print-ready PDF / card-face compositing was dropped; this is **raw illustration files only**, approved cards only, no manifest, no status change.

Spec: `docs/superpowers/specs/2026-06-25-forge-set-artwork-download-design.md` · Plan: `docs/superpowers/plans/2026-06-25-forge-set-artwork-download.md`

### How it works
- **Route** `GET /forge/api/sets/[setId]/artwork` (mirrors the per-card art proxy): `requireForge()` → 404 for non-members; `getSet(setId)` null → 404 (= set-elder/superadmin gate under RLS); reads the approved cards' frozen `card_versions` art keys **server-side under RLS**; `readForgeArt()` each → in-memory `fflate` `zipSync` (level 0) → `attachment; filename="{set-slug}-artwork.zip"`, `Cache-Control: private, no-store`.
- Files named `{NN}_{slug}.{ext}` (extension derived from the blob content-type — fixes the 1a.3 "no extension" follow-up).
- **No migration** — a set-elder can already read their set's approved `card_versions` under existing RLS.
- **Button** on the progress page: enabled `<a>` when the set has approved card art, disabled with a hint otherwise. Only a boolean crosses to the client — **art keys never leave the server**.

### Security
Same leak boundary as the per-card art proxy: gates first (auto-covered by the `forge-gate-first` guardrail), 404-only and indistinguishable for non-members / non-set-elders / empty sets, all bytes via the private-blob `get({access:'private'})` path, no public URL, `private, no-store`. Opus security review: **merge-ready** — gate chain correct, blob keys never reach the client, approved-only enforced at the DB. Applied its one hardening (`status='approved'` filter on the version read).

### Verification
- `npm test`: 955 passed, 1 pre-existing unrelated fail (`threshingfloor/store-route`), 2 skipped. `npm run build`: clean. `forge-gate-first`: 15/15 (new route auto-covered). New `setArtwork` helper unit tests: 5/5.
- New dep: `fflate` (tiny, zero-dependency).

### Manual smoke (pending — no creds in session)
As a set-elder: approve ≥1 card with real art → button enabled → downloads `{set-slug}-artwork.zip` with correctly-named image files; a set with only drafts/placeholders → disabled button; non-member GET of the route → 404.

### Note
When Phase-2 set-grants activate, granted viewers will also be able to download approved art (by design — a granted viewer is a read-viewer of the set's approved cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
