### PR TITLE
Forge: normalize card images at upload + fix stale deckbuilder ability text

### DIFF
--- a/app/forge/components/ForgeCardPreview.tsx
+++ b/app/forge/components/ForgeCardPreview.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { DesignCard } from "@/app/forge/lib/designCard";
-import { isStatBearing } from "@/app/forge/lib/designCard";
+import { isStatBearing, cardRawText } from "@/app/forge/lib/designCard";
 import { washPath, statBoxPath, iconPath, isPreviewApproximate, BRIGADE_HEX } from "@/app/forge/lib/frameAssets";
 
 // Slot geometry as % of the 750×1050 canvas. STARTING VALUES — tune visually
@@ -92,7 +92,7 @@ export default function ForgeCardPreview({
       )}
       {/* 7. ability — light panel so dark text stays readable on any wash */}
       <div style={{ ...abs(G.ability), zIndex: 5, overflow: "hidden", boxSizing: "border-box", background: "rgba(245,241,233,0.96)", borderRadius: "2.5%", padding: "1.4cqw 3cqw", color: "#111", fontWeight: 700, textAlign: "center", fontSize: "4cqw", lineHeight: 1.15, display: "flex", alignItems: "center", justifyContent: "center" }}>
-        {card.specialAbility || ""}
+        {cardRawText(card)}
       </div>
       {/* 8. scripture + reference — dark panel, light italic text */}
       <div style={{ ...abs(G.scripture), zIndex: 5, overflow: "hidden", boxSizing: "border-box", background: "rgba(0,0,0,0.82)", borderRadius: "2.5%", padding: "1.4cqw 3cqw", color: "#e8e8e8", fontStyle: "italic", fontSize: "3.2cqw", lineHeight: 1.15, display: "flex", flexDirection: "column", justifyContent: "space-between" }}>

