### PR TITLE
Add CODEOWNERS requiring repo owner review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Code owners for redemption-tournament-tracker
+#
+# When "Require review from Code Owners" is enabled on the branch ruleset,
+# every PR touching these paths must be approved by an owner listed here
+# before it can be merged. This makes the repo owner's approval mandatory.
+
+# Everything is owned by the repo owner.
+* @timothestes


### PR DESCRIPTION
Adds `.github/CODEOWNERS` making `@timothestes` the owner of all paths.

Once **Require review from Code Owners** is enabled on the `main` ruleset (applied separately), every PR will need approval from @timothestes before it can merge — a write collaborator's approval alone will no longer be sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)