### PR TITLE
fix(forge): restore card metadata for in-game deck search

### DIFF
--- a/app/forge/lib/__tests__/deckAdapter.test.ts
+++ b/app/forge/lib/__tests__/deckAdapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { designCardToCard, forgeDataLine, isForgeDataLine, cardIdFromDataLine } from "../deckAdapter";
+import { designCardToCard, designCardSearchFields, forgeDataLine, isForgeDataLine, cardIdFromDataLine } from "../deckAdapter";
 import type { DesignCard } from "../designCard";
 
 describe("designCardToCard", () => {
@@ -79,5 +79,37 @@ describe("designCardToCard", () => {
     expect(isForgeDataLine(dl)).toBe(true);
     expect(isForgeDataLine("Angel|Pa|Angel_(Pa)")).toBe(false);
     expect(cardIdFromDataLine(dl)).toBe("uuid-9");
+  });
+});
+
+describe("designCardSearchFields", () => {
+  it("derives the in-game deck-search fields from a DesignCard", () => {
+    // These are the fields the in-game Search Deck modal filters on. They must
+    // survive into play so alignment/brigade/identifier/reference searches match
+    // forge cards (regression: evil forge cards were unsearchable by alignment).
+    const d: DesignCard = {
+      name: "Wormwood", cardType: ["EvilCharacter"], alignment: "Evil",
+      brigades: ["Gray"], strength: 7, toughness: 6,
+      identifiers: ["Demon", "Fallen Angel"], reference: "Revelation 8:11",
+    };
+    const f = designCardSearchFields(d);
+    expect(f.alignment).toBe("Evil");
+    expect(f.brigade).toBe("Gray");
+    expect(f.strength).toBe("7");
+    expect(f.toughness).toBe("6");
+    expect(f.identifier).toBe("Demon, Fallen Angel");
+    expect(f.reference).toBe("Revelation 8:11");
+  });
+
+  it("maps Good_Evil/GoodGold to display strings and blanks unset fields with '' (game convention, not em-dash)", () => {
+    const f = designCardSearchFields({ name: "X", cardType: ["Hero"], alignment: "Good_Evil", brigades: ["GoodGold"] });
+    expect(f.alignment).toBe("Good/Evil");
+    expect(f.brigade).toBe("Good Gold");
+    // Public cards serialize missing stats as "" for play; forge must match so
+    // the two never diverge in the deck-search grid.
+    expect(f.strength).toBe("");
+    expect(f.toughness).toBe("");
+    expect(f.identifier).toBe("");
+    expect(f.reference).toBe("");
   });
 });

--- a/app/forge/lib/__tests__/playSerialize.test.ts
+++ b/app/forge/lib/__tests__/playSerialize.test.ts
@@ -13,6 +13,12 @@ const resolverEntry = (overrides: Partial<ForgePlayResolverEntry> = {}): ForgePl
   hasArt: true,
   versionId: "v1",
   typeDisplay: "",
+  alignment: "",
+  brigade: "",
+  strength: "",
+  toughness: "",
+  identifier: "",
+  reference: "",
   ...overrides,
 });
 
