### PR TITLE
Forge: trim v2 — ink bounding box + uniform pad (watermark-immune)

### DIFF
--- a/app/forge/lib/__tests__/imageNormalize.test.ts
+++ b/app/forge/lib/__tests__/imageNormalize.test.ts
@@ -64,15 +64,117 @@ async function lackeyScanWithCornersAndBottomFringe(
     .toBuffer();
 }
 
+/**
+ * Dark content block centered on a white canvas, plus several small
+ * light-gray (rgb 200,200,200) rectangles scattered in the margins outside
+ * the content block — models watermark text (e.g. "Cactus Game Design")
+ * baked into card-tool export margins. Gray min-channel (~200) sits above
+ * INK_MAX_CHANNEL, so these marks must not affect the ink bounding box.
+ */
+async function withWatermarkedMargins(
+  canvasW: number,
+  canvasH: number,
+  contentW: number,
+  contentH: number,
+): Promise<Buffer> {
+  const content = await sharp({ create: { width: contentW, height: contentH, channels: 3, background: DARK } }).png().toBuffer();
+  const contentLeft = Math.floor((canvasW - contentW) / 2);
+  const contentTop = Math.floor((canvasH - contentH) / 2);
+  const wmW = 40;
+  const wmH = 12;
+  const watermark = await sharp({ create: { width: wmW, height: wmH, channels: 3, background: { r: 200, g: 200, b: 200 } } })
+    .png()
+    .toBuffer();
+  const marks = [
+    { top: 5, left: 100 }, // near top edge, above the content block
+    { top: canvasH - wmH - 5, left: 100 }, // near bottom edge, below the content block
+    { top: contentTop + 20, left: 5 }, // left margin
+    { top: contentTop + 20, left: canvasW - wmW - 5 }, // right margin
+  ];
+  return sharp({ create: { width: canvasW, height: canvasH, channels: 3, background: "#ffffff" } })
+    .composite([
+      { input: content, top: contentTop, left: contentLeft },
+      ...marks.map((m) => ({ input: watermark, top: m.top, left: m.left })),
+    ])
+    .png()
+    .toBuffer();
+}
+
+/** Dark content block flush against the bottom edge of the canvas (no bottom
+ * margin at all), horizontally centered so all four single-pixel corners
+ * stay white and the corner gate still passes. */
+async function withFlushBottomContent(
+  canvasW: number,
+  canvasH: number,
+  contentW: number,
+  contentH: number,
+): Promise<Buffer> {
+  const content = await sharp({ create: { width: contentW, height: contentH, channels: 3, background: DARK } }).png().toBuffer();
+  const left = Math.floor((canvasW - contentW) / 2);
+  const top = canvasH - contentH;
+  return sharp({ create: { width: canvasW, height: canvasH, channels: 3, background: "#ffffff" } })
+    .composite([{ input: content, top, left }])
+    .png()
+    .toBuffer();
+}
+
+/** True when the center pixel of the buffer's bottom-most row is dark
+ * ("ink"), independent of imageNormalize's internal INK_MAX_CHANNEL. */
+async function bottomRowHasInk(buf: Buffer): Promise<boolean> {
+  const { data, info } = await sharp(buf).raw().toBuffer({ resolveWithObject: true });
+  const channels = Math.min(3, info.channels);
+  const y = info.height - 1;
+  const x = Math.floor(info.width / 2);
+  const i = (y * info.width + x) * info.channels;
+  for (let c = 0; c < channels; c++) {
+    if (data[i + c] >= 180) return false;
+  }
+  return true;
+}
+
 describe("normalizeCardImage", () => {
-  it("trims white print-bleed margins and re-encodes as JPEG", async () => {
+  it("trims white print-bleed margins to the ink box (+10px pad) and re-encodes as JPEG", async () => {
+    // v2: crop is the ink bounding box + a uniform 10px pad, not a bare trim
+    // of the content block. Cropped dims are content + 2*pad (750+20 x
+    // 1046+20 = 770x1066); but 1066 exceeds MAX_HEIGHT (1050), so the
+    // pipeline's existing height cap resizes the crop down to 1050 tall
+    // (~758 wide) — a resize this exact fixture never triggered under v1,
+    // since the bare trim (1046) was already under the cap. This is a
+    // legitimate emergent interaction between the new pad and the pre-existing
+    // MAX_HEIGHT cap, not a bug.
     const input = await withWhiteMargins(815, 1125, 750, 1046);
     const out = await normalizeCardImage(input);
     const d = await dims(out.data);
     expect(out.contentType).toBe("image/jpeg");
     expect(d.format).toBe("jpeg");
-    expect(Math.abs((d.width ?? 0) - 750)).toBeLessThanOrEqual(4);
-    expect(Math.abs((d.height ?? 0) - 1046)).toBeLessThanOrEqual(4);
+    expect(d.height).toBe(1050);
+    expect(Math.abs((d.width ?? 0) - 758)).toBeLessThanOrEqual(4);
+  });
+
+  it("ignores light-gray watermark text scattered in the margins (ink box, not sharp trim)", async () => {
+    // The headline v2 case: watermark marks sit outside the content block but
+    // well above INK_MAX_CHANNEL, so they must not widen or otherwise disturb
+    // the ink bounding box. Expect the same content+pad framing as a clean
+    // white margin, symmetric on both axes (not flush to one edge).
+    const input = await withWatermarkedMargins(815, 1125, 705, 1018);
+    const out = await normalizeCardImage(input);
+    const d = await dims(out.data);
+    expect(out.contentType).toBe("image/jpeg");
+    expect(Math.abs((d.width ?? 0) - 725)).toBeLessThanOrEqual(6);
+    expect(Math.abs((d.height ?? 0) - 1038)).toBeLessThanOrEqual(6);
+  });
+
+  it("preserves content flush against the bottom edge (pad clamps, no ink lost)", async () => {
+    // Content touches the canvas's bottom edge with no bottom margin at all;
+    // the pad clamps to 0 there instead of losing any ink. Output height
+    // should be content height + top pad + 0 bottom pad, and the bottom-most
+    // row of the output must still be dark (the card's bottom border).
+    const input = await withFlushBottomContent(700, 1000, 500, 900);
+    const out = await normalizeCardImage(input);
+    const d = await dims(out.data);
+    expect(d.height ?? 0).toBeGreaterThanOrEqual(900);
+    expect(Math.abs((d.height ?? 0) - 910)).toBeLessThanOrEqual(4);
+    expect(await bottomRowHasInk(out.data)).toBe(true);
   });
 
   it("does not trim full-bleed images with dark corners (corner gate)", async () => {
@@ -128,17 +230,20 @@ describe("normalizeCardImage", () => {
     // Stored (pre-rotation) canvas is 700x1000 with content 500x650; tagged
     // orientation 6 so .rotate() swaps axes to a post-rotation 1000x700
     // canvas containing 650x500 content (legitimate ~65-70% keep on each
-    // axis — not degenerate). Comparing the trim result against the raw,
+    // axis — not degenerate). Comparing the crop result against the raw,
     // pre-rotation meta.width/meta.height (the bug) instead of the swapped
     // post-rotation dimensions makes this look degenerate (it isn't) and the
-    // trim gets skipped, leaving the full untrimmed 1000x700 canvas.
+    // crop gets skipped, leaving the full untrimmed 1000x700 canvas.
+    // v2: expected dims are content + 2*pad (650+20 x 500+20), not the bare
+    // content dims, since the guards still run against the post-rotation
+    // 1000x700 baseline either way.
     const stored = await withWhiteMargins(700, 1000, 500, 650);
     const input = await withOrientation(stored, 6);
     const out = await normalizeCardImage(input);
     const m = await sharp(out.data).metadata();
     expect(m.orientation).toBeUndefined();
-    expect(m.width).toBe(650);
-    expect(m.height).toBe(500);
+    expect(Math.abs((m.width ?? 0) - 670)).toBeLessThanOrEqual(4);
+    expect(Math.abs((m.height ?? 0) - 520)).toBeLessThanOrEqual(4);
   });
 
   it("trims white margins on grayscale (low-channel) rasters without misreading channels", async () => {
@@ -150,13 +255,16 @@ describe("normalizeCardImage", () => {
     // cannot force a true <3-channel raw buffer through the public
     // Buffer-in/Buffer-out API, but it does confirm grayscale-sourced inputs
     // still trim correctly (no regression), per the fix's intent.
+    // v2: same content+pad framing as the RGB case (750+20 x 1046+20), and
+    // the same MAX_HEIGHT-cap interaction (1066 > 1050 resizes down to
+    // 1050x~758) — see the equivalent RGB test above for why.
     const rgb = await withWhiteMargins(815, 1125, 750, 1046);
     const input = await sharp(rgb).greyscale().toColourspace("b-w").png().toBuffer();
     const out = await normalizeCardImage(input);
     const d = await dims(out.data);
     expect(d.format).toBe("jpeg");
-    expect(Math.abs((d.width ?? 0) - 750)).toBeLessThanOrEqual(4);
-    expect(Math.abs((d.height ?? 0) - 1046)).toBeLessThanOrEqual(4);
+    expect(d.height).toBe(1050);
+    expect(Math.abs((d.width ?? 0) - 758)).toBeLessThanOrEqual(4);
   });
 
   it("does not trim when only some corners are white (corner gate requires all four)", async () => {

--- a/app/forge/lib/imageNormalize.ts
+++ b/app/forge/lib/imageNormalize.ts
@@ -1,35 +1,83 @@
 // Server-only: normalizes Forge card images at upload time so every stored
 // image is flush (no baked-in print-bleed margins), at most 1050px tall, and
 // JPEG-encoded. Design: docs/superpowers/specs/2026-07-06-forge-image-normalization-design.md
-import sharp, { type Sharp } from "sharp";
+import sharp, { type Sharp, type OutputInfo } from "sharp";
 
 export type NormalizedImage = { data: Buffer; contentType: "image/jpeg" };
 
 const MAX_HEIGHT = 1050;
 const CORNER_WHITE_MIN = 240; // per-channel floor for a corner to count as "white margin"
-const TRIM_THRESHOLD = 25;
+const INK_MAX_CHANNEL = 180; // min-available-channel ceiling for a pixel to count as "ink"; light watermark gray (~200+) stays below this and is ignored
+const TRIM_PAD_PX = 10; // uniform padding added around the ink bounding box before cropping
 const MIN_TRIM_RATIO = 0.6; // trim keeping less than this per axis is degenerate
 const MIN_TRIM_FRACTION = 0.03; // trim removing less than this on every axis is noise (e.g. scan fringes), not a real margin
 const JPEG_QUALITY = 85;
 
-/** True when all four corners are near-white after flattening alpha onto white. */
-async function cornersNearWhite(img: Sharp): Promise<boolean> {
-  const { data, info } = await img
-    .clone()
-    .flatten({ background: "#ffffff" })
-    .raw()
-    .toBuffer({ resolveWithObject: true });
+type Raster = { data: Buffer; info: OutputInfo };
+
+/** Raw pixel buffer of the flattened (alpha->white) image, read once and
+ * reused for both the corner-white gate and the ink bounding box below. */
+function readRaster(img: Sharp): Promise<Raster> {
+  return img.clone().flatten({ background: "#ffffff" }).raw().toBuffer({ resolveWithObject: true });
+}
+
+function channelsAt(raster: Raster, x: number, y: number): number[] {
+  const { data, info } = raster;
   const channels = Math.min(3, info.channels); // grayscale rasters have < 3 channels
-  const px = (x: number, y: number): number[] => {
-    const i = (y * info.width + x) * info.channels;
-    return Array.from({ length: channels }, (_, c) => data[i + c]);
-  };
+  const i = (y * info.width + x) * info.channels;
+  return Array.from({ length: channels }, (_, c) => data[i + c]);
+}
+
+/** True when all four corners are near-white after flattening alpha onto white. */
+function cornersNearWhite(raster: Raster): boolean {
+  const { info } = raster;
   return [
-    px(0, 0),
-    px(info.width - 1, 0),
-    px(0, info.height - 1),
-    px(info.width - 1, info.height - 1),
+    channelsAt(raster, 0, 0),
+    channelsAt(raster, info.width - 1, 0),
+    channelsAt(raster, 0, info.height - 1),
+    channelsAt(raster, info.width - 1, info.height - 1),
   ].every((corner) => corner.every((channel) => channel >= CORNER_WHITE_MIN));
+}
+
+type Box = { left: number; top: number; width: number; height: number };
+
+/**
+ * Bounding box of every "ink" pixel (min available channel < INK_MAX_CHANNEL),
+ * padded uniformly by TRIM_PAD_PX and clamped to the raster bounds. Light
+ * watermark gray sits well above INK_MAX_CHANNEL, so watermarked margins
+ * never widen the box; card borders/arcs sit well below it, so they're never
+ * cut. Returns null when there is no ink at all (nothing to trim against).
+ */
+function inkBoundingBox(raster: Raster): Box | null {
+  const { data, info } = raster;
+  const channels = Math.min(3, info.channels);
+  let minX = info.width;
+  let minY = info.height;
+  let maxX = -1;
+  let maxY = -1;
+  for (let y = 0; y < info.height; y++) {
+    const rowOffset = y * info.width * info.channels;
+    for (let x = 0; x < info.width; x++) {
+      const i = rowOffset + x * info.channels;
+      let min = 255;
+      for (let c = 0; c < channels; c++) {
+        if (data[i + c] < min) min = data[i + c];
+      }
+      if (min < INK_MAX_CHANNEL) {
+        if (x < minX) minX = x;
+        if (x > maxX) maxX = x;
+        if (y < minY) minY = y;
+        if (y > maxY) maxY = y;
+      }
+    }
+  }
+  if (maxX < 0) return null; // no ink pixels found
+  return {
+    left: Math.max(0, minX - TRIM_PAD_PX),
+    top: Math.max(0, minY - TRIM_PAD_PX),
+    width: Math.min(info.width, maxX + 1 + TRIM_PAD_PX) - Math.max(0, minX - TRIM_PAD_PX),
+    height: Math.min(info.height, maxY + 1 + TRIM_PAD_PX) - Math.max(0, minY - TRIM_PAD_PX),
+  };
 }
 
 export async function normalizeCardImage(input: Buffer): Promise<NormalizedImage> {
@@ -48,29 +96,24 @@ export async function normalizeCardImage(input: Buffer): Promise<NormalizedImage
 
   // Corner-gated margin trim: white print-bleed margins only. Full-bleed card
   // images have dark frame corners, so the gate skips them and the border
-  // ring survives; trimming against an explicit white background can never
+  // ring survives; cropping against an explicit white background can never
   // eat a dark frame either way.
   let working: Sharp | null = null;
   let trimmed = false;
-  if (await cornersNearWhite(base)) {
-    try {
-      const { data, info } = await base
-        .clone()
-        .flatten({ background: "#ffffff" })
-        .trim({ background: "#ffffff", threshold: TRIM_THRESHOLD })
-        .toBuffer({ resolveWithObject: true });
-      const shrank = info.width < baseWidth || info.height < baseHeight;
+  const raster = await readRaster(base);
+  if (cornersNearWhite(raster)) {
+    const box = inkBoundingBox(raster);
+    if (box) {
+      const shrank = box.width < baseWidth || box.height < baseHeight;
       const degenerate =
-        info.width < baseWidth * MIN_TRIM_RATIO || info.height < baseHeight * MIN_TRIM_RATIO;
+        box.width < baseWidth * MIN_TRIM_RATIO || box.height < baseHeight * MIN_TRIM_RATIO;
       const significant =
-        info.width <= baseWidth * (1 - MIN_TRIM_FRACTION) ||
-        info.height <= baseHeight * (1 - MIN_TRIM_FRACTION);
+        box.width <= baseWidth * (1 - MIN_TRIM_FRACTION) ||
+        box.height <= baseHeight * (1 - MIN_TRIM_FRACTION);
       if (shrank && !degenerate && significant) {
-        working = sharp(data);
+        working = base.clone().flatten({ background: "#ffffff" }).extract(box);
         trimmed = true;
       }
-    } catch {
-      // trim of an (almost) uniform image can fail — treat as nothing to trim
     }
   }
 

--- a/docs/superpowers/specs/2026-07-06-forge-image-normalization-design.md
+++ b/docs/superpowers/specs/2026-07-06-forge-image-normalization-design.md
@@ -62,11 +62,22 @@ Pipeline:
 2. **Corner-gated margin trim.** Sample the four corner pixels (after alpha
    flattening logic below). Only when **all four corners** are near-white
    (each RGB channel ≥ ~240 after flattening transparent pixels to white) does
-   the trim step run: `.trim({ background: "#ffffff", threshold: 25 })`.
+   the trim step run.
+   - **v2 (2026-07-07): ink-bounding-box crop, not sharp `.trim()`.** Compute
+     the bounding box of "ink" pixels (min RGB channel < 180) from the raw
+     pixel buffer, expand it by a uniform 10px pad (clamped to the image), and
+     `.extract()` that region. Two v1 failures drove this: (a) sharp's trim
+     only removes rows/columns that are 100% background, so watermark text
+     ("Cactus Game Design") in the margins blocked side/top trims while the
+     clean bottom strip trimmed to zero — leaving the card flush-bottom and
+     off-center; (b) raising sharp's threshold to defeat the watermark eats
+     the red border instead (its color metric puts saturated red within ~60
+     of white). Light watermark gray (min channel ≥ ~200) is not ink, so the
+     box ignores it; the card's border/arcs are ink, so they are never cut;
+     the uniform pad restores symmetric framing.
    - Rationale: print-bleed margins are white/transparent; full-bleed card
-     images have dark frame borders at the corners. Trimming with a white
-     background cannot eat a dark border ring, and the corner gate skips the
-     step entirely for full-bleed images.
+     images have dark frame borders at the corners, and the corner gate skips
+     the step entirely for full-bleed images.
    - **Degenerate-trim guard:** if the trimmed result is smaller than 60% of
      the original along either axis, discard the trim and use the untrimmed
      image (protects near-white card faces).


### PR DESCRIPTION
## Problem (follow-up to #161)

The v1 trim used sharp's `.trim()`, which only removes rows/columns that are 100% background. Real card-tool exports have light-gray "Cactus Game Design" watermark text in their white margins, so on those images v1:
- left the watermarked top/side margins in place (~50px), but
- trimmed the watermark-free bottom strip to **zero** — cards ended up flush-bottom and off-center (user-visible: "seems like you cut the bottom off?").

Raising sharp's trim threshold instead eats the saturated-red card border (its color metric puts red within ~60 of white — verified: threshold 60 cut through the frame).

## Fix

Replace the trim step with an **ink-bounding-box crop** from the raw pixel buffer: ink = min RGB channel < 180 (watermark gray isn't ink; borders/arcs are), expanded by a uniform 10px pad, applied via `.extract()`. One shared raw pass now feeds both the corner gate and the ink box (v1 did two passes), and the in-pipeline extract removes a hidden JPEG double-compression that v1's trim→buffer→re-read incurred.

All v1 guards keep identical semantics: corner gate, 60% degenerate guard, 3% significance floor, byte-identical conforming-JPEG passthrough, EXIF-orientation-aware dims, 1050px cap.

Validated against all 41 production originals (from the pre-apply backup): 19 watermarked exports crop to aspect ~0.697 (matching the Lackey norm — full-height rendering, no bars); 21 full-bleed exports and the Lackey scans are byte-identically untouched.

## Testing
- 13 unit tests (updated for v2 semantics; new watermark-regression and flush-bottom-preservation fixtures)
- `npm run build` green
- Reviewed + approved (hand-traced all 13 fixtures; independent test run)
- Known minor gap flagged by review: no test where the 3% significance floor is the sole deciding guard — noted for a future touch of this module

Prod repair of the 19 affected images runs separately from the backed-up originals (not from the already-cropped live blobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)