### PR TITLE
perf(forge): collapse art proxy auth to one RPC + empty-src guard

### DIFF
--- a/__tests__/forge-gate-first.test.ts
+++ b/__tests__/forge-gate-first.test.ts
@@ -22,7 +22,17 @@ function listForgeRouteFiles(): string[] {
 
 const GATE = /require(Forge|Elder|ForgeSuperadmin)\s*\(/;
 // Pure redirect with no data exposure — intentionally has no gate.
-const ALLOW_NO_GATE = new Set(["app/forge/art/page.tsx", "app/forge/ideas/[cardId]/page.tsx"]);
+const ALLOW_NO_GATE = new Set([
+  "app/forge/art/page.tsx",
+  "app/forge/ideas/[cardId]/page.tsx",
+  "app/forge/play/games/page.tsx", // bare redirect to /forge/play (lobby moved)
+]);
+// Routes whose gate lives elsewhere still must match their specific gate call.
+const ALT_GATE: Record<string, RegExp> = {
+  // Member role check + RLS run inside the forge_art_key RPC (migration 066);
+  // a null key 404s. Collapsed from requireForge to save per-image round trips.
+  "app/forge/api/art/[cardId]/route.ts": /rpc\(\s*["']forge_art_key["']/,
+};
 
 describe("forge gate-first guardrail", () => {
   const files = listForgeRouteFiles().filter((f) => !ALLOW_NO_GATE.has(f));
@@ -34,7 +44,8 @@ describe("forge gate-first guardrail", () => {
   for (const f of files) {
     it(`${f} calls a Forge gate`, () => {
       const src = readFileSync(join(process.cwd(), f), "utf8");
-      expect(GATE.test(src), `${f} must call requireForge/requireElder/requireForgeSuperadmin`).toBe(true);
+      const gate = ALT_GATE[f] ?? GATE;
+      expect(gate.test(src), `${f} must call its Forge gate (${gate})`).toBe(true);
     });
   }
 });

--- a/app/forge/api/art/[cardId]/__tests__/route.test.ts
+++ b/app/forge/api/art/[cardId]/__tests__/route.test.ts
@@ -1,62 +1,103 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// Mock the auth gate so we can force the unauthenticated branch hermetically.
-vi.mock("@/app/forge/lib/auth", () => ({
-  requireForge: vi.fn(),
-  notFoundResponse: () => new Response("Not Found", { status: 404 }),
-}));
-// Blob read must never be reached on the unauth path; stub it so an accidental
+// The route builds its own Supabase client; mock the factory so each test can
+// shape auth + RPC results hermetically.
+vi.mock("@/utils/supabase/server", () => ({ createClient: vi.fn() }));
+// Blob read must never be reached on denied paths; stub it so an accidental
 // call would be obvious (and to avoid importing the real @vercel/blob).
 vi.mock("@/app/forge/lib/art", () => ({ readForgeArt: vi.fn() }));
 
 import { GET } from "@/app/forge/api/art/[cardId]/route";
-import { requireForge } from "@/app/forge/lib/auth";
+import { createClient } from "@/utils/supabase/server";
 import { readForgeArt } from "@/app/forge/lib/art";
 
-function memberCtx(workingArtKey: string | null) {
-  const maybeSingle = vi.fn().mockResolvedValue({
-    data: workingArtKey === null ? null : { working_art_key: workingArtKey },
+/**
+ * One `forge_art_key` RPC now does the member gate + version resolution + key
+ * lookup server-side (SECURITY INVOKER, RLS-checked — migration 066). The
+ * route only distinguishes: session valid? key returned? blob readable?
+ */
+function mockSupabase(opts: { user?: boolean; artKey?: string | null; rpcError?: boolean }) {
+  const rpc = vi.fn((fn: string) => {
+    if (fn === "forge_art_key") {
+      return Promise.resolve(
+        opts.rpcError
+          ? { data: null, error: { message: "boom" } }
+          : { data: opts.artKey ?? null, error: null },
+      );
+    }
+    // forge_log_art_download audit
+    return Promise.resolve({ data: null, error: null });
   });
-  const eq = vi.fn(() => ({ maybeSingle }));
-  const select = vi.fn(() => ({ eq }));
-  const from = vi.fn(() => ({ select }));
-  const rpc = vi.fn().mockResolvedValue({ data: null, error: null });
-  return { supabase: { from, rpc }, user: { id: "u1", email: "e@x" }, role: "elder" };
+  const getUser = vi.fn().mockResolvedValue(
+    opts.user === false
+      ? { data: { user: null }, error: { message: "no session" } }
+      : { data: { user: { id: "u1" } }, error: null },
+  );
+  const client = { auth: { getUser }, rpc };
+  (createClient as ReturnType<typeof vi.fn>).mockResolvedValue(client);
+  return client;
 }
 
-// Dispatches forge_cards (approved_version_id) then card_versions (art keys) for ?v=approved.
-function approvedCtx(opts: {
-  approvedVersionId: string | null;
-  version?: { art_original_key: string | null; art_key: string | null; art_is_placeholder: boolean } | null;
-}) {
-  const from = vi.fn((table: string) => {
-    if (table === "forge_cards") {
-      const maybeSingle = vi.fn().mockResolvedValue({
-        data: opts.approvedVersionId === null ? null : { approved_version_id: opts.approvedVersionId },
-      });
-      return { select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle })) })) };
-    }
-    // card_versions
-    const maybeSingle = vi.fn().mockResolvedValue({ data: opts.version ?? null });
-    return { select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle })) })) };
-  });
-  const rpc = vi.fn().mockResolvedValue({ data: null, error: null });
-  return { supabase: { from, rpc }, user: { id: "u1", email: "e@x" }, role: "playtester" };
-}
+const okBlob = () => ({
+  statusCode: 200,
+  stream: new ReadableStream(),
+  blob: { contentType: "image/png" },
+});
 
 describe("GET /forge/api/art/[cardId]", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("returns 404 when the caller is not a Forge member", async () => {
-    (requireForge as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+  it("returns 404 when the caller has no session, even if a key would resolve", async () => {
+    mockSupabase({ user: false, artKey: "forge-art/x" });
     const req = new Request("http://localhost/forge/api/art/abc") as never;
     const res = await GET(req, { params: Promise.resolve({ cardId: "abc" }) });
     expect(res.status).toBe(404);
     expect(readForgeArt).not.toHaveBeenCalled();
   });
 
+  it("returns 404 when the RPC yields no key (non-member, unknown card, placeholder…)", async () => {
+    mockSupabase({ artKey: null });
+    const req = new Request("http://localhost/forge/api/art/abc") as never;
+    const res = await GET(req, { params: Promise.resolve({ cardId: "abc" }) });
+    expect(res.status).toBe(404);
+    expect(readForgeArt).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the RPC errors (e.g. malformed card id)", async () => {
+    mockSupabase({ rpcError: true });
+    const req = new Request("http://localhost/forge/api/art/not-a-uuid") as never;
+    const res = await GET(req, { params: Promise.resolve({ cardId: "not-a-uuid" }) });
+    expect(res.status).toBe(404);
+    expect(readForgeArt).not.toHaveBeenCalled();
+  });
+
+  it("maps query params onto the RPC (approved + finished)", async () => {
+    const client = mockSupabase({ artKey: "forge-finished/k" });
+    (readForgeArt as ReturnType<typeof vi.fn>).mockResolvedValue(okBlob());
+    const req = new Request("http://localhost/forge/api/art/abc?v=approved&kind=finished") as never;
+    await GET(req, { params: Promise.resolve({ cardId: "abc" }) });
+    expect(client.rpc).toHaveBeenCalledWith("forge_art_key", {
+      p_card_id: "abc",
+      p_approved: true,
+      p_kind: "finished",
+    });
+    expect(readForgeArt).toHaveBeenCalledWith("forge-finished/k");
+  });
+
+  it("defaults to the working art view when no params are given", async () => {
+    const client = mockSupabase({ artKey: "forge-art/w" });
+    (readForgeArt as ReturnType<typeof vi.fn>).mockResolvedValue(okBlob());
+    const req = new Request("http://localhost/forge/api/art/abc") as never;
+    await GET(req, { params: Promise.resolve({ cardId: "abc" }) });
+    expect(client.rpc).toHaveBeenCalledWith("forge_art_key", {
+      p_card_id: "abc",
+      p_approved: false,
+      p_kind: "art",
+    });
+  });
+
   it("returns 404 when the blob read returns null (dangling key)", async () => {
-    (requireForge as ReturnType<typeof vi.fn>).mockResolvedValue(memberCtx("forge-art/x"));
+    mockSupabase({ artKey: "forge-art/x" });
     (readForgeArt as ReturnType<typeof vi.fn>).mockResolvedValue(null);
     const req = new Request("http://localhost/forge/api/art/abc") as never;
     const res = await GET(req, { params: Promise.resolve({ cardId: "abc" }) });
@@ -64,7 +105,7 @@ describe("GET /forge/api/art/[cardId]", () => {
   });
 
   it("returns 404 when the blob read throws", async () => {
-    (requireForge as ReturnType<typeof vi.fn>).mockResolvedValue(memberCtx("forge-art/x"));
+    mockSupabase({ artKey: "forge-art/x" });
     (readForgeArt as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("blob down"));
     const req = new Request("http://localhost/forge/api/art/abc") as never;
     const res = await GET(req, { params: Promise.resolve({ cardId: "abc" }) });
@@ -72,12 +113,8 @@ describe("GET /forge/api/art/[cardId]", () => {
   });
 
   it("streams the art with private no-store cache when present", async () => {
-    (requireForge as ReturnType<typeof vi.fn>).mockResolvedValue(memberCtx("forge-art/x"));
-    (readForgeArt as ReturnType<typeof vi.fn>).mockResolvedValue({
-      statusCode: 200,
-      stream: new ReadableStream(),
-      blob: { contentType: "image/png" },
-    });
+    mockSupabase({ artKey: "forge-art/x" });
+    (readForgeArt as ReturnType<typeof vi.fn>).mockResolvedValue(okBlob());
     const req = new Request("http://localhost/forge/api/art/abc") as never;
     const res = await GET(req, { params: Promise.resolve({ cardId: "abc" }) });
     expect(res.status).toBe(200);
@@ -85,51 +122,22 @@ describe("GET /forge/api/art/[cardId]", () => {
     expect(res.headers.get("cache-control")).toBe("private, no-store");
   });
 
+  it("serves an immutable private cache header when a t cache-buster is present", async () => {
+    mockSupabase({ artKey: "forge-art/x" });
+    (readForgeArt as ReturnType<typeof vi.fn>).mockResolvedValue(okBlob());
+    const req = new Request("http://localhost/forge/api/art/abc?v=approved&t=v1") as never;
+    const res = await GET(req, { params: Promise.resolve({ cardId: "abc" }) });
+    expect(res.headers.get("cache-control")).toBe("private, max-age=31536000, immutable");
+  });
+
   it("sets attachment disposition and logs the audit on ?download=1", async () => {
-    const ctx = memberCtx("forge-art/x");
-    (requireForge as ReturnType<typeof vi.fn>).mockResolvedValue(ctx);
-    (readForgeArt as ReturnType<typeof vi.fn>).mockResolvedValue({
-      statusCode: 200,
-      stream: new ReadableStream(),
-      blob: { contentType: "image/png" },
-    });
+    const client = mockSupabase({ artKey: "forge-art/x" });
+    (readForgeArt as ReturnType<typeof vi.fn>).mockResolvedValue(okBlob());
     const req = new Request("http://localhost/forge/api/art/abc?download=1") as never;
     const res = await GET(req, { params: Promise.resolve({ cardId: "abc" }) });
     expect(res.headers.get("content-disposition")).toContain("attachment");
-    expect(ctx.supabase.rpc).toHaveBeenCalledWith("forge_log_art_download", { p_card_id: "abc" });
-  });
-
-  it("404 when ?v=approved but the card has no approved version", async () => {
-    (requireForge as ReturnType<typeof vi.fn>).mockResolvedValue(approvedCtx({ approvedVersionId: null }));
-    const req = new Request("http://localhost/forge/api/art/abc?v=approved") as never;
-    const res = await GET(req, { params: Promise.resolve({ cardId: "abc" }) });
-    expect(res.status).toBe(404);
-    expect(readForgeArt).not.toHaveBeenCalled();
-  });
-
-  it("404 when the approved version's art is a placeholder", async () => {
-    (requireForge as ReturnType<typeof vi.fn>).mockResolvedValue(approvedCtx({
-      approvedVersionId: "v1",
-      version: { art_original_key: null, art_key: null, art_is_placeholder: true },
-    }));
-    const req = new Request("http://localhost/forge/api/art/abc?v=approved") as never;
-    const res = await GET(req, { params: Promise.resolve({ cardId: "abc" }) });
-    expect(res.status).toBe(404);
-    expect(readForgeArt).not.toHaveBeenCalled();
-  });
-
-  it("streams the approved version's original art for ?v=approved", async () => {
-    (requireForge as ReturnType<typeof vi.fn>).mockResolvedValue(approvedCtx({
-      approvedVersionId: "v1",
-      version: { art_original_key: "forge-art/orig", art_key: "forge-art/disp", art_is_placeholder: false },
-    }));
-    (readForgeArt as ReturnType<typeof vi.fn>).mockResolvedValue({
-      statusCode: 200, stream: new ReadableStream(), blob: { contentType: "image/webp" },
-    });
-    const req = new Request("http://localhost/forge/api/art/abc?v=approved") as never;
-    const res = await GET(req, { params: Promise.resolve({ cardId: "abc" }) });
-    expect(res.status).toBe(200);
-    expect(readForgeArt).toHaveBeenCalledWith("forge-art/orig"); // original preferred over display key
-    expect(res.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(client.rpc).toHaveBeenCalledWith("forge_log_art_download", { p_card_id: "abc" });
+    // download responses must never be cached
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
   });
 });

--- a/app/forge/api/art/[cardId]/route.ts
+++ b/app/forge/api/art/[cardId]/route.ts
@@ -1,4 +1,5 @@
-import { requireForge, notFoundResponse } from "@/app/forge/lib/auth";
+import { createClient } from "@/utils/supabase/server";
+import { notFoundResponse } from "@/app/forge/lib/auth";
 import { readForgeArt } from "@/app/forge/lib/art";
 
 export const dynamic = "force-dynamic";
@@ -7,53 +8,27 @@ export async function GET(
   req: Request,
   { params }: { params: Promise<{ cardId: string }> }
 ): Promise<Response> {
-  const ctx = await requireForge();
-  if (!ctx) return notFoundResponse(); // 404, never 401/403 — the area stays secret
-
+  const supabase = await createClient();
   const { cardId } = await params;
   const url = new URL(req.url);
   const wantApproved = url.searchParams.get("v") === "approved";
   const kind = url.searchParams.get("kind") === "finished" ? "finished" : "art";
 
-  // RLS-checked: non-members are already rejected above. Granted playtesters can SELECT
-  // only the published/approved versions of granted playtesting/approved cards (migration
-  // 057) — so the reveal branch is leak-safe. We serve the approved snapshot if finalized,
-  // else the published (in-testing) snapshot.
-  let artKey: string | null = null;
-  if (wantApproved) {
-    const { data: card } = await ctx.supabase
-      .from("forge_cards")
-      .select("approved_version_id, published_version_id")
-      .eq("id", cardId)
-      .maybeSingle();
-    const versionId = card?.approved_version_id ?? card?.published_version_id ?? null;
-    if (!versionId) return notFoundResponse();
-    if (kind === "finished") {
-      const { data: version } = await ctx.supabase
-        .from("card_versions")
-        .select("finished_key")
-        .eq("id", versionId)
-        .maybeSingle();
-      artKey = version?.finished_key ?? null;
-    } else {
-      const { data: version } = await ctx.supabase
-        .from("card_versions")
-        .select("art_original_key, art_key, art_is_placeholder")
-        .eq("id", versionId)
-        .maybeSingle();
-      if (!version || version.art_is_placeholder) return notFoundResponse();
-      artKey = version.art_original_key ?? version.art_key ?? null;
-    }
-  } else {
-    const col = kind === "finished" ? "working_finished_key" : "working_art_key";
-    const { data: card } = await ctx.supabase
-      .from("forge_cards")
-      .select(col)
-      .eq("id", cardId)
-      .maybeSingle();
-    artKey = (card as any)?.[col] ?? null;
-  }
-  if (!artKey) return notFoundResponse();
+  // One RPC does the member gate + version resolution + key lookup (SECURITY
+  // INVOKER so the 057 RLS policies still decide what the caller may see —
+  // migration 066). getUser() runs concurrently, not before: it validates and
+  // refreshes the session cookie, while an expired/invalid token makes the RPC
+  // itself return nothing. Either failure is a 404 — the area stays secret.
+  const [{ data: userData, error: userError }, { data: artKey }] = await Promise.all([
+    supabase.auth.getUser(),
+    supabase.rpc("forge_art_key", {
+      p_card_id: cardId,
+      p_approved: wantApproved,
+      p_kind: kind,
+    }),
+  ]);
+  if (userError || !userData?.user) return notFoundResponse();
+  if (!artKey || typeof artKey !== "string") return notFoundResponse();
 
   let result;
   try {
@@ -66,15 +41,15 @@ export async function GET(
   const download = url.searchParams.get("download") === "1";
   if (download) {
     try {
-      await ctx.supabase.rpc("forge_log_art_download", { p_card_id: cardId });
+      await supabase.rpc("forge_log_art_download", { p_card_id: cardId });
     } catch {
       // best-effort audit; never block the download on a logging failure
     }
   }
 
-  // `t` is a cache-buster derived from forge_cards.updated_at (bumped on every image/
-  // snapshot write), so a `t`-stamped response can be cached by the member's OWN browser
-  // indefinitely. `private` forbids shared/CDN caches; auth + RLS above are unchanged.
+  // `t` is a cache-buster (forge_cards.updated_at for the working view; the frozen
+  // versionId in play mode), so a `t`-stamped response can be cached by the member's OWN
+  // browser indefinitely. `private` forbids shared/CDN caches; auth + RLS are unchanged.
   const cacheable = !download && url.searchParams.get("t") !== null;
   const headers = new Headers({
     "Content-Type": result.blob.contentType,

--- a/app/play/components/RightPanel.tsx
+++ b/app/play/components/RightPanel.tsx
@@ -174,7 +174,9 @@ export default function RightPanel({
               }}>
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
-                  src={getCardImageUrl(previewCard.cardImgFile)}
+                  // Unresolved forge refs ("forge:<uuid>") resolve to '' — show the
+                  // card back instead of an empty src (React warns + refetches page).
+                  src={getCardImageUrl(previewCard.cardImgFile) || '/gameplay/cardback.webp'}
                   alt={previewCard.cardName}
                   style={{
                     display: 'block',

--- a/supabase/migrations/066_forge_art_key_rpc.sql
+++ b/supabase/migrations/066_forge_art_key_rpc.sql
@@ -1,0 +1,72 @@
+-- 066_forge_art_key_rpc.sql
+-- Collapse the /forge/api/art per-image lookup chain (my_forge_role RPC +
+-- forge_cards select + card_versions select — three sequential PostgREST round
+-- trips) into one RPC. Perf only: in forge play mode the image preloader fires
+-- dozens of art requests at once and each paid four Supabase round trips before
+-- the blob read; this makes it one.
+--
+-- SECURITY INVOKER on purpose: the reads below stay subject to the 057 RLS
+-- policies (granted playtesters see only published/approved snapshots of
+-- granted cards), so this cannot return anything the caller couldn't already
+-- SELECT. The my_forge_role() gate mirrors requireForge's member check.
+-- Key-resolution rules mirror app/forge/api/art/[cardId]/route.ts exactly.
+-- SCHEMA + FUNCTION ONLY — no data.
+
+create or replace function public.forge_art_key(
+  p_card_id uuid,
+  p_approved boolean,
+  p_kind text
+) returns text
+language plpgsql
+stable
+security invoker
+set search_path = ''
+as $$
+declare
+  v_version_id uuid;
+  v_key text;
+begin
+  if coalesce(public.my_forge_role(), '') not in ('superadmin', 'elder', 'playtester') then
+    return null;
+  end if;
+
+  if p_approved then
+    -- Approved view: approved snapshot if finalized, else published (in-testing).
+    select coalesce(c.approved_version_id, c.published_version_id)
+      into v_version_id
+      from public.forge_cards c
+     where c.id = p_card_id;
+    if v_version_id is null then
+      return null;
+    end if;
+
+    if p_kind = 'finished' then
+      select v.finished_key
+        into v_key
+        from public.card_versions v
+       where v.id = v_version_id;
+    else
+      select case when v.art_is_placeholder then null
+                  else coalesce(v.art_original_key, v.art_key) end
+        into v_key
+        from public.card_versions v
+       where v.id = v_version_id;
+    end if;
+  else
+    if p_kind = 'finished' then
+      select c.working_finished_key into v_key
+        from public.forge_cards c where c.id = p_card_id;
+    else
+      select c.working_art_key into v_key
+        from public.forge_cards c where c.id = p_card_id;
+    end if;
+  end if;
+
+  return v_key;
+end;
+$$;
+
+-- Supabase's default privileges grant EXECUTE directly to anon on new public
+-- functions; strip it explicitly (cf. 048) so anon cannot even probe this.
+revoke execute on function public.forge_art_key(uuid, boolean, text) from public, anon;
+grant execute on function public.forge_art_key(uuid, boolean, text) to authenticated;

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -12,6 +12,8 @@ export default defineConfig({
   },
   test: {
     include: ["**/__tests__/**/*.test.ts", "**/*.test.ts"],
-    exclude: ["node_modules"],
+    // .claude/worktrees holds other branches' checkouts; their test files would
+    // resolve `@/` to THIS tree's source and test the wrong code.
+    exclude: ["node_modules", ".claude/**"],
   },
 });


### PR DESCRIPTION
## Problem

In forge play mode, custom card images render seconds after standard cards. A Firefox profile showed each `/forge/api/art/...` request taking **1.05–2.52s** vs ~250ms for public-CDN standard cards at equal (~180KB) payload size. The route made 4 sequential Supabase round trips per image — `auth.getUser()` → `my_forge_role` RPC → `forge_cards` select → `card_versions` select — before the private-blob read, multiplied across dozens of simultaneous loads.

## Fix

- **Migration 066** adds `forge_art_key(uuid, boolean, text)`: member gate + version resolution + key lookup in **one** round trip. `SECURITY INVOKER` with pinned `search_path` — the migration-057 RLS policies still decide what the caller can see, so leak-safety is unchanged. `EXECUTE` revoked from `public`/`anon`. **Already applied to the live DB** and smoke-tested there (member → exact expected key; non-member → null; anon → permission denied at EXECUTE).
- **Route** runs `getUser()` and the RPC concurrently; either failing 404s before any bytes are served (the area stays secret). Net per image: ~5 sequential round trips → ~2 concurrent + blob read. Expected: ~3× faster in dev, roughly CDN parity in production.
- **RightPanel loupe**: unresolved `forge:` refs resolve to `''` — now falls back to the cardback instead of an empty `img src` (killed a React console error that can trigger a full-page refetch).
- **Guardrail**: `forge-gate-first` now asserts this route's RPC gate explicitly (not a blind exemption) and allowlists the bare `/forge/play/games` redirect page.
- **vitest**: exclude `.claude/**` so stale sibling-worktree test copies stop running against this tree's source.

## Review

Two independent reviews (security/correctness + performance/architecture) both **APPROVE**: RPC verified line-by-line as an exact behavioral mirror of the old route; fail-closed 404 posture and RLS intact; no new oracle (uniform 404, no existence probe). Signed-URL and server-side-caching alternatives were considered and rejected (bearer-token leak surface / stale-authorization risk). Known minor tradeoff: at token-expiry boundary the parallel RPC can 404 once before refresh; the preloader's retry/backoff self-heals it.

## Verification

- Route tests rewritten TDD (10 cases: fail-closed matrix, param mapping, cache headers, download audit) — green
- Full suite on this branch: **1150 passed**; the 2 failures (`forgeBuilderConfig`, threshingfloor `store-route`) are pre-existing on `main` (verified on pristine `origin/main`)
- Live-DB smoke tests of the RPC via impersonated roles (member / non-member / anon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)