### PR TITLE
fix(forge): render practice-mode hover preview with plain <img>

### DIFF
--- a/app/goldfish/components/CardHoverPreview.tsx
+++ b/app/goldfish/components/CardHoverPreview.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
 import { GameCard } from '../types';
 import { getCardImageUrl } from '../../shared/utils/cardImageUrl';
@@ -49,7 +48,13 @@ export function CardHoverPreview({ card, anchorX, anchorY }: CardHoverPreviewPro
           boxShadow: '0 8px 32px rgba(0,0,0,0.8), 0 0 12px rgba(212,168,103,0.3)',
         }}
       >
-        <Image
+        {/* Plain <img>, not next/image: Forge cards resolve to the cookie-authed
+            /forge/api/art proxy, which next/image's server-side optimizer can't
+            fetch (no auth cookies; the proxy is private/no-store) → broken image.
+            A direct <img> loads client-side with the user's cookies. Mirrors
+            CardLoupePanel. */}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
           src={imageUrl}
           alt={card.cardName}
           width={previewWidth}


### PR DESCRIPTION
## Bug
In practice/goldfish mode, hovering an **EoT (Forge) card** shows a broken "?" image square in the on-hover popup — but only when the side **"preview" panel is hidden**. With the preview panel active, the same card renders correctly there. Public cards are unaffected.

## Root cause
Forge cards in goldfish/practice carry a resolved `cardImgFile` of `/forge/api/art/<id>?v=approved…` — the **cookie-authed** Forge art proxy (`requireForge`-gated, `private, no-store`).

The hover popup (`CardHoverPreview.tsx`) rendered that URL through **`next/image`**, whose optimizer does a **server-side** fetch (`/_next/image?url=…`) that carries none of the user's auth cookies → proxy 404s → broken image. The side panel (`CardLoupePanel.tsx`) uses a plain `<img>`, which the browser fetches **client-side with cookies** → works. That's the exact split the user saw.

## Fix
Swap the hover popup to a plain `<img>`, mirroring the already-correct `CardLoupePanel` / `ModalCardHoverPreview`. One file, +7/−2 (removes the now-unused `next/image` import).

## Verification
- `tsc --noEmit` clean.
- Mirrors the proven-working sibling component.
- Live hover-test in practice mode still recommended (needs a forge-granted account + approved EoT deck).

## Notes
- **Latent same-bug, untouched:** `app/shared/components/CardZoomModal.tsx` (right-click zoom) has the identical `next/image` + forge-proxy hazard, but it's currently **dead code** (no render sites) so it can't trigger. Left alone; will need the same swap if ever wired up.
- The `forge-no-next-image` CI guardrail only scans `app/forge/**`, so goldfish/play/shared preview components aren't covered — which is why this slipped through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)