### PR TITLE
Forge: import a set from a card-images zip + spreadsheet

### DIFF
--- a/app/forge/cards/[cardId]/CardDetailsFields.tsx
+++ b/app/forge/cards/[cardId]/CardDetailsFields.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import {
-  CARD_TYPES, ALIGNMENTS, BRIGADES, CLASSES, ICONS, parseStatInput,
+  CARD_TYPES, ALIGNMENTS, BRIGADES, CLASSES, ICONS,
   type DesignCard, type CardType, type Brigade,
 } from "@/app/forge/lib/designCard";
+import StatInput from "./StatInput";
 import { BRIGADE_HEX } from "@/app/forge/lib/frameAssets";
 import { deriveTestamentAndGospel, formatTestament } from "@/app/decklist/card-search/data/testament";
 
@@ -87,14 +88,12 @@ export default function CardDetailsFields({
       <div className="flex gap-3">
         <label className="block">
           <span className="mb-1 block text-sm font-medium">Strength</span>
-          <input type="text" placeholder="6 or X" value={snapshot.strength ?? ""}
-            onChange={(e) => update({ strength: parseStatInput(e.target.value) })}
+          <StatInput value={snapshot.strength} onCommit={(v) => update({ strength: v })}
             className="w-24 rounded-md border bg-background px-3 py-2 text-sm" />
         </label>
         <label className="block">
           <span className="mb-1 block text-sm font-medium">Toughness</span>
-          <input type="text" placeholder="6 or X" value={snapshot.toughness ?? ""}
-            onChange={(e) => update({ toughness: parseStatInput(e.target.value) })}
+          <StatInput value={snapshot.toughness} onCommit={(v) => update({ toughness: v })}
             className="w-24 rounded-md border bg-background px-3 py-2 text-sm" />
         </label>
       </div>

--- a/app/forge/cards/[cardId]/CardDetailsFields.tsx
+++ b/app/forge/cards/[cardId]/CardDetailsFields.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {
-  CARD_TYPES, ALIGNMENTS, BRIGADES, CLASSES, ICONS,
+  CARD_TYPES, ALIGNMENTS, BRIGADES, CLASSES, ICONS, parseStatInput,
   type DesignCard, type CardType, type Brigade,
 } from "@/app/forge/lib/designCard";
 import { BRIGADE_HEX } from "@/app/forge/lib/frameAssets";
@@ -87,14 +87,14 @@ export default function CardDetailsFields({
       <div className="flex gap-3">
         <label className="block">
           <span className="mb-1 block text-sm font-medium">Strength</span>
-          <input type="number" value={snapshot.strength ?? ""}
-            onChange={(e) => update({ strength: e.target.value === "" ? null : Number(e.target.value) })}
+          <input type="text" placeholder="6 or X" value={snapshot.strength ?? ""}
+            onChange={(e) => update({ strength: parseStatInput(e.target.value) })}
             className="w-24 rounded-md border bg-background px-3 py-2 text-sm" />
         </label>
         <label className="block">
           <span className="mb-1 block text-sm font-medium">Toughness</span>
-          <input type="number" value={snapshot.toughness ?? ""}
-            onChange={(e) => update({ toughness: e.target.value === "" ? null : Number(e.target.value) })}
+          <input type="text" placeholder="6 or X" value={snapshot.toughness ?? ""}
+            onChange={(e) => update({ toughness: parseStatInput(e.target.value) })}
             className="w-24 rounded-md border bg-background px-3 py-2 text-sm" />
         </label>
       </div>

--- a/app/forge/cards/[cardId]/FullModeForm.tsx
+++ b/app/forge/cards/[cardId]/FullModeForm.tsx
@@ -4,10 +4,11 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { uploadArt, setPlaceholder, type ForgeCardFull } from "@/app/forge/lib/cards";
 import {
-  CARD_TYPES, ALIGNMENTS, BRIGADES, LEGALITIES, parseStatInput,
+  CARD_TYPES, ALIGNMENTS, BRIGADES, LEGALITIES,
   cardApplicability, isStatBearing, type DesignCard, type CardType, type Brigade,
 } from "@/app/forge/lib/designCard";
 import { BRIGADE_HEX } from "@/app/forge/lib/frameAssets";
+import StatInput from "./StatInput";
 
 // Light-colored brigades need dark text for legible chip labels.
 const LIGHT_BRIGADES = new Set<Brigade>(["White", "Silver", "GoodGold", "PaleGreen"]);
@@ -89,10 +90,10 @@ export default function FullModeForm({
       {isStatBearing(types) && (
         <div className="flex gap-3">
           <label className="block"><span className="mb-1 block font-medium">Strength</span>
-            <input type="text" placeholder="6 or X" value={snapshot.strength ?? ""} onChange={(e) => update({ strength: parseStatInput(e.target.value) })}
+            <StatInput value={snapshot.strength} onCommit={(v) => update({ strength: v })}
               className="w-24 rounded-md border bg-background px-3 py-2" /></label>
           <label className="block"><span className="mb-1 block font-medium">Toughness</span>
-            <input type="text" placeholder="6 or X" value={snapshot.toughness ?? ""} onChange={(e) => update({ toughness: parseStatInput(e.target.value) })}
+            <StatInput value={snapshot.toughness} onCommit={(v) => update({ toughness: v })}
               className="w-24 rounded-md border bg-background px-3 py-2" /></label>
         </div>
       )}

--- a/app/forge/cards/[cardId]/FullModeForm.tsx
+++ b/app/forge/cards/[cardId]/FullModeForm.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { uploadArt, setPlaceholder, type ForgeCardFull } from "@/app/forge/lib/cards";
 import {
-  CARD_TYPES, ALIGNMENTS, BRIGADES, LEGALITIES,
+  CARD_TYPES, ALIGNMENTS, BRIGADES, LEGALITIES, parseStatInput,
   cardApplicability, isStatBearing, type DesignCard, type CardType, type Brigade,
 } from "@/app/forge/lib/designCard";
 import { BRIGADE_HEX } from "@/app/forge/lib/frameAssets";
@@ -89,10 +89,10 @@ export default function FullModeForm({
       {isStatBearing(types) && (
         <div className="flex gap-3">
           <label className="block"><span className="mb-1 block font-medium">Strength</span>
-            <input type="number" value={snapshot.strength ?? ""} onChange={(e) => update({ strength: e.target.value === "" ? null : Number(e.target.value) })}
+            <input type="text" placeholder="6 or X" value={snapshot.strength ?? ""} onChange={(e) => update({ strength: parseStatInput(e.target.value) })}
               className="w-24 rounded-md border bg-background px-3 py-2" /></label>
           <label className="block"><span className="mb-1 block font-medium">Toughness</span>
-            <input type="number" value={snapshot.toughness ?? ""} onChange={(e) => update({ toughness: e.target.value === "" ? null : Number(e.target.value) })}
+            <input type="text" placeholder="6 or X" value={snapshot.toughness ?? ""} onChange={(e) => update({ toughness: parseStatInput(e.target.value) })}
               className="w-24 rounded-md border bg-background px-3 py-2" /></label>
         </div>
       )}

--- a/app/forge/cards/[cardId]/StatInput.tsx
+++ b/app/forge/cards/[cardId]/StatInput.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { parseStatInput, type StatValue } from "@/app/forge/lib/designCard";
+
+// Text input for a stat that may be a number, "X", or a paired dual-side value
+// like "6 (0)". Holds a local draft so partially-typed text ("6 (") isn't
+// clobbered by the controlled snapshot value — commits upward only when the
+// text parses (or empties); blur resyncs an abandoned draft to the saved value.
+export default function StatInput({
+  value,
+  onCommit,
+  className,
+}: {
+  value: StatValue | undefined;
+  onCommit: (v: StatValue) => void;
+  className?: string;
+}) {
+  const [draft, setDraft] = useState(value == null ? "" : String(value));
+  useEffect(() => { setDraft(value == null ? "" : String(value)); }, [value]);
+  return (
+    <input
+      type="text"
+      placeholder="6 · X · 6 (0)"
+      value={draft}
+      className={className}
+      onChange={(e) => {
+        const t = e.target.value;
+        setDraft(t);
+        const parsed = parseStatInput(t);
+        if (parsed !== null || t.trim() === "") onCommit(parsed);
+      }}
+      onBlur={() => setDraft(value == null ? "" : String(value))}
+    />
+  );
+}

--- a/app/forge/components/FilePicker.tsx
+++ b/app/forge/components/FilePicker.tsx
@@ -25,6 +25,7 @@ export default function FilePicker({
         ref={inputRef}
         type="file"
         accept={accept}
+        aria-label={label}
         className="hidden"
         onChange={(e) => {
           const f = e.target.files?.[0];

--- a/app/forge/import/ImportWizard.tsx
+++ b/app/forge/import/ImportWizard.tsx
@@ -27,8 +27,11 @@ import { useImportRunner, mimeFor, type RunCard } from "./useImportRunner";
 import type { SourceSelection } from "./selection";
 
 // Cap on decompressed object-URL previews — a 200-card zip of ~1MB PNGs would
-// otherwise pin hundreds of MB of blobs. Tiles past the cap show a placeholder.
-const PREVIEW_LIMIT = 120;
+// Previews load lazily in chunks as the grid scrolls: decompression is synchronous
+// main-thread work and each ~1MB PNG pins a blob URL, so a 224-card zip decompressed
+// all at once would freeze the page and hold hundreds of MB. Chunks keep each pause
+// short and spend memory only on what the elder actually scrolls to.
+const PREVIEW_CHUNK = 60;
 
 type Source = "lackey" | "spreadsheet";
 
@@ -48,6 +51,7 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
   const [creating, setCreating] = useState(false);
   const [previews, setPreviews] = useState<Map<string, string>>(new Map());
   const [previewError, setPreviewError] = useState(false);
+  const [previewCount, setPreviewCount] = useState(PREVIEW_CHUNK);
 
   const runner = useImportRunner();
   const { items, doneSetId, counts, finished } = runner;
@@ -59,6 +63,7 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
   useEffect(() => {
     runner.reset();
     setRunError(null);
+    setPreviewCount(PREVIEW_CHUNK);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selection?.key]);
 
@@ -67,44 +72,60 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
     if (selection?.defaultSetName) setNewSetName(selection.defaultSetName);
   }, [selection?.defaultSetName]);
 
-  // Decompress selected images into object URLs. Cached by (zip bytes, wanted entries):
-  // mapping/filter edits that don't change which images are shown skip the (synchronous,
-  // main-thread) re-decompression entirely. Guarded — a zip whose directory scanned fine
-  // at pick time can still hold corrupt image data, and that must not crash the wizard.
-  const previewCache = useRef<{ bytes: Uint8Array | null; key: string; urls: Map<string, string> }>(
-    { bytes: null, key: "", urls: new Map() },
+  // Decompress the first `previewCount` selected images into object URLs, incrementally:
+  // already-decompressed entries are kept (mapping/filter edits and scroll growth only
+  // pay for the delta); everything is revoked when the zip itself changes. Guarded — a
+  // zip whose directory scanned fine at pick time can still hold corrupt image data,
+  // and that must not crash the wizard.
+  const previewCache = useRef<{ bytes: Uint8Array | null; urls: Map<string, string> }>(
+    { bytes: null, urls: new Map() },
   );
   useEffect(() => {
     const zipBytes = selection?.zipBytes ?? null;
-    const wanted = [...new Set(
-      (selection?.cards ?? []).map((c) => c.entryName).filter(Boolean) as string[],
-    )].slice(0, PREVIEW_LIMIT);
-    const key = wanted.join("\n");
     const cache = previewCache.current;
-    if (cache.bytes === zipBytes && cache.key === key) return;
-    for (const u of cache.urls.values()) URL.revokeObjectURL(u);
-    cache.bytes = zipBytes;
-    cache.key = key;
-    cache.urls = new Map();
-    setPreviewError(false);
-    if (zipBytes && wanted.length > 0) {
+    if (cache.bytes !== zipBytes) {
+      for (const u of cache.urls.values()) URL.revokeObjectURL(u);
+      cache.bytes = zipBytes;
+      cache.urls = new Map();
+      setPreviewError(false);
+    }
+    const missing = [...new Set(
+      (selection?.cards ?? []).map((c) => c.entryName).filter(Boolean) as string[],
+    )].slice(0, previewCount).filter((n) => !cache.urls.has(n));
+    if (zipBytes && missing.length > 0) {
       try {
-        const wantedSet = new Set(wanted);
-        const files = unzipSync(zipBytes, { filter: (f) => wantedSet.has(f.name) });
+        const missingSet = new Set(missing);
+        const files = unzipSync(zipBytes, { filter: (f) => missingSet.has(f.name) });
         for (const [name, bytes] of Object.entries(files)) {
           cache.urls.set(name, URL.createObjectURL(new Blob([bytes.slice()], { type: mimeFor(name) })));
         }
       } catch {
-        cache.urls = new Map();
         setPreviewError(true);
       }
     }
     setPreviews(new Map(cache.urls));
-  }, [selection]);
+  }, [selection, previewCount]);
   useEffect(() => () => {
     for (const u of previewCache.current.urls.values()) URL.revokeObjectURL(u);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Grow the previewed window when the sentinel below the grid scrolls near the viewport.
+  const totalPreviewable = new Set(cards.map((c) => c.entryName).filter(Boolean)).size;
+  const morePreviews = previewCount < totalPreviewable;
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el || !morePreviews) return;
+    // Re-arm after every growth: observe() reports current intersection immediately,
+    // so a sentinel that STAYS in view keeps growing the window (IO alone only fires
+    // on transitions and would stall after the first chunk).
+    const io = new IntersectionObserver((entries) => {
+      if (entries.some((e) => e.isIntersecting)) setPreviewCount((c) => c + PREVIEW_CHUNK);
+    }, { rootMargin: "600px" });
+    io.observe(el);
+    return () => io.disconnect();
+  }, [morePreviews, previewCount]);
 
   function switchSource(next: Source) {
     if (running || next === source) return;
@@ -191,11 +212,6 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
               images will likely fail to import.
             </p>
           )}
-          {cards.filter((c) => c.entryName).length > PREVIEW_LIMIT && (
-            <p className="mb-2 text-xs text-muted-foreground">
-              Showing the first {PREVIEW_LIMIT} image previews — the rest still import with their images.
-            </p>
-          )}
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
             {cards.map((c) => {
               const url = c.entryName ? previews.get(c.entryName) : null;
@@ -207,7 +223,7 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
                         className="absolute inset-0 h-full w-full object-contain" />
                     ) : (
                       <div className="flex h-full items-center justify-center p-2 text-center text-xs text-muted-foreground">
-                        {c.entryName ? "Image ready (not previewed)" : "No image"}
+                        {c.entryName ? "Loading preview…" : "No image"}
                       </div>
                     )}
                     {c.warnings.length > 0 && (
@@ -224,6 +240,7 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
               );
             })}
           </div>
+          {morePreviews && <div ref={sentinelRef} aria-hidden className="h-px" />}
         </fieldset>
       )}
 

--- a/app/forge/import/ImportWizard.tsx
+++ b/app/forge/import/ImportWizard.tsx
@@ -1,23 +1,18 @@
 "use client";
 
-// Lackey zip import wizard. The zip NEVER goes to the server (37MB > Vercel's ~4.5MB
-// request cap): fflate unpacks it in the browser, carddata.txt is parsed/filtered
-// locally, preview renders from zip bytes, and only the matched cards are sent —
-// batched multipart POSTs to /forge/api/import. A route handler (not a Server Action)
-// because Next serializes Server Action calls from one client; these batches genuinely
-// run in parallel.
+// Set import wizard with two sources: a LackeyCCG plugin zip, or a zip of card
+// images + a .csv/.xlsx spreadsheet. Source files NEVER go to the server (they can
+// exceed 200MB — far past Vercel's ~4.5MB request cap): everything is unpacked and
+// parsed in the browser, and only the selected cards are sent — batched multipart
+// POSTs to /forge/api/import (see useImportRunner). Source panels emit a common
+// SourceSelection; preview, destination, and the run pipeline are shared here.
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { unzipSync } from "fflate";
-import {
-  parseCarddata, matchesFilter, distinctSets, findImageEntry,
-  lackeyRowToDesignCard, type LackeyRow,
-} from "@/app/forge/lib/lackey";
 import { createSet, type ForgeSetSummary } from "@/app/forge/lib/sets";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import FilePicker from "@/app/forge/components/FilePicker";
 import {
   Dialog,
   DialogContent,
@@ -26,220 +21,101 @@ import {
   DialogBody,
   DialogFooter,
 } from "@/components/ui/dialog";
+import LackeySourcePanel from "./LackeySourcePanel";
+import SpreadsheetSourcePanel from "./SpreadsheetSourcePanel";
+import { useImportRunner, mimeFor, type RunCard } from "./useImportRunner";
+import type { SourceSelection } from "./selection";
 
-const BATCH_SIZE = 8;            // cards per request (must stay ≤ the route's cap of 12)
-const BATCH_CONCURRENCY = 4;     // requests in flight
-const MAX_BATCH_BYTES = 3_500_000; // keep each request under Vercel's ~4.5MB body cap
+// Cap on decompressed object-URL previews — a 200-card zip of ~1MB PNGs would
+// otherwise pin hundreds of MB of blobs. Tiles past the cap show a placeholder.
+const PREVIEW_LIMIT = 120;
 
-type CardStatus = "queued" | "importing" | "imported" | "updated" | "skipped" | "failed";
-interface ImportItem {
-  row: LackeyRow;
-  entryName: string | null; // zip entry for the finished-card image, if present
-  status: CardStatus;
-  error?: string;
-}
-
-function mimeFor(entryName: string): string {
-  const lower = entryName.toLowerCase();
-  if (lower.endsWith(".png")) return "image/png";
-  if (lower.endsWith(".webp")) return "image/webp";
-  return "image/jpeg";
-}
-
-function baseName(entryName: string): string {
-  return entryName.split("/").pop() ?? entryName;
-}
-
-interface BatchCardResult { name: string; ok: boolean; cardId?: string; skipped?: boolean; updated?: boolean; error?: string }
-
-// Greedy chunking: ≤ BATCH_SIZE cards and ≤ MAX_BATCH_BYTES of image data per request.
-// An image bigger than the cap still gets its own single-card batch.
-function chunkIntoBatches(
-  indexes: number[],
-  work: { entryName: string | null }[],
-  images: Record<string, Uint8Array>,
-): number[][] {
-  const batches: number[][] = [];
-  let current: number[] = [];
-  let currentBytes = 0;
-  for (const idx of indexes) {
-    const entry = work[idx].entryName;
-    const size = entry && images[entry] ? images[entry].length : 0;
-    if (current.length > 0 && (current.length >= BATCH_SIZE || currentBytes + size > MAX_BATCH_BYTES)) {
-      batches.push(current);
-      current = [];
-      currentBytes = 0;
-    }
-    current.push(idx);
-    currentBytes += size;
-  }
-  if (current.length) batches.push(current);
-  return batches;
-}
+type Source = "lackey" | "spreadsheet";
 
 export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
-  const zipBytes = useRef<Uint8Array | null>(null);
-  const [zipName, setZipName] = useState<string | null>(null);
-  const [zipError, setZipError] = useState<string | null>(null);
-  const [rows, setRows] = useState<LackeyRow[] | null>(null);
-  const [entryNames, setEntryNames] = useState<string[]>([]);
+  const [source, setSource] = useState<Source>("lackey");
+  const [selection, setSelection] = useState<SourceSelection | null>(null);
 
-  const [filter, setFilter] = useState("");
   const [mode, setMode] = useState<"new" | "existing">("new");
   const [newSetName, setNewSetName] = useState("");
   const [newSetPrivate, setNewSetPrivate] = useState(false);
   const [existingSetId, setExistingSetId] = useState(sets[0]?.id ?? "");
   const [overwrite, setOverwrite] = useState(false);
   const [newSetDialogOpen, setNewSetDialogOpen] = useState(false);
-
-  const [items, setItems] = useState<ImportItem[] | null>(null);
-  const [running, setRunning] = useState(false);
   const [runError, setRunError] = useState<string | null>(null);
-  const [doneSetId, setDoneSetId] = useState<string | null>(null);
+  // Covers the createSet round-trip BEFORE the runner flips `running` — without it a
+  // double-click on "Create set & import" creates two sets.
+  const [creating, setCreating] = useState(false);
   const [previews, setPreviews] = useState<Map<string, string>>(new Map());
+  const [previewError, setPreviewError] = useState(false);
 
-  async function onPickZip(file: File) {
-    setZipError(null); setRows(null); setItems(null); setDoneSetId(null); setFilter("");
-    setZipName(file.name);
-    try {
-      const bytes = new Uint8Array(await file.arrayBuffer());
-      zipBytes.current = bytes;
-      // Single pass: collect every entry name, decompress ONLY carddata.txt.
-      const names: string[] = [];
-      const unzipped = unzipSync(bytes, {
-        filter: (f) => {
-          if (!f.name.endsWith("/")) names.push(f.name);
-          return f.name.toLowerCase().endsWith("sets/carddata.txt");
-        },
-      });
-      const carddataEntry = Object.keys(unzipped)[0];
-      if (!carddataEntry) {
-        setZipError("No sets/carddata.txt found in this zip — is it a Lackey plugin export?");
-        return;
-      }
-      const text = new TextDecoder("utf-8").decode(unzipped[carddataEntry]);
-      setRows(parseCarddata(text));
-      setEntryNames(names);
-    } catch (e) {
-      setZipError(e instanceof Error ? e.message : "Could not read this zip file.");
-    }
-  }
+  const runner = useImportRunner();
+  const { items, doneSetId, counts, finished } = runner;
+  const running = runner.running || creating;
+  const cards = selection?.cards ?? [];
 
-  const matched = useMemo(
-    () => (rows ?? []).filter((r) => matchesFilter(r, filter)),
-    [rows, filter],
-  );
-  const zipSets = useMemo(() => distinctSets(rows ?? []), [rows]);
-
-  // Changing the filter starts a fresh selection — clear any previous run.
-  // Locked while a run is in flight: in-flight workers would resurrect the old
-  // status list over the new selection.
-  function onFilterChange(value: string) {
-    if (running) return;
-    setFilter(value);
-    setItems(null);
-    setDoneSetId(null);
+  // A different selection (new file, filter, sheet, or mapping) starts fresh.
+  // Sources are disabled while a run is in flight, so this can't fire mid-run.
+  useEffect(() => {
+    runner.reset();
     setRunError(null);
-  }
-  const invalidRegex = useMemo(() => {
-    const m = filter.trim().match(/^\/(.*)\/$/);
-    if (!m) return false;
-    try { new RegExp(m[1], "i"); return false; } catch { return true; }
-  }, [filter]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selection?.key]);
 
-  // Decompress matched images once per filter change; expose object URLs for preview.
+  // Prefill the new-set name from the source (filter value / sheet name).
   useEffect(() => {
-    if (!zipBytes.current || matched.length === 0) { setPreviews(new Map()); return; }
-    const wanted = new Set(
-      matched.map((r) => findImageEntry(r, entryNames)).filter(Boolean) as string[],
-    );
-    const files = unzipSync(zipBytes.current, { filter: (f) => wanted.has(f.name) });
-    const urls = new Map<string, string>();
-    for (const [name, bytes] of Object.entries(files)) {
-      urls.set(name, URL.createObjectURL(new Blob([bytes.slice()], { type: mimeFor(name) })));
-    }
-    setPreviews(urls);
-    return () => { for (const u of urls.values()) URL.revokeObjectURL(u); };
-  }, [matched, entryNames]);
+    if (selection?.defaultSetName) setNewSetName(selection.defaultSetName);
+  }, [selection?.defaultSetName]);
 
-  // Prefill the new-set name with the (non-regex) filter value.
+  // Decompress selected images into object URLs. Cached by (zip bytes, wanted entries):
+  // mapping/filter edits that don't change which images are shown skip the (synchronous,
+  // main-thread) re-decompression entirely. Guarded — a zip whose directory scanned fine
+  // at pick time can still hold corrupt image data, and that must not crash the wizard.
+  const previewCache = useRef<{ bytes: Uint8Array | null; key: string; urls: Map<string, string> }>(
+    { bytes: null, key: "", urls: new Map() },
+  );
   useEffect(() => {
-    if (filter && !filter.startsWith("/")) setNewSetName(filter.trim());
-  }, [filter]);
-
-  // POST one batch; write each card's result (or the batch-level error) into `work`.
-  async function importBatch(
-    setId: string,
-    batch: number[],
-    work: ImportItem[],
-    images: Record<string, Uint8Array>,
-  ) {
-    const fd = new FormData();
-    const cards = batch.map((idx, j) => {
-      const it = work[idx];
-      let fileField: string | undefined;
-      if (it.entryName && images[it.entryName]) {
-        fileField = `file-${j}`;
-        fd.set(fileField, new File([images[it.entryName].slice()], baseName(it.entryName), { type: mimeFor(it.entryName) }));
-      }
-      return { name: it.row.name, snapshot: lackeyRowToDesignCard(it.row), fileField };
-    });
-    fd.set("payload", JSON.stringify({ setId, cards, overwrite }));
-
-    const res = await fetch("/forge/api/import", { method: "POST", body: fd });
-    if (!res.ok) {
-      let message = `Import failed (${res.status})`;
+    const zipBytes = selection?.zipBytes ?? null;
+    const wanted = [...new Set(
+      (selection?.cards ?? []).map((c) => c.entryName).filter(Boolean) as string[],
+    )].slice(0, PREVIEW_LIMIT);
+    const key = wanted.join("\n");
+    const cache = previewCache.current;
+    if (cache.bytes === zipBytes && cache.key === key) return;
+    for (const u of cache.urls.values()) URL.revokeObjectURL(u);
+    cache.bytes = zipBytes;
+    cache.key = key;
+    cache.urls = new Map();
+    setPreviewError(false);
+    if (zipBytes && wanted.length > 0) {
       try {
-        const body = await res.json();
-        if (body?.error) message = body.error;
-      } catch { /* non-JSON error body */ }
-      for (const idx of batch) { work[idx].status = "failed"; work[idx].error = message; }
-      return;
-    }
-    const body = (await res.json()) as { results?: BatchCardResult[] };
-    batch.forEach((idx, j) => {
-      const r = body.results?.[j];
-      if (!r || r.ok === false) {
-        work[idx].status = "failed";
-        work[idx].error = r?.error ?? "Unexpected error";
-      } else {
-        work[idx].status = r.skipped ? "skipped" : r.updated ? "updated" : "imported";
-      }
-    });
-  }
-
-  // Chunk the given items into batches and run them BATCH_CONCURRENCY at a time.
-  async function runBatches(setId: string, indexes: number[], work: ImportItem[]) {
-    const bytes = zipBytes.current!;
-    const wanted = new Set(indexes.map((i) => work[i].entryName).filter(Boolean) as string[]);
-    const images = unzipSync(bytes, { filter: (f) => wanted.has(f.name) });
-    const batches = chunkIntoBatches(indexes, work, images);
-
-    let cursor = 0;
-    const runOne = async () => {
-      for (;;) {
-        const b = cursor++;
-        if (b >= batches.length) return;
-        for (const idx of batches[b]) work[idx].status = "importing";
-        setItems([...work]);
-        try {
-          await importBatch(setId, batches[b], work, images);
-        } catch (e) {
-          const message = e instanceof Error ? e.message : "Unexpected error";
-          for (const idx of batches[b]) {
-            if (work[idx].status === "importing") { work[idx].status = "failed"; work[idx].error = message; }
-          }
+        const wantedSet = new Set(wanted);
+        const files = unzipSync(zipBytes, { filter: (f) => wantedSet.has(f.name) });
+        for (const [name, bytes] of Object.entries(files)) {
+          cache.urls.set(name, URL.createObjectURL(new Blob([bytes.slice()], { type: mimeFor(name) })));
         }
-        setItems([...work]);
+      } catch {
+        cache.urls = new Map();
+        setPreviewError(true);
       }
-    };
-    await Promise.all(Array.from({ length: BATCH_CONCURRENCY }, runOne));
+    }
+    setPreviews(new Map(cache.urls));
+  }, [selection]);
+  useEffect(() => () => {
+    for (const u of previewCache.current.urls.values()) URL.revokeObjectURL(u);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function switchSource(next: Source) {
+    if (running || next === source) return;
+    setSource(next);
+    setSelection(null); // the outgoing panel unmounts; its files drop with it
   }
 
   async function runImport() {
-    if (running || matched.length === 0) return;
+    if (running || !selection || cards.length === 0) return;
     setRunError(null);
-    setRunning(true);
+    setCreating(true);
     try {
       let setId = existingSetId;
       if (mode === "new") {
@@ -251,46 +127,16 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
       }
       if (!setId) { setRunError("Pick a destination set."); return; }
 
-      const work: ImportItem[] = matched.map((row) => ({
-        row, entryName: findImageEntry(row, entryNames), status: "queued" as CardStatus,
+      const work: RunCard[] = cards.map((c) => ({
+        name: c.name, snapshot: c.snapshot, entryName: c.entryName, status: "queued",
       }));
-      setItems([...work]);
-      await runBatches(setId, work.map((_, i) => i), work);
-      setDoneSetId(setId);
+      await runner.run(setId, work, selection.zipBytes, selection.sizes, overwrite);
+    } catch (e) {
+      setRunError(e instanceof Error ? e.message : "Unexpected error");
     } finally {
-      setRunning(false);
+      setCreating(false);
     }
   }
-
-  async function retryFailed() {
-    if (!items || !doneSetId || running) return;
-    setRunning(true);
-    try {
-      const work = items.map((it) =>
-        it.status === "failed" ? { ...it, error: undefined } : it,
-      );
-      const failedIndexes = work
-        .map((it, i) => (it.status === "failed" ? i : -1))
-        .filter((i) => i >= 0);
-      setItems([...work]);
-      await runBatches(doneSetId, failedIndexes, work);
-    } finally {
-      setRunning(false);
-    }
-  }
-
-  const counts = useMemo(() => {
-    const c = { imported: 0, updated: 0, skipped: 0, failed: 0 };
-    for (const it of items ?? []) {
-      if (it.status === "imported") c.imported++;
-      else if (it.status === "updated") c.updated++;
-      else if (it.status === "skipped") c.skipped++;
-      else if (it.status === "failed") c.failed++;
-    }
-    return c;
-  }, [items]);
-  const finished = !!items && !running && items.every((it) =>
-    it.status === "imported" || it.status === "updated" || it.status === "skipped" || it.status === "failed");
 
   return (
     <div className="mx-auto max-w-4xl p-4">
@@ -299,62 +145,81 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
         <Link href="/forge/sets" className="text-sm text-muted-foreground hover:underline">← Sets</Link>
       </div>
       <p className="mb-4 text-sm text-muted-foreground">
-        Upload a Lackey plugin zip. It’s unpacked in your browser — only the cards you
-        select are uploaded, privately, to the Forge.
+        Import from a Lackey plugin zip, or from a zip of card images plus a spreadsheet.
+        Files are unpacked in your browser — only the cards you select are uploaded,
+        privately, to the Forge.
       </p>
 
-      {/* 1 — zip */}
+      {/* 1 — source */}
       <fieldset className="rounded-md border p-3">
-        <legend className="px-1 text-sm font-medium">1 · Lackey zip</legend>
-        <FilePicker label="Choose zip…" accept=".zip,application/zip" disabled={running} onFile={onPickZip} />
-        {zipName && !zipError && rows && (
-          <p className="mt-2 text-xs text-muted-foreground">
-            {zipName} — {rows.length} cards across {zipSets.length} sets.
-          </p>
-        )}
-        {zipError && <p className="mt-2 text-xs text-destructive">{zipError}</p>}
+        <legend className="px-1 text-sm font-medium">1 · Source</legend>
+        <div className="space-y-2 text-sm">
+          <label className="flex items-start gap-2">
+            <input type="radio" name="source" className="mt-0.5" disabled={running}
+              checked={source === "lackey"} onChange={() => switchSource("lackey")} />
+            <span>
+              Lackey plugin zip
+              <span className="block text-xs text-muted-foreground">
+                One export containing sets/carddata.txt and the set images.
+              </span>
+            </span>
+          </label>
+          <label className="flex items-start gap-2">
+            <input type="radio" name="source" className="mt-0.5" disabled={running}
+              checked={source === "spreadsheet"} onChange={() => switchSource("spreadsheet")} />
+            <span>
+              Card images + spreadsheet
+              <span className="block text-xs text-muted-foreground">
+                A zip of finished card images plus a .csv or .xlsx of the card text.
+              </span>
+            </span>
+          </label>
+        </div>
       </fieldset>
 
-      {/* 2 — filter */}
-      {rows && (
-        <fieldset className="mt-4 rounded-md border p-3">
-          <legend className="px-1 text-sm font-medium">2 · Which set?</legend>
-          <input value={filter} onChange={(e) => onFilterChange(e.target.value)} disabled={running}
-            aria-label="Set filter" placeholder="Set code, e.g. EoT — or /regex/"
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm disabled:opacity-50" />
-          {invalidRegex && <p className="mt-1 text-xs text-destructive">Invalid regular expression.</p>}
-          <p className="mt-2 text-sm">
-            {matched.length === 1 ? "1 card matches" : `${matched.length} cards match`}
-            {matched.length > 0 && (
-              <span className="text-muted-foreground">
-                {" "}· {matched.filter((r) => !findImageEntry(r, entryNames)).length} without an image
-              </span>
-            )}
-          </p>
-        </fieldset>
-      )}
+      {source === "lackey"
+        ? <LackeySourcePanel disabled={running} onSelection={setSelection} />
+        : <SpreadsheetSourcePanel disabled={running} onSelection={setSelection} />}
 
-      {/* 3 — preview */}
-      {matched.length > 0 && !items && (
+      {/* 4 — preview */}
+      {cards.length > 0 && !items && (
         <fieldset className="mt-4 rounded-md border p-3">
-          <legend className="px-1 text-sm font-medium">3 · Preview</legend>
+          <legend className="px-1 text-sm font-medium">4 · Preview</legend>
+          {previewError && (
+            <p className="mb-2 text-xs text-destructive">
+              Couldn’t read image data from the zip — previews are unavailable, and these
+              images will likely fail to import.
+            </p>
+          )}
+          {cards.filter((c) => c.entryName).length > PREVIEW_LIMIT && (
+            <p className="mb-2 text-xs text-muted-foreground">
+              Showing the first {PREVIEW_LIMIT} image previews — the rest still import with their images.
+            </p>
+          )}
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-            {matched.map((r) => {
-              const entry = findImageEntry(r, entryNames);
-              const url = entry ? previews.get(entry) : null;
+            {cards.map((c) => {
+              const url = c.entryName ? previews.get(c.entryName) : null;
               return (
-                <div key={`${r.name}|${r.imageFile}`}>
+                <div key={`${c.name}|${c.entryName}`}>
                   <div className="relative w-full overflow-hidden rounded-md border bg-muted/30" style={{ aspectRatio: "2.5 / 3.5" }}>
                     {url ? (
-                      <img src={url} alt={r.name} loading="lazy" decoding="async"
+                      <img src={url} alt={c.name} loading="lazy" decoding="async"
                         className="absolute inset-0 h-full w-full object-contain" />
                     ) : (
                       <div className="flex h-full items-center justify-center p-2 text-center text-xs text-muted-foreground">
-                        No image
+                        {c.entryName ? "Image ready (not previewed)" : "No image"}
                       </div>
                     )}
+                    {c.warnings.length > 0 && (
+                      <span
+                        title={c.warnings.join("\n")}
+                        className="absolute right-1 top-1 flex h-4 w-4 items-center justify-center rounded-full border border-amber-500/40 bg-amber-500/15 text-[10px] font-semibold text-amber-700 backdrop-blur-sm dark:text-amber-400"
+                      >
+                        !
+                      </span>
+                    )}
                   </div>
-                  <p className="mt-1 truncate text-xs text-muted-foreground">{r.name}</p>
+                  <p className="mt-1 truncate text-xs text-muted-foreground">{c.name}</p>
                 </div>
               );
             })}
@@ -362,10 +227,10 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
         </fieldset>
       )}
 
-      {/* 4 — destination + run (hidden once a run starts; filter change resets) */}
-      {matched.length > 0 && !items && (
+      {/* 5 — destination + run (hidden once a run starts; selection change resets) */}
+      {cards.length > 0 && !items && (
         <fieldset className="mt-4 rounded-md border p-3">
-          <legend className="px-1 text-sm font-medium">4 · Destination</legend>
+          <legend className="px-1 text-sm font-medium">5 · Destination</legend>
           <div className="space-y-2 text-sm">
             <label className="flex items-center gap-2">
               <input type="radio" name="dest" checked={mode === "new"}
@@ -391,7 +256,7 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
                     <span className="block text-xs text-muted-foreground">
                       Cards whose names already exist in the set get their text and finished
                       image replaced (a new testing version — release the update when ready).
-                      Cards not in this zip are untouched.
+                      Cards not in this import are untouched.
                     </span>
                   </span>
                 </label>
@@ -401,8 +266,8 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
           {runError && <p className="mt-2 text-sm text-destructive">{runError}</p>}
           <Button type="button" className="mt-3"
             onClick={() => (mode === "new" ? setNewSetDialogOpen(true) : runImport())}
-            disabled={running || matched.length === 0}>
-            {matched.length === 1 ? "Import 1 card" : `Import ${matched.length} cards`}
+            disabled={running || cards.length === 0}>
+            {cards.length === 1 ? "Import 1 card" : `Import ${cards.length} cards`}
           </Button>
         </fieldset>
       )}
@@ -433,16 +298,16 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
             <Button variant="cancel" onClick={() => setNewSetDialogOpen(false)}>Cancel</Button>
             <Button disabled={running || !newSetName.trim()}
               onClick={() => { setNewSetDialogOpen(false); runImport(); }}>
-              {matched.length === 1 ? "Create set & import 1 card" : `Create set & import ${matched.length} cards`}
+              {cards.length === 1 ? "Create set & import 1 card" : `Create set & import ${cards.length} cards`}
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
-      {/* 5 — progress + summary */}
+      {/* 6 — progress + summary */}
       {items && (
         <fieldset className="mt-4 rounded-md border p-3">
-          <legend className="px-1 text-sm font-medium">5 · Import</legend>
+          <legend className="px-1 text-sm font-medium">6 · Import</legend>
           <p className="text-sm">
             {overwrite ? (
               <>Imported {counts.imported} · Updated {counts.updated} · Skipped {counts.skipped} · Failed {counts.failed}</>
@@ -451,7 +316,7 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
             )}
           </p>
           {finished && counts.failed > 0 && (
-            <Button type="button" variant="outline" size="sm" className="mt-2 h-7 px-3 text-xs" onClick={retryFailed}>
+            <Button type="button" variant="outline" size="sm" className="mt-2 h-7 px-3 text-xs" onClick={runner.retryFailed}>
               Retry failed
             </Button>
           )}
@@ -464,7 +329,7 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
           <ul className="mt-3 max-h-64 space-y-1 overflow-y-auto text-xs">
             {items.map((it, i) => (
               <li key={i} className="flex items-center justify-between gap-2">
-                <span className="truncate">{it.row.name}</span>
+                <span className="truncate">{it.name}</span>
                 <span className={
                   it.status === "failed" ? "text-destructive"
                     : it.status === "imported" || it.status === "updated" ? "text-primary"

--- a/app/forge/import/ImportWizard.tsx
+++ b/app/forge/import/ImportWizard.tsx
@@ -110,22 +110,28 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Grow the previewed window when the sentinel below the grid scrolls near the viewport.
+  // Grow the previewed window when the loaded/unloaded BOUNDARY nears the viewport.
+  // The observed element is the first still-loading tile — a fixed sentinel at the
+  // grid's bottom would sit thousands of px below a mid-grid scroll position and
+  // never fire. The callback ref re-targets the observer as the boundary moves;
+  // observe() reports current intersection immediately, so a boundary that's
+  // already in view cascades until it passes the viewport.
   const totalPreviewable = new Set(cards.map((c) => c.entryName).filter(Boolean)).size;
   const morePreviews = previewCount < totalPreviewable;
-  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const previewObserver = useRef<IntersectionObserver | null>(null);
   useEffect(() => {
-    const el = sentinelRef.current;
-    if (!el || !morePreviews) return;
-    // Re-arm after every growth: observe() reports current intersection immediately,
-    // so a sentinel that STAYS in view keeps growing the window (IO alone only fires
-    // on transitions and would stall after the first chunk).
-    const io = new IntersectionObserver((entries) => {
+    previewObserver.current = new IntersectionObserver((entries) => {
       if (entries.some((e) => e.isIntersecting)) setPreviewCount((c) => c + PREVIEW_CHUNK);
     }, { rootMargin: "600px" });
-    io.observe(el);
-    return () => io.disconnect();
-  }, [morePreviews, previewCount]);
+    return () => previewObserver.current?.disconnect();
+  }, []);
+  const boundaryRef = (el: HTMLDivElement | null) => {
+    const io = previewObserver.current;
+    if (io && el) { io.disconnect(); io.observe(el); }
+  };
+  const firstPendingIdx = morePreviews
+    ? cards.findIndex((c) => c.entryName && !previews.has(c.entryName))
+    : -1;
 
   function switchSource(next: Source) {
     if (running || next === source) return;
@@ -213,10 +219,10 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
             </p>
           )}
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-            {cards.map((c) => {
+            {cards.map((c, i) => {
               const url = c.entryName ? previews.get(c.entryName) : null;
               return (
-                <div key={`${c.name}|${c.entryName}`}>
+                <div key={`${c.name}|${c.entryName}`} ref={i === firstPendingIdx ? boundaryRef : undefined}>
                   <div className="relative w-full overflow-hidden rounded-md border bg-muted/30" style={{ aspectRatio: "2.5 / 3.5" }}>
                     {url ? (
                       <img src={url} alt={c.name} loading="lazy" decoding="async"
@@ -240,7 +246,6 @@ export default function ImportWizard({ sets }: { sets: ForgeSetSummary[] }) {
               );
             })}
           </div>
-          {morePreviews && <div ref={sentinelRef} aria-hidden className="h-px" />}
         </fieldset>
       )}
 

--- a/app/forge/import/LackeySourcePanel.tsx
+++ b/app/forge/import/LackeySourcePanel.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+// Source panel: LackeyCCG plugin zip. Unpacks in the browser (fflate), parses
+// sets/carddata.txt, and lets the elder pick a set by code or /regex/. Emits the
+// matched cards to the shared wizard.
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { unzipSync } from "fflate";
+import {
+  parseCarddata, matchesFilter, distinctSets, findImageEntry,
+  lackeyRowToDesignCard, auditLackeyRow, type LackeyRow,
+} from "@/app/forge/lib/lackey";
+import FilePicker from "@/app/forge/components/FilePicker";
+import type { SourceSelection } from "./selection";
+
+export default function LackeySourcePanel({
+  disabled,
+  onSelection,
+}: {
+  disabled: boolean;
+  onSelection: (s: SourceSelection | null) => void;
+}) {
+  const zipBytes = useRef<Uint8Array | null>(null);
+  const sizesRef = useRef<Record<string, number>>({});
+  const [zipName, setZipName] = useState<string | null>(null);
+  const [zipError, setZipError] = useState<string | null>(null);
+  const [rows, setRows] = useState<LackeyRow[] | null>(null);
+  const [entryNames, setEntryNames] = useState<string[]>([]);
+  const [filter, setFilter] = useState("");
+
+  async function onPickZip(file: File) {
+    setZipError(null); setRows(null); setFilter("");
+    setZipName(file.name);
+    try {
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      zipBytes.current = bytes;
+      // Single pass: collect every entry name + size, decompress ONLY carddata.txt.
+      const names: string[] = [];
+      const sizes: Record<string, number> = {};
+      const unzipped = unzipSync(bytes, {
+        filter: (f) => {
+          if (!f.name.endsWith("/")) { names.push(f.name); sizes[f.name] = f.originalSize; }
+          return f.name.toLowerCase().endsWith("sets/carddata.txt");
+        },
+      });
+      const carddataEntry = Object.keys(unzipped)[0];
+      if (!carddataEntry) {
+        setZipError("No sets/carddata.txt found in this zip — is it a Lackey plugin export?");
+        return;
+      }
+      const text = new TextDecoder("utf-8").decode(unzipped[carddataEntry]);
+      setRows(parseCarddata(text));
+      setEntryNames(names);
+      sizesRef.current = sizes;
+    } catch (e) {
+      setZipError(e instanceof Error ? e.message : "Could not read this zip file.");
+    }
+  }
+
+  const matched = useMemo(
+    () => (rows ?? []).filter((r) => matchesFilter(r, filter)),
+    [rows, filter],
+  );
+  const zipSets = useMemo(() => distinctSets(rows ?? []), [rows]);
+  const invalidRegex = useMemo(() => {
+    const m = filter.trim().match(/^\/(.*)\/$/);
+    if (!m) return false;
+    try { new RegExp(m[1], "i"); return false; } catch { return true; }
+  }, [filter]);
+
+  const selection = useMemo<SourceSelection | null>(() => {
+    if (matched.length === 0) return null;
+    return {
+      cards: matched.map((r) => ({
+        name: r.name,
+        snapshot: lackeyRowToDesignCard(r),
+        entryName: findImageEntry(r, entryNames),
+        warnings: auditLackeyRow(r),
+      })),
+      zipBytes: zipBytes.current,
+      sizes: sizesRef.current,
+      defaultSetName: filter && !filter.startsWith("/") ? filter.trim() : "",
+      key: `lackey|${zipName}|${filter}`,
+    };
+  }, [matched, entryNames, zipName, filter]);
+  useEffect(() => { onSelection(selection); }, [selection, onSelection]);
+
+  const noImage = selection ? selection.cards.filter((c) => !c.entryName).length : 0;
+
+  return (
+    <>
+      {/* 2 — zip */}
+      <fieldset className="mt-4 rounded-md border p-3">
+        <legend className="px-1 text-sm font-medium">2 · Lackey zip</legend>
+        <FilePicker label="Choose zip…" accept=".zip,application/zip" disabled={disabled} onFile={onPickZip} />
+        {zipName && !zipError && rows && (
+          <p className="mt-2 text-xs text-muted-foreground">
+            {zipName} — {rows.length} cards across {zipSets.length} sets.
+          </p>
+        )}
+        {zipError && <p className="mt-2 text-xs text-destructive">{zipError}</p>}
+      </fieldset>
+
+      {/* 3 — filter */}
+      {rows && (
+        <fieldset className="mt-4 rounded-md border p-3">
+          <legend className="px-1 text-sm font-medium">3 · Which set?</legend>
+          <input value={filter} onChange={(e) => !disabled && setFilter(e.target.value)} disabled={disabled}
+            aria-label="Set filter" placeholder="Set code, e.g. EoT — or /regex/"
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm disabled:opacity-50" />
+          {invalidRegex && <p className="mt-1 text-xs text-destructive">Invalid regular expression.</p>}
+          <p className="mt-2 text-sm">
+            {matched.length === 1 ? "1 card matches" : `${matched.length} cards match`}
+            {matched.length > 0 && (
+              <span className="text-muted-foreground"> · {noImage} without an image</span>
+            )}
+          </p>
+        </fieldset>
+      )}
+    </>
+  );
+}

--- a/app/forge/import/SpreadsheetSourcePanel.tsx
+++ b/app/forge/import/SpreadsheetSourcePanel.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+// Source panel: a zip of card images + a .csv/.xlsx of card metadata. Both parse in
+// the browser (fflate — an xlsx is itself a zip of XML). Because column layouts vary
+// between designers' sheets, the mapping is auto-detected but reviewable: every card
+// field can be re-pointed at a different column, and cleaning results (skipped rows,
+// duplicates, values that won't import) are spelled out before anything uploads.
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { unzipSync } from "fflate";
+import {
+  parseCsv, parseXlsx, detectColumns, tableToCards, findLooseImageEntry, isImageEntry,
+  MAPPABLE_FIELDS, type ColumnMapping, type MappableField, type SheetTable,
+} from "@/app/forge/lib/spreadsheet";
+import FilePicker from "@/app/forge/components/FilePicker";
+import type { SourceSelection } from "./selection";
+
+const FIELD_LABELS: Record<MappableField, string> = {
+  name: "Name", image: "Image file", type: "Type", brigade: "Brigade",
+  strength: "Strength", toughness: "Toughness", class: "Class",
+  identifier: "Identifiers", specialAbility: "Special ability", rarity: "Rarity",
+  reference: "Reference", book: "Book", chapter: "Chapter", verse: "Verse",
+  alignment: "Alignment", legality: "Legality", artist: "Artist",
+};
+
+interface ImagesZip {
+  name: string;
+  entryNames: string[];
+  sizes: Record<string, number>;
+  imageCount: number;
+  oversized: number; // images skipped for exceeding the server's per-file cap
+}
+
+// Mirrors MAX_ART_BYTES in app/forge/lib/art.ts (server-only module — can't import here).
+// Bigger entries would fail server validation after a wasted multi-MB upload, so they
+// are excluded up front and surfaced as a count.
+const MAX_IMAGE_BYTES = 15 * 1024 * 1024;
+
+export default function SpreadsheetSourcePanel({
+  disabled,
+  onSelection,
+}: {
+  disabled: boolean;
+  onSelection: (s: SourceSelection | null) => void;
+}) {
+  const zipBytes = useRef<Uint8Array | null>(null);
+  const [zip, setZip] = useState<ImagesZip | null>(null);
+  const [zipError, setZipError] = useState<string | null>(null);
+  const [zipBusy, setZipBusy] = useState(false);
+  const [meta, setMeta] = useState<{ name: string; sheets: SheetTable[] } | null>(null);
+  const [metaError, setMetaError] = useState<string | null>(null);
+  const [metaBusy, setMetaBusy] = useState(false);
+  const [sheetIdx, setSheetIdx] = useState(0);
+  const [override, setOverride] = useState<ColumnMapping | null>(null);
+  // Bumped on every file pick so re-uploading a fixed file with the SAME name still
+  // yields a new selection key — otherwise a finished run's results would never reset.
+  const [pickNonce, setPickNonce] = useState(0);
+
+  async function onPickImagesZip(file: File) {
+    setZipError(null);
+    setZipBusy(true); // images zips run to hundreds of MB — reading takes visible seconds
+    try {
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      // Names + sizes only — nothing is decompressed until preview/upload.
+      const names: string[] = [];
+      const sizes: Record<string, number> = {};
+      let oversized = 0;
+      unzipSync(bytes, {
+        filter: (f) => {
+          if (f.name.endsWith("/")) return false;
+          if (isImageEntry(f.name) && f.originalSize > MAX_IMAGE_BYTES) { oversized++; return false; }
+          names.push(f.name);
+          sizes[f.name] = f.originalSize;
+          return false;
+        },
+      });
+      const imageCount = names.filter(isImageEntry).length;
+      if (imageCount === 0) {
+        setZipError("No images (.jpg/.png/.webp) found in this zip.");
+        zipBytes.current = null;
+        setZip(null);
+        return;
+      }
+      zipBytes.current = bytes;
+      setZip({ name: file.name, entryNames: names, sizes, imageCount, oversized });
+      setPickNonce((n) => n + 1);
+    } catch (e) {
+      zipBytes.current = null;
+      setZip(null);
+      setZipError(e instanceof Error ? e.message : "Could not read this zip file.");
+    } finally {
+      setZipBusy(false);
+    }
+  }
+
+  async function onPickMeta(file: File) {
+    setMetaError(null); setOverride(null);
+    setMetaBusy(true);
+    try {
+      let sheets: SheetTable[];
+      if (file.name.toLowerCase().endsWith(".csv")) {
+        sheets = [{ name: file.name.replace(/\.csv$/i, ""), rows: parseCsv(await file.text()) }];
+      } else {
+        sheets = parseXlsx(new Uint8Array(await file.arrayBuffer()));
+      }
+      const firstWithData = sheets.findIndex((s) => s.rows.length > 1);
+      if (firstWithData === -1) {
+        setMeta(null);
+        setMetaError("No data rows found — is the first row a header and the rest cards?");
+        return;
+      }
+      setMeta({ name: file.name, sheets });
+      setSheetIdx(firstWithData);
+      setPickNonce((n) => n + 1);
+    } catch (e) {
+      setMeta(null);
+      setMetaError(e instanceof Error ? e.message : "Could not read this file.");
+    } finally {
+      setMetaBusy(false);
+    }
+  }
+
+  const sheet = meta?.sheets[sheetIdx] ?? null;
+  const header = useMemo(() => sheet?.rows[0] ?? [], [sheet]);
+  const detected = useMemo(() => detectColumns(header), [header]);
+  const mapping = override ?? detected.mapping;
+  const table = useMemo(
+    () => (sheet ? tableToCards(sheet.rows, mapping) : null),
+    [sheet, mapping],
+  );
+
+  const selection = useMemo<SourceSelection | null>(() => {
+    if (!meta || !sheet || !table || table.cards.length === 0 || mapping.name === undefined) return null;
+    return {
+      cards: table.cards.map((c) => ({
+        name: c.name,
+        snapshot: c.snapshot,
+        entryName: zip ? findLooseImageEntry(c.imageFile, zip.entryNames) : null,
+        warnings: c.warnings,
+      })),
+      zipBytes: zipBytes.current,
+      sizes: zip?.sizes ?? {},
+      defaultSetName: sheet.name,
+      key: `sheet|${pickNonce}|${zip?.name ?? ""}|${meta.name}|${sheetIdx}|${JSON.stringify(mapping)}`,
+    };
+  }, [meta, sheet, table, mapping, zip, sheetIdx, pickNonce]);
+  useEffect(() => { onSelection(selection); }, [selection, onSelection]);
+
+  const withImage = selection ? selection.cards.filter((c) => c.entryName).length : 0;
+  const orphanImages = useMemo(() => {
+    if (!zip || !selection) return 0;
+    const used = new Set(selection.cards.map((c) => c.entryName));
+    return zip.entryNames.filter((n) => isImageEntry(n) && !used.has(n)).length;
+  }, [zip, selection]);
+  const warned = (table?.cards ?? []).filter((c) => c.warnings.length > 0);
+  const ignoredHeaders = detected.ignored.map((i) => header[i]).filter((h) => h?.trim());
+
+  // Mis-mapping tripwires — a wrong-but-complete auto-detection produces a plausible
+  // preview and a "successful" import, so make the suspicious cases loud instead.
+  const nameLooksWrong = useMemo(() => {
+    const names = (table?.cards ?? []).map((c) => c.name);
+    if (names.length < 3) return false;
+    const avg = names.reduce((s, n) => s + n.length, 0) / names.length;
+    const sentencey = names.filter((n) => n.length > 60 || /\. /.test(n)).length;
+    return avg > 40 || sentencey / names.length > 0.2;
+  }, [table]);
+  const doubledColumns = useMemo(() => {
+    const byCol = new Map<number, string[]>();
+    for (const f of MAPPABLE_FIELDS) {
+      const idx = mapping[f];
+      if (idx !== undefined) byCol.set(idx, [...(byCol.get(idx) ?? []), FIELD_LABELS[f]]);
+    }
+    return [...byCol.values()].filter((fields) => fields.length > 1);
+  }, [mapping]);
+  const mappingSuspicious = mapping.name === undefined || nameLooksWrong || doubledColumns.length > 0;
+
+  function remap(field: MappableField, value: string) {
+    const next: ColumnMapping = { ...mapping };
+    if (value === "") delete next[field];
+    else next[field] = Number(value);
+    setOverride(next);
+  }
+
+  return (
+    <>
+      {/* 2 — files */}
+      <fieldset className="mt-4 rounded-md border p-3">
+        <legend className="px-1 text-sm font-medium">2 · Files</legend>
+        <div className="space-y-3">
+          <div>
+            <FilePicker label="Choose spreadsheet…" accept=".csv,.xlsx" disabled={disabled || metaBusy} onFile={onPickMeta}
+              hint="Card text as .csv or .xlsx — first row must be the column headers." />
+            {metaBusy && <p className="mt-1 text-xs text-muted-foreground">Reading spreadsheet…</p>}
+            {meta && !metaError && (
+              <p className="mt-1 text-xs text-muted-foreground">
+                {meta.name}
+                {meta.sheets.length > 1 && ` — ${meta.sheets.length} sheets`}
+              </p>
+            )}
+            {metaError && <p className="mt-1 text-xs text-destructive">{metaError}</p>}
+          </div>
+          <div>
+            <FilePicker label="Choose images zip…" accept=".zip,application/zip" disabled={disabled || zipBusy} onFile={onPickImagesZip}
+              hint="Optional — a zip of finished card images, named like the sheet's Image column." />
+            {zipBusy && <p className="mt-1 text-xs text-muted-foreground">Reading zip…</p>}
+            {zip && !zipError && (
+              <p className="mt-1 text-xs text-muted-foreground">
+                {zip.name} — {zip.imageCount} images.
+                {zip.oversized > 0 && ` ${zip.oversized} ignored (over 15MB).`}
+              </p>
+            )}
+            {zipError && <p className="mt-1 text-xs text-destructive">{zipError}</p>}
+          </div>
+        </div>
+      </fieldset>
+
+      {/* 3 — columns + cleaning */}
+      {meta && sheet && (
+        <fieldset className="mt-4 rounded-md border p-3">
+          <legend className="px-1 text-sm font-medium">3 · Columns &amp; cleaning</legend>
+
+          {meta.sheets.length > 1 && (
+            <label className="mb-3 flex items-center gap-2 text-sm">
+              Sheet
+              <select value={sheetIdx} disabled={disabled}
+                onChange={(e) => { setSheetIdx(Number(e.target.value)); setOverride(null); }}
+                aria-label="Sheet" className="rounded-md border bg-background px-2 py-1 text-sm">
+                {meta.sheets.map((s, i) => (
+                  <option key={i} value={i}>{s.name} ({Math.max(0, s.rows.length - 1)} rows)</option>
+                ))}
+              </select>
+            </label>
+          )}
+
+          {mapping.name === undefined && (
+            <p className="mb-2 text-sm text-destructive">
+              No “Name” column found — pick which column holds the card name below.
+            </p>
+          )}
+          {nameLooksWrong && (
+            <p className="mb-2 text-xs text-amber-600 dark:text-amber-500">
+              The card names look like sentence text — the Name column may be mapped to the
+              wrong column. Check the mapping below.
+            </p>
+          )}
+          {doubledColumns.map((fields) => (
+            <p key={fields.join()} className="mb-2 text-xs text-amber-600 dark:text-amber-500">
+              {fields.join(" and ")} are reading the same column.
+            </p>
+          ))}
+          {ignoredHeaders.length > 0 && (
+            <p className="mb-2 text-xs text-muted-foreground">
+              Not imported: {ignoredHeaders.map((h) => `“${h}”`).join(", ")} — adjust the mapping below if one of these should be.
+            </p>
+          )}
+
+          <details open={mappingSuspicious}>
+            <summary className="cursor-pointer select-none text-xs text-muted-foreground hover:text-foreground">
+              Column mapping {override ? "(edited)" : "(auto-detected)"}
+              {mapping.name !== undefined && (
+                <> — Name ← “{(header[mapping.name] ?? "").trim()}”
+                {mapping.image !== undefined && <>, Image ← “{(header[mapping.image] ?? "").trim()}”</>}</>
+              )}
+            </summary>
+            <div className="mt-2 grid grid-cols-2 gap-x-4 gap-y-2 sm:grid-cols-3">
+              {MAPPABLE_FIELDS.map((f) => (
+                <label key={f} className="text-xs">
+                  <span className="mb-0.5 block text-muted-foreground">
+                    {FIELD_LABELS[f]}{f === "name" && " (required)"}
+                  </span>
+                  <select value={mapping[f] ?? ""} disabled={disabled} onChange={(e) => remap(f, e.target.value)}
+                    aria-label={`Column for ${FIELD_LABELS[f]}`}
+                    className="w-full rounded-md border bg-background px-1.5 py-1 text-xs">
+                    <option value="">—</option>
+                    {header.map((h, i) => (h.trim() ? <option key={i} value={i}>{h.trim()}</option> : null))}
+                  </select>
+                </label>
+              ))}
+            </div>
+            {override && (
+              <button type="button" className="mt-2 text-xs text-muted-foreground underline hover:text-foreground"
+                onClick={() => setOverride(null)} disabled={disabled}>
+                Reset to auto-detected
+              </button>
+            )}
+          </details>
+
+          {table && mapping.name !== undefined && (
+            <div className="mt-3 space-y-1 text-sm">
+              <p>
+                {table.cards.length === 1 ? "1 card" : `${table.cards.length} cards`}
+                {zip
+                  ? <span className="text-muted-foreground"> · {table.cards.length - withImage} without an image</span>
+                  : <span className="text-muted-foreground"> · no images zip — cards import as text only</span>}
+                {table.skipped > 0 && <span className="text-muted-foreground"> · {table.skipped} rows skipped (no name)</span>}
+                {orphanImages > 0 && <span className="text-muted-foreground"> · {orphanImages} zip images match no row</span>}
+              </p>
+              {table.duplicates.length > 0 && (
+                <p className="text-xs text-amber-600 dark:text-amber-500">
+                  {table.duplicates.length} duplicate {table.duplicates.length === 1 ? "name" : "names"} ignored
+                  (first row wins): {[...new Set(table.duplicates)].slice(0, 5).join(", ")}
+                  {table.duplicates.length > 5 && "…"}
+                </p>
+              )}
+              {warned.length > 0 && (
+                <details className="text-xs">
+                  <summary className="cursor-pointer text-amber-600 dark:text-amber-500">
+                    {warned.length} {warned.length === 1 ? "card has" : "cards have"} values that won’t import as structured fields
+                  </summary>
+                  <ul className="mt-1 max-h-40 space-y-0.5 overflow-y-auto text-muted-foreground">
+                    {warned.map((c) => (
+                      <li key={c.rowIndex}>Row {c.rowIndex} · {c.name}: {c.warnings.join("; ")}</li>
+                    ))}
+                  </ul>
+                  <p className="mt-1 text-muted-foreground">
+                    These cards still import — their ability text and image are kept; only the flagged
+                    fields are left blank to fix in the studio.
+                  </p>
+                </details>
+              )}
+            </div>
+          )}
+        </fieldset>
+      )}
+    </>
+  );
+}

--- a/app/forge/import/SpreadsheetSourcePanel.tsx
+++ b/app/forge/import/SpreadsheetSourcePanel.tsx
@@ -10,6 +10,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { unzipSync } from "fflate";
 import {
   parseCsv, parseXlsx, detectColumns, tableToCards, findLooseImageEntry, isImageEntry,
+  imageFileStem, imageEntryStem,
   MAPPABLE_FIELDS, type ColumnMapping, type MappableField, type SheetTable,
 } from "@/app/forge/lib/spreadsheet";
 import FilePicker from "@/app/forge/components/FilePicker";
@@ -55,9 +56,12 @@ export default function SpreadsheetSourcePanel({
   // Bumped on every file pick so re-uploading a fixed file with the SAME name still
   // yields a new selection key — otherwise a finished run's results would never reset.
   const [pickNonce, setPickNonce] = useState(0);
+  // Set when the zip↔sheet affinity check switches sheets on the user's behalf.
+  const [autoNote, setAutoNote] = useState<string | null>(null);
 
   async function onPickImagesZip(file: File) {
     setZipError(null);
+    setAutoNote(null);
     setZipBusy(true); // images zips run to hundreds of MB — reading takes visible seconds
     try {
       const bytes = new Uint8Array(await file.arrayBuffer());
@@ -94,7 +98,7 @@ export default function SpreadsheetSourcePanel({
   }
 
   async function onPickMeta(file: File) {
-    setMetaError(null); setOverride(null);
+    setMetaError(null); setOverride(null); setAutoNote(null);
     setMetaBusy(true);
     try {
       let sheets: SheetTable[];
@@ -128,6 +132,44 @@ export default function SpreadsheetSourcePanel({
     () => (sheet ? tableToCards(sheet.rows, mapping) : null),
     [sheet, mapping],
   );
+
+  // zip ↔ sheet affinity: how many of each sheet's Image values exist in the zip.
+  // A multi-set workbook + a one-set images zip is the normal case (EoT + Roots 2),
+  // and the wrong sheet renders an all-"No image" preview that reads as broken.
+  const sheetMatchCounts = useMemo(() => {
+    if (!meta || !zip) return null;
+    const stems = new Set(zip.entryNames.map(imageEntryStem).filter(Boolean) as string[]);
+    return meta.sheets.map((s) => {
+      const imgIdx = detectColumns(s.rows[0] ?? []).mapping.image;
+      if (imgIdx === undefined) return 0;
+      let count = 0;
+      for (let i = 1; i < s.rows.length; i++) {
+        const stem = imageFileStem(s.rows[i]?.[imgIdx] ?? "");
+        if (stem && stems.has(stem)) count++;
+      }
+      return count;
+    });
+  }, [meta, zip]);
+  const bestSheetIdx = useMemo(() => {
+    if (!sheetMatchCounts) return -1;
+    return sheetMatchCounts.reduce((best, c, i) => (c > (sheetMatchCounts[best] ?? 0) ? i : best), 0);
+  }, [sheetMatchCounts]);
+
+  // When a freshly-picked file pairing leaves the CURRENT sheet with zero image
+  // matches but another sheet matches, switch to it once and say so.
+  const affinityHandled = useRef<{ zip: ImagesZip | null; meta: unknown } | null>(null);
+  useEffect(() => {
+    if (!zip || !meta || !sheetMatchCounts) return;
+    const h = affinityHandled.current;
+    if (h && h.zip === zip && h.meta === meta) return;
+    affinityHandled.current = { zip, meta };
+    if ((sheetMatchCounts[sheetIdx] ?? 0) > 0) return;
+    if (bestSheetIdx !== sheetIdx && (sheetMatchCounts[bestSheetIdx] ?? 0) > 0) {
+      setSheetIdx(bestSheetIdx);
+      setOverride(null);
+      setAutoNote(`Switched to the “${meta.sheets[bestSheetIdx].name}” sheet — its Image column matches this zip.`);
+    }
+  }, [zip, meta, sheetMatchCounts, sheetIdx, bestSheetIdx]);
 
   const selection = useMemo<SourceSelection | null>(() => {
     if (!meta || !sheet || !table || table.cards.length === 0 || mapping.name === undefined) return null;
@@ -223,13 +265,21 @@ export default function SpreadsheetSourcePanel({
             <label className="mb-3 flex items-center gap-2 text-sm">
               Sheet
               <select value={sheetIdx} disabled={disabled}
-                onChange={(e) => { setSheetIdx(Number(e.target.value)); setOverride(null); }}
+                onChange={(e) => { setSheetIdx(Number(e.target.value)); setOverride(null); setAutoNote(null); }}
                 aria-label="Sheet" className="rounded-md border bg-background px-2 py-1 text-sm">
                 {meta.sheets.map((s, i) => (
                   <option key={i} value={i}>{s.name} ({Math.max(0, s.rows.length - 1)} rows)</option>
                 ))}
               </select>
             </label>
+          )}
+          {autoNote && <p className="mb-2 text-xs text-muted-foreground">{autoNote}</p>}
+          {sheetMatchCounts && meta.sheets.length > 1 && bestSheetIdx !== sheetIdx
+            && (sheetMatchCounts[sheetIdx] ?? 0) === 0 && (sheetMatchCounts[bestSheetIdx] ?? 0) > 0 && (
+            <p className="mb-2 text-xs text-amber-600 dark:text-amber-500">
+              None of the zip’s images match this sheet — they match the
+              “{meta.sheets[bestSheetIdx].name}” sheet ({sheetMatchCounts[bestSheetIdx]} cards).
+            </p>
           )}
 
           {mapping.name === undefined && (

--- a/app/forge/import/selection.ts
+++ b/app/forge/import/selection.ts
@@ -1,0 +1,18 @@
+import type { DesignCard } from "@/app/forge/lib/designCard";
+
+export interface SelectedCard {
+  name: string;
+  snapshot: DesignCard;
+  entryName: string | null; // image entry in the source zip, if matched
+  warnings: string[];       // data-quality notes surfaced in the preview
+}
+
+// What a source panel hands the shared wizard: the cards to import plus the zip
+// bytes/sizes needed to preview and upload their images.
+export interface SourceSelection {
+  cards: SelectedCard[];
+  zipBytes: Uint8Array | null;   // null → no images, cards import text-only
+  sizes: Record<string, number>; // uncompressed bytes per zip entry (batch sizing)
+  defaultSetName: string;        // prefill for the "new set" dialog ("" = leave as-is)
+  key: string;                   // identity — a change resets any run in the wizard
+}

--- a/app/forge/import/useImportRunner.ts
+++ b/app/forge/import/useImportRunner.ts
@@ -1,0 +1,205 @@
+"use client";
+
+// Shared batch-upload machinery for both import sources (Lackey zip, images zip +
+// spreadsheet). Cards are POSTed to /forge/api/import in size-capped batches with a
+// small concurrency pool; per-card statuses stream back into React state. Images are
+// decompressed from the source zip PER BATCH (not all upfront) — a 200MB+ images zip
+// would otherwise double in memory before the first request leaves.
+
+import { useMemo, useRef, useState } from "react";
+import { unzipSync } from "fflate";
+import type { DesignCard } from "@/app/forge/lib/designCard";
+
+const BATCH_SIZE = 8;            // cards per request (must stay ≤ the route's cap of 12)
+const BATCH_CONCURRENCY = 4;     // requests in flight
+const MAX_BATCH_BYTES = 3_500_000; // keep each request under Vercel's ~4.5MB body cap
+
+export type CardStatus = "queued" | "importing" | "imported" | "updated" | "skipped" | "failed";
+
+export interface RunCard {
+  name: string;
+  snapshot: DesignCard;
+  entryName: string | null; // zip entry for the finished-card image, if present
+  status: CardStatus;
+  error?: string;
+}
+
+export function mimeFor(entryName: string): string {
+  const lower = entryName.toLowerCase();
+  if (lower.endsWith(".png")) return "image/png";
+  if (lower.endsWith(".webp")) return "image/webp";
+  return "image/jpeg";
+}
+
+function baseName(entryName: string): string {
+  return entryName.split("/").pop() ?? entryName;
+}
+
+interface BatchCardResult { name: string; ok: boolean; cardId?: string; skipped?: boolean; updated?: boolean; error?: string }
+
+// Greedy chunking: ≤ BATCH_SIZE cards and ≤ MAX_BATCH_BYTES of (uncompressed) image
+// data per request. An image bigger than the cap still gets its own single-card batch.
+export function chunkIntoBatches(
+  indexes: number[],
+  work: { entryName: string | null }[],
+  sizes: Record<string, number>,
+): number[][] {
+  const batches: number[][] = [];
+  let current: number[] = [];
+  let currentBytes = 0;
+  for (const idx of indexes) {
+    const entry = work[idx].entryName;
+    const size = entry ? (sizes[entry] ?? 0) : 0;
+    if (current.length > 0 && (current.length >= BATCH_SIZE || currentBytes + size > MAX_BATCH_BYTES)) {
+      batches.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+    current.push(idx);
+    currentBytes += size;
+  }
+  if (current.length) batches.push(current);
+  return batches;
+}
+
+export function useImportRunner() {
+  const [items, setItems] = useState<RunCard[] | null>(null);
+  const [running, setRunning] = useState(false);
+  const [doneSetId, setDoneSetId] = useState<string | null>(null);
+  // Retry re-uses the last run's inputs without threading them back through the wizard.
+  const lastZip = useRef<Uint8Array | null>(null);
+  const lastSizes = useRef<Record<string, number>>({});
+  const lastOverwrite = useRef(false);
+
+  // POST one batch; write each card's result (or the batch-level error) into `work`.
+  async function importBatch(
+    setId: string,
+    batch: number[],
+    work: RunCard[],
+    zipBytes: Uint8Array | null,
+    overwrite: boolean,
+  ) {
+    const wanted = new Set(batch.map((i) => work[i].entryName).filter(Boolean) as string[]);
+    const images = zipBytes && wanted.size > 0
+      ? unzipSync(zipBytes, { filter: (f) => wanted.has(f.name) })
+      : {};
+
+    const fd = new FormData();
+    const cards = batch.map((idx, j) => {
+      const it = work[idx];
+      let fileField: string | undefined;
+      if (it.entryName && images[it.entryName]) {
+        fileField = `file-${j}`;
+        fd.set(fileField, new File([images[it.entryName].slice()], baseName(it.entryName), { type: mimeFor(it.entryName) }));
+      }
+      return { name: it.name, snapshot: it.snapshot, fileField };
+    });
+    fd.set("payload", JSON.stringify({ setId, cards, overwrite }));
+
+    const res = await fetch("/forge/api/import", { method: "POST", body: fd });
+    if (!res.ok) {
+      let message = `Import failed (${res.status})`;
+      try {
+        const body = await res.json();
+        if (body?.error) message = body.error;
+      } catch { /* non-JSON error body */ }
+      for (const idx of batch) { work[idx].status = "failed"; work[idx].error = message; }
+      return;
+    }
+    const body = (await res.json()) as { results?: BatchCardResult[] };
+    batch.forEach((idx, j) => {
+      const r = body.results?.[j];
+      if (!r || r.ok === false) {
+        work[idx].status = "failed";
+        work[idx].error = r?.error ?? "Unexpected error";
+      } else {
+        work[idx].status = r.skipped ? "skipped" : r.updated ? "updated" : "imported";
+      }
+    });
+  }
+
+  // Chunk the given items into batches and run them BATCH_CONCURRENCY at a time.
+  async function runBatches(setId: string, indexes: number[], work: RunCard[]) {
+    const batches = chunkIntoBatches(indexes, work, lastSizes.current);
+    let cursor = 0;
+    const runOne = async () => {
+      for (;;) {
+        const b = cursor++;
+        if (b >= batches.length) return;
+        for (const idx of batches[b]) work[idx].status = "importing";
+        setItems([...work]);
+        try {
+          await importBatch(setId, batches[b], work, lastZip.current, lastOverwrite.current);
+        } catch (e) {
+          const message = e instanceof Error ? e.message : "Unexpected error";
+          for (const idx of batches[b]) {
+            if (work[idx].status === "importing") { work[idx].status = "failed"; work[idx].error = message; }
+          }
+        }
+        setItems([...work]);
+      }
+    };
+    await Promise.all(Array.from({ length: BATCH_CONCURRENCY }, runOne));
+  }
+
+  async function run(
+    setId: string,
+    work: RunCard[],
+    zipBytes: Uint8Array | null,
+    sizes: Record<string, number>,
+    overwrite: boolean,
+  ) {
+    if (running) return;
+    setRunning(true);
+    try {
+      lastZip.current = zipBytes;
+      lastSizes.current = sizes;
+      lastOverwrite.current = overwrite;
+      setItems([...work]);
+      await runBatches(setId, work.map((_, i) => i), work);
+      setDoneSetId(setId);
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  async function retryFailed() {
+    const prior = items;
+    const setId = doneSetId;
+    if (!prior || !setId || running) return;
+    setRunning(true);
+    try {
+      const work = prior.map((it) =>
+        it.status === "failed" ? { ...it, error: undefined } : it,
+      );
+      const failedIndexes = work
+        .map((it, i) => (it.status === "failed" ? i : -1))
+        .filter((i) => i >= 0);
+      setItems([...work]);
+      await runBatches(setId, failedIndexes, work);
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  function reset() {
+    setItems(null);
+    setDoneSetId(null);
+  }
+
+  const counts = useMemo(() => {
+    const c = { imported: 0, updated: 0, skipped: 0, failed: 0 };
+    for (const it of items ?? []) {
+      if (it.status === "imported") c.imported++;
+      else if (it.status === "updated") c.updated++;
+      else if (it.status === "skipped") c.skipped++;
+      else if (it.status === "failed") c.failed++;
+    }
+    return c;
+  }, [items]);
+
+  const finished = !!items && !running && items.every((it) =>
+    it.status === "imported" || it.status === "updated" || it.status === "skipped" || it.status === "failed");
+
+  return { items, running, doneSetId, counts, finished, run, retryFailed, reset };
+}

--- a/app/forge/lib/__tests__/lackeyExport.test.ts
+++ b/app/forge/lib/__tests__/lackeyExport.test.ts
@@ -75,6 +75,14 @@ describe("designCardToLackeyRow → serialize → parseCarddata round-trip", () 
     expect(back.strength).toBeUndefined();
     expect(back.toughness).toBeUndefined();
   });
+
+  it('round-trips variable "X" stats', () => {
+    const back = roundTrip({
+      cardType: ["Hero"], brigades: ["Green"], strength: "X", toughness: "X",
+    }, "The Faithful Followers");
+    expect(back.strength).toBe("X");
+    expect(back.toughness).toBe("X");
+  });
 });
 
 describe("tsv safety", () => {

--- a/app/forge/lib/__tests__/lackeyExport.test.ts
+++ b/app/forge/lib/__tests__/lackeyExport.test.ts
@@ -83,6 +83,15 @@ describe("designCardToLackeyRow → serialize → parseCarddata round-trip", () 
     expect(back.strength).toBe("X");
     expect(back.toughness).toBe("X");
   });
+
+  it('round-trips paired dual-side stats ("6 (0)")', () => {
+    const back = roundTrip({
+      cardType: ["GE", "EE"], strength: "6 (0)", toughness: "0 (6)", alignment: "Good_Evil",
+    }, "Spiritual Warfare");
+    expect(back.cardType).toEqual(["GE", "EE"]);
+    expect(back.strength).toBe("6 (0)");
+    expect(back.toughness).toBe("0 (6)");
+  });
 });
 
 describe("tsv safety", () => {

--- a/app/forge/lib/__tests__/spreadsheet.test.ts
+++ b/app/forge/lib/__tests__/spreadsheet.test.ts
@@ -278,6 +278,17 @@ describe("tableToCards", () => {
     expect(dashes.cards[0].warnings).toEqual([]);
   });
 
+  it('accepts "X" as a valid variable strength/toughness (The Faithful Followers)', () => {
+    const header = ["Name", "Type", "Strength", "Toughness"];
+    const { mapping } = detectColumns(header);
+    const { cards } = tableToCards(
+      [header, ["The Faithful Followers", "Hero", "X", "x"]], mapping,
+    );
+    expect(cards[0].warnings).toEqual([]);
+    expect(cards[0].snapshot.strength).toBe("X");
+    expect(cards[0].snapshot.toughness).toBe("X");
+  });
+
   it("skips rows without a name and dedupes repeated names (first wins)", () => {
     const header = ["Name", "Type"];
     const { mapping } = detectColumns(header);
@@ -354,6 +365,10 @@ describe("auditLackeyRow", () => {
     const warnings = auditLackeyRow({ ...base, class: "Warrior/Wizard" });
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toMatch(/Wizard/);
+  });
+
+  it('is silent on "X" stats', () => {
+    expect(auditLackeyRow({ ...base, strength: "X", toughness: "x" })).toEqual([]);
   });
 });
 

--- a/app/forge/lib/__tests__/spreadsheet.test.ts
+++ b/app/forge/lib/__tests__/spreadsheet.test.ts
@@ -289,6 +289,22 @@ describe("tableToCards", () => {
     expect(cards[0].snapshot.alignment).toBe("Good_Evil");
   });
 
+  it('accepts paired dual-side stats like "6 (0)", normalized to "N (M)"', () => {
+    const header = ["Name", "Type", "Strength", "Toughness"];
+    const { mapping } = detectColumns(header);
+    const { cards } = tableToCards([
+      header,
+      ["Spiritual Warfare [RR2]", "Dual-Alignment Enhancement", "6 (0)", "0 (6)"],
+      ["Philosophy [RR2]", "Dual-Alignment Enhancement", "3(2)", "2(3)"],
+    ], mapping);
+    expect(cards[0].warnings).toEqual([]);
+    expect(cards[0].snapshot.strength).toBe("6 (0)");
+    expect(cards[0].snapshot.toughness).toBe("0 (6)");
+    expect(cards[1].warnings).toEqual([]);
+    expect(cards[1].snapshot.strength).toBe("3 (2)"); // tight spelling normalizes
+    expect(cards[1].snapshot.toughness).toBe("2 (3)");
+  });
+
   it('accepts "X" as a valid variable strength/toughness (The Faithful Followers)', () => {
     const header = ["Name", "Type", "Strength", "Toughness"];
     const { mapping } = detectColumns(header);
@@ -378,8 +394,10 @@ describe("auditLackeyRow", () => {
     expect(warnings[0]).toMatch(/Wizard/);
   });
 
-  it('is silent on "X" stats', () => {
+  it('is silent on "X" and paired stats, but still flags junk', () => {
     expect(auditLackeyRow({ ...base, strength: "X", toughness: "x" })).toEqual([]);
+    expect(auditLackeyRow({ ...base, strength: "6 (0)", toughness: "X (6)" })).toEqual([]);
+    expect(auditLackeyRow({ ...base, strength: "6 (a)" })).toHaveLength(1);
   });
 });
 

--- a/app/forge/lib/__tests__/spreadsheet.test.ts
+++ b/app/forge/lib/__tests__/spreadsheet.test.ts
@@ -1,0 +1,392 @@
+import { describe, it, expect } from "vitest";
+import { zipSync, strToU8 } from "fflate";
+import {
+  parseCsv, parseXlsx, detectColumns, tableToCards, findLooseImageEntry,
+  type ColumnMapping,
+} from "@/app/forge/lib/spreadsheet";
+import { auditLackeyRow, type LackeyRow } from "@/app/forge/lib/lackey";
+
+// ---------------------------------------------------------------------------
+// parseCsv
+// ---------------------------------------------------------------------------
+
+describe("parseCsv", () => {
+  it("parses quoted fields with commas, escaped quotes, and newlines", () => {
+    const text =
+      'Name,Special Ability\n' +
+      '"King\'s Sword","If an Evil Character is blocking, you may add up to 3 angels to battle."\n' +
+      'Plain,"He said ""go"" and\nleft."\n';
+    const rows = parseCsv(text);
+    expect(rows).toHaveLength(3);
+    expect(rows[1]).toEqual([
+      "King's Sword",
+      "If an Evil Character is blocking, you may add up to 3 angels to battle.",
+    ]);
+    expect(rows[2]).toEqual(["Plain", 'He said "go" and\nleft.']);
+  });
+
+  it("handles CRLF, a UTF-8 BOM, and drops fully-empty trailing rows", () => {
+    const rows = parseCsv("﻿a,b\r\n1,2\r\n,\r\n\r\n");
+    expect(rows[0]).toEqual(["a", "b"]);
+    expect(rows[1]).toEqual(["1", "2"]);
+    // the ",\r\n" row is empty cells but still a row; the final blank line is not
+    expect(rows).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseXlsx — fixture built exactly like Google Sheets/Excel structure the parts
+// ---------------------------------------------------------------------------
+
+const WORKBOOK_XML =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+  '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" ' +
+  'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">' +
+  '<sheets>' +
+  '<sheet state="visible" name="End of Times" sheetId="1" r:id="rId5"/>' +
+  '<sheet state="visible" name="Roots 2" sheetId="2" r:id="rId6"/>' +
+  "</sheets></workbook>";
+
+const RELS_XML =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+  '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+  '<Relationship Id="rId3" Type="http://x/sharedStrings" Target="sharedStrings.xml"/>' +
+  '<Relationship Id="rId5" Type="http://x/worksheet" Target="worksheets/sheet1.xml"/>' +
+  '<Relationship Id="rId6" Type="http://x/worksheet" Target="worksheets/sheet2.xml"/>' +
+  "</Relationships>";
+
+// Index:            0        1              2 (rich-text runs)        3
+const SST_XML =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+  '<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="4" uniqueCount="4">' +
+  "<si><t>Name</t></si>" +
+  "<si><t>Alpha &amp; Omega</t></si>" +
+  "<si><r><t>Two</t></r><r><t xml:space=\"preserve\"> Runs</t></r></si>" +
+  "<si><t>Strength</t></si>" +
+  "</sst>";
+
+// Row 1: A=Name(s), B=Strength(s) — header. Row 2: shared string + number.
+// Row 3: sparse (only C has an inline string); B is a self-closing empty cell.
+const SHEET1_XML =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+  '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>' +
+  '<row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>3</v></c></row>' +
+  '<row r="2"><c r="A2" t="s"><v>1</v></c><c r="B2"><v>9.0</v></c></row>' +
+  '<row r="3"><c r="B3"/><c r="C3" t="inlineStr"><is><t>inline &lt;x&gt;</t></is></c></row>' +
+  "</sheetData></worksheet>";
+
+const SHEET2_XML =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+  '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>' +
+  '<row r="1"><c r="A1" t="s"><v>2</v></c><c r="B1" t="str"><v>formula result</v></c></row>' +
+  "</sheetData></worksheet>";
+
+function buildXlsx(): Uint8Array {
+  return zipSync({
+    "xl/workbook.xml": strToU8(WORKBOOK_XML),
+    "xl/_rels/workbook.xml.rels": strToU8(RELS_XML),
+    "xl/sharedStrings.xml": strToU8(SST_XML),
+    "xl/worksheets/sheet1.xml": strToU8(SHEET1_XML),
+    "xl/worksheets/sheet2.xml": strToU8(SHEET2_XML),
+  }, { level: 0 });
+}
+
+describe("parseXlsx", () => {
+  it("returns sheets in workbook order with their names", () => {
+    const sheets = parseXlsx(buildXlsx());
+    expect(sheets.map((s) => s.name)).toEqual(["End of Times", "Roots 2"]);
+  });
+
+  it("reads shared strings, numbers, inline strings, and leaves gaps empty", () => {
+    const [s1] = parseXlsx(buildXlsx());
+    expect(s1.rows[0]).toEqual(["Name", "Strength"]);
+    expect(s1.rows[1]).toEqual(["Alpha & Omega", "9.0"]);
+    // sparse row: A missing → "", B empty cell → "", C inline string (entities unescaped)
+    expect(s1.rows[2]).toEqual(["", "", "inline <x>"]);
+  });
+
+  it("joins rich-text runs and reads formula string results", () => {
+    const [, s2] = parseXlsx(buildXlsx());
+    expect(s2.rows[0]).toEqual(["Two Runs", "formula result"]);
+  });
+
+  it("throws a clear error on a zip that is not an xlsx", () => {
+    const notXlsx = zipSync({ "readme.txt": strToU8("hi") }, { level: 0 });
+    expect(() => parseXlsx(notXlsx)).toThrow(/xlsx/i);
+  });
+
+  it("throws a clear error on bytes that are not a zip at all", () => {
+    expect(() => parseXlsx(strToU8("definitely,a,csv"))).toThrow(/xlsx/i);
+  });
+
+  it("keeps row positions across self-closing <row/> elements (Excel styled-empty rows)", () => {
+    const sheet =
+      '<?xml version="1.0"?><worksheet><sheetData>' +
+      '<row r="1"><c r="A1" t="inlineStr"><is><t>Name</t></is></c></row>' +
+      '<row r="2" ht="24" customHeight="1"/>' +
+      '<row r="3"><c r="A3" t="inlineStr"><is><t>RowThree</t></is></c></row>' +
+      "</sheetData></worksheet>";
+    const xlsx = zipSync({
+      "xl/workbook.xml": strToU8('<workbook><sheets><sheet name="S" r:id="rId1"/></sheets></workbook>'),
+      "xl/_rels/workbook.xml.rels": strToU8('<Relationships><Relationship Id="rId1" Target="worksheets/sheet1.xml"/></Relationships>'),
+      "xl/worksheets/sheet1.xml": strToU8(sheet),
+    }, { level: 0 });
+    const [s] = parseXlsx(xlsx);
+    expect(s.rows).toEqual([["Name"], [], ["RowThree"]]);
+  });
+
+  it("reads single-quoted XML attributes (legal OOXML, uncommon writers)", () => {
+    const xlsx = zipSync({
+      "xl/workbook.xml": strToU8("<workbook><sheets><sheet name='Solo' r:id='rId1'/></sheets></workbook>"),
+      "xl/_rels/workbook.xml.rels": strToU8("<Relationships><Relationship Id='rId1' Target='worksheets/sheet1.xml'/></Relationships>"),
+      "xl/worksheets/sheet1.xml": strToU8('<worksheet><sheetData><row r="1"><c r="A1"><v>7</v></c></row></sheetData></worksheet>'),
+    }, { level: 0 });
+    const sheets = parseXlsx(xlsx);
+    expect(sheets[0].name).toBe("Solo");
+    expect(sheets[0].rows).toEqual([["7"]]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectColumns — both real-world header conventions
+// ---------------------------------------------------------------------------
+
+describe("detectColumns", () => {
+  it("maps Lackey-style headers with trailing colons (End of Times sheet)", () => {
+    const { mapping, ignored } = detectColumns([
+      "#:", "Name:", "Set:", "Image:", "Official Set:", "Type:", "Brigade:",
+      "Strength:", "Toughness:", "Class:", "Identifier:", "Special Ability:",
+      "Rarity:", "Reference:", "Sound:", "Alignment:", "Legality:",
+    ]);
+    expect(mapping.name).toBe(1);
+    expect(mapping.image).toBe(3);
+    expect(mapping.type).toBe(5);
+    expect(mapping.brigade).toBe(6);
+    expect(mapping.strength).toBe(7);
+    expect(mapping.toughness).toBe(8);
+    expect(mapping.class).toBe(9);
+    expect(mapping.identifier).toBe(10);
+    expect(mapping.specialAbility).toBe(11);
+    expect(mapping.rarity).toBe(12);
+    expect(mapping.reference).toBe(13);
+    expect(mapping.alignment).toBe(15);
+    expect(mapping.legality).toBe(16);
+    expect(mapping.book).toBeUndefined();
+    // "#:", "Set:", "Official Set:", "Sound:" are recognized-but-unused → not ignored noise
+    expect(ignored).toEqual([]);
+  });
+
+  it("maps split Book/Chapter/Verse + Artist headers (Roots 2 sheet)", () => {
+    const { mapping, ignored } = detectColumns([
+      "Name", "#", "Set", "Type", "Brigade", "Strength", "Toughness", "Class",
+      "Identifier", "Special Ability", "Rarity", "Book", "Chapter", "Verse",
+      "Alignment", "Legality", "Artist", "Image",
+    ]);
+    expect(mapping.name).toBe(0);
+    expect(mapping.book).toBe(11);
+    expect(mapping.chapter).toBe(12);
+    expect(mapping.verse).toBe(13);
+    expect(mapping.artist).toBe(16);
+    expect(mapping.image).toBe(17);
+    expect(mapping.reference).toBeUndefined();
+    expect(ignored).toEqual([]);
+  });
+
+  it("reports unrecognized headers as ignored column indexes", () => {
+    const { mapping, ignored } = detectColumns(["Name", "Flavor Text", ""]);
+    expect(mapping.name).toBe(0);
+    expect(ignored).toEqual([1]); // empty headers are not reported
+  });
+
+  it("keeps the first column when two headers normalize identically", () => {
+    const { mapping } = detectColumns(["Name", "name:"]);
+    expect(mapping.name).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tableToCards — cleaning, reference synthesis, warnings, dedupe
+// ---------------------------------------------------------------------------
+
+const R2_HEADER = [
+  "Name", "#", "Set", "Type", "Brigade", "Strength", "Toughness", "Class",
+  "Identifier", "Special Ability", "Rarity", "Book", "Chapter", "Verse",
+  "Alignment", "Legality", "Artist", "Image",
+];
+
+function r2Mapping(): ColumnMapping {
+  return detectColumns(R2_HEADER).mapping;
+}
+
+describe("tableToCards", () => {
+  it("builds a DesignCard from a real Roots 2 style row", () => {
+    const rows = [
+      R2_HEADER,
+      ["King's Sword [RR2]", "225", "Redemption Roots 2", "Dominant", "-", "-", "-", "-", "-",
+        "If an Evil Character is blocking, you may add up to 3 angels to battle.",
+        "-", "Revelation", "19", "15", "Good", "Rotation", "Doug Gray", "225-Kings-Sword"],
+    ];
+    const { cards, skipped, duplicates } = tableToCards(rows, r2Mapping());
+    expect(skipped).toBe(0);
+    expect(duplicates).toEqual([]);
+    expect(cards).toHaveLength(1);
+    const c = cards[0];
+    expect(c.name).toBe("King's Sword [RR2]");
+    expect(c.imageFile).toBe("225-Kings-Sword");
+    expect(c.warnings).toEqual([]);
+    expect(c.snapshot.cardType).toEqual(["Dominant"]);
+    expect(c.snapshot.alignment).toBe("Good");
+    expect(c.snapshot.legality).toBe("Rotation");
+    expect(c.snapshot.reference).toBe("Revelation 19:15");
+    expect(c.snapshot.artistCredit).toBe("Doug Gray");
+    expect(c.snapshot.rawText).toMatch(/^If an Evil Character/);
+    expect(c.snapshot.brigades).toBeUndefined();
+  });
+
+  it("synthesizes the reference from Book/Chapter/Verse pieces", () => {
+    const mk = (book: string, ch: string, v: string) => {
+      const row = ["X", "", "", "", "", "", "", "", "", "", "", book, ch, v, "", "", "", ""];
+      return tableToCards([R2_HEADER, row], r2Mapping()).cards[0].snapshot.reference;
+    };
+    expect(mk("Psalm", "23", "")).toBe("Psalm 23");
+    expect(mk("Psalm", "", "")).toBe("Psalm");
+    expect(mk("", "1", "2")).toBeUndefined();
+    // xlsx numeric cells arrive as "19.0" — cleaned to integers
+    expect(mk("Revelation", "19.0", "15.0")).toBe("Revelation 19:15");
+  });
+
+  it("prefers a combined Reference column over Book/Chapter/Verse", () => {
+    const header = ["Name", "Reference", "Book", "Chapter", "Verse"];
+    const { mapping } = detectColumns(header);
+    const { cards } = tableToCards(
+      [header, ["X", "John 3:16", "Genesis", "1", "1"]], mapping,
+    );
+    expect(cards[0].snapshot.reference).toBe("John 3:16");
+  });
+
+  it("cleans dash placeholders and float-formatted stats", () => {
+    const header = ["Name", "Type", "Brigade", "Strength", "Toughness"];
+    const { mapping } = detectColumns(header);
+    const { cards } = tableToCards(
+      [header, ["Hero Guy", "Hero", "Blue", "9.0", "7"]], mapping,
+    );
+    expect(cards[0].snapshot.strength).toBe(9);
+    expect(cards[0].snapshot.toughness).toBe(7);
+    const dashes = tableToCards([header, ["Art Guy", "Artifact", "—", "-", "-"]], mapping);
+    expect(dashes.cards[0].snapshot.brigades).toBeUndefined();
+    expect(dashes.cards[0].snapshot.strength).toBeUndefined();
+    expect(dashes.cards[0].warnings).toEqual([]);
+  });
+
+  it("skips rows without a name and dedupes repeated names (first wins)", () => {
+    const header = ["Name", "Type"];
+    const { mapping } = detectColumns(header);
+    const { cards, skipped, duplicates } = tableToCards([
+      header,
+      ["Alpha", "Hero"],
+      ["", "Hero"],
+      ["-", "Hero"],
+      ["Alpha", "Artifact"],
+    ], mapping);
+    expect(cards).toHaveLength(1);
+    expect(cards[0].snapshot.cardType).toEqual(["Hero"]);
+    expect(skipped).toBe(2);
+    expect(duplicates).toEqual(["Alpha"]);
+  });
+
+  it("warns on unrecognized types, brigades, alignments, legalities, and stats", () => {
+    const header = ["Name", "Type", "Brigade", "Strength", "Alignment", "Legality"];
+    const { mapping } = detectColumns(header);
+    const { cards } = tableToCards(
+      [header, ["Oops", "Herro", "Vermilion", "lots", "Sideways", "Casual"]], mapping,
+    );
+    const w = cards[0].warnings.join(" | ");
+    expect(w).toMatch(/Herro/);
+    expect(w).toMatch(/Vermilion/);
+    expect(w).toMatch(/lots/);
+    expect(w).toMatch(/Sideways/);
+    expect(w).toMatch(/Casual/);
+    // unrecognized values are dropped from the snapshot, not imported as garbage
+    expect(cards[0].snapshot.cardType).toBeUndefined();
+    expect(cards[0].snapshot.brigades).toBeUndefined();
+    expect(cards[0].snapshot.alignment).toBeUndefined();
+    expect(cards[0].snapshot.legality).toBeUndefined();
+  });
+
+  it("reports 1-based spreadsheet row numbers (header is row 1)", () => {
+    const header = ["Name"];
+    const { mapping } = detectColumns(header);
+    const { cards } = tableToCards([header, ["A"], ["B"]], mapping);
+    expect(cards.map((c) => c.rowIndex)).toEqual([2, 3]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// auditLackeyRow — the warning source lives beside the lackey maps
+// ---------------------------------------------------------------------------
+
+describe("auditLackeyRow", () => {
+  const base: LackeyRow = {
+    name: "X", set: "", imageFile: "", officialSet: "", type: "", brigade: "",
+    strength: "", toughness: "", class: "", identifier: "", specialAbility: "",
+    rarity: "", reference: "", alignment: "", legality: "",
+  };
+
+  it("is silent on a fully-valid row", () => {
+    expect(auditLackeyRow({
+      ...base, type: "Hero", brigade: "Blue (Good Gold)", strength: "9",
+      toughness: "9", class: "Warrior/Star", alignment: "Good", legality: "Rotation",
+    })).toEqual([]);
+  });
+
+  it("is silent on empty and dash-only cells", () => {
+    expect(auditLackeyRow({ ...base, type: "-", brigade: "-" })).toEqual([]);
+  });
+
+  it("flags each unrecognized token but keeps valid siblings quiet", () => {
+    const warnings = auditLackeyRow({ ...base, type: "Hero/Villain", brigade: "Blue/Vermilion" });
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toMatch(/Villain/);
+    expect(warnings[1]).toMatch(/Vermilion/);
+  });
+
+  it("flags unknown class tokens", () => {
+    const warnings = auditLackeyRow({ ...base, class: "Warrior/Wizard" });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/Wizard/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findLooseImageEntry — flat images zip with macOS junk
+// ---------------------------------------------------------------------------
+
+describe("findLooseImageEntry", () => {
+  const entries = [
+    "225-Kings-Sword.png",
+    "__MACOSX/._225-Kings-Sword.png",
+    "nested/dir/226-Spreading-Mildew.JPG",
+    "._227-Altar-of-Ahaz.png",
+    "227-Altar-of-Ahaz.webp",
+    "not-an-image.txt",
+  ];
+
+  it("matches a flat entry by base name, case-insensitively", () => {
+    expect(findLooseImageEntry("225-Kings-Sword", entries)).toBe("225-Kings-Sword.png");
+    expect(findLooseImageEntry("225-KINGS-SWORD", entries)).toBe("225-Kings-Sword.png");
+  });
+
+  it("matches nested entries and alternate extensions", () => {
+    expect(findLooseImageEntry("226-Spreading-Mildew", entries)).toBe("nested/dir/226-Spreading-Mildew.JPG");
+    expect(findLooseImageEntry("227-Altar-of-Ahaz", entries)).toBe("227-Altar-of-Ahaz.webp");
+  });
+
+  it("tolerates the column already including an extension", () => {
+    expect(findLooseImageEntry("225-Kings-Sword.png", entries)).toBe("225-Kings-Sword.png");
+  });
+
+  it("never matches __MACOSX or AppleDouble entries, and returns null when absent", () => {
+    expect(findLooseImageEntry("missing", entries)).toBeNull();
+    expect(findLooseImageEntry("", entries)).toBeNull();
+  });
+});

--- a/app/forge/lib/__tests__/spreadsheet.test.ts
+++ b/app/forge/lib/__tests__/spreadsheet.test.ts
@@ -278,6 +278,17 @@ describe("tableToCards", () => {
     expect(dashes.cards[0].warnings).toEqual([]);
   });
 
+  it('maps "Dual-Alignment Enhancement" to GE + EE with no warning', () => {
+    const header = ["Name", "Type", "Alignment"];
+    const { mapping } = detectColumns(header);
+    const { cards } = tableToCards(
+      [header, ["Philosophy [RR2]", "Dual-Alignment Enhancement", "Good/Evil"]], mapping,
+    );
+    expect(cards[0].warnings).toEqual([]);
+    expect(cards[0].snapshot.cardType).toEqual(["GE", "EE"]);
+    expect(cards[0].snapshot.alignment).toBe("Good_Evil");
+  });
+
   it('accepts "X" as a valid variable strength/toughness (The Faithful Followers)', () => {
     const header = ["Name", "Type", "Strength", "Toughness"];
     const { mapping } = detectColumns(header);

--- a/app/forge/lib/cardDiff.ts
+++ b/app/forge/lib/cardDiff.ts
@@ -2,7 +2,7 @@
 // one-line plain-language summary, plus a value coercer for suggestions. No DB,
 // no UI. Drives the Current vs Proposed review diff.
 
-import type { DesignCard } from "@/app/forge/lib/designCard";
+import { parseStatInput, type DesignCard } from "@/app/forge/lib/designCard";
 
 export type FieldChange = {
   field: keyof DesignCard;
@@ -71,11 +71,7 @@ export function summarizeDiff(changes: FieldChange[]): string {
 // Best-effort coercion of a free-text suggestion value into the field's jsonb shape.
 export function coerceFieldValue(field: string, text: string): unknown {
   const t = text.trim();
-  if (NUMBER_FIELDS.has(field)) {
-    if (/^x$/i.test(t)) return "X"; // variable stat
-    const n = Number(t);
-    return Number.isFinite(n) ? n : null;
-  }
+  if (NUMBER_FIELDS.has(field)) return parseStatInput(t); // number, "X", or "6 (0)"
   if (ARRAY_FIELDS.has(field)) return t ? t.split(",").map((s) => s.trim()).filter(Boolean) : [];
   return t;
 }

--- a/app/forge/lib/cardDiff.ts
+++ b/app/forge/lib/cardDiff.ts
@@ -71,7 +71,11 @@ export function summarizeDiff(changes: FieldChange[]): string {
 // Best-effort coercion of a free-text suggestion value into the field's jsonb shape.
 export function coerceFieldValue(field: string, text: string): unknown {
   const t = text.trim();
-  if (NUMBER_FIELDS.has(field)) { const n = Number(t); return Number.isFinite(n) ? n : null; }
+  if (NUMBER_FIELDS.has(field)) {
+    if (/^x$/i.test(t)) return "X"; // variable stat
+    const n = Number(t);
+    return Number.isFinite(n) ? n : null;
+  }
   if (ARRAY_FIELDS.has(field)) return t ? t.split(",").map((s) => s.trim()).filter(Boolean) : [];
   return t;
 }

--- a/app/forge/lib/designCard.ts
+++ b/app/forge/lib/designCard.ts
@@ -26,14 +26,17 @@ export const LEGALITIES = ["Rotation", "Classic", "Scrolls", "Paragon", "Banned"
 // `_forge_is_card_field` (used to validate field-anchored suggestions); its
 // current definition is in supabase/migrations/067_forge_scripture_field.sql.
 // Keep the two lists in sync.
+// "X" is a real stat value (variable strength/toughness, e.g. The Faithful Followers).
+export type StatValue = number | "X" | null;
+
 export type DesignCard = {
   name?: string;
   rawText?: string;
   cardType?: CardType[];
   alignment?: Alignment;
   brigades?: Brigade[];
-  strength?: number | null;
-  toughness?: number | null;
+  strength?: StatValue;
+  toughness?: StatValue;
   class?: (typeof CLASSES)[number][];
   icons?: (typeof ICONS)[number][];
   identifiers?: string[];
@@ -117,4 +120,13 @@ export function validate(card: DesignCard): ValidationHint[] {
  */
 export function cardRawText(card: DesignCard): string {
   return card.rawText ?? card.specialAbility ?? "";
+}
+
+/** Parse a stats text input: "" → null, "x"/"X" → "X", numbers pass, junk → null. Pure. */
+export function parseStatInput(raw: string): StatValue {
+  const t = raw.trim();
+  if (!t) return null;
+  if (/^x$/i.test(t)) return "X";
+  const n = Number(t);
+  return Number.isFinite(n) ? n : null;
 }

--- a/app/forge/lib/designCard.ts
+++ b/app/forge/lib/designCard.ts
@@ -26,8 +26,11 @@ export const LEGALITIES = ["Rotation", "Classic", "Scrolls", "Paragon", "Banned"
 // `_forge_is_card_field` (used to validate field-anchored suggestions); its
 // current definition is in supabase/migrations/067_forge_scripture_field.sql.
 // Keep the two lists in sync.
-// "X" is a real stat value (variable strength/toughness, e.g. The Faithful Followers).
-export type StatValue = number | "X" | null;
+// A stat is a number, "X" (variable, e.g. The Faithful Followers), or a paired
+// dual-side value like "6 (0)" — the official card pool's convention for
+// dual-alignment enhancements and dual-sided characters (142 cards use it).
+// parseStatInput below is the only producer of the string forms.
+export type StatValue = number | string | null;
 
 export type DesignCard = {
   name?: string;
@@ -122,11 +125,19 @@ export function cardRawText(card: DesignCard): string {
   return card.rawText ?? card.specialAbility ?? "";
 }
 
-/** Parse a stats text input: "" → null, "x"/"X" → "X", numbers pass, junk → null. Pure. */
+const PAIRED_STAT_RE = /^(x|\d+)\s*\(\s*(x|\d+)\s*\)$/i;
+
+/** Parse a stat: "" → null, "x"/"X" → "X", numbers pass, paired dual-side values
+ *  normalize to `N (M)` (e.g. "3(2)" → "3 (2)", "x(0)" → "X (0)"), junk → null. Pure. */
 export function parseStatInput(raw: string): StatValue {
   const t = raw.trim();
   if (!t) return null;
   if (/^x$/i.test(t)) return "X";
+  const paired = PAIRED_STAT_RE.exec(t);
+  if (paired) {
+    const side = (s: string) => (/^x$/i.test(s) ? "X" : s);
+    return `${side(paired[1])} (${side(paired[2])})`;
+  }
   const n = Number(t);
   return Number.isFinite(n) ? n : null;
 }

--- a/app/forge/lib/lackey.ts
+++ b/app/forge/lib/lackey.ts
@@ -125,9 +125,10 @@ function clean(v: string): string {
   return t === "-" ? "" : t;
 }
 
-function parseStat(v: string): number | null {
+function parseStat(v: string): number | "X" | null {
   const t = clean(v);
   if (!t) return null;
+  if (/^x$/i.test(t)) return "X"; // variable stats are printed as X (e.g. X/X)
   const n = Number(t);
   return Number.isFinite(n) ? n : null;
 }
@@ -253,7 +254,7 @@ function tsvSafe(value: string): string {
   return value.replace(/[\t\r\n]+/g, " ").trim();
 }
 
-function statCell(v: number | null | undefined): string {
+function statCell(v: number | "X" | null | undefined): string {
   return v === null || v === undefined ? "" : String(v);
 }
 

--- a/app/forge/lib/lackey.ts
+++ b/app/forge/lib/lackey.ts
@@ -1,7 +1,7 @@
 // Pure LackeyCCG plugin-format helpers for the Forge set importer.
 // CLIENT-SAFE: no server-only imports. Column conventions mirror scripts/parse-carddata.js.
 
-import { cardRawText, type Brigade, type CardType, type DesignCard } from "./designCard";
+import { cardRawText, parseStatInput, type Brigade, type CardType, type DesignCard } from "./designCard";
 
 export interface LackeyRow {
   name: string; set: string; imageFile: string; officialSet: string;
@@ -129,12 +129,9 @@ function clean(v: string): string {
   return t === "-" ? "" : t;
 }
 
-function parseStat(v: string): number | "X" | null {
-  const t = clean(v);
-  if (!t) return null;
-  if (/^x$/i.test(t)) return "X"; // variable stats are printed as X (e.g. X/X)
-  const n = Number(t);
-  return Number.isFinite(n) ? n : null;
+// Accepts numbers, "X", and paired dual-side values like "6 (0)" — see parseStatInput.
+function parseStat(v: string): number | string | null {
+  return parseStatInput(clean(v));
 }
 
 const CLASS_TOKENS = new Set(["warrior", "weapon", "territory", "star", "cloud"]);
@@ -258,7 +255,7 @@ function tsvSafe(value: string): string {
   return value.replace(/[\t\r\n]+/g, " ").trim();
 }
 
-function statCell(v: number | "X" | null | undefined): string {
+function statCell(v: number | string | null | undefined): string {
   return v === null || v === undefined ? "" : String(v);
 }
 

--- a/app/forge/lib/lackey.ts
+++ b/app/forge/lib/lackey.ts
@@ -94,10 +94,14 @@ export function findImageEntry(row: LackeyRow, entryNames: string[]): string | n
   return null;
 }
 
-const TYPE_MAP: Record<string, CardType> = {
+// One token may map to multiple design types: a Dual-Alignment Enhancement IS
+// both a good and an evil enhancement (the kit has no separate dual frame).
+const TYPE_MAP: Record<string, CardType | CardType[]> = {
   "hero": "Hero", "evil character": "EvilCharacter",
   "ge": "GE", "good enhancement": "GE",
   "ee": "EE", "evil enhancement": "EE",
+  "dual-alignment enhancement": ["GE", "EE"],
+  "dual alignment enhancement": ["GE", "EE"],
   "lost soul": "LostSoul", "artifact": "Artifact",
   "dominant": "Dominant", "evil dominant": "Dominant",
   "fortress": "Fortress", "site": "Site", "city": "City",
@@ -173,7 +177,7 @@ export function lackeyRowToDesignCard(row: LackeyRow): DesignCard {
   }
 
   const types = [...new Set(
-    splitMulti(row.type).map((t) => TYPE_MAP[t.toLowerCase()]).filter(Boolean),
+    splitMulti(row.type).flatMap((t) => TYPE_MAP[t.toLowerCase()] ?? []),
   )] as CardType[];
   if (types.length) card.cardType = types;
 

--- a/app/forge/lib/lackey.ts
+++ b/app/forge/lib/lackey.ts
@@ -132,6 +132,35 @@ function parseStat(v: string): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+const CLASS_TOKENS = new Set(["warrior", "weapon", "territory", "star", "cloud"]);
+const ALIGNMENT_TOKENS = new Set(["good", "evil", "neutral", "good/evil"]);
+
+/** Data-quality audit: one warning per cell value that lackeyRowToDesignCard would
+ *  silently drop (unknown type/brigade/class token, non-numeric stat, unknown
+ *  alignment or legality). Empty and "-" cells are fine. Pure. */
+export function auditLackeyRow(row: LackeyRow): string[] {
+  const warnings: string[] = [];
+  for (const t of splitMulti(row.type)) {
+    if (!TYPE_MAP[t.toLowerCase()]) warnings.push(`unrecognized type "${t}"`);
+  }
+  for (const b of splitMulti(row.brigade)) {
+    if (!BRIGADE_MAP[b.toLowerCase()]) warnings.push(`unrecognized brigade "${b}"`);
+  }
+  for (const c of splitMulti(row.class)) {
+    if (!CLASS_TOKENS.has(c.toLowerCase())) warnings.push(`unrecognized class "${c}"`);
+  }
+  for (const [label, v] of [["strength", row.strength], ["toughness", row.toughness]] as const) {
+    if (clean(v) && parseStat(v) === null) warnings.push(`non-numeric ${label} "${clean(v)}"`);
+  }
+  const alignment = clean(row.alignment);
+  if (alignment && !ALIGNMENT_TOKENS.has(alignment.toLowerCase())) {
+    warnings.push(`unrecognized alignment "${alignment}"`);
+  }
+  const legality = clean(row.legality);
+  if (legality && !LEGALITIES.includes(legality)) warnings.push(`unrecognized legality "${legality}"`);
+  return warnings;
+}
+
 // Best-effort structured mapping; full fidelity lives in the finished-card image + rawText.
 export function lackeyRowToDesignCard(row: LackeyRow): DesignCard {
   const card: DesignCard = { name: row.name };

--- a/app/forge/lib/spreadsheet.ts
+++ b/app/forge/lib/spreadsheet.ts
@@ -1,0 +1,322 @@
+// Pure CSV/XLSX helpers for the Forge images-zip + spreadsheet importer.
+// CLIENT-SAFE: no server-only imports. An .xlsx file is a zip of OOXML XML parts,
+// so parsing rides on fflate (already used for the images zip) — no new dependency.
+// The OOXML subset handled here is what Excel, Google Sheets, and LibreOffice
+// actually emit for plain tables: sharedStrings (with rich-text runs), inline
+// strings, formula string results, numbers, and sparse rows/cells.
+
+import { unzipSync } from "fflate";
+import { auditLackeyRow, lackeyRowToDesignCard, type LackeyRow } from "./lackey";
+import type { DesignCard } from "./designCard";
+
+// ---------------------------------------------------------------------------
+// CSV
+// ---------------------------------------------------------------------------
+
+/** RFC-4180-style CSV → rows of cells. Handles quoted fields (commas, newlines,
+ *  doubled quotes), CRLF, and a UTF-8 BOM. Blank trailing lines are dropped;
+ *  blank lines elsewhere stay (so row numbers keep matching the user's file). Pure. */
+export function parseCsv(text: string): string[][] {
+  const src = text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let inQuotes = false;
+  for (let i = 0; i < src.length; i++) {
+    const ch = src[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (src[i + 1] === '"') { cell += '"'; i++; }
+        else inQuotes = false;
+      } else cell += ch;
+    } else if (ch === '"' && cell === "") {
+      inQuotes = true;
+    } else if (ch === ",") {
+      row.push(cell); cell = "";
+    } else if (ch === "\n" || ch === "\r") {
+      if (ch === "\r" && src[i + 1] === "\n") i++;
+      row.push(cell); cell = ""; rows.push(row); row = [];
+    } else {
+      cell += ch;
+    }
+  }
+  if (cell !== "" || row.length > 0) { row.push(cell); rows.push(row); }
+  while (rows.length > 0) {
+    const last = rows[rows.length - 1];
+    if (last.length === 1 && last[0] === "") rows.pop(); // trailing blank line(s)
+    else break;
+  }
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// XLSX
+// ---------------------------------------------------------------------------
+
+export interface SheetTable { name: string; rows: string[][] }
+
+const NOT_XLSX = "This file doesn't look like an .xlsx workbook.";
+
+function unescapeXml(s: string): string {
+  return s
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => String.fromCodePoint(parseInt(h, 16)))
+    .replace(/&#(\d+);/g, (_, d) => String.fromCodePoint(Number(d)))
+    .replace(/&lt;/g, "<").replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"').replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+function attr(tag: string, name: string): string | null {
+  const m = new RegExp(`(?:^|\\s)${name}=(?:"([^"]*)"|'([^']*)')`).exec(tag);
+  return m ? unescapeXml(m[1] ?? m[2]) : null;
+}
+
+// All <t> text inside a fragment, rich-text runs joined; phonetic <rPh> runs dropped.
+function textOf(fragment: string): string {
+  const clean = fragment.replace(/<rPh[\s\S]*?<\/rPh>/g, "");
+  let out = "";
+  for (const m of clean.matchAll(/<t(?:\s[^>]*)?>([\s\S]*?)<\/t>/g)) out += unescapeXml(m[1]);
+  return out;
+}
+
+// "B3" → 0-based column index 1.
+function colIndex(ref: string): number {
+  let n = 0;
+  for (const ch of ref) {
+    if (ch < "A" || ch > "Z") break;
+    n = n * 26 + (ch.charCodeAt(0) - 64);
+  }
+  return n - 1;
+}
+
+function parseSheetXml(xml: string, strings: string[]): string[][] {
+  const rows: string[][] = [];
+  let cursor = 0; // fallback position for rows without an r attribute
+  // Self-closing <row/> (styled-but-empty rows from Excel) must consume its own
+  // match, or the following row's cells would land one row early.
+  for (const rowMatch of xml.matchAll(/<row\b([^>]*?)(?:\/>|>([\s\S]*?)<\/row>)/g)) {
+    const rAttr = attr(rowMatch[1], "r");
+    const rowIdx = rAttr ? Number(rAttr) - 1 : cursor;
+    cursor = rowIdx + 1;
+    const cells: string[] = [];
+    for (const cellMatch of (rowMatch[2] ?? "").matchAll(/<c\b([^>]*?)(?:\/>|>([\s\S]*?)<\/c>)/g)) {
+      const ref = attr(cellMatch[1], "r");
+      const col = ref ? colIndex(ref) : cells.length;
+      const t = attr(cellMatch[1], "t");
+      const inner = cellMatch[2] ?? "";
+      const v = /<v(?:\s[^>]*)?>([\s\S]*?)<\/v>/.exec(inner)?.[1];
+      let value = "";
+      if (t === "s") value = strings[Number(v)] ?? "";
+      else if (t === "inlineStr") value = textOf(inner);
+      else if (t === "b") value = v === "1" ? "TRUE" : "FALSE";
+      else if (t === "e") value = ""; // cell error (#N/A etc.) → treat as empty
+      else value = v === undefined ? "" : unescapeXml(v); // number or t="str"
+      if (col >= 0) cells[col] = value;
+    }
+    rows[rowIdx] = cells;
+  }
+  // Normalize holes: missing rows → [], missing cells → "".
+  return Array.from(rows, (r) => (r ? Array.from(r, (c) => c ?? "") : []));
+}
+
+/** Parse an .xlsx workbook into its sheets (workbook order, with names).
+ *  Throws with a user-facing message when the bytes aren't an xlsx. Pure. */
+export function parseXlsx(bytes: Uint8Array): SheetTable[] {
+  let entries: Record<string, Uint8Array>;
+  try {
+    entries = unzipSync(bytes, {
+      filter: (f) =>
+        f.name === "xl/workbook.xml" ||
+        f.name === "xl/_rels/workbook.xml.rels" ||
+        f.name === "xl/sharedStrings.xml" ||
+        /^xl\/worksheets\/[^/]+\.xml$/.test(f.name),
+    });
+  } catch {
+    throw new Error(NOT_XLSX);
+  }
+  const decode = (b: Uint8Array) => new TextDecoder("utf-8").decode(b);
+  if (!entries["xl/workbook.xml"] || !entries["xl/_rels/workbook.xml.rels"]) {
+    throw new Error(NOT_XLSX);
+  }
+
+  const strings = entries["xl/sharedStrings.xml"]
+    ? [...decode(entries["xl/sharedStrings.xml"]).matchAll(/<si(?:\s[^>]*)?>([\s\S]*?)<\/si>/g)]
+        .map((m) => textOf(m[1]))
+    : [];
+
+  const relTargets = new Map<string, string>();
+  for (const rel of decode(entries["xl/_rels/workbook.xml.rels"]).matchAll(/<Relationship\s[^>]*\/?>/g)) {
+    const id = attr(rel[0], "Id");
+    const target = attr(rel[0], "Target");
+    if (id && target) relTargets.set(id, target.startsWith("/") ? target.slice(1) : `xl/${target}`);
+  }
+
+  const sheets: SheetTable[] = [];
+  for (const sheet of decode(entries["xl/workbook.xml"]).matchAll(/<sheet\s[^>]*\/?>/g)) {
+    const name = attr(sheet[0], "name") ?? `Sheet ${sheets.length + 1}`;
+    const rid = attr(sheet[0], "r:id");
+    const part = rid ? relTargets.get(rid) : undefined;
+    const xml = part ? entries[part] : undefined;
+    if (!xml) continue;
+    sheets.push({ name, rows: parseSheetXml(decode(xml), strings) });
+  }
+  if (sheets.length === 0) throw new Error(NOT_XLSX);
+  return sheets;
+}
+
+// ---------------------------------------------------------------------------
+// Column mapping
+// ---------------------------------------------------------------------------
+
+export const MAPPABLE_FIELDS = [
+  "name", "image", "type", "brigade", "strength", "toughness", "class",
+  "identifier", "specialAbility", "rarity", "reference", "book", "chapter",
+  "verse", "alignment", "legality", "artist",
+] as const;
+export type MappableField = (typeof MAPPABLE_FIELDS)[number];
+export type ColumnMapping = Partial<Record<MappableField, number>>;
+
+const HEADER_ALIASES: Record<string, MappableField> = {
+  name: "name", cardname: "name", title: "name",
+  image: "image", imagefile: "image", imagename: "image",
+  type: "type", cardtype: "type",
+  brigade: "brigade", brigades: "brigade",
+  strength: "strength", toughness: "toughness",
+  class: "class",
+  identifier: "identifier", identifiers: "identifier",
+  specialability: "specialAbility", ability: "specialAbility", abilitytext: "specialAbility",
+  rarity: "rarity",
+  reference: "reference", scripturereference: "reference",
+  book: "book", chapter: "chapter", verse: "verse",
+  alignment: "alignment", legality: "legality",
+  artist: "artist", artistcredit: "artist",
+};
+
+// Columns we recognize but deliberately don't import — not surprises worth flagging.
+const KNOWN_UNUSED = new Set(["#", "number", "set", "officialset", "sound"]);
+
+function normalizeHeader(h: string): string {
+  return h.trim().toLowerCase().replace(/[^a-z0-9#]/g, "");
+}
+
+/** Auto-detect which spreadsheet column feeds which card field. Both real-world
+ *  conventions are handled: Lackey-style headers with trailing colons and a combined
+ *  Reference, or split Book/Chapter/Verse plus Artist. `ignored` lists the indexes
+ *  of non-empty headers we didn't recognize, for the wizard to surface. Pure. */
+export function detectColumns(header: string[]): { mapping: ColumnMapping; ignored: number[] } {
+  const mapping: ColumnMapping = {};
+  const ignored: number[] = [];
+  header.forEach((h, i) => {
+    if (!h.trim()) return;
+    const norm = normalizeHeader(h);
+    const field = HEADER_ALIASES[norm];
+    if (field !== undefined && mapping[field] === undefined) mapping[field] = i;
+    else if (!KNOWN_UNUSED.has(norm)) ignored.push(i);
+  });
+  return { mapping, ignored };
+}
+
+// ---------------------------------------------------------------------------
+// Rows → cards
+// ---------------------------------------------------------------------------
+
+export interface SpreadsheetCard {
+  name: string;
+  imageFile: string;   // cleaned Image column value ("" when absent)
+  snapshot: DesignCard;
+  warnings: string[];  // per-card data-quality warnings (values that were dropped)
+  rowIndex: number;    // 1-based row in the user's file (header = row 1)
+}
+
+// "-" (and en/em dash) placeholder cells → empty; everything else just trimmed.
+function cleanCell(v: string): string {
+  const t = (v ?? "").trim();
+  return /^[-–—]+$/.test(t) ? "" : t;
+}
+
+// xlsx numeric cells arrive as "19.0" — strip a zero fraction so references and
+// stats read like the user's sheet. Non-numeric values pass through untouched.
+function numClean(v: string): string {
+  const m = /^(-?\d+)\.0+$/.exec(v);
+  return m ? m[1] : v;
+}
+
+/** Map spreadsheet rows (first row = header) through the column mapping into
+ *  importable cards. Cleaning: blank rows vanish, rows without a Name are counted
+ *  as skipped, repeated names keep the first occurrence (later ones reported in
+ *  `duplicates`), placeholder dashes empty out, and every value the structured
+ *  mapping would silently drop becomes a per-card warning. Pure. */
+export function tableToCards(rows: string[][], mapping: ColumnMapping): {
+  cards: SpreadsheetCard[]; skipped: number; duplicates: string[];
+} {
+  const cards: SpreadsheetCard[] = [];
+  const seen = new Set<string>();
+  let skipped = 0;
+  const duplicates: string[] = [];
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i] ?? [];
+    if (row.every((c) => !cleanCell(c))) continue; // blank spacer row
+    const get = (f: MappableField) => {
+      const idx = mapping[f];
+      return idx === undefined ? "" : cleanCell(row[idx] ?? "");
+    };
+    const name = get("name");
+    if (!name) { skipped++; continue; }
+    if (seen.has(name.toLowerCase())) { duplicates.push(name); continue; }
+    seen.add(name.toLowerCase());
+
+    let reference = get("reference");
+    if (!reference) {
+      const book = get("book");
+      const chapter = numClean(get("chapter"));
+      const verse = numClean(get("verse"));
+      if (book) reference = book + (chapter ? ` ${chapter}${verse ? `:${verse}` : ""}` : "");
+    }
+
+    const lackeyRow: LackeyRow = {
+      name, set: "", imageFile: "", officialSet: "",
+      type: get("type"), brigade: get("brigade"),
+      strength: numClean(get("strength")), toughness: numClean(get("toughness")),
+      class: get("class"), identifier: get("identifier"),
+      specialAbility: get("specialAbility"), rarity: get("rarity"),
+      reference, alignment: get("alignment"), legality: get("legality"),
+    };
+    const snapshot = lackeyRowToDesignCard(lackeyRow);
+    const artist = get("artist");
+    if (artist) snapshot.artistCredit = artist;
+
+    cards.push({
+      name, imageFile: get("image"), snapshot,
+      warnings: auditLackeyRow(lackeyRow), rowIndex: i + 1,
+    });
+  }
+  return { cards, skipped, duplicates };
+}
+
+// ---------------------------------------------------------------------------
+// Images zip matching
+// ---------------------------------------------------------------------------
+
+const IMAGE_EXT_RE = /\.(jpe?g|png|webp)$/i;
+
+/** True for zip entries that are usable card images — not directories, macOS junk
+ *  (__MACOSX/ trees, "._" AppleDouble files), or non-image files. Pure. */
+export function isImageEntry(entryName: string): boolean {
+  if (entryName.endsWith("/") || entryName.includes("__MACOSX/")) return false;
+  const base = (entryName.split("/").pop() ?? "").toLowerCase();
+  return !base.startsWith("._") && IMAGE_EXT_RE.test(base);
+}
+
+/** Match a spreadsheet Image value to a zip entry by BASE NAME at any depth —
+ *  images zips are flat folder exports, not Lackey trees. Case-insensitive and
+ *  tolerates the column already carrying an extension. Pure. */
+export function findLooseImageEntry(imageFile: string, entryNames: string[]): string | null {
+  const stem = imageFile.trim().toLowerCase().replace(IMAGE_EXT_RE, "");
+  if (!stem) return null;
+  for (const entry of entryNames) {
+    if (!isImageEntry(entry)) continue;
+    const base = (entry.split("/").pop() ?? "").toLowerCase();
+    if (base.replace(IMAGE_EXT_RE, "") === stem) return entry;
+  }
+  return null;
+}

--- a/app/forge/lib/spreadsheet.ts
+++ b/app/forge/lib/spreadsheet.ts
@@ -307,16 +307,27 @@ export function isImageEntry(entryName: string): boolean {
   return !base.startsWith("._") && IMAGE_EXT_RE.test(base);
 }
 
+/** Canonical form of an Image column value for matching: lowercased, trimmed,
+ *  extension stripped ("" when blank). Pure. */
+export function imageFileStem(value: string): string {
+  return value.trim().toLowerCase().replace(IMAGE_EXT_RE, "");
+}
+
+/** Canonical form of a zip entry for matching: lowercased base name without the
+ *  extension — or null for directories, macOS junk, and non-images. Pure. */
+export function imageEntryStem(entryName: string): string | null {
+  if (!isImageEntry(entryName)) return null;
+  return (entryName.split("/").pop() ?? "").toLowerCase().replace(IMAGE_EXT_RE, "");
+}
+
 /** Match a spreadsheet Image value to a zip entry by BASE NAME at any depth —
  *  images zips are flat folder exports, not Lackey trees. Case-insensitive and
  *  tolerates the column already carrying an extension. Pure. */
 export function findLooseImageEntry(imageFile: string, entryNames: string[]): string | null {
-  const stem = imageFile.trim().toLowerCase().replace(IMAGE_EXT_RE, "");
+  const stem = imageFileStem(imageFile);
   if (!stem) return null;
   for (const entry of entryNames) {
-    if (!isImageEntry(entry)) continue;
-    const base = (entry.split("/").pop() ?? "").toLowerCase();
-    if (base.replace(IMAGE_EXT_RE, "") === stem) return entry;
+    if (imageEntryStem(entry) === stem) return entry;
   }
   return null;
 }

--- a/e2e/forge/import.spec.ts
+++ b/e2e/forge/import.spec.ts
@@ -27,7 +27,7 @@ test.describe("forge lackey set import", () => {
 
   async function uploadFixture(page: Page) {
     await gotoSettled(page, "/forge/import");
-    await page.getByLabel("Lackey zip file").setInputFiles({
+    await page.getByLabel("Choose zip…").setInputFiles({
       name: "Test Plugin V1.zip", mimeType: "application/zip", buffer: buildFixtureZip(),
     });
     await page.getByLabel("Set filter").fill("TST");

--- a/e2e/forge/spreadsheet-import.spec.ts
+++ b/e2e/forge/spreadsheet-import.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect, type Page } from "@playwright/test";
+import { zipSync, strToU8 } from "fflate";
+import { adminAvailable, seedForgeMember, cleanupForgeMember, type SeededForgeMember } from "./forgeSeed";
+
+// Smallest valid JPEG (1×1 white) — renders with naturalWidth 1.
+const TINY_JPEG_BASE64 =
+  "/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a" +
+  "HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAA" +
+  "AAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AKp//2Q==";
+
+const FIXTURE_CARDS = ["Sheet Hero Alpha", "Sheet Relic Beta"];
+
+// Roots 2 convention: split Book/Chapter/Verse + Artist + Image columns.
+const CSV = [
+  "Name,#,Set,Type,Brigade,Strength,Toughness,Class,Identifier,Special Ability,Rarity,Book,Chapter,Verse,Alignment,Legality,Artist,Image",
+  '"Sheet Hero Alpha",1,Test Set,Hero,Silver,9,9,Warrior,-,"Test ability alpha.",-,Genesis,1,1,Good,Rotation,E2E Artist,Sheet-Hero-Alpha',
+  // Beta deliberately has NO image in the zip (exercises the imageless path)
+  '"Sheet Relic Beta",2,Test Set,Artifact,-,-,-,-,-,"Test ability beta.",-,-,-,-,Neutral,Rotation,-,Sheet-Relic-Beta',
+].join("\n");
+
+function buildImagesZip(): Buffer {
+  const jpeg = new Uint8Array(Buffer.from(TINY_JPEG_BASE64, "base64"));
+  const zipped = zipSync({
+    "Sheet-Hero-Alpha.jpg": jpeg,
+    "__MACOSX/._Sheet-Hero-Alpha.jpg": new Uint8Array([0]), // macOS junk must be ignored
+    "unrelated-extra.jpg": jpeg,                             // orphan image, matches no row
+  }, { level: 0 });
+  return Buffer.from(zipped.buffer, zipped.byteOffset, zipped.byteLength);
+}
+
+test.describe("forge spreadsheet set import", () => {
+  test.skip(!adminAvailable, "requires SUPABASE_SERVICE_ROLE_KEY + NEXT_PUBLIC_SUPABASE_URL");
+
+  async function signIn(page: Page, seed: SeededForgeMember) {
+    await page.goto("/sign-in");
+    await page.getByLabel(/email/i).fill(seed.email);
+    await page.getByLabel(/password/i).fill(seed.password);
+    await page.getByRole("button", { name: /sign in/i }).click();
+    await page.waitForURL((u) => !u.pathname.startsWith("/sign-in"), { timeout: 15_000 });
+    await page.waitForLoadState("load");
+  }
+
+  async function gotoSettled(page: Page, path: string) {
+    try {
+      await page.goto(path);
+    } catch {
+      await page.goto(path);
+    }
+  }
+
+  async function uploadFixture(page: Page) {
+    await gotoSettled(page, "/forge/import");
+    await page.getByText("Card images + spreadsheet").click();
+    await page.getByLabel("Choose spreadsheet…").setInputFiles({
+      name: "test-cards.csv", mimeType: "text/csv", buffer: Buffer.from(CSV),
+    });
+    await expect(page.getByText(/2 cards/).first()).toBeVisible();
+  }
+
+  test("elder imports csv + images zip; cleaning stats, images, and idempotent re-run", async ({ page }) => {
+    test.setTimeout(180_000);
+    const seed = await seedForgeMember("elder");
+    try {
+      await signIn(page, seed);
+      await uploadFixture(page);
+
+      // Without a zip: clearly communicated text-only mode.
+      await expect(page.getByText("no images zip — cards import as text only")).toBeVisible();
+
+      await page.getByLabel("Choose images zip…").setInputFiles({
+        name: "images.zip", mimeType: "application/zip", buffer: buildImagesZip(),
+      });
+      // 2 images counted (junk ignored), 1 card matched, 1 without, 1 orphan surfaced.
+      await expect(page.getByText("2 images")).toBeVisible();
+      await expect(page.getByText("1 without an image")).toBeVisible();
+      await expect(page.getByText("1 zip images match no row")).toBeVisible();
+
+      // destination: new set (name prefilled from the csv file name)
+      const setName = `E2E Sheet Import ${Date.now()}`;
+      await page.getByRole("button", { name: "Import 2 cards" }).click();
+      await page.getByLabel("New set name").fill(setName);
+      await page.getByRole("button", { name: "Create set & import 2 cards" }).click();
+      await expect(page.getByText("Imported 2 · Skipped 0 · Failed 0")).toBeVisible({ timeout: 120_000 });
+
+      // set grid shows both cards; the matched finished image renders via the authed proxy
+      await page.getByRole("link", { name: "View set →" }).click();
+      for (const name of FIXTURE_CARDS) {
+        await expect(page.getByText(name).first()).toBeVisible();
+      }
+      const img = page.locator('img[src*="kind=finished"]').first();
+      await expect(img).toBeVisible();
+      await img.scrollIntoViewIfNeeded();
+      await expect
+        .poll(() => img.evaluate((el) => (el as HTMLImageElement).naturalWidth), { timeout: 15_000 })
+        .toBeGreaterThan(0);
+
+      // idempotent re-run into the same set (no zip needed): everything skips
+      await uploadFixture(page);
+      await page.getByLabel("Add to an existing set").check();
+      await page.getByLabel("Existing set", { exact: true }).selectOption({ label: setName });
+      await page.getByRole("button", { name: "Import 2 cards" }).click();
+      await expect(page.getByText("Imported 0 · Skipped 2 · Failed 0")).toBeVisible({ timeout: 120_000 });
+    } finally {
+      await cleanupForgeMember(seed);
+    }
+  });
+});


### PR DESCRIPTION
## What

A second source for the `/forge/import` wizard: alongside the Lackey plugin zip, elders can now import from **a zip of finished card images + a `.csv`/`.xlsx` of card metadata** (the format design teams actually hand around — built against the real Roots 2 files).

Everything parses in the browser: an xlsx is itself a zip of XML, so parsing rides on the existing fflate dependency — nothing new added. The elder-gated server route is untouched; both sources feed the same batched upload pipeline, so idempotent skip and overwrite re-runs behave identically.

## How it works

- **Header auto-detection** handles both real-world conventions: Lackey-style headers (`Name:`, combined `Reference:`) and split `Book`/`Chapter`/`Verse` + `Artist` columns. `Book Chapter:Verse` → `reference`, `Artist` → `artistCredit`.
- **Column mapping is reviewable** — every card field has a dropdown, with the auto-detected Name/Image mappings always visible in the collapsed summary.
- **Mis-mapping tripwires**: warns when card names look like sentence text (the classic wrong-column mistake that would otherwise import "successfully") and when two fields read the same column; the mapping panel force-opens when anything is suspicious.
- **Cleaning report before upload**: skipped rows, ignored duplicates (first wins), cards whose type/brigade/stats/alignment/legality values can't map (they still import — text + image kept, flagged fields left blank), unmatched cards, orphan zip images, over-15MB images.
- **Multi-sheet xlsx** gets a sheet picker; images zip is optional (text-only import).
- Image matching is by base name at any depth, case-insensitive, ignoring `__MACOSX`/AppleDouble junk.

## Refactor

The old single-file wizard split into a shared shell + two source panels + a `useImportRunner` hook. The batch machinery is behavior-identical (8 cards / 3.5MB per request, 4 in flight, route cap 12) with one deliberate change: images decompress **per batch** instead of all upfront — the Roots 2 images zip is 229MB and would otherwise double in memory. Preview object URLs are capped at 120 and cached across mapping edits.

## Verified

- 28 unit tests on the parsers/mapping/cleaning (vitest), including fixtures replicating both real header conventions
- Against the real files: **224 cards parsed, 0 skipped, 0 duplicates, all 224 images matched**, 1 orphan image surfaced, 6 dual-alignment cards correctly flagged
- Live e2e (Playwright): full import of real Roots 2 cards → images render via the authed blob proxy → skip re-run → overwrite re-run; new `spreadsheet-import.spec.ts` passes
- The existing Lackey e2e spec was silently broken since #149 (stale `getByLabel("Lackey zip file")` locator); repaired via a FilePicker `aria-label` and now passes against the refactored wizard — parity proof
- Two independent review passes (correctness/parity + security/UX); all P1s fixed: double-click duplicate set creation, same-filename re-upload deadlock, self-closing `<row/>` off-by-one, unguarded preview decompression

## Screenshot-verified flows

Real 229MB zip + 2-sheet xlsx: sheet picker, auto-mapping, warnings line, orphan count, capped previews with real card art; tripwires fire on deliberate mis-mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)