### PR TITLE
fix(nationals-history): restore Data Coverage disclaimer + Threshing Floor credit

### DIFF
--- a/app/tournaments/history/components/DataCoverageModal.tsx
+++ b/app/tournaments/history/components/DataCoverageModal.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { HiX } from "react-icons/hi";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogBody } from "@/components/ui/dialog";
+
+interface DataCoverageModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const FULL_DATA_ROWS: Array<[string, string]> = [
+  ["T1 2-Player", "2003–present (all years)"],
+  ["T2 2-Player", "2004–present (missing 2019)"],
+  ["Sealed", "2003–present (missing 2004)"],
+  ["Booster Draft (2P)", "2005–present (missing 2015)"],
+  ["Teams", "2010–present (missing 2014)"],
+  ["Type A", "2005–present (missing several years due to insufficient participation)"],
+  ["T1 Multiplayer", "2004–2021 (missing 2015; retired after 2021)"],
+  ["T2 Multiplayer", "2004–2021 (missing 2015; retired after 2021)"],
+  ["Booster Draft (Multi)", "2005–2017 (missing 2015; retired after 2017)"],
+];
+
+export function DataCoverageModal({ open, onClose }: DataCoverageModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent size="lg" className="max-w-xl">
+        <DialogHeader className="relative">
+          <DialogTitle>Data Coverage Details</DialogTitle>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="absolute right-4 top-4 text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <HiX className="h-4 w-4" />
+          </button>
+        </DialogHeader>
+        <DialogBody className="space-y-5 text-sm leading-relaxed text-muted-foreground">
+          <section className="space-y-2">
+            <h3 className="font-semibold text-foreground">Full Standings (2003–present)</h3>
+            <p>
+              Complete player standings are available from 2003 through the present for most
+              formats. The following formats have full data for the years listed:
+            </p>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="border-b border-border">
+                    <th className="px-2.5 py-1.5 text-left font-semibold uppercase tracking-wide text-muted-foreground">
+                      Format
+                    </th>
+                    <th className="px-2.5 py-1.5 text-left font-semibold uppercase tracking-wide text-muted-foreground">
+                      Full Data Available
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {FULL_DATA_ROWS.map(([fmt, coverage]) => (
+                    <tr key={fmt} className="border-b border-border/60">
+                      <td className="px-2.5 py-1.5 text-foreground">{fmt}</td>
+                      <td className="px-2.5 py-1.5">{coverage}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="space-y-2">
+            <h3 className="font-semibold text-foreground">Early Years (1995–2002)</h3>
+            <p>
+              Records from 1995–2002 are incomplete — only some top-3 placings were preserved from
+              this era. These years are excluded from Avg Placement and Soul Differential metrics,
+              but top-3 finishes <em>are</em> counted in Podium Finishes (marked with * in
+              Appearances). No match-level W/L data exists for these years.
+            </p>
+          </section>
+
+          <section className="space-y-2">
+            <h3 className="font-semibold text-foreground">Match Records (W/L)</h3>
+            <p>
+              Head-to-head match records for 2-player formats cover 2003 through the present.
+              Multiplayer W/L records cover 2005–2021 for T1 &amp; T2 Multiplayer and 2005–2017 for
+              Booster Draft (Multi), sourced from tournament spreadsheets and software exports.
+            </p>
+          </section>
+
+          <section className="space-y-2">
+            <h3 className="font-semibold text-foreground">Win % Calculations</h3>
+            <p>
+              Draws are excluded from Win % — only decisive games (W+L) are counted in the
+              denominator. Multiplayer Win % is calculated separately from 2-Player Win % and not
+              combined.
+            </p>
+          </section>
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/tournaments/history/page.tsx
+++ b/app/tournaments/history/page.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { Suspense } from "react";
 import TopNav from "@/components/top-nav";
 import SponsorFooter from "@/components/sponsor-footer";
@@ -19,6 +20,34 @@ export default async function Page() {
         <Suspense fallback={null}>
           <HistoryClient initialLeaderboard={initialLeaderboard} />
         </Suspense>
+
+        {/* Attribution — the supplied logo is the white-wordmark (dark-bg)
+            variant, so it sits on a dark branded badge to stay legible in
+            both light and dark themes. */}
+        <div className="border-t border-border">
+          <div className="mx-auto max-w-6xl px-4 py-8">
+            <a
+              href="https://thethreshingfloorpodcast.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mx-auto flex max-w-xs flex-col items-center gap-3 rounded-xl bg-zinc-900 px-6 py-6 text-center ring-1 ring-white/10 transition hover:ring-white/25"
+            >
+              <Image
+                src="/threshingfloor/the-threshing-floor-logo-wheat-light-tag.png"
+                alt="The Threshing Floor"
+                width={120}
+                height={128}
+                className="h-20 w-auto"
+              />
+              <span className="text-sm text-zinc-300">
+                Nationals History brought to you by{" "}
+                <span className="font-semibold text-white">
+                  The Threshing Floor
+                </span>
+              </span>
+            </a>
+          </div>
+        </div>
       </div>
       <SponsorFooter />
     </div>

--- a/app/tournaments/history/views/MetricsView.tsx
+++ b/app/tournaments/history/views/MetricsView.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useReducer, useMemo, useRef, useEffect, useCallback } from "react";
+import { useReducer, useMemo, useRef, useEffect, useCallback, useState } from "react";
 import { useSeed } from "../seed-context";
 import { SectionTitle } from "../components/SectionTitle";
 import { EmptyState } from "../components/EmptyState";
+import { DataCoverageModal } from "../components/DataCoverageModal";
 import {
   AM_MODES,
   AM_COLS,
@@ -546,6 +547,9 @@ export function MetricsView() {
     return () => document.removeEventListener("mousedown", handleDocClick);
   }, [handleDocClick]);
 
+  // Data-coverage disclaimer modal
+  const [coverageOpen, setCoverageOpen] = useState(false);
+
   // ── Handlers ────────────────────────────────────────────────────────────────
 
   function handleFmtSelectChange(val: string) {
@@ -580,6 +584,20 @@ export function MetricsView() {
   return (
     <div>
       <SectionTitle title="Advanced Metrics" sub={subtitle} />
+
+      {/* Data coverage disclaimer — not all years/formats have full data */}
+      <div className="mb-4 flex flex-wrap items-center gap-x-2 gap-y-1 rounded-lg border border-border bg-muted/50 px-3.5 py-2.5 text-xs text-muted-foreground">
+        <span>⚠️ Data not available for all years and formats.</span>
+        <button
+          type="button"
+          onClick={() => setCoverageOpen(true)}
+          className="font-medium text-primary underline-offset-2 hover:underline"
+        >
+          Click for details
+        </button>
+      </div>
+
+      <DataCoverageModal open={coverageOpen} onClose={() => setCoverageOpen(false)} />
 
       {/* Mode tabs */}
       <div className="flex flex-wrap gap-1.5 mb-3">


### PR DESCRIPTION
## What

Two small fixes to the new **Nationals History** page (`/tournaments/history`), which was rebuilt in React in #134:

1. **Restore the lost data disclaimer.** The original standalone HTML showed a *"⚠️ Data not available for all years and formats — Click for details"* banner on the Advanced Metrics view, opening a **Data Coverage Details** modal (full-standings coverage table, the 1995–2002 early-years caveat, match-record W/L coverage, and Win % methodology). That disclaimer didn't carry over in the React rebuild, so it's restored here via a new `DataCoverageModal` component, wired into the Advanced Metrics view.

2. **Add Threshing Floor attribution.** A *"Nationals History brought to you by The Threshing Floor"* footer at the bottom of the page, mirroring the existing RNRS Points page attribution.

## Notes

- The disclaimer wording was taken verbatim from the original `nationals-history (36).html` source export (now deleted locally).
- The attribution block reuses the exact pattern/markup from `app/tournaments/rnrs-points/page.tsx`.
- Branched from `main` (where the Nationals History page lives), independent of in-flight work on other branches.

## Verify

- Visit `/tournaments/history` → **Advanced Metrics** tab → see the disclaimer banner; click "Click for details" to open the coverage modal.
- Scroll to the bottom of the page → see the Threshing Floor badge linking to the podcast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)