### PR TITLE
fix(rnrs): 15s timeout on sheet fetches so a hung worker can't fail builds

### DIFF
--- a/lib/rnrs/fetch.test.ts
+++ b/lib/rnrs/fetch.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { fetchAllRnrsData } from "./fetch";
+import { SEASONS, FORMATS } from "./config";
+
+const okResponse = { ok: true, text: async () => "" } as Response;
+
+describe("fetchAllRnrsData", () => {
+  const realFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  // A hung (never-resolving) worker request stalled page prerender past Next's
+  // 60s static-generation limit and failed the whole production build — every
+  // sheet request must carry an abort/timeout signal so it can't hang.
+  it("passes an abort signal to every sheet request", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse);
+    global.fetch = fetchMock as typeof fetch;
+
+    await fetchAllRnrsData();
+
+    expect(fetchMock).toHaveBeenCalledTimes(SEASONS.length * FORMATS.length);
+    for (const [, init] of fetchMock.mock.calls) {
+      expect((init as RequestInit)?.signal).toBeInstanceOf(AbortSignal);
+    }
+  });
+
+  it("degrades a timed-out sheet to an empty array instead of throwing", async () => {
+    const timedOutKey = FORMATS[0].key;
+    const fetchMock = vi.fn(async (url: RequestInfo | URL) => {
+      if (String(url).includes(`sheet=${timedOutKey}`)) {
+        throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+      }
+      return okResponse;
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    const data = await fetchAllRnrsData();
+
+    expect(data[SEASONS[0]]?.[timedOutKey]).toEqual([]);
+    // Healthy sheets are unaffected by the sick one.
+    expect(data[SEASONS[0]]?.[FORMATS[1].key]).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(SEASONS.length * FORMATS.length);
+  });
+});

--- a/lib/rnrs/fetch.ts
+++ b/lib/rnrs/fetch.ts
@@ -5,8 +5,13 @@ import type { FormatKey, NormalizedData, PlayerFormatResult } from "./types";
 /**
  * Fetch and parse every season × format sheet through the proxy, in parallel.
  * Runs server-side; results are cached for an hour (`revalidate: 3600`). A sheet
- * that fails to load degrades to an empty array rather than breaking the page.
+ * that fails to load — or hangs past SHEET_TIMEOUT_MS — degrades to an empty
+ * array rather than breaking the page. The timeout is load-bearing for deploys:
+ * this page prerenders at build time, and a hung worker request once stalled it
+ * past Next's 60s static-generation limit, failing the whole production build.
  */
+const SHEET_TIMEOUT_MS = 15_000;
+
 export async function fetchAllRnrsData(): Promise<NormalizedData> {
   const data: NormalizedData = {};
 
@@ -19,7 +24,7 @@ export async function fetchAllRnrsData(): Promise<NormalizedData> {
           try {
             const res = await fetch(
               `${RNRS_PROXY}/?sheet=${key}&season=${season}&id=${id}`,
-              { next: { revalidate: 3600 } },
+              { next: { revalidate: 3600 }, signal: AbortSignal.timeout(SHEET_TIMEOUT_MS) },
             );
             if (!res.ok) throw new Error(`HTTP ${res.status}`);
             formats[key] = parseSheetCsv(await res.text());


### PR DESCRIPTION
## Problem

PR #152's first preview deploy failed with:

```
Failed to build /tournaments/rnrs-points/page ... because it took more than 60 seconds (3 attempts)
Export encountered an error on /tournaments/rnrs-points/page, exiting the build.
```

The page prerenders at build time (ISR, `revalidate = 3600`) and `fetchAllRnrsData()` pulls every season × format sheet from the third-party RNRS proxy worker. The fetch layer already degrades **failed** sheets to empty arrays — but it had no timeout, so a slow-but-alive worker hangs the prerender past Next's 60s static-generation limit and sinks the entire deploy. Any branch, any time the worker hiccups.

## Fix

`AbortSignal.timeout(15_000)` on each sheet request. A hung sheet now aborts into the existing catch and degrades to an empty array like any other failure; healthy sheets in the same batch are unaffected. Worst-case prerender is ~15s, comfortably under the 60s limit. Normal operation is unchanged (requests complete in well under 15s).

## Verification

- New `lib/rnrs/fetch.test.ts` (TDD, watched red first): every sheet request must carry an abort signal; a timed-out sheet degrades to `[]` without breaking sibling sheets — 2/2 green
- Full suite: 1164 passed; the only failures are the two pre-existing on `main` (`forgeBuilderConfig`, threshingfloor `store-route`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)