@@ -116,6 +122,26 @@ describe("buildForgeGoldfishCards", () => {
     expect(c.card_img_file.startsWith("/forge/api/art/")).toBe(true);
     expect(c.quantity).toBe(3);
     expect(c.is_reserve).toBe(false);
+  });
+
+  it("restores searchable metadata (alignment/brigade/stats/identifier/reference) from the resolver", () => {
+    // Regression: goldfish forge cards had card_alignment: "" hardcoded, so the
+    // in-game Search Deck alignment/brigade/identifier/reference filters never
+    // matched them even though the resolver knows the values.
+    const entries: ForgeDeckEntry[] = [
+      { source: "forge", cardId: FORGE_ID, qty: 1, zone: "main" },
+    ];
+    const entry = resolverEntry({
+      alignment: "Evil", brigade: "Gray", strength: "7", toughness: "6",
+      identifier: "Demon", reference: "Revelation 8:11",
+    });
+    const c = buildForgeGoldfishCards(entries, () => entry)[0];
+    expect(c.card_alignment).toBe("Evil");
+    expect(c.card_brigade).toBe("Gray");
+    expect(c.card_strength).toBe("7");
+    expect(c.card_toughness).toBe("6");
+    expect(c.card_identifier).toBe("Demon");
+    expect(c.card_reference).toBe("Revelation 8:11");
   });
 
   it("emits the resolver's type display string in card_type (LostSoul, not 'LS')", () => {

--- a/app/forge/lib/deckAdapter.ts
+++ b/app/forge/lib/deckAdapter.ts
@@ -33,6 +33,33 @@ function alignmentDisplay(a?: string): string {
   return a === "Good_Evil" ? "Good/Evil" : (a ?? "");
 }
 
+// The subset of card fields the in-game "Search Deck" modal filters on, derived
+// from a DesignCard. Mirrors designCardToCard's field mapping but blanks unset
+// stats/brigade with "" (not "—") to match how PUBLIC cards are serialized for
+// play — so forge and public cards behave identically in the deck-search grid.
+// Carried on the forge play resolver so the owner's client can re-hydrate these
+// after the leak spine blanks them on the world-readable STDB row.
+export interface ForgeSearchFields {
+  alignment: string;
+  brigade: string;
+  strength: string;
+  toughness: string;
+  identifier: string;
+  reference: string;
+}
+
+export function designCardSearchFields(data: DesignCard): ForgeSearchFields {
+  const brigades = data.brigades ?? [];
+  return {
+    alignment: alignmentDisplay(data.alignment),
+    brigade: brigades.map((b) => BRIGADE_DISPLAY[b] ?? b).join("/"),
+    strength: data.strength != null ? String(data.strength) : "",
+    toughness: data.toughness != null ? String(data.toughness) : "",
+    identifier: (data.identifiers ?? []).join(", "),
+    reference: data.reference ?? "",
+  };
+}
+
 export function designCardToCard(data: DesignCard, cardId: string, setName: string): Card {
   const types = data.cardType ?? [];
   const brigades = data.brigades ?? [];

--- a/app/forge/lib/playDecks.ts
+++ b/app/forge/lib/playDecks.ts
@@ -9,7 +9,7 @@ import { listGrantedForgeCards } from "@/app/forge/lib/deckPool";
 import type { GrantedForgeCard } from "@/app/forge/lib/deckPool";
 import { buildForgePlayDeck, buildForgeGoldfishCards, sanitizeParagon } from "@/app/forge/lib/playSerialize";
 import { cardRawText } from "@/app/forge/lib/designCard";
-import { TYPE_DISPLAY } from "@/app/forge/lib/deckAdapter";
+import { TYPE_DISPLAY, designCardSearchFields } from "@/app/forge/lib/deckAdapter";
 import { stdbHttpBase } from "@/app/forge/lib/stdbHttp";
 import type { GameCardData } from "@/app/play/actions";
 import type { DeckDataForGoldfish } from "@/app/shared/types/gameCard";
@@ -36,9 +36,14 @@ export async function loadForgeDeckForGame(deckId: string): Promise<ForgePlayDec
   };
 }
 
+// alignment/brigade/strength/toughness/identifier/reference ride the resolver so
+// the owner's client can re-hydrate them for the in-game deck search — the
+// world-readable STDB row deliberately blanks them (leak spine, playSerialize.ts).
 export type ForgePlayResolverEntry = {
   cardId: string; name: string; rawText: string;
   hasFinished: boolean; hasArt: boolean; versionId: string; typeDisplay: string;
+  alignment: string; brigade: string; strength: string; toughness: string;
+  identifier: string; reference: string;
 };
 
 function toResolverEntry(g: GrantedForgeCard): ForgePlayResolverEntry {
@@ -52,6 +57,7 @@ function toResolverEntry(g: GrantedForgeCard): ForgePlayResolverEntry {
     hasArt: g.hasApprovedArt,
     versionId: g.versionId,
     typeDisplay,
+    ...designCardSearchFields(g.data),
   };
 }
 

--- a/app/forge/lib/playSerialize.ts
+++ b/app/forge/lib/playSerialize.ts
@@ -70,9 +70,10 @@ export function buildForgeGoldfishCards(
         card_name: r.name,
         card_set: "Forge",
         card_img_file: forgeProxyUrl(r), // '' when no image; leading-/ proxy URL otherwise
-        card_type: r.typeDisplay, card_brigade: "", card_strength: "", card_toughness: "",
+        card_type: r.typeDisplay,
+        card_brigade: r.brigade, card_strength: r.strength, card_toughness: r.toughness,
         card_special_ability: r.rawText,
-        card_identifier: "", card_reference: "", card_alignment: "",
+        card_identifier: r.identifier, card_reference: r.reference, card_alignment: r.alignment,
         quantity: e.qty,
         is_reserve,
       });

--- a/app/play/utils/__tests__/cardAdapterForge.test.ts
+++ b/app/play/utils/__tests__/cardAdapterForge.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from "vitest";
 import { cardInstanceToGameCard } from "../cardAdapter";
 
 const ID = "11111111-2222-3333-4444-555555555555";
