### PR TITLE
Forge: import wizard polish (no pills, modal set naming) + rename Missives → Announcements

### DIFF
--- a/app/forge/announcements/AnnouncementComposer.tsx
+++ b/app/forge/announcements/AnnouncementComposer.tsx
@@ -9,7 +9,7 @@ type ForgeRole = "superadmin" | "elder" | "playtester";
 type Member = { userId: string; displayName: string | null; role: ForgeRole; email: string; setIds: string[] };
 type Recent = { id: string; sender: string; subject: string; recipientCount: number; sentAt: string };
 
-export default function MissiveComposer({
+export default function AnnouncementComposer({
   members,
   sets,
   recent,
@@ -62,7 +62,7 @@ export default function MissiveComposer({
   }
 
   function handleSend() {
-    if (!window.confirm(`Send this missive to ${selected.size} member(s)?`)) return;
+    if (!window.confirm(`Send this announcement to ${selected.size} member(s)?`)) return;
     setMsg(null);
     startTransition(async () => {
       const r = await sendMissive({ subject, body, recipientIds: Array.from(selected) });
@@ -80,7 +80,7 @@ export default function MissiveComposer({
   return (
     <div className="mt-6 space-y-8">
       <section>
-        <h2 className="text-lg font-medium">Compose a missive</h2>
+        <h2 className="text-lg font-medium">Compose an announcement</h2>
 
         <div className="mt-2 flex flex-wrap items-center gap-2">
           <button
@@ -213,7 +213,7 @@ export default function MissiveComposer({
       </section>
 
       <section>
-        <h2 className="text-lg font-medium">Recent missives</h2>
+        <h2 className="text-lg font-medium">Recent announcements</h2>
         <ul className="mt-2 space-y-1 text-sm">
           {recent.map((r) => (
             <li key={r.id} className="text-muted-foreground">
@@ -222,7 +222,7 @@ export default function MissiveComposer({
               {new Date(r.sentAt).toLocaleDateString()}
             </li>
           ))}
-          {recent.length === 0 && <li className="text-muted-foreground">No missives sent yet.</li>}
+          {recent.length === 0 && <li className="text-muted-foreground">No announcements sent yet.</li>}
         </ul>
       </section>
     </div>

--- a/app/forge/announcements/page.tsx
+++ b/app/forge/announcements/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { requireElder } from "@/app/forge/lib/auth";
 import { getMissiveDirectory, listRecentMissives } from "@/app/forge/lib/missives";
-import MissiveComposer from "./MissiveComposer";
+import AnnouncementComposer from "./AnnouncementComposer";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -9,16 +9,16 @@ export const revalidate = 0;
 // function timeout (Next.js applies the page's segment config to server actions invoked from it).
 export const maxDuration = 300;
 
-export default async function ForgeMissivesPage() {
+export default async function ForgeAnnouncementsPage() {
   const ctx = await requireElder();
   if (!ctx) notFound();
   const [{ members, sets }, recent] = await Promise.all([getMissiveDirectory(), listRecentMissives()]);
   return (
     <main className="mx-auto max-w-3xl p-6">
       <h1 className="text-2xl" style={{ fontFamily: "Cinzel, serif" }}>
-        Missives
+        Announcements
       </h1>
-      <MissiveComposer members={members} sets={sets} recent={recent} callerId={ctx.user.id} />
+      <AnnouncementComposer members={members} sets={sets} recent={recent} callerId={ctx.user.id} />
     </main>
   );
 }

--- a/app/forge/components/ForgeNav.tsx
+++ b/app/forge/components/ForgeNav.tsx
@@ -22,7 +22,7 @@ export default function ForgeNav({ role }: { role: ForgeRole }) {
           { href: "/forge/ideas", label: "Ideas", match: (p) => p.startsWith("/forge/ideas") },
           { href: "/forge/sets", label: "Sets", match: (p) => p.startsWith("/forge/sets") },
           { href: "/forge/play", label: "Play", match: (p) => p.startsWith("/forge/play") },
-          { href: "/forge/missives", label: "Missives", match: (p) => p.startsWith("/forge/missives") },
+          { href: "/forge/announcements", label: "Announcements", match: (p) => p.startsWith("/forge/announcements") },
           ...(role === "superadmin"
             ? [{ href: "/forge/admin", label: "Admin", match: (p: string) => p.startsWith("/forge/admin") }]
             : []),

--- a/app/forge/import/ImportWizard.tsx
+++ b/app/forge/import/ImportWizard.tsx
@@ -15,6 +15,15 @@ import {
   lackeyRowToDesignCard, type LackeyRow,
 } from "@/app/forge/lib/lackey";
 import { createSet, type ForgeSetSummary } from "@/app/forge/lib/sets";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+  DialogFooter,
+} from "@/components/ui/dialog";
 
 const BATCH_SIZE = 8;            // cards per request (must stay ≤ the route's cap of 12)
 const BATCH_CONCURRENCY = 4;     // requests in flight
@@ -78,6 +87,7 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
   const [newSetName, setNewSetName] = useState("");
   const [existingSetId, setExistingSetId] = useState(sets[0]?.id ?? "");
   const [overwrite, setOverwrite] = useState(false);
+  const [newSetDialogOpen, setNewSetDialogOpen] = useState(false);
 
   const [items, setItems] = useState<ImportItem[] | null>(null);
   const [running, setRunning] = useState(false);
@@ -308,14 +318,6 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
       {rows && (
         <fieldset className="mt-4 rounded-md border p-3">
           <legend className="px-1 text-sm font-medium">2 · Which set?</legend>
-          <div className="mb-2 flex flex-wrap gap-1">
-            {zipSets.slice(0, 12).map(({ set, count }) => (
-              <button key={set} type="button" onClick={() => onFilterChange(set)} disabled={running}
-                className={`rounded-full border px-2 py-0.5 text-xs disabled:opacity-50 ${filter === set ? "border-primary bg-primary/10" : "hover:bg-muted"}`}>
-                {set} <span className="text-muted-foreground">({count})</span>
-              </button>
-            ))}
-          </div>
           <input value={filter} onChange={(e) => onFilterChange(e.target.value)} disabled={running}
             aria-label="Set filter" placeholder="Set code, e.g. EoT — or /regex/"
             className="w-full rounded-md border bg-background px-3 py-2 text-sm disabled:opacity-50" />
@@ -369,11 +371,6 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
                 onChange={() => { setMode("new"); setOverwrite(false); }} />
               Create a new set
             </label>
-            {mode === "new" && (
-              <input value={newSetName} onChange={(e) => setNewSetName(e.target.value)}
-                aria-label="New set name" placeholder="Set name"
-                className="ml-6 w-64 rounded-md border bg-background px-2 py-1 text-sm" />
-            )}
             <label className="flex items-center gap-2">
               <input type="radio" name="dest" checked={mode === "existing"} onChange={() => setMode("existing")}
                 disabled={sets.length === 0} />
@@ -401,12 +398,36 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
             )}
           </div>
           {runError && <p className="mt-2 text-sm text-red-500">{runError}</p>}
-          <button type="button" onClick={runImport} disabled={running || matched.length === 0}
+          <button type="button" onClick={() => (mode === "new" ? setNewSetDialogOpen(true) : runImport())}
+            disabled={running || matched.length === 0}
             className="mt-3 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50">
             {matched.length === 1 ? "Import 1 card" : `Import ${matched.length} cards`}
           </button>
         </fieldset>
       )}
+
+      <Dialog open={newSetDialogOpen} onOpenChange={(o) => !running && setNewSetDialogOpen(o)}>
+        <DialogContent size="sm">
+          <DialogHeader>
+            <DialogTitle>New set for this import</DialogTitle>
+          </DialogHeader>
+          <DialogBody>
+            <label className="block text-sm">
+              <span className="mb-1 block font-medium">Set name</span>
+              <input value={newSetName} onChange={(e) => setNewSetName(e.target.value)}
+                aria-label="New set name" placeholder="Set name"
+                className="w-full rounded-md border bg-background px-2 py-1 text-sm" />
+            </label>
+          </DialogBody>
+          <DialogFooter className="justify-end">
+            <Button variant="cancel" onClick={() => setNewSetDialogOpen(false)}>Cancel</Button>
+            <Button disabled={running || !newSetName.trim()}
+              onClick={() => { setNewSetDialogOpen(false); runImport(); }}>
+              {matched.length === 1 ? "Create set & import 1 card" : `Create set & import ${matched.length} cards`}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* 5 — progress + summary */}
       {items && (

--- a/app/forge/lib/__tests__/missives.test.ts
+++ b/app/forge/lib/__tests__/missives.test.ts
@@ -148,7 +148,7 @@ describe("sendMissive", () => {
     (requireElder as any).mockResolvedValue(c);
     const r = await sendMissive({ subject: "Hi", body: "Body", recipientIds: ["p1"] });
     expect(r.ok).toBe(false);
-    expect(r.error).toBe("Set your Forge display name before sending a missive.");
+    expect(r.error).toBe("Set your Forge display name before sending an announcement.");
     expect(sendEmail).not.toHaveBeenCalled();
   });
 
@@ -207,7 +207,7 @@ describe("sendMissive", () => {
       p_body_text: "Hello {name}",
       p_recipient_ids: ["p1", "p2"],
     });
-    expect(revalidatePath).toHaveBeenCalledWith("/forge/missives");
+    expect(revalidatePath).toHaveBeenCalledWith("/forge/announcements");
     expect(r).toEqual({ ok: true, sent: 2, failed: 0, error: undefined });
   });
 

--- a/app/forge/lib/missiveTemplate.ts
+++ b/app/forge/lib/missiveTemplate.ts
@@ -1,3 +1,5 @@
+// UI name: "Announcements" (renamed 2026-07-04). DB objects keep the missive name (migration 062 is live).
+//
 // Forge missive email template.
 // Pure, synchronous HTML builders for the "Forge Missives" feature: elders emailing
 // playtesters. Emails ship as raw HTML via Resend, so every style that carries the
@@ -66,7 +68,7 @@ export function wrapForgeMissive(opts: {
             <tr>
               <td align="center" style="padding:28px 30px 22px;border-bottom:1px solid #33261e;">
                 <div style="font-family:${display};font-size:26px;color:#fafaf9;letter-spacing:4px;text-transform:uppercase;">THE FORGE</div>
-                <div style="font-family:${display};font-size:12px;color:#fbbf24;letter-spacing:3px;text-transform:uppercase;margin-top:8px;">A MISSIVE FROM THE ELDERS</div>
+                <div style="font-family:${display};font-size:12px;color:#fbbf24;letter-spacing:3px;text-transform:uppercase;margin-top:8px;">AN ANNOUNCEMENT FROM THE ELDERS</div>
               </td>
             </tr>
             <!-- Body + signature -->
@@ -84,7 +86,7 @@ export function wrapForgeMissive(opts: {
             <tr>
               <td style="padding:0 30px 28px;">
                 <div style="background:#201409;border:1px solid #7c2d12;border-left:4px solid #ea580c;border-radius:6px;padding:16px 18px;font-size:14px;line-height:1.65;color:#e9e4de;font-family:${bodyFont};">
-                  <span style="color:#fbbf24;font-weight:bold;">Keep it in the Forge.</span> Everything in this missive — card designs, names, mechanics, set details, images, and timelines — is confidential playtest material. Do not share, screenshot, forward, or discuss it outside the Forge. You are reading this because the elders trust you with unfinished work; that trust is what makes the Forge possible. Guard it.
+                  <span style="color:#fbbf24;font-weight:bold;">Keep it in the Forge.</span> Everything in this announcement — card designs, names, mechanics, set details, images, and timelines — is confidential playtest material. Do not share, screenshot, forward, or discuss it outside the Forge. You are reading this because the elders trust you with unfinished work; that trust is what makes the Forge possible. Guard it.
                 </div>
               </td>
             </tr>

--- a/app/forge/lib/missives.ts
+++ b/app/forge/lib/missives.ts
@@ -1,5 +1,7 @@
 "use server";
 
+// UI name: "Announcements" (renamed 2026-07-04). DB objects keep the missive name (migration 062 is live).
+
 import { revalidatePath } from "next/cache";
 import { requireElder, type ForgeRole } from "@/app/forge/lib/auth";
 import { sendEmail } from "@/utils/email";
@@ -98,7 +100,7 @@ export async function sendMissive(input: {
       ok: false,
       sent: 0,
       failed: 0,
-      error: "Set your Forge display name before sending a missive.",
+      error: "Set your Forge display name before sending an announcement.",
     };
   }
 
@@ -155,13 +157,13 @@ export async function sendMissive(input: {
     p_recipient_ids: recipients.map((r) => r.userId),
   });
   if (logError) console.error("forge_log_missive failed:", logError);
-  revalidatePath("/forge/missives");
+  revalidatePath("/forge/announcements");
 
   let error = failed > 0 ? "Some sends failed" : undefined;
   if (logError) {
     error = error
-      ? error + " Sent, but the missive log could not be written."
-      : "Sent, but the missive log could not be written.";
+      ? error + " Sent, but the announcement log could not be written."
+      : "Sent, but the announcement log could not be written.";
   }
 
   return { ok: failed === 0, sent, failed, error };
@@ -191,7 +193,7 @@ export async function sendMissiveTest(input: {
 
   const sender = directory.find((m) => m.userId === ctx.user.id);
   if (!sender || !sender.displayName) {
-    return { ok: false, error: "Set your Forge display name before sending a missive." };
+    return { ok: false, error: "Set your Forge display name before sending an announcement." };
   }
 
   const html = wrapForgeMissive({

--- a/e2e/forge/import.spec.ts
+++ b/e2e/forge/import.spec.ts
@@ -62,8 +62,9 @@ test.describe("forge lackey set import", () => {
 
       // destination: new set (name is prefilled with the filter "TST")
       const setName = `E2E Import ${Date.now()}`;
-      await page.getByLabel("New set name").fill(setName);
       await page.getByRole("button", { name: "Import 3 cards" }).click();
+      await page.getByLabel("New set name").fill(setName);
+      await page.getByRole("button", { name: "Create set & import 3 cards" }).click();
 
       await expect(page.getByText("Imported 3 · Skipped 0 · Failed 0")).toBeVisible({ timeout: 120_000 });
 

--- a/e2e/forge/uiux.spec.ts
+++ b/e2e/forge/uiux.spec.ts
@@ -44,8 +44,9 @@ test.describe("forge uiux pass", () => {
       await page.getByLabel("Set filter").fill("TST");
       await expect(page.getByText("3 cards match")).toBeVisible();
       const setName = `E2E UIUX ${Date.now()}`;
-      await page.getByLabel("New set name").fill(setName);
       await page.getByRole("button", { name: "Import 3 cards" }).click();
+      await page.getByLabel("New set name").fill(setName);
+      await page.getByRole("button", { name: "Create set & import 3 cards" }).click();
       await expect(page.getByText("Imported 3 · Skipped 0 · Failed 0")).toBeVisible({ timeout: 120_000 });
       await page.getByRole("link", { name: "View set →" }).click();
 


### PR DESCRIPTION
## Summary

Follow-ups on the merged UI/UX pass (#148):

- **Import wizard**: the set-code pill row is gone (it ranked by row count, which never surfaced the set you were actually importing); the free-text code/regex input stays. New-set naming moved out of the inline prefilled text box into a small dialog that opens on "Import N cards" when "Create a new set" is selected — prefilled from the filter, confirmed with "Create set & import N cards". Adding to an existing set (and overwrite mode) is unchanged.
- **Missives → Announcements**: nav tab, route (`/forge/announcements`), page, composer copy, and the recipient-facing email text ("AN ANNOUNCEMENT FROM THE ELDERS") all renamed. The live DB objects from migration 062 (`forge_missives`, `forge_log_missive`) and the lib file/function names that mirror them are intentionally unchanged, with header comments explaining the split.

No migrations, no new RPCs or routes beyond the renamed page.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run` — in-tree green (only failures live in sibling worktree checkouts)
- [x] Playwright `import.spec.ts` + `uiux.spec.ts` — 5/5 (both updated for the modal naming flow)
- [x] `grep -rin missive app/ e2e/` residue = only DB-mirroring lib internals, by design

🤖 Generated with [Claude Code](https://claude.com/claude-code)