### PR TITLE
Forge: fix identifier + dual-stat entry in the card editor

### DIFF
--- a/app/forge/cards/[cardId]/CardDetailsFields.tsx
+++ b/app/forge/cards/[cardId]/CardDetailsFields.tsx
@@ -5,6 +5,7 @@ import {
   type DesignCard, type CardType, type Brigade,
 } from "@/app/forge/lib/designCard";
 import StatInput from "./StatInput";
+import IdentifiersInput from "./IdentifiersInput";
 import { BRIGADE_HEX } from "@/app/forge/lib/frameAssets";
 import { deriveTestamentAndGospel, formatTestament } from "@/app/decklist/card-search/data/testament";
 
@@ -85,17 +86,22 @@ export default function CardDetailsFields({
       </div>
 
       {/* Strength / Toughness */}
-      <div className="flex gap-3">
-        <label className="block">
-          <span className="mb-1 block text-sm font-medium">Strength</span>
-          <StatInput value={snapshot.strength} onCommit={(v) => update({ strength: v })}
-            className="w-24 rounded-md border bg-background px-3 py-2 text-sm" />
-        </label>
-        <label className="block">
-          <span className="mb-1 block text-sm font-medium">Toughness</span>
-          <StatInput value={snapshot.toughness} onCommit={(v) => update({ toughness: v })}
-            className="w-24 rounded-md border bg-background px-3 py-2 text-sm" />
-        </label>
+      <div>
+        <div className="flex gap-3">
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium">Strength</span>
+            <StatInput value={snapshot.strength} onCommit={(v) => update({ strength: v })}
+              className="w-24 rounded-md border bg-background px-3 py-2 text-sm" />
+          </label>
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium">Toughness</span>
+            <StatInput value={snapshot.toughness} onCommit={(v) => update({ toughness: v })}
+              className="w-24 rounded-md border bg-background px-3 py-2 text-sm" />
+          </label>
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Dual-alignment or dual-sided? Enter both sides per stat as <span className="font-medium">6/0</span> (stored as 6 (0)). Use <span className="font-medium">X</span> for a variable value.
+        </p>
       </div>
 
       {/* Class */}
@@ -135,9 +141,9 @@ export default function CardDetailsFields({
       {/* Identifier(s) */}
       <label className="block">
         <span className="mb-1 block text-sm font-medium">Identifier(s)</span>
-        <input
-          value={(snapshot.identifiers ?? []).join(", ")}
-          onChange={(e) => update({ identifiers: e.target.value.split(",").map((s) => s.trim()).filter(Boolean) })}
+        <IdentifiersInput
+          value={snapshot.identifiers ?? []}
+          onChange={(identifiers) => update({ identifiers })}
           placeholder="Comma-separated, e.g. Genesis, Patriarch"
           className="w-full rounded-md border bg-background px-3 py-2 text-sm" />
       </label>

--- a/app/forge/cards/[cardId]/IdentifiersInput.tsx
+++ b/app/forge/cards/[cardId]/IdentifiersInput.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// Comma-separated identifier list edited as free text. Like StatInput, it holds a
+// local draft so transient input isn't clobbered by the controlled value. Parsing on
+// every keystroke and re-joining the array — the old approach — stripped a trailing
+// comma ("Genesis," → "Genesis", so a second identifier could never be started) and a
+// space mid-word ("Chief " → "Chief", so multi-word identifiers like "Chief Priest"
+// were untypeable). The parsed array commits upward on each change; the draft resyncs
+// only when the model changes to something it doesn't already represent (an external
+// load/reset), never on our own commits.
+export default function IdentifiersInput({
+  value,
+  onChange,
+  className,
+  placeholder,
+}: {
+  value: string[];
+  onChange: (ids: string[]) => void;
+  className?: string;
+  placeholder?: string;
+}) {
+  const [draft, setDraft] = useState(() => value.join(", "));
+  useEffect(() => {
+    // `draft` is intentionally omitted: resync tracks external model changes, not
+    // typing. The guard skips our own commits, whose array differs by reference but
+    // not content, so an in-progress "Genesis, " isn't snapped back to "Genesis".
+    if (!sameIds(value, parseIdentifiers(draft))) setDraft(value.join(", "));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+  return (
+    <input
+      value={draft}
+      onChange={(e) => {
+        setDraft(e.target.value);
+        onChange(parseIdentifiers(e.target.value));
+      }}
+      placeholder={placeholder}
+      className={className}
+    />
+  );
+}
+
+function parseIdentifiers(text: string): string[] {
+  return text.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+function sameIds(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((x, i) => x === b[i]);
+}

--- a/app/forge/cards/[cardId]/StatInput.tsx
+++ b/app/forge/cards/[cardId]/StatInput.tsx
@@ -21,7 +21,7 @@ export default function StatInput({
   return (
     <input
       type="text"
-      placeholder="6 · X · 6 (0)"
+      placeholder="6 · X · 6/0"
       value={draft}
       className={className}
       onChange={(e) => {

--- a/app/forge/lib/__tests__/parseStatInput.test.ts
+++ b/app/forge/lib/__tests__/parseStatInput.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { parseStatInput } from "../designCard";
+
+describe("parseStatInput", () => {
+  it("returns null for empty / whitespace / junk", () => {
+    expect(parseStatInput("")).toBeNull();
+    expect(parseStatInput("   ")).toBeNull();
+    expect(parseStatInput("abc")).toBeNull();
+    expect(parseStatInput("6-0")).toBeNull();
+  });
+
+  it("passes plain numbers through as numbers", () => {
+    expect(parseStatInput("6")).toBe(6);
+    expect(parseStatInput(" 12 ")).toBe(12);
+    expect(parseStatInput("0")).toBe(0);
+  });
+
+  it("normalizes a variable stat to X", () => {
+    expect(parseStatInput("x")).toBe("X");
+    expect(parseStatInput("X")).toBe("X");
+  });
+
+  it("normalizes canonical parenthesized dual-side stats", () => {
+    expect(parseStatInput("6 (0)")).toBe("6 (0)");
+    expect(parseStatInput("3(2)")).toBe("3 (2)");
+    expect(parseStatInput("x(0)")).toBe("X (0)");
+  });
+
+  it("accepts slash-separated dual-side stats and normalizes to N (M)", () => {
+    expect(parseStatInput("6/0")).toBe("6 (0)");
+    expect(parseStatInput("6 / 0")).toBe("6 (0)");
+    expect(parseStatInput("x/0")).toBe("X (0)");
+    expect(parseStatInput("6/x")).toBe("6 (X)");
+  });
+});

--- a/app/forge/lib/designCard.ts
+++ b/app/forge/lib/designCard.ts
@@ -125,10 +125,14 @@ export function cardRawText(card: DesignCard): string {
   return card.rawText ?? card.specialAbility ?? "";
 }
 
-const PAIRED_STAT_RE = /^(x|\d+)\s*\(\s*(x|\d+)\s*\)$/i;
+// A dual-side stat carries both alignments' values. Accept either the pool's
+// canonical parens ("6 (0)") or a slash ("6/0") — the separator designers reach for
+// first — and normalize both to the canonical `N (M)`.
+const PAIRED_STAT_RE = /^(x|\d+)\s*(?:\(\s*(x|\d+)\s*\)|\/\s*(x|\d+))$/i;
 
 /** Parse a stat: "" → null, "x"/"X" → "X", numbers pass, paired dual-side values
- *  normalize to `N (M)` (e.g. "3(2)" → "3 (2)", "x(0)" → "X (0)"), junk → null. Pure. */
+ *  normalize to `N (M)` (e.g. "3(2)" → "3 (2)", "6/0" → "6 (0)", "x/0" → "X (0)"),
+ *  junk → null. Pure. */
 export function parseStatInput(raw: string): StatValue {
   const t = raw.trim();
   if (!t) return null;
@@ -136,7 +140,7 @@ export function parseStatInput(raw: string): StatValue {
   const paired = PAIRED_STAT_RE.exec(t);
   if (paired) {
     const side = (s: string) => (/^x$/i.test(s) ? "X" : s);
-    return `${side(paired[1])} (${side(paired[2])})`;
+    return `${side(paired[1])} (${side(paired[2] ?? paired[3])})`;
   }
   const n = Number(t);
   return Number.isFinite(n) ? n : null;


### PR DESCRIPTION
Two input fixes in the Forge card-details form, both reported from real use.

## Identifiers — allow spaces and commas
The **Identifier(s)** field was a controlled input that re-derived its text from `identifiers.join(", ")` while re-parsing (`split(",").map(trim).filter(Boolean)`) on **every keystroke**. That destroyed transient input:
- **Trailing comma** — `"Genesis,"` parsed to `["Genesis"]` and rendered back as `"Genesis"`, so a second identifier could never be started.
- **Mid-word space** — `"Chief "` snapped back to `"Chief"`, so multi-word identifiers like `Chief Priest` were untypeable.

New `IdentifiersInput` buffers the raw text locally and commits the parsed array upward — the same "hold a draft, commit the parsed value" pattern the codebase already uses in `StatInput`. It resyncs from the model only on a genuine external change (guarded so it never clobbers in-progress typing).

## Dual-alignment stats — accept a slash
The stat field already supported two values per stat via the pool's canonical `6 (0)` notation (142 pool cards use it), but `parseStatInput` only accepted the parenthesized form. Typing the slash designers reach for (`6/0`) didn't parse, so `StatInput` silently reverted it on blur — feeling like "numbers only."

`parseStatInput` now accepts a slash pair (`6/0`, `6 / 0`, `x/0`, `6/x`) and **normalizes to the canonical `N (M)`**, keeping stored data consistent with the rest of the pool and all downstream consumers (deck adapter, play state). The placeholder now shows `6/0` and a hint under the stat fields makes dual stats discoverable.

For a dual-alignment character: Strength `6/4`, Toughness `8/2` → Good side 6/8, Evil side 4/2.

## Notes
- The sibling `FullModeForm.tsx` has the identical identifier bug but is **dead code** (removed from the studio per the DESCOPE comment in `StudioEditor.tsx`, kept only for recovery), so it's left untouched.
- Canonical stat form stays `N (M)` rather than storing the slash — slash is just an input convenience that normalizes.

## Verification
- New `parseStatInput.test.ts` — 5 tests passing (numbers, `X`, parens, slash, junk).
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)