-const entry = { cardId: ID, name: "Test Hero", rawText: "Does things.", hasFinished: false, hasArt: true, versionId: "v-9" };
+const entry = {
+  cardId: ID, name: "Test Hero", rawText: "Does things.", hasFinished: false, hasArt: true, versionId: "v-9",
+  typeDisplay: "Hero", alignment: "Good", brigade: "Blue", strength: "5", toughness: "4",
+  identifier: "Judah", reference: "Genesis 1:1",
+};
 
 function stubInstance(over: Record<string, unknown> = {}) {
   return {
@@ -32,5 +36,23 @@ describe("cardInstanceToGameCard forge resolution", () => {
     const gc = cardInstanceToGameCard(stubInstance({ cardImgFile: "Public.jpg", cardName: "Pub" }), [], "player1", new Map([[ID, entry]]));
     expect(gc.cardName).toBe("Pub");
     expect(gc.cardImgFile).toBe("Public.jpg");
+  });
+  it("restores searchable metadata from the resolver so the deck search can filter forge cards", () => {
+    // The STDB row blanks alignment/brigade/stats/identifier/reference (leak
+    // spine); the viewer's granted resolver re-hydrates them here. Without this
+    // the in-game Search Deck alignment filter never matched forge cards.
+    const gc = cardInstanceToGameCard(stubInstance(), [], "player1", new Map([[ID, entry]]));
+    expect(gc.alignment).toBe("Good");
+    expect(gc.brigade).toBe("Blue");
+    expect(gc.strength).toBe("5");
+    expect(gc.toughness).toBe("4");
+    expect(gc.identifier).toBe("Judah");
+    expect(gc.reference).toBe("Genesis 1:1");
+  });
+  it("keeps the blank STDB values for an unresolved (ungranted) forge card — no leak", () => {
+    const gc = cardInstanceToGameCard(stubInstance(), [], "player1", new Map());
+    expect(gc.alignment).toBe("");
+    expect(gc.brigade).toBe("");
+    expect(gc.reference).toBe("");
   });
 });

--- a/app/play/utils/__tests__/forgeResolver.test.ts
+++ b/app/play/utils/__tests__/forgeResolver.test.ts
@@ -3,7 +3,11 @@ import { forgeCardIdFromImgFile, forgeProxyUrl, resolveCardImageUrl, mergeForgeD
 import { getCardImageUrl, getCardImageUrlOrNull } from "@/app/shared/utils/cardImageUrl";
 
 const ID = "11111111-2222-3333-4444-555555555555";
-const entry = { cardId: ID, name: "Test Hero", rawText: "Does things.", hasFinished: true, hasArt: true, versionId: "v-1" };
+const entry = {
+  cardId: ID, name: "Test Hero", rawText: "Does things.", hasFinished: true, hasArt: true, versionId: "v-1",
+  typeDisplay: "Hero", alignment: "Good", brigade: "Blue", strength: "5", toughness: "4",
+  identifier: "Judah", reference: "Genesis 1:1",
+};
 const resolver = new Map([[ID, entry]]);
 
 describe("forge image seams", () => {
@@ -33,10 +37,31 @@ describe("forge image seams", () => {
       { cardName: "", cardSet: "Forge", cardImgFile: `forge:${ID}`, cardType: "", brigade: "", strength: "", toughness: "", alignment: "", identifier: "", reference: "", specialAbility: "", isReserve: false },
       { cardName: "Public", cardSet: "S", cardImgFile: "Public.jpg", cardType: "", brigade: "", strength: "", toughness: "", alignment: "", identifier: "", reference: "", specialAbility: "", isReserve: false },
     ];
-    const merged = mergeForgeDeckData(cards as any, resolver);
+    const merged = mergeForgeDeckData(cards as any, resolver as any);
     expect(merged[0].cardName).toBe("Test Hero");
     expect(merged[0].specialAbility).toBe("Does things.");
     expect(merged[0].cardImgFile).toContain("/forge/api/art/");
     expect(merged[1]).toBe(cards[1]);
+  });
+
+  it("mergeForgeDeckData restores the searchable metadata (alignment/brigade/stats/identifier/reference)", () => {
+    // Regression: the world-readable STDB row blanks these fields (leak spine),
+    // so the owner's client must re-hydrate them — otherwise the in-game Search
+    // Deck modal can't match forge cards by alignment/brigade/identifier/reference.
+    const evil = {
+      cardId: ID, name: "Wormwood", rawText: "Bad things.", hasFinished: false, hasArt: false, versionId: "v-2",
+      typeDisplay: "Evil Character", alignment: "Evil", brigade: "Gray", strength: "7", toughness: "6",
+      identifier: "Demon", reference: "Revelation 8:11",
+    };
+    const cards = [
+      { cardName: "", cardSet: "Forge", cardImgFile: `forge:${ID}`, cardType: "Evil Character", brigade: "", strength: "", toughness: "", alignment: "", identifier: "", reference: "", specialAbility: "", isReserve: false },
+    ];
+    const merged = mergeForgeDeckData(cards as any, new Map([[ID, evil]]) as any);
+    expect(merged[0].alignment).toBe("Evil");
+    expect(merged[0].brigade).toBe("Gray");
+    expect(merged[0].strength).toBe("7");
+    expect(merged[0].toughness).toBe("6");
+    expect(merged[0].identifier).toBe("Demon");
+    expect(merged[0].reference).toBe("Revelation 8:11");
   });
 });

