### PR TITLE
feat(forge): prev/next card arrows in the card detail view

### DIFF
--- a/app/forge/cards/[cardId]/StudioEditor.tsx
+++ b/app/forge/cards/[cardId]/StudioEditor.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Download } from "lucide-react";
+import Link from "next/link";
+import { Download, ChevronLeft, ChevronRight } from "lucide-react";
 import ForgeCardFace from "@/app/forge/components/ForgeCardFace";
 import ForgeBreadcrumbs from "@/app/forge/components/ForgeBreadcrumbs";
 import FilePicker from "@/app/forge/components/FilePicker";
@@ -25,14 +26,21 @@ import CardDetailsFields from "./CardDetailsFields";
 // raw text + optional artwork + optional finished-card image. Both files remain on
 // disk (unused here) for recovery.
 
+// Prev/next arrows overlaid on the card face edges. Inside the edges (not the
+// gutter) so they never clip on mobile.
+const arrowClass =
+  "absolute top-1/2 z-10 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full border bg-background/70 text-muted-foreground shadow-sm backdrop-blur transition-colors hover:bg-background hover:text-foreground";
+
 export default function StudioEditor({
-  card, sets, currentUser, setId, setName,
+  card, sets, currentUser, setId, setName, prevId, nextId,
 }: {
   card: ForgeCardFull;
   sets: ForgeSetSummary[];
   currentUser: { userId: string; displayName: string | null };
   setId: string | null;
   setName: string | null;
+  prevId?: string | null;
+  nextId?: string | null;
 }) {
   const [snapshot, setSnapshot] = useState<DesignCard>(card.snapshot ?? {});
   const [saved, setSaved] = useState<"idle" | "saving" | "saved" | "error">("idle");
@@ -84,6 +92,23 @@ export default function StudioEditor({
       if (latest.current !== lastSaved.current) void saveCard(card.id, latest.current);
     };
   }, [card.id]);
