### PR TITLE
Update selectors.ts to fix teams w/l doubling

### DIFF
--- a/lib/nationals/selectors.test.ts
+++ b/lib/nationals/selectors.test.ts
@@ -73,6 +73,35 @@ describe("headToHead", () => {
   });
 });
 
+describe("playerProfile Teams record (per-round, not per-game)", () => {
+  it("counts one W/L/D per team round for a clean player (no per-game doubling)", () => {
+    // Chris Ericson has 22 Teams game records across 11 unanimous rounds.
+    // Per-round = 9-2-0; the per-game bug would report 18-4-0.
+    const p = playerProfile(data, "Chris Ericson");
+    expect(p.matchStatsByFmt["Teams"]).toEqual({ wins: 9, losses: 2, draws: 0 });
+  });
+
+  it("resolves split Teams rounds by majority with ties as draws (order-independent)", () => {
+    // Andrew Wills, 2013 Teams: three 2-2 rounds (each W/L split) -> 3 draws.
+    // Per-round majority = 3-5-3; first-encountered (the PR bug) = 3-8-0;
+    // raw per-game = 18-26-0.
+    const p = playerProfile(data, "Andrew Wills");
+    expect(p.matchStatsByFmt["Teams"]).toEqual({ wins: 3, losses: 5, draws: 3 });
+  });
+
+  it("keeps full per-game head-to-head credit for Teams cross-pairings", () => {
+    // Head-to-head must not be collapsed per round: Wills met two distinct
+    // opponents per 2013 round, so each is credited separately.
+    const p = playerProfile(data, "Andrew Wills");
+    const oppGames = Object.values(p.matchStatsByOpp).reduce(
+      (s, v) => s + v.wins + v.losses + v.draws,
+      0
+    );
+    // Per-round Teams total is 11 (3+5+3); per-game H2H must exceed it.
+    expect(oppGames).toBeGreaterThan(11);
+  });
+});
+
 describe("playerProfile multiWL", () => {
   it("returns numeric totals and an object for a player with multiplayer data", () => {
     // Pick the first player listed in multiWL so we exercise the typed path

--- a/lib/nationals/selectors.ts
+++ b/lib/nationals/selectors.ts
@@ -237,13 +237,14 @@ export function playerProfile(seed: NationalsData, name: string): PlayerProfile 
     const i = key.indexOf("_");
     const year = parseInt(key.slice(0, i), 10);
     const fmt = key.slice(i + 1);
-
-    // Teams matches are stored as 4 cross-pairings per round (P1vP3, P1vP4, P2vP3, P2vP4)
-    // so each player appears in 2 records per round. We want full head-to-head credit for
-    // every individual opponent pairing, but only one W/L credit per round toward format
-    // totals and allMatches (to avoid doubling the aggregate record).
     const isTeams = fmt === "Teams";
-    const creditedRounds = new Set<string>();
+
+    // Teams is team-vs-team: each player plays every opposing player, so a player
+    // has multiple cross-pairing records per round. Head-to-head keeps full per-game
+    // credit, but the format record should count one result per team round. Tally
+    // this player's games per round, then collapse by majority (tie -> draw).
+    // Round labels are unique within a year+format key, so a plain map is safe.
+    const roundTally: Record<string, WLDRecord> = {};
 
     for (const m of matches) {
       if (m.playerA !== name && m.playerB !== name) continue;
@@ -253,22 +254,40 @@ export function playerProfile(seed: NationalsData, name: string): PlayerProfile 
       const lost = !!m.winner && m.winner !== name;
       const draw = !m.winner;
 
-      // Always credit head-to-head vs this specific opponent regardless of format.
+      // Head-to-head: always full per-game credit, every format.
       if (!matchStatsByOpp[opp]) matchStatsByOpp[opp] = { wins: 0, losses: 0, draws: 0 };
       if (won) matchStatsByOpp[opp].wins++;
       else if (lost) matchStatsByOpp[opp].losses++;
       else if (draw) matchStatsByOpp[opp].draws++;
 
-      // For Teams format, only count one W/L per round toward format totals and allMatches.
-      if (isTeams && creditedRounds.has(m.round)) continue;
-      if (isTeams) creditedRounds.add(m.round);
+      // Keep every individual game in allMatches (only consumed for top-cut and a
+      // non-empty flag; no Teams record has topCut, so this is pure data fidelity).
+      allMatches.push({ year, format: fmt, ...m });
 
+      if (isTeams) {
+        // Defer format credit until the whole round is aggregated.
+        if (!roundTally[m.round]) roundTally[m.round] = { wins: 0, losses: 0, draws: 0 };
+        if (won) roundTally[m.round].wins++;
+        else if (lost) roundTally[m.round].losses++;
+        else if (draw) roundTally[m.round].draws++;
+        continue;
+      }
+
+      // Non-Teams: one record == one game == one format credit.
       if (!matchStatsByFmt[fmt]) matchStatsByFmt[fmt] = { wins: 0, losses: 0, draws: 0 };
       if (won) matchStatsByFmt[fmt].wins++;
       else if (lost) matchStatsByFmt[fmt].losses++;
       else if (draw) matchStatsByFmt[fmt].draws++;
+    }
 
-      allMatches.push({ year, format: fmt, ...m });
+    // Teams: collapse each round into a single W/L/D by majority of its games.
+    if (isTeams) {
+      for (const t of Object.values(roundTally)) {
+        if (!matchStatsByFmt[fmt]) matchStatsByFmt[fmt] = { wins: 0, losses: 0, draws: 0 };
+        if (t.wins > t.losses) matchStatsByFmt[fmt].wins++;
+        else if (t.losses > t.wins) matchStatsByFmt[fmt].losses++;
+        else matchStatsByFmt[fmt].draws++;
+      }
     }
   }
 

--- a/lib/nationals/selectors.ts
+++ b/lib/nationals/selectors.ts
@@ -238,6 +238,13 @@ export function playerProfile(seed: NationalsData, name: string): PlayerProfile 
     const year = parseInt(key.slice(0, i), 10);
     const fmt = key.slice(i + 1);
 
+    // Teams matches are stored as 4 cross-pairings per round (P1vP3, P1vP4, P2vP3, P2vP4)
+    // so each player appears in 2 records per round. We want full head-to-head credit for
+    // every individual opponent pairing, but only one W/L credit per round toward format
+    // totals and allMatches (to avoid doubling the aggregate record).
+    const isTeams = fmt === "Teams";
+    const creditedRounds = new Set<string>();
+
     for (const m of matches) {
       if (m.playerA !== name && m.playerB !== name) continue;
 
@@ -246,19 +253,20 @@ export function playerProfile(seed: NationalsData, name: string): PlayerProfile 
       const lost = !!m.winner && m.winner !== name;
       const draw = !m.winner;
 
-      if (!matchStatsByFmt[fmt]) matchStatsByFmt[fmt] = { wins: 0, losses: 0, draws: 0 };
+      // Always credit head-to-head vs this specific opponent regardless of format.
       if (!matchStatsByOpp[opp]) matchStatsByOpp[opp] = { wins: 0, losses: 0, draws: 0 };
+      if (won) matchStatsByOpp[opp].wins++;
+      else if (lost) matchStatsByOpp[opp].losses++;
+      else if (draw) matchStatsByOpp[opp].draws++;
 
-      if (won) {
-        matchStatsByFmt[fmt].wins++;
-        matchStatsByOpp[opp].wins++;
-      } else if (lost) {
-        matchStatsByFmt[fmt].losses++;
-        matchStatsByOpp[opp].losses++;
-      } else if (draw) {
-        matchStatsByFmt[fmt].draws++;
-        matchStatsByOpp[opp].draws++;
-      }
+      // For Teams format, only count one W/L per round toward format totals and allMatches.
+      if (isTeams && creditedRounds.has(m.round)) continue;
+      if (isTeams) creditedRounds.add(m.round);
+
+      if (!matchStatsByFmt[fmt]) matchStatsByFmt[fmt] = { wins: 0, losses: 0, draws: 0 };
+      if (won) matchStatsByFmt[fmt].wins++;
+      else if (lost) matchStatsByFmt[fmt].losses++;
+      else if (draw) matchStatsByFmt[fmt].draws++;
 
       allMatches.push({ year, format: fmt, ...m });
     }


### PR DESCRIPTION
Problem: 
Teams format matches are stored as 4 cross-pairings per round (every player vs every opponent). Each player appears in 2 records per round, causing W/L totals to double.

Fix: 
Added a creditedRounds set that tracks which rounds have already been counted toward matchStatsByFmt and allMatches. Head-to-head (matchStatsByOpp) still gets full credit for every individual pairing. The deduplication only applies when fmt === "Teams", so no other formats are affected.