--- a/app/play/utils/cardAdapter.ts
+++ b/app/play/utils/cardAdapter.ts
@@ -27,13 +27,17 @@ export function cardInstanceToGameCard(
     cardSet: card.cardSet,
     cardImgFile: resolved ? (forgeProxyUrl(resolved) || card.cardImgFile) : card.cardImgFile,
     type: card.cardType,
-    brigade: card.brigade,
-    strength: card.strength,
-    toughness: card.toughness,
+    // Forge cards blank these on the world-readable STDB row (leak spine); the
+    // viewer's granted resolver re-hydrates them so the in-game deck search can
+    // filter forge cards by brigade/alignment/identifier/reference. Unresolved
+    // (ungranted) forge cards keep the blank row values — no leak.
+    brigade: resolved ? resolved.brigade : card.brigade,
+    strength: resolved ? resolved.strength : card.strength,
+    toughness: resolved ? resolved.toughness : card.toughness,
     specialAbility: resolved ? resolved.rawText : card.specialAbility,
-    identifier: card.identifier,
-    reference: card.reference,
-    alignment: card.alignment,
+    identifier: resolved ? resolved.identifier : card.identifier,
+    reference: resolved ? resolved.reference : card.reference,
+    alignment: resolved ? resolved.alignment : card.alignment,
     isMeek: card.isMeek,
     isFlipped: card.isFlipped,
     isToken: card.isToken,

--- a/app/play/utils/forgeResolver.ts
+++ b/app/play/utils/forgeResolver.ts
@@ -34,6 +34,20 @@ export function mergeForgeDeckData(cards: GameCardData[], resolver?: ForgeResolv
     if (!id) return c;
     const e = resolver.get(id);
     if (!e) return c;
-    return { ...c, cardName: e.name, specialAbility: e.rawText, cardImgFile: forgeProxyUrl(e) || c.cardImgFile };
+    // Restore the searchable fields the leak spine blanked on the STDB row, so
+    // the in-game Search Deck modal can filter forge cards by alignment/brigade/
+    // identifier/reference (not just name/type/ability).
+    return {
+      ...c,
+      cardName: e.name,
+      specialAbility: e.rawText,
+      cardImgFile: forgeProxyUrl(e) || c.cardImgFile,
+      alignment: e.alignment,
+      brigade: e.brigade,
+      strength: e.strength,
+      toughness: e.toughness,
+      identifier: e.identifier,
+      reference: e.reference,
+    };
   });
 }


### PR DESCRIPTION
## Problem

During gameplay, searching your deck by **Alignment** (e.g. typing `evil`) never matched Forge cards — even though the alignment was correctly set to Evil in the card data. The same was true for the **Brigade**, **Identifier**, and **Reference** filters. Only Name, Type, and Ability searches worked for Forge cards.

## Root cause

The Forge privacy design ("leak spine") blanks all Forge card metadata on the **world-readable** SpacetimeDB rows, then re-hydrates it per-viewer from the RLS-granted resolver. But that re-hydration only restored **name, ability text, and image** — `alignment` / `brigade` / `strength` / `toughness` / `identifier` / `reference` were left as the blank `""` from the shared row, so the deck-search filters had nothing to match.

## Fix

Carry the searchable fields on the granted resolver and restore them on the **owner's own client**, across all three deck-search paths:

- **`deckAdapter`** — new pure `designCardSearchFields(DesignCard)` derives the fields (using the existing display mappings, with `""` fallbacks matching how public cards serialize for play).
- **`playDecks`** — `ForgePlayResolverEntry` + `toResolverEntry` now carry them.
- **`cardAdapter`** — `cardInstanceToGameCard` restores them (the real online-multiplayer STDB read path).
- **`forgeResolver`** — `mergeForgeDeckData` restores them (practice-while-waiting goldfish).
- **`playSerialize`** — `buildForgeGoldfishCards` populates them (dedicated goldfish page).

## Not a leak

The world-readable rows stay blank — `buildForgePlayDeck` is untouched and its leak assertion still passes. Restoration happens only from the viewer's own RLS-granted resolver (which already carries the card's name and full rules text). Ungranted Forge cards keep the blank values — verified by test.

## Tests

37 passing across the 4 affected test files, including: a Forge Evil card surviving each path with `alignment: "Evil"`, the `designCardSearchFields` derivation (incl. `Good_Evil` → `Good/Evil`), and a "no leak" test that ungranted Forge cards keep blank values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)