+
+  // Arrow keys step to the prev/next card in the set — but only when focus is
+  // outside a field, so they still move the text cursor while editing.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+      const el = document.activeElement as HTMLElement | null;
+      if (el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.tagName === "SELECT" || el.isContentEditable)) return;
+      const dest = e.key === "ArrowLeft" ? prevId : nextId;
+      if (!dest) return;
+      e.preventDefault();
+      router.push(`/forge/cards/${dest}`);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [prevId, nextId, router]);
 
   const update = (patch: Partial<DesignCard>) => {
     fieldsDirty.current = true;
@@ -176,12 +201,25 @@ export default function StudioEditor({
       <div className="grid gap-6 md:grid-cols-[minmax(0,360px)_1fr]">
         {/* Face — sticky on desktop, top on mobile */}
         <div className="md:sticky md:top-4 md:self-start">
-          <ForgeCardFace
-            name={snapshot.name ?? null}
-            rawText={cardRawText(snapshot)}
-            finishedUrl={card.hasFinished ? `/forge/api/art/${card.id}?kind=finished&t=${t}` : null}
-            artUrl={card.hasArt ? `/forge/api/art/${card.id}?t=${t}` : null}
-          />
+          <div className="relative">
+            <ForgeCardFace
+              name={snapshot.name ?? null}
+              rawText={cardRawText(snapshot)}
+              finishedUrl={card.hasFinished ? `/forge/api/art/${card.id}?kind=finished&t=${t}` : null}
+              artUrl={card.hasArt ? `/forge/api/art/${card.id}?t=${t}` : null}
+            />
+            {/* Prev/next within the set — same order as the grid, no wrap at ends. */}
+            {prevId && (
+              <Link href={`/forge/cards/${prevId}`} aria-label="Previous card in set" className={arrowClass + " left-1.5"}>
+                <ChevronLeft className="h-5 w-5" aria-hidden="true" />
+              </Link>
+            )}
+            {nextId && (
+              <Link href={`/forge/cards/${nextId}`} aria-label="Next card in set" className={arrowClass + " right-1.5"}>
+                <ChevronRight className="h-5 w-5" aria-hidden="true" />
+              </Link>
+            )}
+          </div>
         </div>
 
         {/* Form */}

--- a/app/forge/cards/[cardId]/page.tsx
+++ b/app/forge/cards/[cardId]/page.tsx
@@ -1,7 +1,8 @@
 import { notFound, redirect } from "next/navigation";
 import { requireForge } from "@/app/forge/lib/auth";
 import { getCard } from "@/app/forge/lib/cards";
-import { getSet, listSets } from "@/app/forge/lib/sets";
+import { getSet, listSets, listSetCards } from "@/app/forge/lib/sets";
+import { sortSetCards } from "@/app/forge/lib/cardOrder";
 import { getOpenProposalDiffs, listProposals } from "@/app/forge/lib/proposals";
 import { listComments } from "@/app/forge/lib/comments";
 import { listVersions, listCardEvents } from "@/app/forge/lib/versions";
@@ -21,16 +22,24 @@ export default async function StudioPage({ params }: { params: Promise<{ cardId:
 
   const inSet = card.setId !== null;
   const sets = inSet ? [] : await listSets();
-  const [openDiffs, proposals, comments, versions, events] = inSet
+  const [openDiffs, proposals, comments, versions, events, siblings] = inSet
     ? await Promise.all([
         getOpenProposalDiffs(cardId),
         listProposals(cardId),
         listComments(cardId),
         listVersions(cardId),
         listCardEvents(cardId),
+        listSetCards(card.setId!),
       ])
-    : [[], [], [], [], []];
+    : [[], [], [], [], [], []];
   const canReview = ctx.role === "elder" || ctx.role === "superadmin";
+
+  // Prev/next arrows on the card face walk the set in the same order as the grid.
+  // No wrap: the boundary card gets null and hides that arrow.
+  const ordered = sortSetCards(siblings);
+  const idx = ordered.findIndex((c) => c.id === cardId);
+  const prevId = idx > 0 ? ordered[idx - 1].id : null;
+  const nextId = idx >= 0 && idx < ordered.length - 1 ? ordered[idx + 1].id : null;
 
   const { data: meRow } = await ctx.supabase
     .from("playtest_members")
@@ -41,7 +50,7 @@ export default async function StudioPage({ params }: { params: Promise<{ cardId:
 
   return (
     <>
-      <StudioEditor card={card} sets={sets} currentUser={currentUser} setId={card.setId ?? null} setName={set?.name ?? null} />
+      <StudioEditor card={card} sets={sets} currentUser={currentUser} setId={card.setId ?? null} setName={set?.name ?? null} prevId={prevId} nextId={nextId} />
       {inSet && (
         <ReviewPanel
           card={card}

--- a/app/forge/lib/cardOrder.ts
+++ b/app/forge/lib/cardOrder.ts
@@ -1,0 +1,27 @@
+import { BRIGADES } from "@/app/forge/lib/designCard";
+import type { ForgeCardFull } from "@/app/forge/lib/cards";
+
+// Default set-card display order: by card type alphabetically, then brigade
+// (canonical BRIGADES order ascending), then title. Cards missing a primary type
+// sort last. Shared by the set grid (SetCardsBrowser) and the single-card detail
+// view's prev/next arrows so both walk the set in the same order.
+export function sortSetCards(cards: ForgeCardFull[]): ForgeCardFull[] {
+  const rank = (value: string | undefined, order: readonly string[]) => {
+    const i = value ? order.indexOf(value) : -1;
+    return i === -1 ? Number.MAX_SAFE_INTEGER : i;
+  };
+  const brigadeRank = (c: ForgeCardFull) => rank(c.snapshot?.brigades?.[0], BRIGADES);
+  const typeAlpha = (a: ForgeCardFull, b: ForgeCardFull) => {
+    const ta = a.snapshot?.cardType?.[0], tb = b.snapshot?.cardType?.[0];
+    if (ta === tb) return 0;
+    if (!ta) return 1; // no primary type → last
+    if (!tb) return -1;
+    return ta.localeCompare(tb);
+  };
+  return [...cards].sort(
+    (a, b) =>
+      typeAlpha(a, b) ||
+      brigadeRank(a) - brigadeRank(b) ||
+      (a.title ?? "").localeCompare(b.title ?? ""),
+  );
+}

--- a/app/forge/sets/[setId]/cards/SetCardsBrowser.tsx
+++ b/app/forge/sets/[setId]/cards/SetCardsBrowser.tsx
@@ -10,6 +10,7 @@ import {
   STATUS_LABEL, ACTION_LABEL, BULK_DONE_VERB, CONFIRM_COPY, isEligible, type LifecycleAction,
 } from "@/app/forge/lib/lifecycleCopy";
 import { cardRawText, CARD_TYPES, BRIGADES, type CardType, type Brigade } from "@/app/forge/lib/designCard";
+import { sortSetCards } from "@/app/forge/lib/cardOrder";
 import type { ForgeCardFull } from "@/app/forge/lib/cards";
 import type { ReleaseInfo } from "@/app/forge/lib/versions";
 import { Button } from "@/components/ui/button";
@@ -47,29 +48,9 @@ export default function SetCardsBrowser({ cards, setId, canCreate, commentCounts
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
-  // Default order: by card type alphabetically, then brigade, then title. Cards
-  // missing a primary type sort last; brigade uses the canonical BRIGADES order
-  // ascending.
-  const sorted = useMemo(() => {
-    const rank = (value: string | undefined, order: readonly string[]) => {
-      const i = value ? order.indexOf(value) : -1;
-      return i === -1 ? Number.MAX_SAFE_INTEGER : i;
-    };
-    const brigadeRank = (c: ForgeCardFull) => rank(c.snapshot?.brigades?.[0], BRIGADES);
-    const typeAlpha = (a: ForgeCardFull, b: ForgeCardFull) => {
-      const ta = a.snapshot?.cardType?.[0], tb = b.snapshot?.cardType?.[0];
-      if (ta === tb) return 0;
-      if (!ta) return 1; // no primary type → last
-      if (!tb) return -1;
-      return ta.localeCompare(tb);
-    };
-    return [...cards].sort(
-      (a, b) =>
-        typeAlpha(a, b) ||
-        brigadeRank(a) - brigadeRank(b) ||
-        (a.title ?? "").localeCompare(b.title ?? ""),
-    );
-  }, [cards]);
+  // Default order: by card type alphabetically, then brigade, then title. Shared
+  // with the single-card detail view's prev/next arrows via sortSetCards.
+  const sorted = useMemo(() => sortSetCards(cards), [cards]);
 
   const filtered = useMemo(() => sorted.filter((c) => {
     const s = c.snapshot ?? {};


### PR DESCRIPTION
## What

A low-friction QoL for the Forge single-card view: left/right arrows on the card face (and **←/→** keys) step to the previous/next card **in the same set** without clicking back out to the grid.

## Why

Reviewing a set's cards one at a time currently means: open card → read → back to grid → open next. This removes the round-trip.

## How

- **`app/forge/lib/cardOrder.ts`** *(new)* — extracts the grid's `type → brigade → name` sort into a shared `sortSetCards()` helper.
- **`SetCardsBrowser.tsx`** — grid now calls `sortSetCards()` (no behavior change) so the grid and the arrows walk the set in the exact same order.
- **`app/forge/cards/[cardId]/page.tsx`** — for in-set cards, fetches siblings, sorts them, and computes `prevId`/`nextId` (folded into the existing `Promise.all`).
- **`StudioEditor.tsx`** — renders the two arrow `<Link>`s overlaid on the card-face edges + an `ArrowLeft`/`ArrowRight` keydown handler.

## Behavior

- **No wrap** — the first/last card just hides the boundary arrow.
- **Neutral styling** — subtle bordered pill, muted at rest → foreground on hover; no green, no focus ring. Placed *inside* the card edges so they never clip on mobile.
- **Keyboard arrows only fire when focus is outside a form field** (mirrors the existing `/` shortcut), so they still move the text cursor while editing. In-flight edits are flushed on navigation by the existing autosave-on-unmount path.
- Cards outside a set (ideas) get no arrows.

## Notes

- **Stacked on `forge-version-history`** (base), not `main` — all three modified files also live under that branch's version-history work, so this targets it to keep the diff to just the card-nav change.
- **Known limitation:** arrows follow the set's *default* order, not any active search/filter/sort in the grid (that state lives only in the client grid component). Matching the live filter would require a modal rearchitecture — out of scope for this QoL pass.
- `tsc --noEmit` clean for the touched files. Not verified in-browser yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)