### PR TITLE
fix(tests): update 3 stale unit tests to match shipped features

### DIFF
--- a/app/forge/lib/__tests__/members.test.ts
+++ b/app/forge/lib/__tests__/members.test.ts
@@ -35,11 +35,10 @@ describe("mintInvite", () => {
     expect(r.ok).toBe(false);
   });
 
-  it("an elder cannot mint an elder invite (needs superadmin)", async () => {
+  it("an elder can mint an elder invite (DB forge_role_outranks caps the role)", async () => {
     (requireElder as any).mockResolvedValue(ctx("elder"));
-    (requireForgeSuperadmin as any).mockResolvedValue(null);
     const r = await mintInvite({ role: "elder" });
-    expect(r.ok).toBe(false);
+    expect(r.ok).toBe(true);
   });
 
   it("mints: hashes the token (raw never sent to RPC) and emails the URL", async () => {

--- a/app/forge/lib/__tests__/sets.test.ts
+++ b/app/forge/lib/__tests__/sets.test.ts
@@ -32,7 +32,7 @@ describe("createSet", () => {
     (requireElder as any).mockResolvedValue(c);
     const r = await createSet("Genesis");
     expect(r).toEqual({ ok: true, id: "set-1" });
-    expect((c.supabase.rpc as any).mock.calls[0]).toEqual(["forge_create_set", { p_name: "Genesis" }]);
+    expect((c.supabase.rpc as any).mock.calls[0]).toEqual(["forge_create_set", { p_name: "Genesis", p_is_private: false }]);
   });
 });
 

--- a/app/threshingfloor/api/__tests__/store-route.test.ts
+++ b/app/threshingfloor/api/__tests__/store-route.test.ts
@@ -90,9 +90,9 @@ describe("PUT /threshingfloor/api/store/[key]", () => {
     expect(r.status).toBe(400);
   });
 
-  it("400s when data is a primitive", async () => {
+  it("400s when data is a disallowed primitive (number)", async () => {
     authorized([]);
-    const r = await put("players", { data: "nope" });
+    const r = await put("players", { data: 42 });
     expect(r.status).toBe(400);
   });
 


### PR DESCRIPTION
## What

Three unit tests were failing on `main`. All three are **stale tests** — their assertions weren't updated when the underlying features shipped. **No production code is changed**; the code is correct in every case.

| Test | Feature that changed the behavior | Landed in |
|------|-----------------------------------|-----------|
| `app/forge/lib/__tests__/sets.test.ts` | `createSet` now passes `p_is_private` to the RPC | Forge private sets (#156) |
| `app/forge/lib/__tests__/members.test.ts` | Elders can now mint elder invites; the DB `forge_role_outranks` caps the role instead of an app-layer superadmin gate | Elder peer management (migration `069`, commit `f1a5003`) |
| `app/threshingfloor/api/__tests__/store-route.test.ts` | String payloads are now valid (`ztempleart` stores a base64 image data URL), so the test's `"nope"` string is accepted; assert `400` on a number instead | Outline tool store keys (#115) |

## Verification

`npm test` (vitest) — full suite green:

```
Test Files  98 passed | 3 skipped (101)
     Tests  1208 passed | 76 skipped (1286)
```

The 3 skipped files include the two `FORGE_LEAK_TEST`-gated anon-leak suites, which skip cleanly when that env var is unset (they are **not** failures — they only crash at collection in a checkout that lacks `.env.local`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)