### PR TITLE
Forge: Missives — elder→playtester email announcements

### DIFF
--- a/app/forge/components/ForgeNav.tsx
+++ b/app/forge/components/ForgeNav.tsx
@@ -24,6 +24,7 @@ export default function ForgeNav({ role }: { role: ForgeRole }) {
           { href: "/forge/ideas", label: "Ideas", match: (p) => p.startsWith("/forge/ideas") },
           { href: "/forge/sets", label: "Sets", match: (p) => p.startsWith("/forge/sets") },
           { href: "/forge/play", label: "Play", match: (p) => p.startsWith("/forge/play") },
+          { href: "/forge/missives", label: "Missives", match: (p) => p.startsWith("/forge/missives") },
           ...(role === "superadmin"
             ? [{ href: "/forge/admin", label: "Admin", match: (p: string) => p.startsWith("/forge/admin") }]
             : []),

--- a/app/forge/lib/__tests__/missiveTemplate.test.ts
+++ b/app/forge/lib/__tests__/missiveTemplate.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { escapeHtml, missiveBodyHtml, wrapForgeMissive } from "../missiveTemplate";
+
+describe("escapeHtml", () => {
+  it("escapes angle brackets, ampersands, and quotes", () => {
+    expect(escapeHtml("<script>alert('x')</script>")).toBe(
+      "&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;",
+    );
+    expect(escapeHtml("a & b")).toBe("a &amp; b");
+    expect(escapeHtml('say "hi"')).toBe("say &quot;hi&quot;");
+  });
+});
+
+describe("missiveBodyHtml", () => {
+  it("substitutes {name}, splits blank-line blocks into <p>, and drops raw {name}", () => {
+    const html = missiveBodyHtml("Hi {name},\n\nRound two begins.", "Ada");
+    expect(html).toContain("Hi Ada,");
+    expect(html).not.toContain("{name}");
+    const pCount = (html.match(/<p/g) || []).length;
+    expect(pCount).toBe(2);
+  });
+
+  it("escapes a recipient name containing HTML", () => {
+    const html = missiveBodyHtml("Hi {name}", "<b>x</b>");
+    expect(html).not.toContain("<b>x</b>");
+    expect(html).toContain("&lt;b&gt;x&lt;/b&gt;");
+  });
+
+  it("converts a single newline within a block to <br>", () => {
+    expect(missiveBodyHtml("a\nb", "x")).toContain("a<br>b");
+  });
+});
+
+describe("wrapForgeMissive", () => {
+  const out = wrapForgeMissive({
+    bodyHtml: missiveBodyHtml("Hi {name},\n\nWelcome.", "Ada"),
+    senderName: "Tim",
+    senderEmail: "tim@example.com",
+  });
+
+  it("contains the body html, wordmark, sender name/email, and both block copies", () => {
+    expect(out).toContain("Hi Ada,");
+    expect(out).toContain("THE FORGE");
+    expect(out).toContain("Tim");
+    expect(out).toContain("tim@example.com");
+    expect(out).toContain("Keep it in the Forge");
+    expect(out).toContain("DM");
+    expect(out).toContain("Discord");
+  });
+
+  it("does not leak the {name} placeholder", () => {
+    expect(out).not.toContain("{name}");
+  });
+
+  it("escapes a malicious senderName", () => {
+    const evil = wrapForgeMissive({
+      bodyHtml: "<p>hi</p>",
+      senderName: '<img src=x onerror=alert(1)>',
+      senderEmail: "tim@example.com",
+    });
+    expect(evil).not.toContain("<img");
+    expect(evil).toContain("&lt;img");
+  });
+});

--- a/app/forge/lib/__tests__/missives.test.ts
+++ b/app/forge/lib/__tests__/missives.test.ts
@@ -168,9 +168,14 @@ describe("sendMissive", () => {
     expect(sendEmail).toHaveBeenCalledTimes(1);
     expect((sendEmail as any).mock.calls[0][0].to).toBe("alice@x.com");
     expect(r.ok).toBe(true);
+    expect(c.supabase.rpc).toHaveBeenCalledWith(
+      "forge_log_missive",
+      expect.objectContaining({ p_recipient_ids: ["p1"] })
+    );
   });
 
   it("happy path: 2 recipients get personalized, prefixed, reply-to'd emails and the send is logged", async () => {
+    expect(process.env.FORGE_FROM_EMAIL).toBeUndefined();
     vi.useFakeTimers();
     const c = ctx();
     (requireElder as any).mockResolvedValue(c);
@@ -194,6 +199,8 @@ describe("sendMissive", () => {
     expect(call2.html).toContain("Bob");
     expect(call1.replyTo).toBe("c@x.com");
     expect(call2.replyTo).toBe("c@x.com");
+    expect(call1.from).toBe("The Forge <noreply@landofredemption.com>");
+    expect(call2.from).toBe("The Forge <noreply@landofredemption.com>");
 
     expect(c.supabase.rpc).toHaveBeenCalledWith("forge_log_missive", {
       p_subject: "Update",
@@ -227,6 +234,49 @@ describe("sendMissive", () => {
       "forge_log_missive",
       expect.objectContaining({ p_recipient_ids: ["p1", "p2"] })
     );
+  });
+
+  it("returns a directory error when the directory RPC fails, without sending anything", async () => {
+    const c = ctx(async (name: string) => {
+      if (name === "forge_member_directory") {
+        return { data: null, error: { message: "db down" } };
+      }
+      return { data: null, error: null };
+    });
+    (requireElder as any).mockResolvedValue(c);
+    const r = await sendMissive({ subject: "Hi", body: "Body", recipientIds: ["p1"] });
+    expect(r).toEqual({
+      ok: false,
+      sent: 0,
+      failed: 0,
+      error: "Could not load the member directory.",
+    });
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns an unconfigured-email error and does not log when every send fails", async () => {
+    vi.useFakeTimers();
+    (sendEmail as any)
+      .mockResolvedValueOnce({ success: false, error: "Email service not configured" })
+      .mockResolvedValueOnce({ success: false, error: "Email service not configured" });
+    const c = ctx();
+    (requireElder as any).mockResolvedValue(c);
+    const promise = sendMissive({
+      subject: "Update",
+      body: "Hello {name}",
+      recipientIds: ["p1", "p2"],
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    const r = await promise;
+    vi.useRealTimers();
+
+    expect(r).toEqual({
+      ok: false,
+      sent: 0,
+      failed: 2,
+      error: "No emails were sent — email service may be unconfigured.",
+    });
+    expect(c.supabase.rpc).not.toHaveBeenCalledWith("forge_log_missive", expect.anything());
   });
 });
 

--- a/app/forge/lib/__tests__/missives.test.ts
+++ b/app/forge/lib/__tests__/missives.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/app/forge/lib/auth", () => ({
+  requireElder: vi.fn(),
+}));
+vi.mock("@/utils/email", () => ({
+  sendEmail: vi.fn(async () => ({ success: true })),
+}));
+vi.mock("@/utils/supabase/server", () => ({ createClient: vi.fn() }));
+
+import { requireElder } from "@/app/forge/lib/auth";
+import { sendEmail } from "@/utils/email";
+import { revalidatePath } from "next/cache";
+import {
+  getMissiveDirectory,
+  sendMissive,
+  sendMissiveTest,
+  listRecentMissives,
+} from "../missives";
+
+const DIRECTORY_ROWS = [
+  { user_id: "caller", display_name: "Smith", role: "elder", email: "c@x.com", set_ids: [] },
+  { user_id: "p1", display_name: "Alice", role: "playtester", email: "alice@x.com", set_ids: [] },
+  { user_id: "p2", display_name: "Bob", role: "playtester", email: "bob@x.com", set_ids: [] },
+];
+
+function ctx(rpcImpl?: any, fromImpl?: any) {
+  return {
+    role: "elder",
+    user: { id: "caller", email: "c@x.com" },
+    supabase: {
+      rpc: vi.fn(
+        rpcImpl ??
+          (async (name: string) => {
+            if (name === "forge_member_directory") return { data: DIRECTORY_ROWS, error: null };
+            if (name === "forge_log_missive") return { data: "missive-id", error: null };
+            return { data: null, error: null };
+          })
+      ),
+      from: vi.fn(
+        fromImpl ??
+          (() => ({
+            select: vi.fn(() => ({
+              order: vi.fn(() => ({
+                limit: vi.fn(async () => ({ data: [], error: null })),
+              })),
+            })),
+          }))
+      ),
+    },
+  };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("getMissiveDirectory", () => {
+  it("returns empty for a non-elder", async () => {
+    (requireElder as any).mockResolvedValue(null);
+    const r = await getMissiveDirectory();
+    expect(r).toEqual({ members: [], sets: [] });
+  });
+
+  it("maps directory rows to camelCase and fetches sets", async () => {
+    const c = ctx(undefined, () => ({
+      select: vi.fn(() => ({
+        order: vi.fn(async () => ({
+          data: [{ id: "s1", name: "Set One" }],
+          error: null,
+        })),
+      })),
+    }));
+    (requireElder as any).mockResolvedValue(c);
+    const r = await getMissiveDirectory();
+    expect(r.members).toEqual([
+      { userId: "caller", displayName: "Smith", role: "elder", email: "c@x.com", setIds: [] },
+      { userId: "p1", displayName: "Alice", role: "playtester", email: "alice@x.com", setIds: [] },
+      { userId: "p2", displayName: "Bob", role: "playtester", email: "bob@x.com", setIds: [] },
+    ]);
+    expect(r.sets).toEqual([{ id: "s1", name: "Set One" }]);
+  });
+});
+
+describe("sendMissive", () => {
+  it("rejects a non-elder", async () => {
+    (requireElder as any).mockResolvedValue(null);
+    const r = await sendMissive({ subject: "Hi", body: "Body", recipientIds: ["p1"] });
+    expect(r).toEqual({ ok: false, sent: 0, failed: 0, error: "Not authorized" });
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty subject", async () => {
+    (requireElder as any).mockResolvedValue(ctx());
+    const r = await sendMissive({ subject: "   ", body: "Body", recipientIds: ["p1"] });
+    expect(r.ok).toBe(false);
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("rejects a subject over 150 chars", async () => {
+    (requireElder as any).mockResolvedValue(ctx());
+    const r = await sendMissive({ subject: "a".repeat(151), body: "Body", recipientIds: ["p1"] });
+    expect(r.ok).toBe(false);
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty body", async () => {
+    (requireElder as any).mockResolvedValue(ctx());
+    const r = await sendMissive({ subject: "Hi", body: "   ", recipientIds: ["p1"] });
+    expect(r.ok).toBe(false);
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("rejects a body over 20000 chars", async () => {
+    (requireElder as any).mockResolvedValue(ctx());
+    const r = await sendMissive({ subject: "Hi", body: "a".repeat(20001), recipientIds: ["p1"] });
+    expect(r.ok).toBe(false);
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("rejects 0 recipients", async () => {
+    (requireElder as any).mockResolvedValue(ctx());
+    const r = await sendMissive({ subject: "Hi", body: "Body", recipientIds: [] });
+    expect(r.ok).toBe(false);
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("rejects more than 100 recipients", async () => {
+    (requireElder as any).mockResolvedValue(ctx());
+    const ids = Array.from({ length: 101 }, (_, i) => `p${i}`);
+    const r = await sendMissive({ subject: "Hi", body: "Body", recipientIds: ids });
+    expect(r.ok).toBe(false);
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("blocks the sender when they have no display name", async () => {
+    const c = ctx(async (name: string) => {
+      if (name === "forge_member_directory") {
+        return {
+          data: [
+            { user_id: "caller", display_name: null, role: "elder", email: "c@x.com", set_ids: [] },
+            { user_id: "p1", display_name: "Alice", role: "playtester", email: "alice@x.com", set_ids: [] },
+          ],
+          error: null,
+        };
+      }
+      return { data: null, error: null };
+    });
+    (requireElder as any).mockResolvedValue(c);
+    const r = await sendMissive({ subject: "Hi", body: "Body", recipientIds: ["p1"] });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("Set your Forge display name before sending a missive.");
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("drops unknown recipientIds and only emails directory addresses", async () => {
+    vi.useFakeTimers();
+    const c = ctx();
+    (requireElder as any).mockResolvedValue(c);
+    const promise = sendMissive({
+      subject: "Hi",
+      body: "Body",
+      recipientIds: ["p1", "unknown-id"],
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    const r = await promise;
+    vi.useRealTimers();
+
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect((sendEmail as any).mock.calls[0][0].to).toBe("alice@x.com");
+    expect(r.ok).toBe(true);
+  });
+
+  it("happy path: 2 recipients get personalized, prefixed, reply-to'd emails and the send is logged", async () => {
+    vi.useFakeTimers();
+    const c = ctx();
+    (requireElder as any).mockResolvedValue(c);
+    const promise = sendMissive({
+      subject: "Update",
+      body: "Hello {name}",
+      recipientIds: ["p1", "p2"],
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    const r = await promise;
+    vi.useRealTimers();
+
+    expect(sendEmail).toHaveBeenCalledTimes(2);
+    const call1 = (sendEmail as any).mock.calls[0][0];
+    const call2 = (sendEmail as any).mock.calls[1][0];
+    expect(call1.subject).toBe("[Forge] Update");
+    expect(call2.subject).toBe("[Forge] Update");
+    expect(call1.to).toBe("alice@x.com");
+    expect(call2.to).toBe("bob@x.com");
+    expect(call1.html).toContain("Alice");
+    expect(call2.html).toContain("Bob");
+    expect(call1.replyTo).toBe("c@x.com");
+    expect(call2.replyTo).toBe("c@x.com");
+
+    expect(c.supabase.rpc).toHaveBeenCalledWith("forge_log_missive", {
+      p_subject: "Update",
+      p_body_text: "Hello {name}",
+      p_recipient_ids: ["p1", "p2"],
+    });
+    expect(revalidatePath).toHaveBeenCalledWith("/forge/missives");
+    expect(r).toEqual({ ok: true, sent: 2, failed: 0, error: undefined });
+  });
+
+  it("counts a failed send, still logs, and returns ok:false", async () => {
+    vi.useFakeTimers();
+    (sendEmail as any)
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValueOnce({ success: false, error: "boom" });
+    const c = ctx();
+    (requireElder as any).mockResolvedValue(c);
+    const promise = sendMissive({
+      subject: "Update",
+      body: "Hello {name}",
+      recipientIds: ["p1", "p2"],
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    const r = await promise;
+    vi.useRealTimers();
+
+    expect(r.ok).toBe(false);
+    expect(r.sent).toBe(1);
+    expect(r.failed).toBe(1);
+    expect(c.supabase.rpc).toHaveBeenCalledWith(
+      "forge_log_missive",
+      expect.objectContaining({ p_recipient_ids: ["p1", "p2"] })
+    );
+  });
+});
+
+describe("sendMissiveTest", () => {
+  it("rejects a non-elder", async () => {
+    (requireElder as any).mockResolvedValue(null);
+    const r = await sendMissiveTest({ subject: "Hi", body: "Body" });
+    expect(r.ok).toBe(false);
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("blocks the sender when they have no display name", async () => {
+    const c = ctx(async (name: string) => {
+      if (name === "forge_member_directory") {
+        return {
+          data: [{ user_id: "caller", display_name: null, role: "elder", email: "c@x.com", set_ids: [] }],
+          error: null,
+        };
+      }
+      return { data: null, error: null };
+    });
+    (requireElder as any).mockResolvedValue(c);
+    const r = await sendMissiveTest({ subject: "Hi", body: "Body" });
+    expect(r.ok).toBe(false);
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("sends exactly one email to the caller with the TEST prefix and does not log", async () => {
+    const c = ctx();
+    (requireElder as any).mockResolvedValue(c);
+    const r = await sendMissiveTest({ subject: "Update", body: "Hello {name}" });
+
+    expect(r.ok).toBe(true);
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    const call = (sendEmail as any).mock.calls[0][0];
+    expect(call.to).toBe("c@x.com");
+    expect(call.subject).toBe("[TEST] [Forge] Update");
+    expect(call.replyTo).toBe("c@x.com");
+    expect(call.html).toContain("Smith");
+
+    expect(c.supabase.rpc).not.toHaveBeenCalledWith("forge_log_missive", expect.anything());
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+});
+
+describe("listRecentMissives", () => {
+  it("returns empty for a non-elder", async () => {
+    (requireElder as any).mockResolvedValue(null);
+    expect(await listRecentMissives()).toEqual([]);
+  });
+
+  it("maps rows to camelCase", async () => {
+    const c = ctx(undefined, () => ({
+      select: vi.fn(() => ({
+        order: vi.fn(() => ({
+          limit: vi.fn(async () => ({
+            data: [
+              {
+                id: "m1",
+                sender: "caller",
+                subject: "Hi",
+                recipient_count: 3,
+                sent_at: "2026-01-01T00:00:00Z",
+              },
+            ],
+            error: null,
+          })),
+        })),
+      })),
+    }));
+    (requireElder as any).mockResolvedValue(c);
+    const r = await listRecentMissives();
+    expect(r).toEqual([
+      { id: "m1", sender: "caller", subject: "Hi", recipientCount: 3, sentAt: "2026-01-01T00:00:00Z" },
+    ]);
+  });
+});

--- a/app/forge/lib/missiveTemplate.ts
+++ b/app/forge/lib/missiveTemplate.ts
@@ -66,35 +66,35 @@ export function wrapForgeMissive(opts: {
             <tr>
               <td align="center" style="padding:28px 30px 22px;border-bottom:1px solid #33261e;">
                 <div style="font-family:${display};font-size:26px;color:#fafaf9;letter-spacing:4px;text-transform:uppercase;">THE FORGE</div>
-                <div style="font-family:${display};font-size:11px;color:#fbbf24;letter-spacing:3px;text-transform:uppercase;margin-top:8px;">A MISSIVE FROM THE ELDERS</div>
+                <div style="font-family:${display};font-size:12px;color:#fbbf24;letter-spacing:3px;text-transform:uppercase;margin-top:8px;">A MISSIVE FROM THE ELDERS</div>
               </td>
             </tr>
             <!-- Body + signature -->
             <tr>
-              <td style="padding:32px 30px;color:#e7e5e4;font-size:16px;line-height:1.7;font-family:${bodyFont};">
+              <td style="padding:32px 30px;color:#f5f5f4;font-size:17px;line-height:1.75;font-family:${bodyFont};">
                 ${bodyHtml}
                 <div style="margin-top:28px;padding-top:18px;border-top:1px solid #33261e;">
-                  <div style="color:#78716c;font-size:12px;">Sent from the Forge by</div>
-                  <div style="margin-top:4px;"><strong style="color:#fafaf9;">${senderName}</strong> <span style="color:#a8a29e;"> — Elder of the Forge</span></div>
-                  <div style="margin-top:4px;color:#a8a29e;font-size:13px;">${senderEmail}</div>
+                  <div style="color:#a8a29e;font-size:13px;">Sent from the Forge by</div>
+                  <div style="margin-top:4px;"><strong style="color:#ffffff;">${senderName}</strong> <span style="color:#c9c3bc;"> — Elder of the Forge</span></div>
+                  <div style="margin-top:4px;color:#c9c3bc;font-size:14px;">${senderEmail}</div>
                 </div>
               </td>
             </tr>
             <!-- Confidentiality block -->
             <tr>
               <td style="padding:0 30px 28px;">
-                <div style="background:#201409;border:1px solid #7c2d12;border-left:4px solid #ea580c;border-radius:6px;padding:16px 18px;font-size:13px;line-height:1.6;color:#d6d3d1;font-family:${bodyFont};">
+                <div style="background:#201409;border:1px solid #7c2d12;border-left:4px solid #ea580c;border-radius:6px;padding:16px 18px;font-size:14px;line-height:1.65;color:#e9e4de;font-family:${bodyFont};">
                   <span style="color:#fbbf24;font-weight:bold;">Keep it in the Forge.</span> Everything in this missive — card designs, names, mechanics, set details, images, and timelines — is confidential playtest material. Do not share, screenshot, forward, or discuss it outside the Forge. You are reading this because the elders trust you with unfinished work; that trust is what makes the Forge possible. Guard it.
                 </div>
               </td>
             </tr>
             <!-- Footer -->
             <tr>
-              <td align="center" style="padding:20px 30px 26px;border-top:1px solid #33261e;text-align:center;color:#78716c;font-size:12px;font-family:${bodyFont};">
+              <td align="center" style="padding:20px 30px 26px;border-top:1px solid #33261e;text-align:center;color:#a8a29e;font-size:13px;line-height:1.6;font-family:${bodyFont};">
                 <div>
-                  <strong style="color:#a8a29e;">Need to respond?</strong> DM <strong style="color:#a8a29e;">${senderName}</strong> on Discord — that's where the Forge talks. Replies to this email reach ${senderName} as a backstop, but Discord is faster.
+                  <strong style="color:#e7e5e4;">Need to respond?</strong> DM <strong style="color:#e7e5e4;">${senderName}</strong> on Discord — that's where the Forge talks. Replies to this email reach ${senderName} as a backstop, but Discord is faster.
                 </div>
-                <div style="margin-top:12px;font-style:italic;color:#57534e;letter-spacing:1px;">Forged in fire. Kept in shadow.</div>
+                <div style="margin-top:12px;font-style:italic;color:#857c72;letter-spacing:1px;">Forged in fire. Kept in shadow.</div>
               </td>
             </tr>
           </table>

--- a/app/forge/lib/missiveTemplate.ts
+++ b/app/forge/lib/missiveTemplate.ts
@@ -1,0 +1,106 @@
+// Forge missive email template.
+// Pure, synchronous HTML builders for the "Forge Missives" feature: elders emailing
+// playtesters. Emails ship as raw HTML via Resend, so every style that carries the
+// design is inline, tables use role="presentation", and solid-color fallbacks back
+// gradients for Outlook. No shared code with utils/email.ts — this is fully forge-branded.
+
+/** Escapes the five HTML-significant characters. */
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Turns a raw plain-text body into email-safe HTML.
+ * Escapes the whole body first, substitutes {name} with the (escaped) recipient name
+ * ({name} survives escaping since it has no special chars), then converts
+ * blank-line-separated blocks into <p> and single newlines into <br>.
+ */
+export function missiveBodyHtml(body: string, recipientName: string): string {
+  const escaped = escapeHtml(body).replace(/\{name\}/g, escapeHtml(recipientName));
+  return escaped
+    .split(/\n\s*\n/)
+    .map((block) => block.trim())
+    .filter((block) => block.length > 0)
+    .map((block) => `<p style="margin:0 0 16px 0;">${block.replace(/\n/g, "<br>")}</p>`)
+    .join("");
+}
+
+/**
+ * Wraps a missive body (output of missiveBodyHtml) in the full forge-branded email
+ * document: ember strip, header wordmark + kicker, body, signature, confidentiality
+ * block, and footer. senderName/senderEmail are escaped where injected.
+ */
+export function wrapForgeMissive(opts: {
+  bodyHtml: string;
+  senderName: string;
+  senderEmail: string;
+}): string {
+  const { bodyHtml } = opts;
+  const senderName = escapeHtml(opts.senderName);
+  const senderEmail = escapeHtml(opts.senderEmail);
+
+  const display = "Impact, 'Arial Narrow', 'Helvetica Neue', Arial, sans-serif";
+  const bodyFont = "Arimo, Arial, 'Helvetica Neue', Helvetica, sans-serif";
+
+  return `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  </head>
+  <body style="margin:0;padding:0;background-color:#0c0a09;font-family:${bodyFont};">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#0c0a09;">
+      <tr>
+        <td align="center" style="padding:40px 16px;">
+          <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background-color:#1b1613;border:1px solid #33261e;border-radius:12px;overflow:hidden;">
+            <!-- Ember strip -->
+            <tr>
+              <td height="6" style="height:6px;font-size:0;line-height:0;background-color:#9a3412;background-image:linear-gradient(90deg,#431407,#9a3412,#f59e0b,#9a3412,#431407);">&nbsp;</td>
+            </tr>
+            <!-- Header: wordmark + kicker -->
+            <tr>
+              <td align="center" style="padding:28px 30px 22px;border-bottom:1px solid #33261e;">
+                <div style="font-family:${display};font-size:26px;color:#fafaf9;letter-spacing:4px;text-transform:uppercase;">THE FORGE</div>
+                <div style="font-family:${display};font-size:11px;color:#fbbf24;letter-spacing:3px;text-transform:uppercase;margin-top:8px;">A MISSIVE FROM THE ELDERS</div>
+              </td>
+            </tr>
+            <!-- Body + signature -->
+            <tr>
+              <td style="padding:32px 30px;color:#e7e5e4;font-size:16px;line-height:1.7;font-family:${bodyFont};">
+                ${bodyHtml}
+                <div style="margin-top:28px;padding-top:18px;border-top:1px solid #33261e;">
+                  <div style="color:#78716c;font-size:12px;">Sent from the Forge by</div>
+                  <div style="margin-top:4px;"><strong style="color:#fafaf9;">${senderName}</strong> <span style="color:#a8a29e;"> — Elder of the Forge</span></div>
+                  <div style="margin-top:4px;color:#a8a29e;font-size:13px;">${senderEmail}</div>
+                </div>
+              </td>
+            </tr>
+            <!-- Confidentiality block -->
+            <tr>
+              <td style="padding:0 30px 28px;">
+                <div style="background:#201409;border:1px solid #7c2d12;border-left:4px solid #ea580c;border-radius:6px;padding:16px 18px;font-size:13px;line-height:1.6;color:#d6d3d1;font-family:${bodyFont};">
+                  <span style="color:#fbbf24;font-weight:bold;">Keep it in the Forge.</span> Everything in this missive — card designs, names, mechanics, set details, images, and timelines — is confidential playtest material. Do not share, screenshot, forward, or discuss it outside the Forge. You are reading this because the elders trust you with unfinished work; that trust is what makes the Forge possible. Guard it.
+                </div>
+              </td>
+            </tr>
+            <!-- Footer -->
+            <tr>
+              <td align="center" style="padding:20px 30px 26px;border-top:1px solid #33261e;text-align:center;color:#78716c;font-size:12px;font-family:${bodyFont};">
+                <div>
+                  <strong style="color:#a8a29e;">Need to respond?</strong> DM <strong style="color:#a8a29e;">${senderName}</strong> on Discord — that's where the Forge talks. Replies to this email reach ${senderName} as a backstop, but Discord is faster.
+                </div>
+                <div style="margin-top:12px;font-style:italic;color:#57534e;letter-spacing:1px;">Forged in fire. Kept in shadow.</div>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+}

--- a/app/forge/lib/missives.ts
+++ b/app/forge/lib/missives.ts
@@ -42,8 +42,10 @@ export async function getMissiveDirectory(): Promise<{
   const ctx = await requireElder();
   if (!ctx) return { members: [], sets: [] };
 
-  const { data: rows } = await ctx.supabase.rpc("forge_member_directory");
+  const { data: rows, error } = await ctx.supabase.rpc("forge_member_directory");
   const { data: sets } = await ctx.supabase.from("forge_sets").select("id, name").order("name");
+
+  if (error) return { members: [], sets: sets ?? [] };
 
   return {
     members: ((rows ?? []) as DirectoryRow[]).map(mapMember),
@@ -79,7 +81,15 @@ export async function sendMissive(input: {
     };
   }
 
-  const { data: rows } = await ctx.supabase.rpc("forge_member_directory");
+  const { data: rows, error: directoryError } = await ctx.supabase.rpc("forge_member_directory");
+  if (directoryError) {
+    return {
+      ok: false,
+      sent: 0,
+      failed: 0,
+      error: "Could not load the member directory.",
+    };
+  }
   const directory = ((rows ?? []) as DirectoryRow[]).map(mapMember);
 
   const sender = directory.find((m) => m.userId === ctx.user.id);
@@ -130,14 +140,31 @@ export async function sendMissive(input: {
     }
   }
 
-  await ctx.supabase.rpc("forge_log_missive", {
+  if (sent === 0) {
+    return {
+      ok: false,
+      sent: 0,
+      failed,
+      error: "No emails were sent — email service may be unconfigured.",
+    };
+  }
+
+  const { error: logError } = await ctx.supabase.rpc("forge_log_missive", {
     p_subject: subject,
     p_body_text: body,
     p_recipient_ids: recipients.map((r) => r.userId),
   });
+  if (logError) console.error("forge_log_missive failed:", logError);
   revalidatePath("/forge/missives");
 
-  return { ok: failed === 0, sent, failed, error: failed > 0 ? "Some sends failed" : undefined };
+  let error = failed > 0 ? "Some sends failed" : undefined;
+  if (logError) {
+    error = error
+      ? error + " Sent, but the missive log could not be written."
+      : "Sent, but the missive log could not be written.";
+  }
+
+  return { ok: failed === 0, sent, failed, error };
 }
 
 export async function sendMissiveTest(input: {
@@ -156,7 +183,10 @@ export async function sendMissiveTest(input: {
     return { ok: false, error: "Body must be 1-20000 characters" };
   }
 
-  const { data: rows } = await ctx.supabase.rpc("forge_member_directory");
+  const { data: rows, error: directoryError } = await ctx.supabase.rpc("forge_member_directory");
+  if (directoryError) {
+    return { ok: false, error: "Could not load the member directory." };
+  }
   const directory = ((rows ?? []) as DirectoryRow[]).map(mapMember);
 
   const sender = directory.find((m) => m.userId === ctx.user.id);

--- a/app/forge/lib/missives.ts
+++ b/app/forge/lib/missives.ts
@@ -1,0 +1,205 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { requireElder, type ForgeRole } from "@/app/forge/lib/auth";
+import { sendEmail } from "@/utils/email";
+import { missiveBodyHtml, wrapForgeMissive } from "@/app/forge/lib/missiveTemplate";
+
+export type MissiveMember = {
+  userId: string;
+  displayName: string | null;
+  role: ForgeRole;
+  email: string;
+  setIds: string[];
+};
+
+const MAX_RECIPIENTS = 100; // Resend free tier: 100/day
+const SEND_DELAY_MS = 600; // Resend default rate limit: 2 req/s
+const FORGE_FROM = process.env.FORGE_FROM_EMAIL || "The Forge <noreply@landofredemption.com>";
+
+type DirectoryRow = {
+  user_id: string;
+  display_name: string | null;
+  role: ForgeRole;
+  email: string;
+  set_ids: string[] | null;
+};
+
+function mapMember(row: DirectoryRow): MissiveMember {
+  return {
+    userId: row.user_id,
+    displayName: row.display_name,
+    role: row.role,
+    email: row.email,
+    setIds: row.set_ids ?? [],
+  };
+}
+
+export async function getMissiveDirectory(): Promise<{
+  members: MissiveMember[];
+  sets: { id: string; name: string }[];
+}> {
+  const ctx = await requireElder();
+  if (!ctx) return { members: [], sets: [] };
+
+  const { data: rows } = await ctx.supabase.rpc("forge_member_directory");
+  const { data: sets } = await ctx.supabase.from("forge_sets").select("id, name").order("name");
+
+  return {
+    members: ((rows ?? []) as DirectoryRow[]).map(mapMember),
+    sets: sets ?? [],
+  };
+}
+
+export async function sendMissive(input: {
+  subject: string;
+  body: string;
+  recipientIds: string[];
+}): Promise<{ ok: boolean; sent: number; failed: number; error?: string }> {
+  const ctx = await requireElder();
+  if (!ctx) return { ok: false, sent: 0, failed: 0, error: "Not authorized" };
+
+  const subject = input.subject.trim();
+  const body = input.body.trim();
+  if (subject.length < 1 || subject.length > 150) {
+    return { ok: false, sent: 0, failed: 0, error: "Subject must be 1-150 characters" };
+  }
+  if (body.length < 1 || body.length > 20000) {
+    return { ok: false, sent: 0, failed: 0, error: "Body must be 1-20000 characters" };
+  }
+  if (input.recipientIds.length < 1) {
+    return { ok: false, sent: 0, failed: 0, error: "Select at least one recipient" };
+  }
+  if (input.recipientIds.length > MAX_RECIPIENTS) {
+    return {
+      ok: false,
+      sent: 0,
+      failed: 0,
+      error: `Too many recipients — split the send into groups of ${MAX_RECIPIENTS} or fewer`,
+    };
+  }
+
+  const { data: rows } = await ctx.supabase.rpc("forge_member_directory");
+  const directory = ((rows ?? []) as DirectoryRow[]).map(mapMember);
+
+  const sender = directory.find((m) => m.userId === ctx.user.id);
+  if (!sender || !sender.displayName) {
+    return {
+      ok: false,
+      sent: 0,
+      failed: 0,
+      error: "Set your Forge display name before sending a missive.",
+    };
+  }
+
+  const directoryById = new Map(directory.map((m) => [m.userId, m]));
+  const seen = new Set<string>();
+  const recipients: MissiveMember[] = [];
+  for (const id of input.recipientIds) {
+    const member = directoryById.get(id);
+    if (!member || !member.email || seen.has(member.userId)) continue;
+    seen.add(member.userId);
+    recipients.push(member);
+  }
+
+  if (recipients.length === 0) {
+    return { ok: false, sent: 0, failed: 0, error: "No valid recipients" };
+  }
+
+  let sent = 0;
+  let failed = 0;
+  for (let i = 0; i < recipients.length; i++) {
+    const recipient = recipients[i];
+    const html = wrapForgeMissive({
+      bodyHtml: missiveBodyHtml(body, recipient.displayName ?? "Forge member"),
+      senderName: sender.displayName,
+      senderEmail: ctx.user.email ?? "",
+    });
+    const result = await sendEmail({
+      to: recipient.email,
+      subject: "[Forge] " + subject,
+      html,
+      from: FORGE_FROM,
+      replyTo: ctx.user.email ?? undefined,
+    });
+    if (result.success) sent++;
+    else failed++;
+
+    if (i < recipients.length - 1) {
+      await new Promise((r) => setTimeout(r, SEND_DELAY_MS));
+    }
+  }
+
+  await ctx.supabase.rpc("forge_log_missive", {
+    p_subject: subject,
+    p_body_text: body,
+    p_recipient_ids: recipients.map((r) => r.userId),
+  });
+  revalidatePath("/forge/missives");
+
+  return { ok: failed === 0, sent, failed, error: failed > 0 ? "Some sends failed" : undefined };
+}
+
+export async function sendMissiveTest(input: {
+  subject: string;
+  body: string;
+}): Promise<{ ok: boolean; error?: string }> {
+  const ctx = await requireElder();
+  if (!ctx) return { ok: false, error: "Not authorized" };
+
+  const subject = input.subject.trim();
+  const body = input.body.trim();
+  if (subject.length < 1 || subject.length > 150) {
+    return { ok: false, error: "Subject must be 1-150 characters" };
+  }
+  if (body.length < 1 || body.length > 20000) {
+    return { ok: false, error: "Body must be 1-20000 characters" };
+  }
+
+  const { data: rows } = await ctx.supabase.rpc("forge_member_directory");
+  const directory = ((rows ?? []) as DirectoryRow[]).map(mapMember);
+
+  const sender = directory.find((m) => m.userId === ctx.user.id);
+  if (!sender || !sender.displayName) {
+    return { ok: false, error: "Set your Forge display name before sending a missive." };
+  }
+
+  const html = wrapForgeMissive({
+    bodyHtml: missiveBodyHtml(body, sender.displayName),
+    senderName: sender.displayName,
+    senderEmail: ctx.user.email ?? "",
+  });
+  const result = await sendEmail({
+    to: ctx.user.email ?? "",
+    subject: "[TEST] [Forge] " + subject,
+    html,
+    from: FORGE_FROM,
+    replyTo: ctx.user.email ?? undefined,
+  });
+
+  if (result.success === false) {
+    return { ok: false, error: "Test send failed" };
+  }
+  return { ok: true };
+}
+
+export async function listRecentMissives(): Promise<
+  { id: string; sender: string; subject: string; recipientCount: number; sentAt: string }[]
+> {
+  const ctx = await requireElder();
+  if (!ctx) return [];
+
+  const { data } = await ctx.supabase
+    .from("forge_missives")
+    .select("id, sender, subject, recipient_count, sent_at")
+    .order("sent_at", { ascending: false })
+    .limit(20);
+
+  return (data ?? []).map((row: any) => ({
+    id: row.id,
+    sender: row.sender,
+    subject: row.subject,
+    recipientCount: row.recipient_count,
+    sentAt: row.sent_at,
+  }));
+}

--- a/app/forge/missives/MissiveComposer.tsx
+++ b/app/forge/missives/MissiveComposer.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { sendMissive, sendMissiveTest } from "@/app/forge/lib/missives";
+
+// Inlined (not imported from lib/missives) so this client component never pulls the
+// server-only supabase client into the browser bundle.
+type ForgeRole = "superadmin" | "elder" | "playtester";
+type Member = { userId: string; displayName: string | null; role: ForgeRole; email: string; setIds: string[] };
+type Recent = { id: string; sender: string; subject: string; recipientCount: number; sentAt: string };
+
+export default function MissiveComposer({
+  members,
+  sets,
+  recent,
+  callerId,
+}: {
+  members: Member[];
+  sets: { id: string; name: string }[];
+  recent: Recent[];
+  callerId: string;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [subject, setSubject] = useState("");
+  const [body, setBody] = useState("");
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const membersByUserId = new Map(members.map((m) => [m.userId, m]));
+  const canSend = selected.size > 0 && subject.trim().length > 0 && body.trim().length > 0 && !pending;
+
+  function selectAll() {
+    setSelected(new Set(members.map((m) => m.userId)));
+  }
+  function selectElders() {
+    setSelected(new Set(members.filter((m) => m.role === "elder" || m.role === "superadmin").map((m) => m.userId)));
+  }
+  function selectPlaytesters() {
+    setSelected(new Set(members.filter((m) => m.role === "playtester").map((m) => m.userId)));
+  }
+  function selectNone() {
+    setSelected(new Set());
+  }
+  function selectSet(setId: string) {
+    setSelected(new Set(members.filter((m) => m.setIds.includes(setId)).map((m) => m.userId)));
+  }
+  function toggleMember(userId: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(userId)) next.delete(userId);
+      else next.add(userId);
+      return next;
+    });
+  }
+
+  function handleTestSend() {
+    setMsg(null);
+    startTransition(async () => {
+      const r = await sendMissiveTest({ subject, body });
+      setMsg(r.ok ? "Test sent." : r.error ?? "Failed");
+    });
+  }
+
+  function handleSend() {
+    if (!window.confirm(`Send this missive to ${selected.size} member(s)?`)) return;
+    setMsg(null);
+    startTransition(async () => {
+      const r = await sendMissive({ subject, body, recipientIds: Array.from(selected) });
+      if (r.ok === false) {
+        setMsg(r.error ?? "Failed");
+        return;
+      }
+      setSubject("");
+      setBody("");
+      setSelected(new Set());
+      setMsg(`Sent ${r.sent}, failed ${r.failed}.`);
+    });
+  }
+
+  return (
+    <div className="mt-6 space-y-8">
+      <section>
+        <h2 className="text-lg font-medium">Compose a missive</h2>
+
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            className="rounded-md border px-2.5 py-1 text-xs"
+            onClick={selectAll}
+            disabled={pending}
+          >
+            All
+          </button>
+          <button
+            type="button"
+            className="rounded-md border px-2.5 py-1 text-xs"
+            onClick={selectElders}
+            disabled={pending}
+          >
+            Elders
+          </button>
+          <button
+            type="button"
+            className="rounded-md border px-2.5 py-1 text-xs"
+            onClick={selectPlaytesters}
+            disabled={pending}
+          >
+            Playtesters
+          </button>
+          <button
+            type="button"
+            className="rounded-md border px-2.5 py-1 text-xs"
+            onClick={selectNone}
+            disabled={pending}
+          >
+            None
+          </button>
+          {sets.length > 0 && (
+            <label className="text-xs">
+              Everyone on set…
+              <select
+                className="ml-1.5 rounded-md border bg-background px-2 py-1 text-xs"
+                value=""
+                onChange={(e) => {
+                  if (e.target.value) selectSet(e.target.value);
+                  e.target.value = "";
+                }}
+                disabled={pending}
+              >
+                <option value="" disabled>
+                  Choose a set
+                </option>
+                {sets.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+        </div>
+
+        <div className="mt-2 max-h-64 overflow-y-auto rounded-md border">
+          {members.map((m) => (
+            <label key={m.userId} className="flex items-center gap-2 border-b px-2 py-1.5 text-sm last:border-b-0">
+              <input
+                type="checkbox"
+                checked={selected.has(m.userId)}
+                onChange={() => toggleMember(m.userId)}
+                disabled={pending}
+              />
+              <span>{m.displayName ?? "(no name)"}</span>
+              <span className="text-xs text-muted-foreground">{m.role}</span>
+              <span className="ml-auto text-xs text-muted-foreground">{m.email}</span>
+            </label>
+          ))}
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {selected.size} recipient{selected.size === 1 ? "" : "s"} selected
+        </p>
+
+        <label className="mt-4 block text-sm">
+          Subject
+          <input
+            type="text"
+            className="mt-1 block w-full rounded-md border bg-background px-2 py-1.5 text-sm"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            disabled={pending}
+          />
+        </label>
+        <p className="mt-1 text-xs text-muted-foreground">Sent as: [Forge] {subject}</p>
+
+        <label className="mt-4 block text-sm">
+          Body
+          <textarea
+            rows={10}
+            className="mt-1 block w-full rounded-md border bg-background px-2 py-1.5 text-sm"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            disabled={pending}
+          />
+        </label>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Plain text. {"{name}"} becomes each member&apos;s display name. Your signature and the
+          confidentiality notice are added automatically.
+        </p>
+
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            className="rounded-md border px-3 py-1.5 text-sm"
+            onClick={handleTestSend}
+            disabled={pending || subject.trim().length === 0 || body.trim().length === 0}
+          >
+            Send test to me
+          </button>
+          <button
+            type="button"
+            className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground disabled:opacity-50"
+            onClick={handleSend}
+            disabled={!canSend}
+          >
+            Send to {selected.size} member{selected.size === 1 ? "" : "s"}
+          </button>
+        </div>
+
+        {msg && (
+          <p aria-live="polite" className="mt-2 text-sm">
+            {msg}
+          </p>
+        )}
+      </section>
+
+      <section>
+        <h2 className="text-lg font-medium">Recent missives</h2>
+        <ul className="mt-2 space-y-1 text-sm">
+          {recent.map((r) => (
+            <li key={r.id} className="text-muted-foreground">
+              {r.subject} · {membersByUserId.get(r.sender)?.displayName ?? "Former member"} ·{" "}
+              {r.recipientCount} recipient{r.recipientCount === 1 ? "" : "s"} ·{" "}
+              {new Date(r.sentAt).toLocaleDateString()}
+            </li>
+          ))}
+          {recent.length === 0 && <li className="text-muted-foreground">No missives sent yet.</li>}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/app/forge/missives/page.tsx
+++ b/app/forge/missives/page.tsx
@@ -1,0 +1,21 @@
+import { notFound } from "next/navigation";
+import { requireElder } from "@/app/forge/lib/auth";
+import { getMissiveDirectory, listRecentMissives } from "@/app/forge/lib/missives";
+import MissiveComposer from "./MissiveComposer";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function ForgeMissivesPage() {
+  const ctx = await requireElder();
+  if (!ctx) notFound();
+  const [{ members, sets }, recent] = await Promise.all([getMissiveDirectory(), listRecentMissives()]);
+  return (
+    <main className="mx-auto max-w-3xl p-6">
+      <h1 className="text-2xl" style={{ fontFamily: "Cinzel, serif" }}>
+        Missives
+      </h1>
+      <MissiveComposer members={members} sets={sets} recent={recent} callerId={ctx.user.id} />
+    </main>
+  );
+}

--- a/app/forge/missives/page.tsx
+++ b/app/forge/missives/page.tsx
@@ -5,6 +5,9 @@ import MissiveComposer from "./MissiveComposer";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
+// Sequential sends + 600ms spacing for up to 100 recipients can exceed the default
+// function timeout (Next.js applies the page's segment config to server actions invoked from it).
+export const maxDuration = 300;
 
 export default async function ForgeMissivesPage() {
   const ctx = await requireElder();

--- a/docs/superpowers/plans/2026-07-03-forge-missives-plan.md
+++ b/docs/superpowers/plans/2026-07-03-forge-missives-plan.md
@@ -1,0 +1,379 @@
+# Forge Missives — Implementation Plan
+
+Elder→member email announcements for The Forge. Elders (and the superadmin) compose a
+plain-text missive, target Forge members (all / elders / playtesters / by set / individual),
+test-send it to themselves, then send. Emails are forge-themed (ash/ember), always carry the
+sender's identity (display name + auth email) in the signature, always carry a confidentiality
+notice, and direct replies to Discord DMs (with `Reply-To` set to the sender as a backstop).
+
+Reconciled from two independent architect plans; consensus decisions are binding.
+
+## Global Constraints (binding for every task)
+
+- **Workspace**: work ONLY inside the worktree
+  `/Users/timestes/projects/redemption-tournament-tracker/.claude/worktrees/forge-missives`
+  (branch `forge-missives`). Use absolute paths. There is a sibling checkout at
+  `/Users/timestes/projects/redemption-tournament-tracker` where another agent is working —
+  do NOT read from or write to it.
+- **Access control**: only Forge elders and the superadmin may use any part of this feature.
+  Every server action starts with `requireElder()` from `app/forge/lib/auth.ts` and returns
+  an error/empty result when it fails. The page 404s via `notFound()`. Every new DB function
+  self-gates with `public.is_forge_elder_or_super()` (returning zero rows or raising), so the
+  DB enforces this independently of the app layer. Playtesters must never see the feature.
+- **TypeScript**: `tsconfig.json` has `strict: false`, which breaks `if (r.ok) / else` union
+  narrowing on discriminated unions. Use explicit comparisons: `if (r.ok === false)`.
+- **Style**: match existing code. Server actions mirror `app/forge/lib/members.ts`
+  (`"use server"`, `{ ok, error? }` result shapes). UI mirrors `app/forge/admin/AdminConsole.tsx`
+  (plain Tailwind, `rounded-md border bg-background px-2 py-1.5 text-sm` controls, sections with
+  `h2.text-lg.font-medium`, `useTransition` + inline status message). Never use `focus:ring-*`
+  classes on form controls. Keep the UI minimal and functional — a UI refresh is happening in
+  parallel; do not restyle anything that already exists.
+- **Email HTML**: table-based layout, `role="presentation"`, ALL styles inline, max-width 600px.
+  No external images, no external fonts, no `<style>` blocks that carry the design (a client
+  that strips `<head>` must still render correctly).
+- **Verification**: `npm run test` (vitest) passes from the worktree root before committing.
+- **Commits**: commit in the worktree; message style `Forge: <what>` matching repo history;
+  end the message with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Do not modify any file a task does not list.
+
+## Task 1: Migration 062 + `sendEmail` reply-to support
+
+**Files:**
+- CREATE `supabase/migrations/062_forge_missives.sql` (worktree-absolute:
+  `/Users/timestes/projects/redemption-tournament-tracker/.claude/worktrees/forge-missives/supabase/migrations/062_forge_missives.sql`)
+- MODIFY `utils/email.ts` (same worktree root)
+
+**Migration — use this SQL verbatim** (it follows the established patterns of migrations
+048/049: SECURITY DEFINER + `set search_path = ''`, no-oracle empty results for non-elders,
+explicit `revoke ... from public, anon` because Supabase default-grants EXECUTE to anon,
+`forge_audit` stamps on writes):
+
+```sql
+-- 062_forge_missives.sql
+-- Forge Missives: elder→member email. Directory RPC (emails live only in auth.users)
+-- + sent-missive log. Follows 048/049 definer/no-oracle/revoke patterns.
+
+-- 1) Sent-missive log. Read: elders+. Write: only via forge_log_missive below.
+create table if not exists public.forge_missives (
+  id              uuid primary key default gen_random_uuid(),
+  sender          uuid not null references auth.users(id),
+  subject         text not null,
+  body_text       text not null,          -- raw composed body, pre-template
+  recipient_ids   uuid[] not null,
+  recipient_count int not null,
+  sent_at         timestamptz not null default now()
+);
+alter table public.forge_missives enable row level security;
+drop policy if exists "forge_missives_select" on public.forge_missives;
+create policy "forge_missives_select" on public.forge_missives
+  for select to authenticated using (public.is_forge_elder_or_super());
+revoke all on public.forge_missives from anon;
+grant select on public.forge_missives to authenticated;
+-- no insert/update/delete policies: writes land via forge_log_missive only
+
+-- 2) Member directory with emails (auth.users) + set scoping for targeting.
+--    NO ORACLE: returns zero rows for non-elders (mirrors forge_list_invites).
+--    set_ids = grants ∪ set-elderships, so "everyone on set X" includes that
+--    set's elders as well as granted playtesters.
+create or replace function public.forge_member_directory()
+returns table(user_id uuid, display_name text, role public.playtest_role,
+              email text, set_ids uuid[])
+language sql security definer stable set search_path = '' as $$
+  select m.user_id, m.display_name, m.role, u.email::text,
+         coalesce((
+           select array_agg(distinct s.set_id) from (
+             select g.set_id from public.forge_set_grants g where g.user_id = m.user_id
+             union
+             select e.set_id from public.forge_set_elders e where e.user_id = m.user_id
+           ) s
+         ), '{}')
+  from public.playtest_members m
+  join auth.users u on u.id = m.user_id
+  where public.is_forge_elder_or_super()
+  order by m.role, m.display_name nulls last;
+$$;
+
+-- 3) Log a sent missive (elders+; also stamps forge_audit).
+create or replace function public.forge_log_missive(
+  p_subject text, p_body_text text, p_recipient_ids uuid[]
+) returns uuid language plpgsql security definer set search_path = '' as $$
+declare v_id uuid;
+begin
+  if not public.is_forge_elder_or_super() then
+    raise exception 'not authorized';
+  end if;
+  insert into public.forge_missives (sender, subject, body_text, recipient_ids, recipient_count)
+  values (auth.uid(), p_subject, p_body_text, coalesce(p_recipient_ids, '{}'),
+          coalesce(array_length(p_recipient_ids, 1), 0))
+  returning id into v_id;
+  insert into public.forge_audit (actor, action, target)
+  values (auth.uid(), 'missive_sent', v_id::text);
+  return v_id;
+end; $$;
+
+-- 4) Lock down execute (Supabase default-grants anon directly; strip it — cf. 048 §3).
+revoke execute on function public.forge_member_directory() from public, anon;
+revoke execute on function public.forge_log_missive(text, text, uuid[]) from public, anon;
+grant execute on function public.forge_member_directory() to authenticated;
+grant execute on function public.forge_log_missive(text, text, uuid[]) to authenticated;
+```
+
+**`utils/email.ts` change — minimal and backward-compatible.** Extend `EmailOptions` with two
+optional fields and pass them through to the Resend REST payload:
+
+```ts
+interface EmailOptions {
+  to: string;
+  subject: string;
+  html: string;
+  from?: string;     // overrides FROM_EMAIL / default
+  replyTo?: string;  // maps to Resend "reply_to"
+}
+```
+
+In `sendEmail`, destructure the new fields; in the `fetch` body use
+`from: from ?? fromEmail` and include `...(replyTo ? { reply_to: replyTo } : {})`.
+No other behavior changes; existing callers are unaffected.
+
+**Tests/verification for this task:** `npm run test` passes (proves no existing caller broke).
+No new tests required (SQL is not unit-testable here; the email.ts change is a passthrough).
+
+## Task 2: Forge missive email template
+
+**Files:**
+- CREATE `app/forge/lib/missiveTemplate.ts`
+- CREATE `app/forge/lib/__tests__/missiveTemplate.test.ts`
+
+A plain TypeScript module (NOT `"use server"` — sync pure functions) exporting:
+
+```ts
+export function escapeHtml(s: string): string;
+// Escapes the raw plain-text body, substitutes {name} with the (escaped) recipient
+// name, converts blank-line-separated blocks to <p style="margin:0 0 16px 0;"> and
+// single newlines to <br>.
+export function missiveBodyHtml(body: string, recipientName: string): string;
+export function wrapForgeMissive(opts: {
+  bodyHtml: string;      // output of missiveBodyHtml
+  senderName: string;    // Forge display name — already guaranteed non-empty by caller
+  senderEmail: string;   // sender's auth email
+}): string;              // full HTML document
+```
+
+Implementation notes: `escapeHtml` escapes `& < > " '`. In `missiveBodyHtml`, escape the whole
+body FIRST, then replace `{name}` (regex `/\{name\}/g`) with `escapeHtml(recipientName)` —
+`{name}` survives escaping since it has no special chars. `wrapForgeMissive` must also
+escape `senderName`/`senderEmail` where injected.
+
+**Design (binding).** This is the deliverable the product owner cares most about — a dark,
+fire-and-ash forge aesthetic that still renders in Gmail/Outlook/Apple Mail. Structure it as
+the same email-safe skeleton as `wrapEmailInTemplate` in `utils/email.ts` (outer full-width
+table, centered 600px inner table, `role="presentation"`, inline styles, `<!DOCTYPE html>`,
+meta charset + viewport) but fully forge-branded — no site logo, no nationals footer.
+
+Palette:
+- Outer page background `#0c0a09` (ash black); outer padding `40px 16px`.
+- Panel: background `#1b1613`, border `1px solid #33261e`, `border-radius:12px`,
+  `overflow:hidden`.
+- Ember strip: the panel's first row, a `<td>` with `height:6px`,
+  `background-color:#9a3412` and
+  `background-image:linear-gradient(90deg,#431407,#9a3412,#f59e0b,#9a3412,#431407)`
+  (solid color is the Outlook fallback). `font-size:0;line-height:0;` so it stays 6px.
+- Title/wordmark `#fafaf9`; body text `#e7e5e4`; amber accent `#fbbf24`; ember orange
+  `#f97316`; muted `#a8a29e`; faint `#78716c`; hairlines `#33261e`.
+
+Font stacks (the real Forge fonts — Anton, Arimo — will not load in email clients):
+- Display: `Impact, 'Arial Narrow', 'Helvetica Neue', Arial, sans-serif`, uppercase,
+  letter-spaced.
+- Body: `Arimo, Arial, 'Helvetica Neue', Helvetica, sans-serif`.
+
+Rows, top to bottom:
+1. Ember strip (above).
+2. Header cell, centered, `padding:28px 30px 22px`, bottom border `1px solid #33261e`:
+   `THE FORGE` (26px display stack, `#fafaf9`, `letter-spacing:4px`) with kicker line below:
+   `A MISSIVE FROM THE ELDERS` (11px, `letter-spacing:3px`, `#fbbf24`, uppercase).
+3. Body cell `padding:32px 30px`, `color:#e7e5e4`, `font-size:16px`, `line-height:1.7`,
+   body font stack: `bodyHtml` content.
+4. Signature (inside the same cell, after the content, separated by
+   `margin-top:28px; padding-top:18px; border-top:1px solid #33261e`), auto-injected:
+   - line 1, `color:#78716c;font-size:12px;`: `Sent from the Forge by`
+   - line 2: `<strong style="color:#fafaf9;">{senderName}</strong>
+     <span style="color:#a8a29e;"> — Elder of the Forge</span>`
+   - line 3, `color:#a8a29e;font-size:13px;`: `{senderEmail}`
+5. Confidentiality block — its own row, `padding:0 30px 28px`: an inner box with
+   `background:#201409; border:1px solid #7c2d12; border-left:4px solid #ea580c;
+   border-radius:6px; padding:16px 18px; font-size:13px; line-height:1.6; color:#d6d3d1;`.
+   Copy VERBATIM (lead phrase styled `color:#fbbf24;font-weight:bold;`):
+   > **Keep it in the Forge.** Everything in this missive — card designs, names, mechanics,
+   > set details, images, and timelines — is confidential playtest material. Do not share,
+   > screenshot, forward, or discuss it outside the Forge. You are reading this because the
+   > elders trust you with unfinished work; that trust is what makes the Forge possible.
+   > Guard it.
+6. Footer row: `padding:20px 30px 26px`, top border `1px solid #33261e`, centered, 12px,
+   `color:#78716c`. Copy VERBATIM (sender name repeated; `#a8a29e` for the strong tags):
+   > **Need to respond?** DM **{senderName}** on Discord — that's where the Forge talks.
+   > Replies to this email reach {senderName} as a backstop, but Discord is faster.
+
+   then on its own line, italic, `color:#57534e`, `letter-spacing:1px`:
+   > Forged in fire. Kept in shadow.
+
+**Tests** (`app/forge/lib/__tests__/missiveTemplate.test.ts`, plain vitest, no mocks needed):
+- `escapeHtml` escapes `<script>` / `&` / quotes.
+- `missiveBodyHtml("Hi {name},\n\nRound two begins.", "Ada")` contains `Hi Ada,`, two `<p`
+  blocks, no raw `{name}`.
+- `missiveBodyHtml` with a recipient name containing `<` escapes it.
+- `missiveBodyHtml("a\nb", "x")` produces `a<br>b` (single newline → `<br>`).
+- `wrapForgeMissive` output contains: the body html, `THE FORGE`, sender name, sender email,
+  `Keep it in the Forge`, `DM`/`Discord` footer copy, and does NOT contain `{name}`.
+- `wrapForgeMissive` escapes a malicious senderName (`<img` must not appear unescaped).
+
+## Task 3: Server actions
+
+**Files:**
+- CREATE `app/forge/lib/missives.ts`
+- CREATE `app/forge/lib/__tests__/missives.test.ts`
+
+`"use server"` module mirroring `app/forge/lib/members.ts`. Imports: `requireElder` +
+`ForgeRole` from `@/app/forge/lib/auth`, `sendEmail` from `@/utils/email`,
+`missiveBodyHtml`/`wrapForgeMissive` from `@/app/forge/lib/missiveTemplate`,
+`revalidatePath` from `next/cache`.
+
+```ts
+export type MissiveMember = {
+  userId: string;
+  displayName: string | null;
+  role: ForgeRole;
+  email: string;
+  setIds: string[];
+};
+
+const MAX_RECIPIENTS = 100;      // Resend free tier: 100/day
+const SEND_DELAY_MS = 600;       // Resend default rate limit: 2 req/s
+
+export async function getMissiveDirectory(): Promise<{
+  members: MissiveMember[];
+  sets: { id: string; name: string }[];
+}>;
+
+export async function sendMissive(input: {
+  subject: string;
+  body: string;
+  recipientIds: string[];
+}): Promise<{ ok: boolean; sent: number; failed: number; error?: string }>;
+
+export async function sendMissiveTest(input: {
+  subject: string;
+  body: string;
+}): Promise<{ ok: boolean; error?: string }>;
+
+export async function listRecentMissives(): Promise<
+  { id: string; sender: string; subject: string; recipientCount: number; sentAt: string }[]
+>;
+```
+
+**`getMissiveDirectory`**: `requireElder()`; on null return `{ members: [], sets: [] }`.
+Call `ctx.supabase.rpc("forge_member_directory")` and map rows
+(`user_id/display_name/role/email/set_ids` → camelCase, `set_ids ?? []`). Sets:
+`ctx.supabase.from("forge_sets").select("id, name").order("name")` (RLS already scopes what
+this elder can see). Nulls → empty arrays.
+
+**`sendMissive`** — the load-bearing action:
+1. `requireElder()`; on null `{ ok: false, sent: 0, failed: 0, error: "Not authorized" }`.
+2. Validate: trimmed subject 1–150 chars; trimmed body 1–20000 chars; recipientIds length
+   1–MAX_RECIPIENTS (over cap → error asking to split the send). Clear error strings.
+3. Fetch the directory RPC once. Find the sender's own row (`user_id === ctx.user.id`).
+   If the sender has no `display_name`, return
+   `{ ok: false, ..., error: "Set your Forge display name before sending a missive." }` —
+   missives are never anonymous.
+4. Resolve recipients by INTERSECTING `input.recipientIds` with the directory (unknown ids
+   dropped silently; emails only ever come from the directory — the client can never supply
+   an arbitrary address). Dedupe by userId; drop rows with null/empty email. Zero valid
+   recipients → error.
+5. For each recipient: personalize
+   `wrapForgeMissive({ bodyHtml: missiveBodyHtml(body, r.displayName ?? "Forge member"), senderName, senderEmail: ctx.user.email ?? "" })`
+   and `sendEmail({ to: r.email, subject: "[Forge] " + subject, html, from: FORGE_FROM, replyTo: ctx.user.email ?? undefined })`
+   where `const FORGE_FROM = process.env.FORGE_FROM_EMAIL || "The Forge <noreply@landofredemption.com>"`.
+   Send sequentially; `await new Promise((r) => setTimeout(r, SEND_DELAY_MS))` BETWEEN sends
+   (not after the last). Count sent/failed off `result.success` like `sendBulkEmail` in
+   `app/admin/registrations/actions.ts`.
+6. Log via `ctx.supabase.rpc("forge_log_missive", { p_subject, p_body_text, p_recipient_ids })`
+   with the attempted recipient userIds (log even when some sends failed; skip only if all
+   validation failed before any send). Then `revalidatePath("/forge/missives")`.
+7. Return `{ ok: failed === 0, sent, failed, error: failed > 0 ? "Some sends failed" : undefined }`.
+
+**`sendMissiveTest`**: same gate + subject/body validation + display-name guard; renders the
+IDENTICAL pipeline for the sender only (`{name}` → own displayName), subject
+`"[TEST] [Forge] " + subject`, to `ctx.user.email`, same `from`/`replyTo`. NOT logged, no
+revalidate, no delay.
+
+**`listRecentMissives`**: gate; `ctx.supabase.from("forge_missives")
+.select("id, sender, subject, recipient_count, sent_at").order("sent_at", { ascending: false })
+.limit(20)`; map to camelCase.
+
+**Tests** (`missives.test.ts`) — copy the mocking pattern from
+`app/forge/lib/__tests__/members.test.ts` exactly (vi.mock `next/cache`,
+`@/app/forge/lib/auth`, `@/utils/email`, `@/utils/supabase/server`; do NOT mock
+missiveTemplate — let the real template run). Directory RPC mock returns e.g. sender row
+(`user_id: "caller"`, display_name "Smith", email "c@x.com", role "elder") + two playtesters.
+Cases:
+- not-elder → `sendMissive`/`sendMissiveTest`/`getMissiveDirectory` reject/empty.
+- empty subject, empty body, 0 recipients, >100 recipients → validation errors, no sendEmail calls.
+- sender without display_name → blocked with the display-name error.
+- unknown recipientIds are dropped; only directory emails are used (assert `sendEmail` called
+  with the directory email, not anything client-supplied).
+- happy path 2 recipients: 2 sendEmail calls, subject prefixed `[Forge] `, html contains
+  each recipient's name (personalization), `replyTo` = sender email, log RPC called with
+  attempted ids, ok true. (2 recipients = one 600ms delay; acceptable test cost. If you
+  prefer, use `vi.useFakeTimers` + `advanceTimersByTimeAsync`.)
+- one send fails (mock sendEmail second call `{ success: false }`) → `ok === false`,
+  `sent === 1`, `failed === 1`, still logged.
+- `sendMissiveTest`: sends exactly one email to the caller, subject `[TEST] [Forge] ...`,
+  log RPC NOT called.
+
+## Task 4: Page, composer, nav
+
+**Files:**
+- CREATE `app/forge/missives/page.tsx`
+- CREATE `app/forge/missives/MissiveComposer.tsx`
+- MODIFY `app/forge/components/ForgeNav.tsx` (one array entry — nothing else)
+
+**`page.tsx`** — mirror `app/forge/admin/page.tsx` exactly in shape:
+`export const dynamic = "force-dynamic"; export const revalidate = 0;`;
+`requireElder()` else `notFound()`; load `getMissiveDirectory()` and `listRecentMissives()`
+in `Promise.all`; render `<main className="mx-auto max-w-3xl p-6">` with
+`<h1 className="text-2xl" style={{ fontFamily: "Cinzel, serif" }}>Missives</h1>` and
+`<MissiveComposer members={...} sets={...} recent={...} callerId={ctx.user.id} />`.
+
+**`MissiveComposer.tsx`** — `"use client"`, minimal, styled like `AdminConsole.tsx`.
+Props: `{ members: MissiveMember-shaped[]; sets: {id,name}[]; recent: {...}[]; callerId: string }`
+(re-declare prop types locally like ForgeNav does — do not import server-only modules).
+State: `selected: Set<string>`, `subject`, `body`, status message, `useTransition`.
+
+Sections:
+1. `h2` "Compose a missive".
+   - Recipients: quick-select buttons `All`, `Elders`, `Playtesters`, `None` (buttons REPLACE
+     the selection with that group; elders group = role elder or superadmin) plus, when
+     `sets.length > 0`, a `<select>` "Everyone on set…" that replaces the selection with
+     members whose `setIds` includes the chosen set. Below: a scrollable checkbox list
+     (`max-h-64 overflow-y-auto rounded-md border`) of all members — checkbox, display name
+     (fallback "(no name)"), small role tag, muted email. Live count line: "N recipient(s)
+     selected".
+   - Subject: text input; helper text `Sent as: [Forge] <your subject>`.
+   - Body: `<textarea rows={10}>`; helper text: `Plain text. {name} becomes each member's
+     display name. Your signature and the confidentiality notice are added automatically.`
+   - Buttons row: secondary button `Send test to me` → `sendMissiveTest({ subject, body })`;
+     primary button `Send to N member(s)` (disabled while pending or when N === 0 or subject/
+     body empty) → `window.confirm(...)` then `sendMissive({ subject, body, recipientIds })`.
+     On success clear subject/body/selection and show the sent/failed counts; on failure show
+     the returned error. Remember `=== false` narrowing.
+2. `h2` "Recent missives": list `recent` (subject, sender display name resolved from
+   `members` by userId — fallback "Former member", recipientCount, date via
+   `new Date(sentAt).toLocaleDateString()`); empty state "No missives sent yet."
+
+**`ForgeNav.tsx`**: in the elder/superadmin branch, after the `Play` item and before the
+superadmin-only `Admin` spread, add:
+`{ href: "/forge/missives", label: "Missives", match: (p) => p.startsWith("/forge/missives") }`.
+The playtester branch is untouched — playtesters never see the tab.
+
+**Tests/verification:** `npm run test` still passes (no new unit tests required for the page —
+the actions are covered by Task 3; note in your report that visual verification happens after
+merge). `npx tsc --noEmit` if quick; otherwise rely on vitest + review.

--- a/supabase/migrations/062_forge_missives.sql
+++ b/supabase/migrations/062_forge_missives.sql
@@ -1,0 +1,67 @@
+-- 062_forge_missives.sql
+-- Forge Missives: elder→member email. Directory RPC (emails live only in auth.users)
+-- + sent-missive log. Follows 048/049 definer/no-oracle/revoke patterns.
+
+-- 1) Sent-missive log. Read: elders+. Write: only via forge_log_missive below.
+create table if not exists public.forge_missives (
+  id              uuid primary key default gen_random_uuid(),
+  sender          uuid not null references auth.users(id),
+  subject         text not null,
+  body_text       text not null,          -- raw composed body, pre-template
+  recipient_ids   uuid[] not null,
+  recipient_count int not null,
+  sent_at         timestamptz not null default now()
+);
+alter table public.forge_missives enable row level security;
+drop policy if exists "forge_missives_select" on public.forge_missives;
+create policy "forge_missives_select" on public.forge_missives
+  for select to authenticated using (public.is_forge_elder_or_super());
+revoke all on public.forge_missives from anon;
+grant select on public.forge_missives to authenticated;
+-- no insert/update/delete policies: writes land via forge_log_missive only
+
+-- 2) Member directory with emails (auth.users) + set scoping for targeting.
+--    NO ORACLE: returns zero rows for non-elders (mirrors forge_list_invites).
+--    set_ids = grants ∪ set-elderships, so "everyone on set X" includes that
+--    set's elders as well as granted playtesters.
+create or replace function public.forge_member_directory()
+returns table(user_id uuid, display_name text, role public.playtest_role,
+              email text, set_ids uuid[])
+language sql security definer stable set search_path = '' as $$
+  select m.user_id, m.display_name, m.role, u.email::text,
+         coalesce((
+           select array_agg(distinct s.set_id) from (
+             select g.set_id from public.forge_set_grants g where g.user_id = m.user_id
+             union
+             select e.set_id from public.forge_set_elders e where e.user_id = m.user_id
+           ) s
+         ), '{}')
+  from public.playtest_members m
+  join auth.users u on u.id = m.user_id
+  where public.is_forge_elder_or_super()
+  order by m.role, m.display_name nulls last;
+$$;
+
+-- 3) Log a sent missive (elders+; also stamps forge_audit).
+create or replace function public.forge_log_missive(
+  p_subject text, p_body_text text, p_recipient_ids uuid[]
+) returns uuid language plpgsql security definer set search_path = '' as $$
+declare v_id uuid;
+begin
+  if not public.is_forge_elder_or_super() then
+    raise exception 'not authorized';
+  end if;
+  insert into public.forge_missives (sender, subject, body_text, recipient_ids, recipient_count)
+  values (auth.uid(), p_subject, p_body_text, coalesce(p_recipient_ids, '{}'),
+          coalesce(array_length(p_recipient_ids, 1), 0))
+  returning id into v_id;
+  insert into public.forge_audit (actor, action, target)
+  values (auth.uid(), 'missive_sent', v_id::text);
+  return v_id;
+end; $$;
+
+-- 4) Lock down execute (Supabase default-grants anon directly; strip it — cf. 048 §3).
+revoke execute on function public.forge_member_directory() from public, anon;
+revoke execute on function public.forge_log_missive(text, text, uuid[]) from public, anon;
+grant execute on function public.forge_member_directory() to authenticated;
+grant execute on function public.forge_log_missive(text, text, uuid[]) to authenticated;

--- a/utils/email.ts
+++ b/utils/email.ts
@@ -8,11 +8,13 @@ interface EmailOptions {
   to: string;
   subject: string;
   html: string;
+  from?: string;
+  replyTo?: string;
 }
 
-export async function sendEmail({ to, subject, html }: EmailOptions) {
+export async function sendEmail({ to, subject, html, from, replyTo }: EmailOptions) {
   const resendApiKey = process.env.RESEND_API_KEY;
-  const fromEmail = process.env.FROM_EMAIL || "RedemptionCCG.app <noreply@landofredemption.com>";
+  const fromEmail = from ?? (process.env.FROM_EMAIL || "RedemptionCCG.app <noreply@landofredemption.com>");
 
   if (!resendApiKey) {
     console.warn("RESEND_API_KEY not configured. Email not sent.");
@@ -31,6 +33,7 @@ export async function sendEmail({ to, subject, html }: EmailOptions) {
         to,
         subject,
         html,
+        ...(replyTo ? { reply_to: replyTo } : {}),
       }),
     });
 


### PR DESCRIPTION
## What

**Missives** — a new elder-only tab under The Forge (`/forge/missives`) for emailing playtesters and fellow elders: instructions, round announcements, notifications.

- **Compose & target**: quick-selects (All / Elders / Playtesters / by set) driving an individual member checklist; `{name}` personalization; live recipient count; confirm before send.
- **Test-send**: "Send test to me" delivers the fully rendered draft (`[TEST] [Forge]` prefix, never logged) so you can see exactly what recipients get.
- **Forge-themed email**: dark ash/ember design (ember gradient strip, THE FORGE wordmark, amber kicker), tuned for readability — table-based inline-style HTML that survives Gmail/Outlook/Apple Mail.
- **Never anonymous**: the sender's Forge display name + auth email are auto-injected into the signature; sends are blocked until the elder has a display name.
- **Confidentiality**: every missive carries a "Keep it in the Forge" trust/confidentiality block.
- **Replies**: copy directs recipients to Discord DMs; `Reply-To` is set to the sending elder as a backstop so replies never silently black-hole.

## Access control

Elder/superadmin only, enforced twice: `requireElder()` on the page (404 for playtesters/non-members) and every server action, plus DB-side `is_forge_elder_or_super()` gates inside the new SECURITY DEFINER RPCs (no-oracle empty results). Recipient emails resolve exclusively from the `forge_member_directory()` RPC — client-supplied ids are intersected, so arbitrary addresses can't be injected.

## Schema (migration 062 — already applied to remote)

- `forge_missives` send log (RLS: elders read; writes only via `forge_log_missive`, which also stamps `forge_audit`)
- `forge_member_directory()` — member emails from `auth.users` + set scoping (grants ∪ set-elderships)

## Hardening (from multi-agent review)

`maxDuration = 300` for long sends (up to 100 recipients at 600ms spacing for Resend rate limits), directory/log RPC error handling, zero-sent guard so the log never records a missive that didn't go out.

## Tests

25 new unit tests (template escaping/personalization/copy; action gating, recipient intersection, validation bounds, partial-failure accounting, test-send isolation). Suite green apart from two pre-existing failures unrelated to this branch (`forge-anon-leak` needs `SUPABASE_URL`; `store-route` mock bug — both fail on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)