--- a/app/forge/lib/__tests__/art.test.ts
+++ b/app/forge/lib/__tests__/art.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from "vitest";
-import { validateArtFile, MAX_ART_BYTES } from "@/app/forge/lib/art";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@vercel/blob", () => ({ put: vi.fn(), get: vi.fn(), del: vi.fn() }));
+vi.mock("@/app/forge/lib/imageNormalize", () => ({ normalizeCardImage: vi.fn() }));
+
+import { put } from "@vercel/blob";
+import { normalizeCardImage } from "@/app/forge/lib/imageNormalize";
+import { validateArtFile, MAX_ART_BYTES, uploadForgeArt, uploadForgeFinished } from "../art";
 
 describe("validateArtFile", () => {
   it("accepts a normal PNG", () => {
@@ -12,5 +18,41 @@ describe("validateArtFile", () => {
 
   it("rejects a file over the size cap", () => {
     expect(validateArtFile({ type: "image/png", size: MAX_ART_BYTES + 1 })).toMatch(/too large/i);
+  });
+});
+
+const file = new File([new Uint8Array([1, 2, 3])], "art.png", { type: "image/png" });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (put as any).mockResolvedValue({ pathname: "forge-art/some-key" });
+  (normalizeCardImage as any).mockResolvedValue({
+    data: Buffer.from("normalized"),
+    contentType: "image/jpeg",
+  });
+});
+
+describe("uploadForgeArt / uploadForgeFinished", () => {
+  it("uploads the NORMALIZED bytes as image/jpeg, not the original file", async () => {
+    await uploadForgeArt(file);
+    const [key, body, opts] = (put as any).mock.calls[0];
+    expect(String(key)).toMatch(/^forge-art\//);
+    expect(Buffer.from(body).toString()).toBe("normalized");
+    expect(opts.contentType).toBe("image/jpeg");
+  });
+
+  it("uploadForgeFinished stores under forge-finished/ with normalized bytes", async () => {
+    (put as any).mockResolvedValue({ pathname: "forge-finished/some-key" });
+    await uploadForgeFinished(file);
+    const [key, body, opts] = (put as any).mock.calls[0];
+    expect(String(key)).toMatch(/^forge-finished\//);
+    expect(Buffer.from(body).toString()).toBe("normalized");
+    expect(opts.contentType).toBe("image/jpeg");
+  });
+
+  it("propagates decode failures without uploading anything", async () => {
+    (normalizeCardImage as any).mockRejectedValue(new Error("unsupported image format"));
+    await expect(uploadForgeArt(file)).rejects.toThrow();
+    expect(put).not.toHaveBeenCalled();
   });
 });

--- a/app/forge/lib/__tests__/cards.test.ts
+++ b/app/forge/lib/__tests__/cards.test.ts
@@ -5,8 +5,8 @@ vi.mock("@/app/forge/lib/auth", () => ({ requireForge: vi.fn(), requireElder: vi
 vi.mock("@/app/forge/lib/art", () => ({ validateArtFile: vi.fn(), uploadForgeArt: vi.fn(), uploadForgeFinished: vi.fn() }));
 
 import { requireForge, requireElder } from "@/app/forge/lib/auth";
-import { validateArtFile, uploadForgeFinished } from "@/app/forge/lib/art";
-import { saveCard, getCard, listForgeCards, uploadFinished } from "../cards";
+import { validateArtFile, uploadForgeArt, uploadForgeFinished } from "@/app/forge/lib/art";
+import { saveCard, getCard, listForgeCards, uploadArt, uploadFinished } from "../cards";
 
 function ctx(rpcImpl?: any, queryRows?: any[]) {
   const order = vi.fn(async () => ({ data: queryRows ?? [], error: null }));
@@ -91,5 +91,27 @@ describe("getCard maps hasFinished", () => {
     const row = { id: "c1", title: "T", working_snapshot: {}, working_art_key: null, working_art_is_placeholder: false, working_finished_key: "forge-finished/x", status: "draft", updated_at: "t", set_id: null, published_version_id: null, approved_version_id: null };
     (requireForge as any).mockResolvedValue(ctx(undefined, [row]));
     expect((await getCard("c1"))?.hasFinished).toBe(true);
+  });
+});
+
+describe("upload decode failures", () => {
+  it("uploadArt returns a clear error when the image cannot be decoded", async () => {
+    const c = ctx();
+    (requireElder as any).mockResolvedValue(c);
+    (validateArtFile as any).mockReturnValue(null);
+    (uploadForgeArt as any).mockRejectedValue(new Error("unsupported image format"));
+    const fd = new FormData();
+    fd.set("file", new File([new Uint8Array([1, 2, 3])], "a.png", { type: "image/png" }));
+    expect(await uploadArt("c1", fd)).toEqual({ ok: false, error: "Could not read image file." });
+  });
+
+  it("uploadFinished returns a clear error when the image cannot be decoded", async () => {
+    const c = ctx();
+    (requireElder as any).mockResolvedValue(c);
+    (validateArtFile as any).mockReturnValue(null);
+    (uploadForgeFinished as any).mockRejectedValue(new Error("unsupported image format"));
+    const fd = new FormData();
+    fd.set("file", new File([new Uint8Array([1, 2, 3])], "c.png", { type: "image/png" }));
+    expect(await uploadFinished("c1", fd)).toEqual({ ok: false, error: "Could not read image file." });
   });
 });

--- a/app/forge/lib/__tests__/deckAdapter.test.ts
+++ b/app/forge/lib/__tests__/deckAdapter.test.ts
@@ -63,6 +63,17 @@ describe("designCardToCard", () => {
     expect(designCardToCard({ name: "Z", cardType: ["Hero"] }, "z1", "S").testament).toBe("");
   });
 
+  it("prefers rawText over a stale specialAbility, falling back when rawText is absent", () => {
+    // Regression: designCardToCard must read via cardRawText (rawText-first) so a
+    // stale legacy specialAbility can't shadow a newer rawText edit (Heavenly
+    // Temple bug, 2026-07-06).
+    const both: DesignCard = { name: "A", cardType: ["Hero"], rawText: "new text", specialAbility: "old text" };
+    expect(designCardToCard(both, "a1", "S").specialAbility).toBe("new text");
+
+    const legacyOnly: DesignCard = { name: "B", cardType: ["Hero"], specialAbility: "legacy" };
+    expect(designCardToCard(legacyOnly, "b1", "S").specialAbility).toBe("legacy");
+  });
+
   it("dataLine helpers round-trip", () => {
     const dl = forgeDataLine("uuid-9");
     expect(isForgeDataLine(dl)).toBe(true);

--- a/app/forge/lib/__tests__/imageNormalize.test.ts
+++ b/app/forge/lib/__tests__/imageNormalize.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import sharp from "sharp";
+import { normalizeCardImage } from "../imageNormalize";
+
+const DARK = { r: 60, g: 20, b: 20 };
+
+/** Solid dark block, encoded as requested. */
+function solid(width: number, height: number, format: "png" | "jpeg"): Promise<Buffer> {
+  const img = sharp({ create: { width, height, channels: 3, background: DARK } });
+  return format === "png" ? img.png().toBuffer() : img.jpeg({ quality: 90 }).toBuffer();
+}
+
+/** Dark content block centered on a white canvas (print-bleed style). */
+async function withWhiteMargins(canvasW: number, canvasH: number, contentW: number, contentH: number): Promise<Buffer> {
+  const content = await sharp({ create: { width: contentW, height: contentH, channels: 3, background: DARK } }).png().toBuffer();
+  return sharp({ create: { width: canvasW, height: canvasH, channels: 3, background: "#ffffff" } })
+    .composite([{ input: content, top: Math.floor((canvasH - contentH) / 2), left: Math.floor((canvasW - contentW) / 2) }])
+    .png()
+    .toBuffer();
+}
+
+async function dims(buf: Buffer): Promise<{ width?: number; height?: number; format?: string }> {
+  const m = await sharp(buf).metadata();
+  return { width: m.width, height: m.height, format: m.format };
+}
+
+describe("normalizeCardImage", () => {
+  it("trims white print-bleed margins and re-encodes as JPEG", async () => {
+    const input = await withWhiteMargins(815, 1125, 750, 1046);
+    const out = await normalizeCardImage(input);
+    const d = await dims(out.data);
+    expect(out.contentType).toBe("image/jpeg");
+    expect(d.format).toBe("jpeg");
+    expect(Math.abs((d.width ?? 0) - 750)).toBeLessThanOrEqual(4);
+    expect(Math.abs((d.height ?? 0) - 1046)).toBeLessThanOrEqual(4);
+  });
+
+  it("does not trim full-bleed images with dark corners (corner gate)", async () => {
+    const input = await solid(700, 980, "png");
+    const out = await normalizeCardImage(input);
+    const d = await dims(out.data);
+    expect(d.width).toBe(700);
+    expect(d.height).toBe(980);
+    expect(d.format).toBe("jpeg"); // PNG input is still re-encoded
+  });
+
+  it("downscales oversized images to 1050px tall, preserving aspect", async () => {
+    const input = await solid(750, 1500, "png");
+    const out = await normalizeCardImage(input);
+    const d = await dims(out.data);
+    expect(d.height).toBe(1050);
+    expect(d.width).toBe(525);
+  });
+
+  it("returns already-conforming JPEGs byte-identical (no generation loss)", async () => {
+    const input = await solid(345, 495, "jpeg");
+    const out = await normalizeCardImage(input);
+    expect(out.data.equals(input)).toBe(true);
+    expect(out.contentType).toBe("image/jpeg");
+  });
+
+  it("keeps original dimensions when trim would be degenerate (near-all-white input)", async () => {
+    const input = await withWhiteMargins(600, 800, 50, 50); // tiny dot on white
+    const out = await normalizeCardImage(input);
+    const d = await dims(out.data);
+    expect(d.width).toBe(600);
+    expect(d.height).toBe(800);
+  });
+
+  it("throws on undecodable input", async () => {
+    await expect(normalizeCardImage(Buffer.from("not an image"))).rejects.toThrow();
+  });
+});

--- a/app/forge/lib/__tests__/imageNormalize.test.ts
+++ b/app/forge/lib/__tests__/imageNormalize.test.ts
@@ -24,6 +24,20 @@ async function dims(buf: Buffer): Promise<{ width?: number; height?: number; for
   return { width: m.width, height: m.height, format: m.format };
 }
 
+/** Re-tags an image with an EXIF orientation value without touching its pixel data. */
+function withOrientation(buf: Buffer, orientation: number): Promise<Buffer> {
+  return sharp(buf).withMetadata({ orientation }).toBuffer();
+}
+
+/** Dark canvas with a pure-white strip across the top only (bottom corners stay dark). */
+async function darkWithWhiteTopStrip(canvasW: number, canvasH: number, stripH: number): Promise<Buffer> {
+  const strip = await sharp({ create: { width: canvasW, height: stripH, channels: 3, background: "#ffffff" } }).png().toBuffer();
+  return sharp({ create: { width: canvasW, height: canvasH, channels: 3, background: DARK } })
+    .composite([{ input: strip, top: 0, left: 0 }])
+    .png()
+    .toBuffer();
+}
+
 describe("normalizeCardImage", () => {
   it("trims white print-bleed margins and re-encodes as JPEG", async () => {
     const input = await withWhiteMargins(815, 1125, 750, 1046);
@@ -69,5 +83,64 @@ describe("normalizeCardImage", () => {
 
   it("throws on undecodable input", async () => {
     await expect(normalizeCardImage(Buffer.from("not an image"))).rejects.toThrow();
+  });
+
+  it("re-encodes EXIF-rotated (orientation 6) images upright and height-caps them", async () => {
+    // Solid color, so corners stay dark and the trim path is never engaged —
+    // this isolates the orientation-aware resize/passthrough handling.
+    const input = await withOrientation(await solid(1300, 700, "jpeg"), 6);
+    const out = await normalizeCardImage(input);
+    const m = await sharp(out.data).metadata();
+    expect(out.data.equals(input)).toBe(false); // must be re-encoded, not passed through
+    expect(m.format).toBe("jpeg");
+    expect(m.orientation).toBeUndefined(); // upright: no leftover orientation tag
+    expect(m.height).toBe(1050);
+    expect(Math.abs((m.width ?? 0) - 565)).toBeLessThanOrEqual(2);
+  });
+
+  it("trims legitimate margins on EXIF-rotated images using post-rotation dimensions (swapped-axis degenerate guard)", async () => {
+    // Stored (pre-rotation) canvas is 700x1000 with content 500x650; tagged
+    // orientation 6 so .rotate() swaps axes to a post-rotation 1000x700
+    // canvas containing 650x500 content (legitimate ~65-70% keep on each
+    // axis — not degenerate). Comparing the trim result against the raw,
+    // pre-rotation meta.width/meta.height (the bug) instead of the swapped
+    // post-rotation dimensions makes this look degenerate (it isn't) and the
+    // trim gets skipped, leaving the full untrimmed 1000x700 canvas.
+    const stored = await withWhiteMargins(700, 1000, 500, 650);
+    const input = await withOrientation(stored, 6);
+    const out = await normalizeCardImage(input);
+    const m = await sharp(out.data).metadata();
+    expect(m.orientation).toBeUndefined();
+    expect(m.width).toBe(650);
+    expect(m.height).toBe(500);
+  });
+
+  it("trims white margins on grayscale (low-channel) rasters without misreading channels", async () => {
+    // Intent test for the cornersNearWhite channel-count fix: a grayscale
+    // raster piped through the same margin fixture used above. Note: sharp's
+    // default output colourspace is srgb (verified against the installed
+    // version), so in practice the raw buffer read by cornersNearWhite ends
+    // up 3-channel here regardless of the source's channel depth — this test
+    // cannot force a true <3-channel raw buffer through the public
+    // Buffer-in/Buffer-out API, but it does confirm grayscale-sourced inputs
+    // still trim correctly (no regression), per the fix's intent.
+    const rgb = await withWhiteMargins(815, 1125, 750, 1046);
+    const input = await sharp(rgb).greyscale().toColourspace("b-w").png().toBuffer();
+    const out = await normalizeCardImage(input);
+    const d = await dims(out.data);
+    expect(d.format).toBe("jpeg");
+    expect(Math.abs((d.width ?? 0) - 750)).toBeLessThanOrEqual(4);
+    expect(Math.abs((d.height ?? 0) - 1046)).toBeLessThanOrEqual(4);
+  });
+
+  it("does not trim when only some corners are white (corner gate requires all four)", async () => {
+    // A white strip across the top only: top corners are white but bottom
+    // corners stay dark. An unconditional trim would crop the top strip; the
+    // corner gate must reject this and leave the image untouched.
+    const input = await darkWithWhiteTopStrip(600, 800, 100);
+    const out = await normalizeCardImage(input);
+    const d = await dims(out.data);
+    expect(d.width).toBe(600);
+    expect(d.height).toBe(800);
   });
 });

--- a/app/forge/lib/__tests__/imageNormalize.test.ts
+++ b/app/forge/lib/__tests__/imageNormalize.test.ts
@@ -38,6 +38,32 @@ async function darkWithWhiteTopStrip(canvasW: number, canvasH: number, stripH: n
     .toBuffer();
 }
 
+/**
+ * Dark JPEG scan with small near-white rounded-corner squares (passes the
+ * corner gate, like real Lackey scans) plus a thin pure-white fringe band
+ * across the bottom — models the print-scan artifact the trim floor exists
+ * to ignore.
+ */
+async function lackeyScanWithCornersAndBottomFringe(
+  width: number,
+  height: number,
+  cornerSize: number,
+  fringeHeight: number,
+): Promise<Buffer> {
+  const corner = await sharp({ create: { width: cornerSize, height: cornerSize, channels: 3, background: "#ffffff" } }).png().toBuffer();
+  const fringe = await sharp({ create: { width, height: fringeHeight, channels: 3, background: "#ffffff" } }).png().toBuffer();
+  return sharp({ create: { width, height, channels: 3, background: DARK } })
+    .composite([
+      { input: corner, top: 0, left: 0 },
+      { input: corner, top: 0, left: width - cornerSize },
+      { input: corner, top: height - cornerSize, left: 0 },
+      { input: corner, top: height - cornerSize, left: width - cornerSize },
+      { input: fringe, top: height - fringeHeight, left: 0 },
+    ])
+    .jpeg({ quality: 90 })
+    .toBuffer();
+}
+
 describe("normalizeCardImage", () => {
   it("trims white print-bleed margins and re-encodes as JPEG", async () => {
     const input = await withWhiteMargins(815, 1125, 750, 1046);
@@ -142,5 +168,18 @@ describe("normalizeCardImage", () => {
     const d = await dims(out.data);
     expect(d.width).toBe(600);
     expect(d.height).toBe(800);
+  });
+
+  it("returns real-scan JPEGs with rounded corners and a thin fringe byte-identical (trim significance floor)", async () => {
+    // Models a 345x495 Lackey scan: near-white rounded-corner squares pass
+    // the corner gate, and a ~1.8%-of-height (9px) near-white fringe along
+    // the bottom would trim under the old logic — defeating the passthrough
+    // for every already-conforming image. The significance floor rejects
+    // trims removing less than 3% on both axes, so this must come back
+    // untouched, byte-identical.
+    const input = await lackeyScanWithCornersAndBottomFringe(345, 495, 8, 9);
+    const out = await normalizeCardImage(input);
+    expect(out.data.equals(input)).toBe(true);
+    expect(out.contentType).toBe("image/jpeg");
   });
 });

--- a/app/forge/lib/art.ts
+++ b/app/forge/lib/art.ts
@@ -9,6 +9,7 @@
 // app's public card-image store. See `forgeAuth` below for how requests authenticate.
 import { randomUUID } from "crypto";
 import { put, get, del, type GetBlobResult } from "@vercel/blob";
+import { normalizeCardImage } from "@/app/forge/lib/imageNormalize";
 
 /**
  * Auth for the PRIVATE Forge store. Production uses Vercel OIDC (no static secret):
@@ -38,26 +39,32 @@ export function validateArtFile(file: { type: string; size: number }): string | 
   return null;
 }
 
-/** Upload to the PRIVATE blob store under an unguessable UUID key. Returns the stored pathname. */
+/**
+ * Normalize (trim white print-bleed margins, cap 1050px tall, re-encode JPEG)
+ * and upload to the PRIVATE blob store under an unguessable UUID key.
+ * Throws if the file cannot be decoded as an image. Returns the stored pathname.
+ */
 export async function uploadForgeArt(file: File): Promise<string> {
+  const normalized = await normalizeCardImage(Buffer.from(await file.arrayBuffer()));
   const key = `${ART_PREFIX}${randomUUID()}`;
-  const blob = await put(key, file, {
+  const blob = await put(key, normalized.data, {
     access: "private",
     addRandomSuffix: false,
     ...forgeAuth,
-    contentType: file.type,
+    contentType: normalized.contentType,
   });
   return blob.pathname;
 }
 
-/** Upload a finished-card image to the PRIVATE store under an unguessable UUID key. */
+/** Same normalization + upload for finished-card images under forge-finished/. */
 export async function uploadForgeFinished(file: File): Promise<string> {
+  const normalized = await normalizeCardImage(Buffer.from(await file.arrayBuffer()));
   const key = `${FINISHED_PREFIX}${randomUUID()}`;
-  const blob = await put(key, file, {
+  const blob = await put(key, normalized.data, {
     access: "private",
     addRandomSuffix: false,
     ...forgeAuth,
-    contentType: file.type,
+    contentType: normalized.contentType,
   });
   return blob.pathname;
 }

--- a/app/forge/lib/cards.ts
+++ b/app/forge/lib/cards.ts
@@ -45,8 +45,13 @@ export async function uploadArt(
   const invalid = validateArtFile(file);
   if (invalid) return { ok: false, error: invalid };
 
-  const key = await uploadForgeArt(file);
-  // No image processing in 1a.3: the uploaded file IS the original.
+  let key: string;
+  try {
+    key = await uploadForgeArt(file);
+  } catch {
+    return { ok: false, error: "Could not read image file." };
+  }
+  // Art is normalized at upload (trim/resize/JPEG); original_key mirrors the stored key.
   const { error } = await ctx.supabase.rpc("forge_set_working_art", {
     p_card_id: cardId,
     p_key: key,
@@ -69,7 +74,12 @@ export async function uploadFinished(
   const invalid = validateArtFile(file);
   if (invalid) return { ok: false, error: invalid };
 
-  const key = await uploadForgeFinished(file);
+  let key: string;
+  try {
+    key = await uploadForgeFinished(file);
+  } catch {
+    return { ok: false, error: "Could not read image file." };
+  }
   const { error } = await ctx.supabase.rpc("forge_set_working_finished", {
     p_card_id: cardId,
     p_key: key,

--- a/app/forge/lib/deckAdapter.ts
+++ b/app/forge/lib/deckAdapter.ts
@@ -5,7 +5,7 @@
 // collision-proof `forge:{cardId}` dataLine identity.
 import type { Card } from "@/app/decklist/card-search/utils";
 import { deriveTestamentAndGospel } from "@/app/decklist/card-search/data/testament";
-import type { DesignCard, CardType, Brigade } from "@/app/forge/lib/designCard";
+import { cardRawText, type DesignCard, type CardType, type Brigade } from "@/app/forge/lib/designCard";
 
 export const FORGE_DATALINE_PREFIX = "forge:";
 export function forgeDataLine(cardId: string): string { return FORGE_DATALINE_PREFIX + cardId; }
@@ -52,7 +52,9 @@ export function designCardToCard(data: DesignCard, cardId: string, setName: stri
     toughness: data.toughness != null ? String(data.toughness) : "—",
     class: (data.class ?? []).join("/"),
     identifier: (data.identifiers ?? []).join(", "),
-    specialAbility: data.specialAbility || data.rawText || "",
+    // rawText-first (via cardRawText) — the studio edits rawText; a stale legacy
+    // specialAbility must not shadow it (Heavenly Temple bug, 2026-07-06).
+    specialAbility: cardRawText(data),
     rarity: data.rarity ?? "",
     reference: data.reference ?? "",
     alignment: alignmentDisplay(data.alignment),

--- a/app/forge/lib/imageNormalize.ts
+++ b/app/forge/lib/imageNormalize.ts
@@ -18,9 +18,10 @@ async function cornersNearWhite(img: sharp.Sharp): Promise<boolean> {
     .flatten({ background: "#ffffff" })
     .raw()
     .toBuffer({ resolveWithObject: true });
+  const channels = Math.min(3, info.channels); // grayscale rasters have < 3 channels
   const px = (x: number, y: number): number[] => {
     const i = (y * info.width + x) * info.channels;
-    return [data[i], data[i + 1], data[i + 2]];
+    return Array.from({ length: channels }, (_, c) => data[i + c]);
   };
   return [
     px(0, 0),
@@ -35,6 +36,15 @@ export async function normalizeCardImage(input: Buffer): Promise<NormalizedImage
   if (!meta.width || !meta.height) throw new Error("Could not read image");
   const base = sharp(input).rotate(); // apply EXIF orientation
 
+  // EXIF orientations 5-8 turn the image 90°, so the base pipeline's output
+  // dimensions are transposed relative to meta.width/meta.height (which
+  // describe the pre-rotation raster). Compare trim output against these
+  // post-rotation dimensions, not the raw stored ones.
+  const orientationSwapsAxes =
+    meta.orientation !== undefined && meta.orientation >= 5 && meta.orientation <= 8;
+  const baseWidth = orientationSwapsAxes ? meta.height : meta.width;
+  const baseHeight = orientationSwapsAxes ? meta.width : meta.height;
+
   // Corner-gated margin trim: white print-bleed margins only. Full-bleed card
   // images have dark frame corners, so the gate skips them and the border
   // ring survives; trimming against an explicit white background can never
@@ -48,9 +58,9 @@ export async function normalizeCardImage(input: Buffer): Promise<NormalizedImage
         .flatten({ background: "#ffffff" })
         .trim({ background: "#ffffff", threshold: TRIM_THRESHOLD })
         .toBuffer({ resolveWithObject: true });
-      const shrank = info.width < meta.width || info.height < meta.height;
+      const shrank = info.width < baseWidth || info.height < baseHeight;
       const degenerate =
-        info.width < meta.width * MIN_TRIM_RATIO || info.height < meta.height * MIN_TRIM_RATIO;
+        info.width < baseWidth * MIN_TRIM_RATIO || info.height < baseHeight * MIN_TRIM_RATIO;
       if (shrank && !degenerate) {
         working = sharp(data);
         trimmed = true;

--- a/app/forge/lib/imageNormalize.ts
+++ b/app/forge/lib/imageNormalize.ts
@@ -1,0 +1,76 @@
+// Server-only: normalizes Forge card images at upload time so every stored
+// image is flush (no baked-in print-bleed margins), at most 1050px tall, and
+// JPEG-encoded. Design: docs/superpowers/specs/2026-07-06-forge-image-normalization-design.md
+import sharp from "sharp";
+
+export type NormalizedImage = { data: Buffer; contentType: "image/jpeg" };
+
+const MAX_HEIGHT = 1050;
+const CORNER_WHITE_MIN = 240; // per-channel floor for a corner to count as "white margin"
+const TRIM_THRESHOLD = 25;
+const MIN_TRIM_RATIO = 0.6; // trim keeping less than this per axis is degenerate
+const JPEG_QUALITY = 85;
+
+/** True when all four corners are near-white after flattening alpha onto white. */
+async function cornersNearWhite(img: sharp.Sharp): Promise<boolean> {
+  const { data, info } = await img
+    .clone()
+    .flatten({ background: "#ffffff" })
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  const px = (x: number, y: number): number[] => {
+    const i = (y * info.width + x) * info.channels;
+    return [data[i], data[i + 1], data[i + 2]];
+  };
+  return [
+    px(0, 0),
+    px(info.width - 1, 0),
+    px(0, info.height - 1),
+    px(info.width - 1, info.height - 1),
+  ].every((corner) => corner.every((channel) => channel >= CORNER_WHITE_MIN));
+}
+
+export async function normalizeCardImage(input: Buffer): Promise<NormalizedImage> {
+  const meta = await sharp(input).metadata(); // throws on undecodable input
+  if (!meta.width || !meta.height) throw new Error("Could not read image");
+  const base = sharp(input).rotate(); // apply EXIF orientation
+
+  // Corner-gated margin trim: white print-bleed margins only. Full-bleed card
+  // images have dark frame corners, so the gate skips them and the border
+  // ring survives; trimming against an explicit white background can never
+  // eat a dark frame either way.
+  let working: sharp.Sharp | null = null;
+  let trimmed = false;
+  if (await cornersNearWhite(base)) {
+    try {
+      const { data, info } = await base
+        .clone()
+        .flatten({ background: "#ffffff" })
+        .trim({ background: "#ffffff", threshold: TRIM_THRESHOLD })
+        .toBuffer({ resolveWithObject: true });
+      const shrank = info.width < meta.width || info.height < meta.height;
+      const degenerate =
+        info.width < meta.width * MIN_TRIM_RATIO || info.height < meta.height * MIN_TRIM_RATIO;
+      if (shrank && !degenerate) {
+        working = sharp(data);
+        trimmed = true;
+      }
+    } catch {
+      // trim of an (almost) uniform image can fail — treat as nothing to trim
+    }
+  }
+
+  // Passthrough: already JPEG, small enough, upright, nothing trimmed — return
+  // the original bytes so re-runs and the backfill cause no generation loss.
+  const upright = meta.orientation === undefined || meta.orientation === 1;
+  if (!trimmed && meta.format === "jpeg" && meta.height <= MAX_HEIGHT && upright) {
+    return { data: input, contentType: "image/jpeg" };
+  }
+
+  const data = await (working ?? base)
+    .resize({ height: MAX_HEIGHT, withoutEnlargement: true })
+    .flatten({ background: "#ffffff" })
+    .jpeg({ quality: JPEG_QUALITY, mozjpeg: true })
+    .toBuffer();
+  return { data, contentType: "image/jpeg" };
+}

--- a/app/forge/lib/imageNormalize.ts
+++ b/app/forge/lib/imageNormalize.ts
@@ -9,6 +9,7 @@ const MAX_HEIGHT = 1050;
 const CORNER_WHITE_MIN = 240; // per-channel floor for a corner to count as "white margin"
 const TRIM_THRESHOLD = 25;
 const MIN_TRIM_RATIO = 0.6; // trim keeping less than this per axis is degenerate
+const MIN_TRIM_FRACTION = 0.03; // trim removing less than this on every axis is noise (e.g. scan fringes), not a real margin
 const JPEG_QUALITY = 85;
 
 /** True when all four corners are near-white after flattening alpha onto white. */
@@ -61,7 +62,10 @@ export async function normalizeCardImage(input: Buffer): Promise<NormalizedImage
       const shrank = info.width < baseWidth || info.height < baseHeight;
       const degenerate =
         info.width < baseWidth * MIN_TRIM_RATIO || info.height < baseHeight * MIN_TRIM_RATIO;
-      if (shrank && !degenerate) {
+      const significant =
+        info.width <= baseWidth * (1 - MIN_TRIM_FRACTION) ||
+        info.height <= baseHeight * (1 - MIN_TRIM_FRACTION);
+      if (shrank && !degenerate && significant) {
         working = sharp(data);
         trimmed = true;
       }

--- a/app/forge/lib/imageNormalize.ts
+++ b/app/forge/lib/imageNormalize.ts
@@ -1,7 +1,7 @@
 // Server-only: normalizes Forge card images at upload time so every stored
 // image is flush (no baked-in print-bleed margins), at most 1050px tall, and
 // JPEG-encoded. Design: docs/superpowers/specs/2026-07-06-forge-image-normalization-design.md
-import sharp from "sharp";
+import sharp, { type Sharp } from "sharp";
 
 export type NormalizedImage = { data: Buffer; contentType: "image/jpeg" };
 
@@ -12,7 +12,7 @@ const MIN_TRIM_RATIO = 0.6; // trim keeping less than this per axis is degenerat
 const JPEG_QUALITY = 85;
 
 /** True when all four corners are near-white after flattening alpha onto white. */
-async function cornersNearWhite(img: sharp.Sharp): Promise<boolean> {
+async function cornersNearWhite(img: Sharp): Promise<boolean> {
   const { data, info } = await img
     .clone()
     .flatten({ background: "#ffffff" })
@@ -49,7 +49,7 @@ export async function normalizeCardImage(input: Buffer): Promise<NormalizedImage
   // images have dark frame corners, so the gate skips them and the border
   // ring survives; trimming against an explicit white background can never
   // eat a dark frame either way.
-  let working: sharp.Sharp | null = null;
+  let working: Sharp | null = null;
   let trimmed = false;
   if (await cornersNearWhite(base)) {
     try {

--- a/app/forge/lib/lackey.ts
+++ b/app/forge/lib/lackey.ts
@@ -139,7 +139,7 @@ export function lackeyRowToDesignCard(row: LackeyRow): DesignCard {
   const rawText = clean(row.specialAbility);
   if (rawText) {
     card.rawText = rawText;        // what the studio textarea edits
-    card.specialAbility = rawText; // what the Phase-2.2 deckbuilder reads
+    card.specialAbility = rawText; // legacy fallback field, kept in sync for older readers
   }
 
   const types = [...new Set(

--- a/docs/superpowers/plans/2026-07-06-forge-image-normalization.md
+++ b/docs/superpowers/plans/2026-07-06-forge-image-normalization.md
@@ -14,7 +14,7 @@
 
 - Never import server-only modules (`app/forge/lib/art.ts`, `imageNormalize.ts`) into `"use client"` files.
 - Never upscale images; never re-encode already-conforming JPEGs (byte-identical passthrough).
-- Trim only fires when ALL four corner pixels are near-white (each RGB channel ≥ 240 after flattening alpha onto white); trim threshold 25; degenerate-trim guard at 60% of original per axis.
+- Trim only fires when ALL four corner pixels are near-white (each RGB channel ≥ 240 after flattening alpha onto white); trim threshold 25; degenerate-trim guard at 60% of original per axis; significance floor: the trim must remove ≥3% along at least one axis or it is discarded (live Lackey scans have white rounded corners + a ~1.8% fringe that must NOT trigger re-encoding).
 - Output is always JPEG quality 85 (mozjpeg) unless the passthrough applies.
 - Height cap: 1050px.
 - Tests: Vitest, run with `npx vitest run <path>`. Generate image fixtures in-test with sharp — no binary fixtures in the repo.

--- a/docs/superpowers/plans/2026-07-06-forge-image-normalization.md
+++ b/docs/superpowers/plans/2026-07-06-forge-image-normalization.md
@@ -1,0 +1,664 @@
+# Forge Image Normalization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Normalize every Forge card image at upload time (trim white print-bleed margins, cap at 1050px tall, re-encode JPEG) and backfill existing odd-sized blobs, so all cards render at the same visual size.
+
+**Architecture:** A single server-only normalizer module (`sharp`) is called from the two blob-upload helpers in `app/forge/lib/art.ts` — the choke point every upload path (studio actions, Lackey import) already flows through. A one-off `scripts/` backfill runs the same normalizer over every blob referenced by `forge_cards`/`card_versions`.
+
+**Tech Stack:** Next.js 15 server actions, `sharp`, Vercel Blob (private store via `@vercel/blob`), Supabase (`@supabase/supabase-js` service role in the script), Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-07-06-forge-image-normalization-design.md`
+
+## Global Constraints
+
+- Never import server-only modules (`app/forge/lib/art.ts`, `imageNormalize.ts`) into `"use client"` files.
+- Never upscale images; never re-encode already-conforming JPEGs (byte-identical passthrough).
+- Trim only fires when ALL four corner pixels are near-white (each RGB channel ≥ 240 after flattening alpha onto white); trim threshold 25; degenerate-trim guard at 60% of original per axis.
+- Output is always JPEG quality 85 (mozjpeg) unless the passthrough applies.
+- Height cap: 1050px.
+- Tests: Vitest, run with `npx vitest run <path>`. Generate image fixtures in-test with sharp — no binary fixtures in the repo.
+- Match existing code style; commits end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Normalizer module + unit tests
+
+**Files:**
+- Create: `app/forge/lib/imageNormalize.ts`
+- Test: `app/forge/lib/__tests__/imageNormalize.test.ts`
+- Modify: `package.json` (add `sharp` dependency)
+
+**Interfaces:**
+- Consumes: nothing (leaf module; only `sharp`).
+- Produces: `normalizeCardImage(input: Buffer): Promise<NormalizedImage>` and `type NormalizedImage = { data: Buffer; contentType: "image/jpeg" }` — Tasks 2 and 3 import exactly these from `@/app/forge/lib/imageNormalize` (Task 3 via relative path).
+
+- [ ] **Step 1: Install sharp**
+
+```bash
+cd /Users/timestes/projects/redemption-tournament-tracker && npm install sharp
+```
+
+Expected: `sharp` appears under `dependencies` in package.json (version ^0.34.x).
+
+- [ ] **Step 2: Write the failing test**
+
+Create `app/forge/lib/__tests__/imageNormalize.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import sharp from "sharp";
+import { normalizeCardImage } from "../imageNormalize";
+
+const DARK = { r: 60, g: 20, b: 20 };
+
+/** Solid dark block, encoded as requested. */
+function solid(width: number, height: number, format: "png" | "jpeg"): Promise<Buffer> {
+  const img = sharp({ create: { width, height, channels: 3, background: DARK } });
+  return format === "png" ? img.png().toBuffer() : img.jpeg({ quality: 90 }).toBuffer();
+}
+
+/** Dark content block centered on a white canvas (print-bleed style). */
+async function withWhiteMargins(canvasW: number, canvasH: number, contentW: number, contentH: number): Promise<Buffer> {
+  const content = await sharp({ create: { width: contentW, height: contentH, channels: 3, background: DARK } }).png().toBuffer();
+  return sharp({ create: { width: canvasW, height: canvasH, channels: 3, background: "#ffffff" } })
+    .composite([{ input: content, top: Math.floor((canvasH - contentH) / 2), left: Math.floor((canvasW - contentW) / 2) }])
+    .png()
+    .toBuffer();
+}
+
+async function dims(buf: Buffer): Promise<{ width?: number; height?: number; format?: string }> {
+  const m = await sharp(buf).metadata();
+  return { width: m.width, height: m.height, format: m.format };
+}
+
+describe("normalizeCardImage", () => {
+  it("trims white print-bleed margins and re-encodes as JPEG", async () => {
+    const input = await withWhiteMargins(815, 1125, 750, 1046);
+    const out = await normalizeCardImage(input);
+    const d = await dims(out.data);
+    expect(out.contentType).toBe("image/jpeg");
+    expect(d.format).toBe("jpeg");
+    expect(Math.abs((d.width ?? 0) - 750)).toBeLessThanOrEqual(4);
+    expect(Math.abs((d.height ?? 0) - 1046)).toBeLessThanOrEqual(4);
+  });
+
+  it("does not trim full-bleed images with dark corners (corner gate)", async () => {
+    const input = await solid(700, 980, "png");
+    const out = await normalizeCardImage(input);
+    const d = await dims(out.data);
+    expect(d.width).toBe(700);
+    expect(d.height).toBe(980);
+    expect(d.format).toBe("jpeg"); // PNG input is still re-encoded
+  });
+
+  it("downscales oversized images to 1050px tall, preserving aspect", async () => {
+    const input = await solid(750, 1500, "png");
+    const out = await normalizeCardImage(input);
+    const d = await dims(out.data);
+    expect(d.height).toBe(1050);
+    expect(d.width).toBe(525);
+  });
+
+  it("returns already-conforming JPEGs byte-identical (no generation loss)", async () => {
+    const input = await solid(345, 495, "jpeg");
+    const out = await normalizeCardImage(input);
+    expect(out.data.equals(input)).toBe(true);
+    expect(out.contentType).toBe("image/jpeg");
+  });
+
+  it("keeps original dimensions when trim would be degenerate (near-all-white input)", async () => {
+    const input = await withWhiteMargins(600, 800, 50, 50); // tiny dot on white
+    const out = await normalizeCardImage(input);
+    const d = await dims(out.data);
+    expect(d.width).toBe(600);
+    expect(d.height).toBe(800);
+  });
+
+  it("throws on undecodable input", async () => {
+    await expect(normalizeCardImage(Buffer.from("not an image"))).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `npx vitest run app/forge/lib/__tests__/imageNormalize.test.ts`
+Expected: FAIL — cannot resolve `../imageNormalize`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `app/forge/lib/imageNormalize.ts`:
+
+```ts
+// Server-only: normalizes Forge card images at upload time so every stored
+// image is flush (no baked-in print-bleed margins), at most 1050px tall, and
+// JPEG-encoded. Design: docs/superpowers/specs/2026-07-06-forge-image-normalization-design.md
+import sharp from "sharp";
+
+export type NormalizedImage = { data: Buffer; contentType: "image/jpeg" };
+
+const MAX_HEIGHT = 1050;
+const CORNER_WHITE_MIN = 240; // per-channel floor for a corner to count as "white margin"
+const TRIM_THRESHOLD = 25;
+const MIN_TRIM_RATIO = 0.6; // trim keeping less than this per axis is degenerate
+const JPEG_QUALITY = 85;
+
+/** True when all four corners are near-white after flattening alpha onto white. */
+async function cornersNearWhite(img: sharp.Sharp): Promise<boolean> {
+  const { data, info } = await img
+    .clone()
+    .flatten({ background: "#ffffff" })
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  const px = (x: number, y: number): number[] => {
+    const i = (y * info.width + x) * info.channels;
+    return [data[i], data[i + 1], data[i + 2]];
+  };
+  return [
+    px(0, 0),
+    px(info.width - 1, 0),
+    px(0, info.height - 1),
+    px(info.width - 1, info.height - 1),
+  ].every((corner) => corner.every((channel) => channel >= CORNER_WHITE_MIN));
+}
+
+export async function normalizeCardImage(input: Buffer): Promise<NormalizedImage> {
+  const meta = await sharp(input).metadata(); // throws on undecodable input
+  if (!meta.width || !meta.height) throw new Error("Could not read image");
+  const base = sharp(input).rotate(); // apply EXIF orientation
+
+  // Corner-gated margin trim: white print-bleed margins only. Full-bleed card
+  // images have dark frame corners, so the gate skips them and the border
+  // ring survives; trimming against an explicit white background can never
+  // eat a dark frame either way.
+  let working: sharp.Sharp | null = null;
+  let trimmed = false;
+  if (await cornersNearWhite(base)) {
+    try {
+      const { data, info } = await base
+        .clone()
+        .flatten({ background: "#ffffff" })
+        .trim({ background: "#ffffff", threshold: TRIM_THRESHOLD })
+        .toBuffer({ resolveWithObject: true });
+      const shrank = info.width < meta.width || info.height < meta.height;
+      const degenerate =
+        info.width < meta.width * MIN_TRIM_RATIO || info.height < meta.height * MIN_TRIM_RATIO;
+      if (shrank && !degenerate) {
+        working = sharp(data);
+        trimmed = true;
+      }
+    } catch {
+      // trim of an (almost) uniform image can fail — treat as nothing to trim
+    }
+  }
+
+  // Passthrough: already JPEG, small enough, upright, nothing trimmed — return
+  // the original bytes so re-runs and the backfill cause no generation loss.
+  const upright = meta.orientation === undefined || meta.orientation === 1;
+  if (!trimmed && meta.format === "jpeg" && meta.height <= MAX_HEIGHT && upright) {
+    return { data: input, contentType: "image/jpeg" };
+  }
+
+  const data = await (working ?? base)
+    .resize({ height: MAX_HEIGHT, withoutEnlargement: true })
+    .flatten({ background: "#ffffff" })
+    .jpeg({ quality: JPEG_QUALITY, mozjpeg: true })
+    .toBuffer();
+  return { data, contentType: "image/jpeg" };
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run app/forge/lib/__tests__/imageNormalize.test.ts`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json package-lock.json app/forge/lib/imageNormalize.ts app/forge/lib/__tests__/imageNormalize.test.ts
+git commit -m "feat(forge): image normalizer — trim white margins, cap 1050px, JPEG
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Wire the normalizer into the upload helpers
+
+**Files:**
+- Modify: `app/forge/lib/art.ts` (uploadForgeArt lines 42-51, uploadForgeFinished lines 54-63)
+- Modify: `app/forge/lib/cards.ts` (uploadArt line 48, uploadFinished line 72, stale comment line 49)
+- Test: create `app/forge/lib/__tests__/art.test.ts`; extend `app/forge/lib/__tests__/cards.test.ts`
+
+**Interfaces:**
+- Consumes: `normalizeCardImage(input: Buffer): Promise<{ data: Buffer; contentType: "image/jpeg" }>` from `@/app/forge/lib/imageNormalize` (Task 1).
+- Produces: `uploadForgeArt(file: File): Promise<string>` / `uploadForgeFinished(file: File): Promise<string>` — signatures unchanged, but they now store normalized JPEG bytes and REJECT (throw) on undecodable input. The studio actions return `{ ok: false, error: "Could not read image file." }` in that case.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `app/forge/lib/__tests__/art.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@vercel/blob", () => ({ put: vi.fn(), get: vi.fn(), del: vi.fn() }));
+vi.mock("@/app/forge/lib/imageNormalize", () => ({ normalizeCardImage: vi.fn() }));
+
+import { put } from "@vercel/blob";
+import { normalizeCardImage } from "@/app/forge/lib/imageNormalize";
+import { uploadForgeArt, uploadForgeFinished } from "../art";
+
+const file = new File([new Uint8Array([1, 2, 3])], "art.png", { type: "image/png" });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (put as any).mockResolvedValue({ pathname: "forge-art/some-key" });
+  (normalizeCardImage as any).mockResolvedValue({
+    data: Buffer.from("normalized"),
+    contentType: "image/jpeg",
+  });
+});
+
+describe("uploadForgeArt / uploadForgeFinished", () => {
+  it("uploads the NORMALIZED bytes as image/jpeg, not the original file", async () => {
+    await uploadForgeArt(file);
+    const [key, body, opts] = (put as any).mock.calls[0];
+    expect(String(key)).toMatch(/^forge-art\//);
+    expect(Buffer.from(body).toString()).toBe("normalized");
+    expect(opts.contentType).toBe("image/jpeg");
+  });
+
+  it("uploadForgeFinished stores under forge-finished/ with normalized bytes", async () => {
+    (put as any).mockResolvedValue({ pathname: "forge-finished/some-key" });
+    await uploadForgeFinished(file);
+    const [key, body, opts] = (put as any).mock.calls[0];
+    expect(String(key)).toMatch(/^forge-finished\//);
+    expect(Buffer.from(body).toString()).toBe("normalized");
+    expect(opts.contentType).toBe("image/jpeg");
+  });
+
+  it("propagates decode failures without uploading anything", async () => {
+    (normalizeCardImage as any).mockRejectedValue(new Error("unsupported image format"));
+    await expect(uploadForgeArt(file)).rejects.toThrow();
+    expect(put).not.toHaveBeenCalled();
+  });
+});
+```
+
+Extend `app/forge/lib/__tests__/cards.test.ts` — add `uploadForgeArt` and `uploadArt` to the existing imports on lines 8-9 (`validateArtFile, uploadForgeArt, uploadForgeFinished` from `@/app/forge/lib/art`; `uploadArt, uploadFinished` from `../cards` — the `lib/art` mock on line 5 already stubs all three), then append this describe block:
+
+```ts
+describe("upload decode failures", () => {
+  it("uploadArt returns a clear error when the image cannot be decoded", async () => {
+    const c = ctx();
+    (requireElder as any).mockResolvedValue(c);
+    (validateArtFile as any).mockReturnValue(null);
+    (uploadForgeArt as any).mockRejectedValue(new Error("unsupported image format"));
+    const fd = new FormData();
+    fd.set("file", new File([new Uint8Array([1, 2, 3])], "a.png", { type: "image/png" }));
+    expect(await uploadArt("c1", fd)).toEqual({ ok: false, error: "Could not read image file." });
+  });
+
+  it("uploadFinished returns a clear error when the image cannot be decoded", async () => {
+    const c = ctx();
+    (requireElder as any).mockResolvedValue(c);
+    (validateArtFile as any).mockReturnValue(null);
+    (uploadForgeFinished as any).mockRejectedValue(new Error("unsupported image format"));
+    const fd = new FormData();
+    fd.set("file", new File([new Uint8Array([1, 2, 3])], "c.png", { type: "image/png" }));
+    expect(await uploadFinished("c1", fd)).toEqual({ ok: false, error: "Could not read image file." });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run app/forge/lib/__tests__/art.test.ts app/forge/lib/__tests__/cards.test.ts`
+Expected: art.test.ts FAILS (put still receives the original file / decode-failure test rejects nothing); the two new cards tests FAIL (currently the rejection propagates as an unhandled throw instead of `{ ok: false, ... }`).
+
+- [ ] **Step 3: Implement**
+
+In `app/forge/lib/art.ts`, add the import and rewrite the two upload helpers (leave `validateArtFile`, `readForgeArt`, `deleteForgeArt` untouched):
+
+```ts
+import { normalizeCardImage } from "@/app/forge/lib/imageNormalize";
+```
+
+```ts
+/**
+ * Normalize (trim white print-bleed margins, cap 1050px tall, re-encode JPEG)
+ * and upload to the PRIVATE blob store under an unguessable UUID key.
+ * Throws if the file cannot be decoded as an image. Returns the stored pathname.
+ */
+export async function uploadForgeArt(file: File): Promise<string> {
+  const normalized = await normalizeCardImage(Buffer.from(await file.arrayBuffer()));
+  const key = `${ART_PREFIX}${randomUUID()}`;
+  const blob = await put(key, normalized.data, {
+    access: "private",
+    addRandomSuffix: false,
+    ...forgeAuth,
+    contentType: normalized.contentType,
+  });
+  return blob.pathname;
+}
+
+/** Same normalization + upload for finished-card images under forge-finished/. */
+export async function uploadForgeFinished(file: File): Promise<string> {
+  const normalized = await normalizeCardImage(Buffer.from(await file.arrayBuffer()));
+  const key = `${FINISHED_PREFIX}${randomUUID()}`;
+  const blob = await put(key, normalized.data, {
+    access: "private",
+    addRandomSuffix: false,
+    ...forgeAuth,
+    contentType: normalized.contentType,
+  });
+  return blob.pathname;
+}
+```
+
+In `app/forge/lib/cards.ts` — `uploadArt` (line 48): replace
+
+```ts
+  const key = await uploadForgeArt(file);
+  // No image processing in 1a.3: the uploaded file IS the original.
+```
+
+with
+
+```ts
+  let key: string;
+  try {
+    key = await uploadForgeArt(file);
+  } catch {
+    return { ok: false, error: "Could not read image file." };
+  }
+  // Art is normalized at upload (trim/resize/JPEG); original_key mirrors the stored key.
+```
+
+and `uploadFinished` (line 72): replace `const key = await uploadForgeFinished(file);` with
+
+```ts
+  let key: string;
+  try {
+    key = await uploadForgeFinished(file);
+  } catch {
+    return { ok: false, error: "Could not read image file." };
+  }
+```
+
+- [ ] **Step 4: Run the forge test suite**
+
+Run: `npx vitest run app/forge/lib/__tests__/`
+Expected: art.test.ts, cards.test.ts, imageNormalize.test.ts all PASS. Note: `members.test.ts` and `sets.test.ts` have 2 pre-existing failures on main — ignore those two, they are not yours to fix.
+
+- [ ] **Step 5: Verify the production build (sharp/RSC bundling)**
+
+Run: `npm run build`
+Expected: build succeeds. If it fails with a sharp module-load/bundling error, add `"sharp"` to the `serverExternalPackages` array in `next.config.js` (same treatment as `@vercel/blob`) and re-run.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/forge/lib/art.ts app/forge/lib/cards.ts app/forge/lib/__tests__/art.test.ts app/forge/lib/__tests__/cards.test.ts
+git commit -m "feat(forge): normalize card images at upload via the art helpers
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+(Include `next.config.js` in the add if Step 5 modified it.)
+
+---
+
+### Task 3: Backfill script (dry-run verified)
+
+**Files:**
+- Create: `scripts/forge-normalize-images.ts`
+
+**Interfaces:**
+- Consumes: `normalizeCardImage` from `../app/forge/lib/imageNormalize` (relative import — tsx does not resolve the `@/` alias).
+- Produces: a manually-run CLI. `npx tsx scripts/forge-normalize-images.ts` = dry-run (default, prints plan, writes nothing); `--apply` executes. NOT imported by app code.
+
+- [ ] **Step 1: Write the script**
+
+Create `scripts/forge-normalize-images.ts`:
+
+```ts
+/**
+ * One-off backfill: run every blob referenced by forge_cards/card_versions
+ * through the Forge image normalizer (trim white print-bleed margins, cap
+ * 1050px tall, re-encode JPEG). Conforming blobs are skipped byte-identically.
+ * Rewritten images get a NEW key; referencing rows are re-pointed and the
+ * card's updated_at is touched (busts the working-view `t` cache param).
+ * Also sweeps 44 known-orphaned 1x1 blobs (2026-07-06 survey), re-verified
+ * unreferenced at run time.
+ *
+ * Design: docs/superpowers/specs/2026-07-06-forge-image-normalization-design.md
+ *
+ * Usage: npx tsx scripts/forge-normalize-images.ts [--apply]
+ * Default is dry-run: prints the plan, writes nothing.
+ */
+import { config } from "dotenv";
+config({ path: ".env.local" });
+
+import { randomUUID } from "crypto";
+import { createClient } from "@supabase/supabase-js";
+import { put, get, del } from "@vercel/blob";
+import { normalizeCardImage } from "../app/forge/lib/imageNormalize";
+
+const APPLY = process.argv.includes("--apply");
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+const auth = process.env.FORGE_BLOB_READ_WRITE_TOKEN
+  ? { token: process.env.FORGE_BLOB_READ_WRITE_TOKEN }
+  : { storeId: process.env.FORGE_BLOB_STORE_ID! };
+
+type Ref = { table: "forge_cards" | "card_versions"; id: string; column: string; cardId: string };
+
+// Orphaned 1x1 JPEG blobs found in the 2026-07-06 store survey. None are
+// referenced by forge_cards or card_versions (verified then and re-verified
+// against live refs below before deletion).
+const ORPHANED_1X1: string[] = [
+  "forge-finished/022d0513-7a80-4f88-8726-f9768fb58837",
+  "forge-finished/035b56cd-469a-410d-9487-ef0afa3cf8b0",
+  "forge-finished/04c17b40-b699-4189-b9c9-2a148d003d98",
+  "forge-finished/087c415c-fe60-415b-b4cf-0d6a7ebf1deb",
+  "forge-finished/098fea86-a8d6-4468-a0c2-9d8f00adb4ca",
+  "forge-finished/1918ce3f-41d1-4f47-b49d-c76e922591ca",
+  "forge-finished/1c72f871-5eaa-4ad6-9bf6-890f6ace9ef1",
+  "forge-finished/1d84410e-14cd-42ef-af63-b69412946d00",
+  "forge-finished/2c2c78cd-cc64-4b1b-a384-ea1f2e52c07b",
+  "forge-finished/31431ea6-1536-41ca-bdc6-d6afd2fca203",
+  "forge-finished/40d26f6a-95d6-45cc-96e4-b87c8d0afd8e",
+  "forge-finished/4cbd58ad-b590-455b-8f85-e863a5febea1",
+  "forge-finished/4fc72d08-d338-4e31-a6b6-7ca0e678edb7",
+  "forge-finished/6b214645-356d-450e-bc48-177ecce1bd2e",
+  "forge-finished/700a0e8d-117e-4fca-87cb-bceb952eca69",
+  "forge-finished/75e1a10a-ae52-4463-bef4-1b9ddeda2925",
+  "forge-finished/77ceee10-a2dc-4594-96b2-46649ae4d3cc",
+  "forge-finished/7b47fb10-c478-49ed-bc60-137769887ced",
+  "forge-finished/805141d5-c4ed-4d04-a50b-e130f13a9ab9",
+  "forge-finished/8d238df4-7629-4aa7-a8cd-614f55b7dcc4",
+  "forge-finished/9542375d-9279-4839-973b-7587079d7905",
+  "forge-finished/99a2cf80-c2a8-430e-ace9-8c01ccec704c",
+  "forge-finished/9a313283-e34a-423e-9383-9aa9c68c238e",
+  "forge-finished/9eaba425-d56e-4dab-8719-032d1a9c351f",
+  "forge-finished/9f141a4a-03a3-4118-b691-5cbf7289ea60",
+  "forge-finished/a797a8ff-778b-42fc-b689-5cfca6b5a9c1",
+  "forge-finished/b427c7a8-55cb-40e6-ba62-f8f40d5406f4",
+  "forge-finished/b64a6b56-d3b5-4f81-bef0-547efebcaceb",
+  "forge-finished/c19f047f-b9ae-4899-bb13-16d64137846d",
+  "forge-finished/c6121e2e-6573-4411-83d7-3b76b19abb8a",
+  "forge-finished/cbd4bf29-38c5-49bd-bad8-41a87f9a7f5d",
+  "forge-finished/d382c831-6855-4dc4-bd1c-49bd9dfd3226",
+  "forge-finished/d451d556-d37e-42de-932f-885618bb8d69",
+  "forge-finished/d576be34-4700-4980-aafb-946feedeb69a",
+  "forge-finished/dedc057b-00ee-45aa-b59b-f6c54177bf25",
+  "forge-finished/dfff9e02-6ea8-49fc-8631-83422e3d8ee5",
+  "forge-finished/ea44811a-9596-4392-adbb-dc837ab1cacf",
+  "forge-finished/e996aa36-e969-44b7-9d45-da8b846efc89",
+  "forge-finished/ea461c64-0168-4eac-bb76-61bddb6c6785",
+  "forge-finished/ec18221d-a1ef-4c3e-8688-a443f851c40c",
+  "forge-finished/ed31e18f-2304-4a8f-be2b-4aad31607eec",
+  "forge-finished/efb442d5-7e90-454d-b95c-4278cb2bba77",
+  "forge-finished/f1408b2c-97b9-46d3-ac19-c7e619f59298",
+  "forge-finished/fca38891-2d65-4b19-9aba-614d1aabd8da",
+];
+
+async function collectRefs(): Promise<Map<string, Ref[]>> {
+  const refs = new Map<string, Ref[]>();
+  const add = (key: string | null, ref: Ref) => {
+    if (!key) return;
+    refs.set(key, [...(refs.get(key) ?? []), ref]);
+  };
+  const { data: cards, error: cardsErr } = await supabase
+    .from("forge_cards")
+    .select("id, working_art_key, working_art_original_key, working_finished_key");
+  if (cardsErr) throw cardsErr;
+  for (const c of cards ?? []) {
+    for (const col of ["working_art_key", "working_art_original_key", "working_finished_key"] as const) {
+      add(c[col], { table: "forge_cards", id: c.id, column: col, cardId: c.id });
+    }
+  }
+  const { data: versions, error: versionsErr } = await supabase
+    .from("card_versions")
+    .select("id, card_id, art_key, art_original_key, finished_key");
+  if (versionsErr) throw versionsErr;
+  for (const v of versions ?? []) {
+    for (const col of ["art_key", "art_original_key", "finished_key"] as const) {
+      add(v[col], { table: "card_versions", id: v.id, column: col, cardId: v.card_id });
+    }
+  }
+  return refs;
+}
+
+async function download(key: string): Promise<Buffer> {
+  const res = await get(key, { access: "private", ...auth });
+  if (!res || res.statusCode !== 200) throw new Error(`GET ${key} -> ${res?.statusCode}`);
+  const chunks: Buffer[] = [];
+  for await (const chunk of res.stream) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks);
+}
+
+async function main() {
+  const refs = await collectRefs();
+  console.log(`${refs.size} referenced blob keys; mode=${APPLY ? "APPLY" : "dry-run"}`);
+  let rewritten = 0, skipped = 0, failed = 0;
+  const touchedCards = new Set<string>();
+
+  for (const [key, refList] of refs) {
+    let input: Buffer;
+    try {
+      input = await download(key);
+    } catch (e) {
+      console.error(`FAIL download ${key}: ${e}`);
+      failed++;
+      continue;
+    }
+    let out: Awaited<ReturnType<typeof normalizeCardImage>>;
+    try {
+      out = await normalizeCardImage(input);
+    } catch (e) {
+      console.error(`FAIL normalize ${key} (${input.length}B): ${e}`);
+      failed++;
+      continue;
+    }
+    if (out.data.equals(input)) {
+      skipped++;
+      continue;
+    }
+
+    console.log(
+      `rewrite ${key} (${input.length}B -> ${out.data.length}B) refs=${refList
+        .map((r) => `${r.table}.${r.column}`)
+        .join(",")}`
+    );
+    rewritten++;
+    if (!APPLY) continue;
+
+    const newKey = `${key.split("/")[0]}/${randomUUID()}`;
+    await put(newKey, out.data, {
+      access: "private",
+      addRandomSuffix: false,
+      contentType: out.contentType,
+      ...auth,
+    });
+    for (const ref of refList) {
+      const { error } = await supabase
+        .from(ref.table)
+        .update({ [ref.column]: newKey })
+        .eq("id", ref.id);
+      if (error) throw new Error(`UPDATE ${ref.table}.${ref.column} for ${ref.id}: ${error.message}`);
+      touchedCards.add(ref.cardId);
+    }
+    try {
+      await del(key, { ...auth });
+    } catch {
+      // a dangling private+UUID blob is invisible and harmless
+    }
+  }
+
+  if (APPLY) {
+    for (const cardId of touchedCards) {
+      const { error } = await supabase
+        .from("forge_cards")
+        .update({ updated_at: new Date().toISOString() })
+        .eq("id", cardId);
+      if (error) console.error(`FAIL touch updated_at for ${cardId}: ${error.message}`);
+    }
+  }
+
+  let swept = 0;
+  for (const key of ORPHANED_1X1) {
+    if (refs.has(key)) {
+      console.error(`SKIP orphan ${key}: now referenced!`);
+      continue;
+    }
+    console.log(`delete orphan ${key}`);
+    if (APPLY) {
+      try {
+        await del(key, { ...auth });
+        swept++;
+      } catch (e) {
+        console.error(`FAIL delete orphan ${key}: ${e}`);
+      }
+    }
+  }
+
+  console.log(
+    `done: ${rewritten} rewritten, ${skipped} conforming (skipped), ${failed} failed, ` +
+      `${APPLY ? swept : ORPHANED_1X1.length} orphans ${APPLY ? "deleted" : "to delete"}`
+  );
+  if (failed > 0) process.exitCode = 1;
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Dry-run against the live store (read-only)**
+
+Run: `npx tsx scripts/forge-normalize-images.ts`
+Expected output shape (counts are approximate — verify plausibility, exact numbers depend on live data):
+- `~200 referenced blob keys; mode=dry-run` (176 cards + 180 versions share many keys)
+- ~45 `rewrite ...` lines — the 815–825×1125 PNGs, 1047×1503 PNGs, and WebPs from the survey; each shows a large byte reduction (e.g. `940655B -> ~150000B`)
+- The vast majority skipped as conforming (the 345×495 JPEGs)
+- `0` failed; 44 orphan `delete orphan ...` lines
+- **Sanity check:** the key `forge-finished/101dc581-ff7e-471e-8a4d-bea060df03aa` (Heavenly Temple) MUST appear as a rewrite. If more than ~60 keys rewrite, STOP and report — the conforming passthrough is not engaging.
+
+Do NOT run `--apply` in this task — that is a deliberate post-review operational step.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/forge-normalize-images.ts
+git commit -m "feat(forge): backfill script normalizing existing card image blobs
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```

--- a/docs/superpowers/specs/2026-07-06-forge-image-normalization-design.md
+++ b/docs/superpowers/specs/2026-07-06-forge-image-normalization-design.md
@@ -70,6 +70,13 @@ Pipeline:
    - **Degenerate-trim guard:** if the trimmed result is smaller than 60% of
      the original along either axis, discard the trim and use the untrimmed
      image (protects near-white card faces).
+   - **Significance floor:** the trim must remove at least 3% along at least
+     one axis, or it is discarded. Live Lackey scans have white rounded-corner
+     pixels (passing the corner gate) plus a ~9px (1.8%) near-white fringe; a
+     2026-07-06 dry-run showed that without this floor every one of the 1,323
+     conforming JPEGs would trim marginally and re-encode, violating the
+     no-generation-loss non-goal. Real print-bleed margins (Heavenly Temple:
+     ~8%) clear the floor easily.
 3. `.resize({ height: 1050, withoutEnlargement: true })` — cap resolution,
    preserve aspect ratio, never upscale.
 4. `.flatten({ background: "#ffffff" })` — remove alpha.

--- a/docs/superpowers/specs/2026-07-06-forge-image-normalization-design.md
+++ b/docs/superpowers/specs/2026-07-06-forge-image-normalization-design.md
@@ -1,0 +1,163 @@
+# Forge Image Normalization — Design Spec
+
+**Date:** 2026-07-06
+**Status:** Approved (design review in session)
+
+## Problem
+
+Forge card images arrive at wildly different sizes and framings. A survey of all
+1,420 blobs in the private Forge store (2026-07-06) found:
+
+| Dimensions | Count | Source |
+|---|---|---|
+| 345×495 JPEG (~50KB) | 1,323 | Lackey bulk import — flush, edge-to-edge |
+| 815–825×1125 PNG (0.9–1.6MB) | 42 | Card-tool exports (recent studio uploads) |
+| 1047×1503 PNG | 3 | Oversized exports |
+| 1×1 JPEG | 44 | Broken uploads — all orphaned (unreferenced) |
+
+Two user-visible problems:
+
+1. **Baked-in print-bleed margins.** Card-tool exports (e.g. Heavenly Temple
+   [EoT], 815×1125) include white bleed margins in the file; the card face
+   occupies ~92% of the canvas. In any equal-size display box the card renders
+   visibly smaller than its flush neighbors.
+2. **Weight.** The PNG exports are 20–30× heavier than the JPEG norm, served
+   through the authed `/forge/api/art` proxy on every uncached view.
+
+There is currently **no image processing anywhere in the pipeline**: uploads are
+stored byte-for-byte ([app/forge/lib/art.ts](../../../app/forge/lib/art.ts), "the
+uploaded file IS the original").
+
+## Goals
+
+- Every stored card image is flush (no baked-in margins), at most 1050px tall,
+  and JPEG-encoded.
+- One implementation covers every upload path (studio upload, Lackey bulk
+  import, future callers).
+- Existing odd-sized/margined images are backfilled to the same standard.
+- Undecodable uploads are rejected with a clear error instead of stored.
+
+## Non-goals
+
+- No upscaling of small images (the 345×495 Lackey norm stays as-is).
+- No re-encode of already-conforming images (no generation loss on 1,323 JPEGs).
+- No changes to display CSS, the art proxy, RLS, or auth.
+- No general orphaned-blob garbage collection (only the 44 known 1×1 orphans
+  are swept, as they are unambiguously garbage).
+
+## Design
+
+### 1. Normalizer module — `app/forge/lib/imageNormalize.ts`
+
+Server-only module using a new `sharp` dependency.
+
+```ts
+export type NormalizedImage = { data: Buffer; contentType: "image/jpeg" };
+export async function normalizeCardImage(input: Buffer): Promise<NormalizedImage>;
+```
+
+Pipeline:
+
+1. `sharp(input).rotate()` — apply EXIF orientation.
+2. **Corner-gated margin trim.** Sample the four corner pixels (after alpha
+   flattening logic below). Only when **all four corners** are near-white
+   (each RGB channel ≥ ~240 after flattening transparent pixels to white) does
+   the trim step run: `.trim({ background: "#ffffff", threshold: 25 })`.
+   - Rationale: print-bleed margins are white/transparent; full-bleed card
+     images have dark frame borders at the corners. Trimming with a white
+     background cannot eat a dark border ring, and the corner gate skips the
+     step entirely for full-bleed images.
+   - **Degenerate-trim guard:** if the trimmed result is smaller than 60% of
+     the original along either axis, discard the trim and use the untrimmed
+     image (protects near-white card faces).
+3. `.resize({ height: 1050, withoutEnlargement: true })` — cap resolution,
+   preserve aspect ratio, never upscale.
+4. `.flatten({ background: "#ffffff" })` — remove alpha.
+5. `.jpeg({ quality: 85, mozjpeg: true })`.
+
+Skip-if-conforming: when the input is already JPEG, ≤1050px tall, and the
+corner gate says no trim is needed, return the **original buffer unchanged**
+(`contentType: "image/jpeg"`). This makes the backfill safe to run over all
+referenced blobs and avoids generation loss.
+
+Errors: if sharp cannot decode the input, throw. Callers surface a clear
+upload error ("Could not read image file.") instead of storing garbage — this
+closes the door on future 1×1-style blank blobs.
+
+### 2. Wire-in — `app/forge/lib/art.ts`
+
+`uploadForgeArt(file)` and `uploadForgeFinished(file)` normalize before `put()`:
+
+- Convert the `File` to a `Buffer`, run `normalizeCardImage`, upload the result
+  with `contentType: "image/jpeg"`.
+- Existing validation (`validateArtFile`: type allowlist, 15MB cap) still runs
+  first, against the original file — unchanged semantics.
+- Decode failure → the studio server actions return `{ ok: false, error:
+  "Could not read image file." }`; the import route already wraps
+  `uploadForgeFinished` in a per-card try/catch and reports that card as
+  failed ("Image upload failed"), which is unchanged.
+
+This is the single choke point: `uploadArt`/`uploadFinished` server actions
+([app/forge/lib/cards.ts](../../../app/forge/lib/cards.ts)) and the Lackey
+import route ([app/forge/api/import/route.ts](../../../app/forge/api/import/route.ts))
+all pass through these two helpers.
+
+### 3. Backfill script — `scripts/forge-normalize-images.mjs`
+
+One-off, run manually with `.env.local` creds (service-role Supabase key +
+`FORGE_BLOB_READ_WRITE_TOKEN`). Never runs in the app.
+
+1. Collect every **referenced** blob key: `forge_cards.working_art_key`,
+   `working_art_original_key`, `working_finished_key`; `card_versions.art_key`,
+   `finished_key`.
+2. For each unique key: download, run `normalizeCardImage`. If the output is
+   byte-identical (skip-if-conforming), do nothing.
+3. Otherwise: upload the normalized bytes under a **new** UUID key with the
+   same prefix, update **every** row/column referencing the old key, touch
+   `forge_cards.updated_at` for affected cards (busts the working-view `t`
+   cache param), then best-effort delete the old blob.
+4. Sweep the 44 orphaned 1×1 blobs (hardcoded list captured in the 2026-07-06
+   survey, re-verified unreferenced at run time before deletion).
+5. `--dry-run` (default) prints the per-key plan (trim? resize? re-encode? →
+   new dims/bytes) without writing; `--apply` executes.
+
+Uses `@supabase/supabase-js` (already a dependency) with
+`SUPABASE_SERVICE_ROLE_KEY`. Column updates are plain
+`UPDATE ... WHERE <col> = <old key>`; RLS is bypassed by the service role. `card_versions` rows are otherwise immutable — only the key
+column is re-pointed; `data` JSON is untouched.
+
+**Known caveat:** play-mode art URLs are browser-cached immutably keyed on
+`t=versionId`, which does not change. Players who already loaded a card may
+see the old margins until their cache evicts. Cosmetic and accepted.
+
+### 4. Tests
+
+Vitest unit tests for the normalizer, using sharp itself to generate fixtures
+in-test (no binary fixtures in the repo):
+
+- White-margin PNG (card-colored center block, white border) → trimmed to the
+  content block, JPEG out.
+- Full-bleed image with dark corner pixels → dimensions unchanged (corner gate
+  skips trim).
+- 1500px-tall PNG → 1050px tall JPEG.
+- 345×495 JPEG → returned byte-identical (skip-if-conforming, no upscale).
+- Near-all-white image → degenerate-trim guard keeps original dimensions.
+- Corrupt buffer → throws.
+
+Existing `cards.test.ts` upload tests keep passing (they mock `lib/art`).
+A small test asserts the upload helpers reject undecodable files with the new
+error string (mock `normalizeCardImage` to throw).
+
+### 5. Config / deployment
+
+- `sharp` added to `dependencies`. Next 15 externalizes `sharp` for the server
+  build by default; if the build complains, add it to `serverExternalPackages`
+  in `next.config.js` (same treatment as `@vercel/blob`).
+- Vercel's Node runtime ships sharp-compatible binaries; no config expected.
+- Verify with `npm run build` before PR.
+
+## Expected outcome
+
+Heavenly Temple [EoT]: 815×1125 PNG, 940KB, white bleed margins → ~750×1046
+flush JPEG, ~150KB, renders the same visual size as every other card in the
+studio, set grids, deckbuilder, and online play.

--- a/docs/superpowers/specs/2026-07-06-forge-image-normalization-design.md
+++ b/docs/superpowers/specs/2026-07-06-forge-image-normalization-design.md
@@ -109,7 +109,7 @@ This is the single choke point: `uploadArt`/`uploadFinished` server actions
 import route ([app/forge/api/import/route.ts](../../../app/forge/api/import/route.ts))
 all pass through these two helpers.
 
-### 3. Backfill script — `scripts/forge-normalize-images.mjs`
+### 3. Backfill script — `scripts/forge-normalize-images.ts`
 
 One-off, run manually with `.env.local` creds (service-role Supabase key +
 `FORGE_BLOB_READ_WRITE_TOKEN`). Never runs in the app.

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "react-konva": "^19.2.2",
         "react-markdown": "^10.1.0",
         "resend": "^6.7.0",
+        "sharp": "^0.35.3",
         "spacetimedb": "^2.5.0",
         "topojson-client": "^3.1.0",
         "use-sound": "^5.0.0",
@@ -218,10 +219,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-      "license": "MIT",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -706,65 +706,80 @@
       }
     },
     "node_modules/@img/colour": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "optional": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "darwin"
@@ -774,13 +789,12 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "darwin"
@@ -790,13 +804,12 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -806,13 +819,12 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -822,13 +834,12 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -838,13 +849,12 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -854,13 +864,12 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -870,13 +879,12 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -886,13 +894,12 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -902,13 +909,12 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -918,252 +924,255 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
       "cpu": [
         "wasm32"
       ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@img/sharp-wasm32": "0.35.3"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -7894,6 +7903,438 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/next/node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/next/node_modules/@swc/helpers": {
       "version": "0.5.15",
       "license": "Apache-2.0",
@@ -7925,6 +8366,50 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/next/node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/node-fetch": {
@@ -9031,8 +9516,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "license": "ISC",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -9046,46 +9532,51 @@
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-konva": "^19.2.2",
     "react-markdown": "^10.1.0",
     "resend": "^6.7.0",
+    "sharp": "^0.35.3",
     "spacetimedb": "^2.5.0",
     "topojson-client": "^3.1.0",
     "use-sound": "^5.0.0",

--- a/scripts/forge-normalize-images.ts
+++ b/scripts/forge-normalize-images.ts
@@ -161,10 +161,14 @@ async function main() {
       ...auth,
     });
     for (const ref of refList) {
+      // WHERE <col> = <old key> guards against an elder replacing the art between
+      // collectRefs() and this write. A 0-row update is a silent no-op in
+      // supabase-js (no error) — that's correct: the ref moved on, our blob dangles.
       const { error } = await supabase
         .from(ref.table)
         .update({ [ref.column]: newKey })
-        .eq("id", ref.id);
+        .eq("id", ref.id)
+        .eq(ref.column, key);
       if (error) throw new Error(`UPDATE ${ref.table}.${ref.column} for ${ref.id}: ${error.message}`);
       touchedCards.add(ref.cardId);
     }

--- a/scripts/forge-normalize-images.ts
+++ b/scripts/forge-normalize-images.ts
@@ -1,0 +1,215 @@
+/**
+ * One-off backfill: run every blob referenced by forge_cards/card_versions
+ * through the Forge image normalizer (trim white print-bleed margins, cap
+ * 1050px tall, re-encode JPEG). Conforming blobs are skipped byte-identically.
+ * Rewritten images get a NEW key; referencing rows are re-pointed and the
+ * card's updated_at is touched (busts the working-view `t` cache param).
+ * Also sweeps 44 known-orphaned 1x1 blobs (2026-07-06 survey), re-verified
+ * unreferenced at run time.
+ *
+ * Design: docs/superpowers/specs/2026-07-06-forge-image-normalization-design.md
+ *
+ * Usage: npx tsx scripts/forge-normalize-images.ts [--apply]
+ * Default is dry-run: prints the plan, writes nothing.
+ */
+import { config } from "dotenv";
+config({ path: ".env.local" });
+
+import { randomUUID } from "crypto";
+import { createClient } from "@supabase/supabase-js";
+import { put, get, del } from "@vercel/blob";
+import { normalizeCardImage } from "../app/forge/lib/imageNormalize";
+
+const APPLY = process.argv.includes("--apply");
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+const auth = process.env.FORGE_BLOB_READ_WRITE_TOKEN
+  ? { token: process.env.FORGE_BLOB_READ_WRITE_TOKEN }
+  : { storeId: process.env.FORGE_BLOB_STORE_ID! };
+
+type Ref = { table: "forge_cards" | "card_versions"; id: string; column: string; cardId: string };
+
+// Orphaned 1x1 JPEG blobs found in the 2026-07-06 store survey. None are
+// referenced by forge_cards or card_versions (verified then and re-verified
+// against live refs below before deletion).
+const ORPHANED_1X1: string[] = [
+  "forge-finished/022d0513-7a80-4f88-8726-f9768fb58837",
+  "forge-finished/035b56cd-469a-410d-9487-ef0afa3cf8b0",
+  "forge-finished/04c17b40-b699-4189-b9c9-2a148d003d98",
+  "forge-finished/087c415c-fe60-415b-b4cf-0d6a7ebf1deb",
+  "forge-finished/098fea86-a8d6-4468-a0c2-9d8f00adb4ca",
+  "forge-finished/1918ce3f-41d1-4f47-b49d-c76e922591ca",
+  "forge-finished/1c72f871-5eaa-4ad6-9bf6-890f6ace9ef1",
+  "forge-finished/1d84410e-14cd-42ef-af63-b69412946d00",
+  "forge-finished/2c2c78cd-cc64-4b1b-a384-ea1f2e52c07b",
+  "forge-finished/31431ea6-1536-41ca-bdc6-d6afd2fca203",
+  "forge-finished/40d26f6a-95d6-45cc-96e4-b87c8d0afd8e",
+  "forge-finished/4cbd58ad-b590-455b-8f85-e863a5febea1",
+  "forge-finished/4fc72d08-d338-4e31-a6b6-7ca0e678edb7",
+  "forge-finished/6b214645-356d-450e-bc48-177ecce1bd2e",
+  "forge-finished/700a0e8d-117e-4fca-87cb-bceb952eca69",
+  "forge-finished/75e1a10a-ae52-4463-bef4-1b9ddeda2925",
+  "forge-finished/77ceee10-a2dc-4594-96b2-46649ae4d3cc",
+  "forge-finished/7b47fb10-c478-49ed-bc60-137769887ced",
+  "forge-finished/805141d5-c4ed-4d04-a50b-e130f13a9ab9",
+  "forge-finished/8d238df4-7629-4aa7-a8cd-614f55b7dcc4",
+  "forge-finished/9542375d-9279-4839-973b-7587079d7905",
+  "forge-finished/99a2cf80-c2a8-430e-ace9-8c01ccec704c",
+  "forge-finished/9a313283-e34a-423e-9383-9aa9c68c238e",
+  "forge-finished/9eaba425-d56e-4dab-8719-032d1a9c351f",
+  "forge-finished/9f141a4a-03a3-4118-b691-5cbf7289ea60",
+  "forge-finished/a797a8ff-778b-42fc-b689-5cfca6b5a9c1",
+  "forge-finished/b427c7a8-55cb-40e6-ba62-f8f40d5406f4",
+  "forge-finished/b64a6b56-d3b5-4f81-bef0-547efebcaceb",
+  "forge-finished/c19f047f-b9ae-4899-bb13-16d64137846d",
+  "forge-finished/c6121e2e-6573-4411-83d7-3b76b19abb8a",
+  "forge-finished/cbd4bf29-38c5-49bd-bad8-41a87f9a7f5d",
+  "forge-finished/d382c831-6855-4dc4-bd1c-49bd9dfd3226",
+  "forge-finished/d451d556-d37e-42de-932f-885618bb8d69",
+  "forge-finished/d576be34-4700-4980-aafb-946feedeb69a",
+  "forge-finished/dedc057b-00ee-45aa-b59b-f6c54177bf25",
+  "forge-finished/dfff9e02-6ea8-49fc-8631-83422e3d8ee5",
+  "forge-finished/ea44811a-9596-4392-adbb-dc837ab1cacf",
+  "forge-finished/e996aa36-e969-44b7-9d45-da8b846efc89",
+  "forge-finished/ea461c64-0168-4eac-bb76-61bddb6c6785",
+  "forge-finished/ec18221d-a1ef-4c3e-8688-a443f851c40c",
+  "forge-finished/ed31e18f-2304-4a8f-be2b-4aad31607eec",
+  "forge-finished/efb442d5-7e90-454d-b95c-4278cb2bba77",
+  "forge-finished/f1408b2c-97b9-46d3-ac19-c7e619f59298",
+  "forge-finished/fca38891-2d65-4b19-9aba-614d1aabd8da",
+];
+
+async function collectRefs(): Promise<Map<string, Ref[]>> {
+  const refs = new Map<string, Ref[]>();
+  const add = (key: string | null, ref: Ref) => {
+    if (!key) return;
+    refs.set(key, [...(refs.get(key) ?? []), ref]);
+  };
+  const { data: cards, error: cardsErr } = await supabase
+    .from("forge_cards")
+    .select("id, working_art_key, working_art_original_key, working_finished_key");
+  if (cardsErr) throw cardsErr;
+  for (const c of cards ?? []) {
+    for (const col of ["working_art_key", "working_art_original_key", "working_finished_key"] as const) {
+      add(c[col], { table: "forge_cards", id: c.id, column: col, cardId: c.id });
+    }
+  }
+  const { data: versions, error: versionsErr } = await supabase
+    .from("card_versions")
+    .select("id, card_id, art_key, art_original_key, finished_key");
+  if (versionsErr) throw versionsErr;
+  for (const v of versions ?? []) {
+    for (const col of ["art_key", "art_original_key", "finished_key"] as const) {
+      add(v[col], { table: "card_versions", id: v.id, column: col, cardId: v.card_id });
+    }
+  }
+  return refs;
+}
+
+async function download(key: string): Promise<Buffer> {
+  const res = await get(key, { access: "private", ...auth });
+  if (!res || res.statusCode !== 200) throw new Error(`GET ${key} -> ${res?.statusCode}`);
+  const chunks: Buffer[] = [];
+  for await (const chunk of res.stream) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks);
+}
+
+async function main() {
+  const refs = await collectRefs();
+  console.log(`${refs.size} referenced blob keys; mode=${APPLY ? "APPLY" : "dry-run"}`);
+  let rewritten = 0, skipped = 0, failed = 0;
+  const touchedCards = new Set<string>();
+
+  for (const [key, refList] of refs) {
+    let input: Buffer;
+    try {
+      input = await download(key);
+    } catch (e) {
+      console.error(`FAIL download ${key}: ${e}`);
+      failed++;
+      continue;
+    }
+    let out: Awaited<ReturnType<typeof normalizeCardImage>>;
+    try {
+      out = await normalizeCardImage(input);
+    } catch (e) {
+      console.error(`FAIL normalize ${key} (${input.length}B): ${e}`);
+      failed++;
+      continue;
+    }
+    if (out.data.equals(input)) {
+      skipped++;
+      continue;
+    }
+
+    console.log(
+      `rewrite ${key} (${input.length}B -> ${out.data.length}B) refs=${refList
+        .map((r) => `${r.table}.${r.column}`)
+        .join(",")}`
+    );
+    rewritten++;
+    if (!APPLY) continue;
+
+    const newKey = `${key.split("/")[0]}/${randomUUID()}`;
+    await put(newKey, out.data, {
+      access: "private",
+      addRandomSuffix: false,
+      contentType: out.contentType,
+      ...auth,
+    });
+    for (const ref of refList) {
+      const { error } = await supabase
+        .from(ref.table)
+        .update({ [ref.column]: newKey })
+        .eq("id", ref.id);
+      if (error) throw new Error(`UPDATE ${ref.table}.${ref.column} for ${ref.id}: ${error.message}`);
+      touchedCards.add(ref.cardId);
+    }
+    try {
+      await del(key, { ...auth });
+    } catch {
+      // a dangling private+UUID blob is invisible and harmless
+    }
+  }
+
+  if (APPLY) {
+    for (const cardId of touchedCards) {
+      const { error } = await supabase
+        .from("forge_cards")
+        .update({ updated_at: new Date().toISOString() })
+        .eq("id", cardId);
+      if (error) console.error(`FAIL touch updated_at for ${cardId}: ${error.message}`);
+    }
+  }
+
+  let swept = 0;
+  for (const key of ORPHANED_1X1) {
+    if (refs.has(key)) {
+      console.error(`SKIP orphan ${key}: now referenced!`);
+      continue;
+    }
+    console.log(`delete orphan ${key}`);
+    if (APPLY) {
+      try {
+        await del(key, { ...auth });
+        swept++;
+      } catch (e) {
+        console.error(`FAIL delete orphan ${key}: ${e}`);
+      }
+    }
+  }
+
+  console.log(
+    `done: ${rewritten} rewritten, ${skipped} conforming (skipped), ${failed} failed, ` +
+      `${APPLY ? swept : ORPHANED_1X1.length} orphans ${APPLY ? "deleted" : "to delete"}`
+  );
+  if (failed > 0) process.exitCode = 1;
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Two related Forge fixes that both surfaced from the same report (Heavenly Temple [EoT]):

### 1. Deckbuilder showed stale special-ability text after card edits
The studio edits `rawText`, but the deck adapter preferred the legacy `specialAbility` snapshot field. Lackey-imported cards set both at import time, so every subsequent edit showed up everywhere *except* the deckbuilder. The adapter (and `ForgeCardPreview`) now route through `cardRawText()` like every other reader. Regression tests added.

### 2. Image normalization at upload
A survey of all 1,420 Forge blobs found card-tool exports (815-825×1125 PNG, ~1MB) with baked-in white print-bleed margins rendering visibly smaller than the 1,323 flush 345×495 Lackey JPEGs.

New `sharp`-based normalizer (`app/forge/lib/imageNormalize.ts`), wired into both blob-upload helpers (covers studio uploads + Lackey bulk import):
- **Corner-gated white-margin trim** — only fires when all 4 corners are near-white, with a 60% degenerate guard and a 3% significance floor (live Lackey scans have white rounded corners + a ~1.8% fringe that must NOT trigger re-encoding — caught by a production dry-run)
- **1050px height cap**, never upscales
- **JPEG q85 re-encode**, with byte-identical passthrough for already-conforming JPEGs (no generation loss)
- Undecodable uploads now rejected with a clear error instead of stored (44 orphaned 1×1 blobs in the store came from this hole)

### 3. Backfill script (`scripts/forge-normalize-images.ts`)
One-off, dry-run by default. Production dry-run verified: **41 rewritten / 147 skipped byte-identical / 0 failed / 44 orphans swept**. Heavenly Temple: 940KB PNG → 158KB flush JPEG. Repoint is guarded (`WHERE col = old_key`) against concurrent uploads.

## Docs
Spec: `docs/superpowers/specs/2026-07-06-forge-image-normalization-design.md`
Plan: `docs/superpowers/plans/2026-07-06-forge-image-normalization.md`

## Testing
- 11 normalizer unit tests (sharp-generated fixtures, incl. stash-proven regression tests for EXIF-orientation axis swap and the trim floor)
- Upload wire-in + decode-failure tests; deckAdapter precedence tests
- Forge suite 233 passed / 2 pre-existing failures (members/sets tests, also fail on main)
- `npm run build` green
- Multi-round subagent review incl. final whole-branch review: READY TO MERGE

🤖 Generated with [Claude Code](https://claude.com/claude-code)