### PR TITLE
fix(play): Lost Souls can never be hidden as Land of Bondage accessories

### DIFF
--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -15,6 +15,7 @@ import {
 import { toScreenPos, toDbPos, cardCenter, adjustAnchorForRotationChange } from '../utils/coordinateTransforms';
 import { calculateHandPositions, HAND_TOOLBAR_RESERVE } from '../layout/multiplayerHandLayout';
 import { calculateAutoArrangePositions } from '../layout/multiplayerAutoArrange';
+import { splitLobCards } from '../layout/lobClassification';
 import { useDealAnimation } from '@/app/shared/hooks/useDealAnimation';
 import { useHandLayoutTween } from '@/app/shared/hooks/useHandLayoutTween';
 import { DealLayer, type DealSpriteSpec } from '@/app/shared/components/DealLayer';
@@ -3452,7 +3453,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
           const sortedLob = [...myLobRaw].sort(
             (a, b) => Number(a.zoneIndex) - Number(b.zoneIndex),
           );
-          const lobHosts = sortedLob.filter((c) => c.equippedToInstanceId === 0n);
+          const lobHosts = splitLobCards(sortedLob).hosts;
           const slotPositions = calculateAutoArrangePositions(
             lobHosts.length,
             myLobZone,
@@ -4142,14 +4143,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
       return { hostPositions, accessoryPositions };
     }
     const sorted = [...cards].sort((a, b) => Number(a.zoneIndex) - Number(b.zoneIndex));
-    const hosts = sorted.filter((c) => c.equippedToInstanceId === 0n);
-    const accessoriesByHost = new Map<bigint, CardInstance[]>();
-    for (const c of sorted) {
-      if (c.equippedToInstanceId === 0n) continue;
-      const list = accessoriesByHost.get(c.equippedToInstanceId);
-      if (list) list.push(c);
-      else accessoriesByHost.set(c.equippedToInstanceId, [c]);
-    }
+    const { hosts, accessoriesByHost } = splitLobCards(sorted);
     const slotPositions = calculateAutoArrangePositions(
       hosts.length,
       zone,
@@ -4190,14 +4184,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
       return { hostPositions, accessoryPositions };
     }
     const sorted = [...cards].sort((a, b) => Number(a.zoneIndex) - Number(b.zoneIndex));
-    const hosts = sorted.filter((c) => c.equippedToInstanceId === 0n);
-    const accessoriesByHost = new Map<bigint, CardInstance[]>();
-    for (const c of sorted) {
-      if (c.equippedToInstanceId === 0n) continue;
-      const list = accessoriesByHost.get(c.equippedToInstanceId);
-      if (list) list.push(c);
-      else accessoriesByHost.set(c.equippedToInstanceId, [c]);
-    }
+    const { hosts, accessoriesByHost } = splitLobCards(sorted);
     const slotPositions = calculateAutoArrangePositions(
       hosts.length,
       zone,
@@ -4243,14 +4230,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
     if (!zone || cards.length === 0) {
       return { hostPositions, accessoryPositions };
     }
-    const hosts = cards.filter((c) => c.equippedToInstanceId === 0n);
-    const accessoriesByHost = new Map<bigint, CardInstance[]>();
-    for (const c of cards) {
-      if (c.equippedToInstanceId === 0n) continue;
-      const list = accessoriesByHost.get(c.equippedToInstanceId);
-      if (list) list.push(c);
-      else accessoriesByHost.set(c.equippedToInstanceId, [c]);
-    }
+    const { hosts, accessoriesByHost } = splitLobCards(cards);
     // Base 3 slots (canonical rescue-slot grid). Expand the grid if any host
     // has zoneIndex beyond slot 2 — e.g., a stray card dropped into an
     // overflow slot must render in its own position, not stacked on slot 0.
@@ -4458,7 +4438,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
       const zone = myZones[zoneKey];
       if (cards.length > 0 && zone) {
         const sorted = [...cards].sort((a, b) => Number(a.zoneIndex) - Number(b.zoneIndex));
-        const hosts = sorted.filter((c) => c.equippedToInstanceId === 0n);
+        const { hosts, accessoriesByHost } = splitLobCards(sorted);
         const positions = calculateAutoArrangePositions(hosts.length, zone, lobCard.cardWidth, lobCard.cardHeight);
         hosts.forEach((host, i) => {
           const pos = positions[i];
@@ -4472,7 +4452,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
             rotation: 0,
             owner: 'my',
           });
-          const attached = sorted.filter((c) => c.equippedToInstanceId === host.id);
+          const attached = accessoriesByHost.get(host.id) ?? [];
           for (const accessory of attached) {
             const derived = myDerivedWeaponPositions.get(String(accessory.id));
             if (!derived) continue;
@@ -4497,10 +4477,9 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
       const cards = sharedCards['land-of-bondage'] ?? [];
       for (const card of cards) {
         const idStr = String(card.id);
-        const isAccessory = card.equippedToInstanceId !== 0n;
-        const pos = isAccessory
-          ? sharedLobLayout.accessoryPositions.get(idStr)
-          : sharedLobLayout.hostPositions.get(idStr);
+        const pos =
+          sharedLobLayout.hostPositions.get(idStr) ??
+          sharedLobLayout.accessoryPositions.get(idStr);
         if (!pos) continue;
         bounds.push({
           instanceId: idStr,
@@ -4521,7 +4500,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
       const zone = opponentZones[zoneKey];
       if (cards.length > 0 && zone) {
         const sorted = [...cards].sort((a, b) => Number(a.zoneIndex) - Number(b.zoneIndex));
-        const hosts = sorted.filter((c) => c.equippedToInstanceId === 0n);
+        const { hosts, accessoriesByHost } = splitLobCards(sorted);
         const positions = calculateAutoArrangePositions(hosts.length, zone, lobCard.cardWidth, lobCard.cardHeight);
         hosts.forEach((host, i) => {
           const pos = positions[i];
@@ -4537,7 +4516,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
             rotation: 180,
             owner: 'opponent',
           });
-          const attached = sorted.filter((c) => c.equippedToInstanceId === host.id);
+          const attached = accessoriesByHost.get(host.id) ?? [];
           for (const accessory of attached) {
             const derived = opponentDerivedWeaponPositions.get(String(accessory.id));
             if (!derived) continue;
@@ -5285,7 +5264,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
             const zone = myZones[zoneKey];
             if (!zone) return null;
             const sorted = [...cards].sort((a, b) => Number(a.zoneIndex) - Number(b.zoneIndex));
-            const hosts = sorted.filter((c) => c.equippedToInstanceId === 0n);
+            const { hosts, accessoriesByHost } = splitLobCards(sorted);
             const renderLobCard = (card: CardInstance, overridePos: { x: number; y: number }) => {
               const gameCard = adaptCard(card, 'player1');
               const cardIdStr = String(card.id);
@@ -5323,7 +5302,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
             for (const host of hosts) {
               const hostPos = myLobLayout.hostPositions.get(String(host.id));
               if (!hostPos) continue;
-              const attached = sorted.filter((c) => c.equippedToInstanceId === host.id);
+              const attached = accessoriesByHost.get(host.id) ?? [];
               for (const accessory of attached) {
                 const pos = myLobLayout.accessoryPositions.get(String(accessory.id));
                 if (!pos) continue;
@@ -5355,7 +5334,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
             const zone = opponentZones[zoneKey];
             if (!zone) return null;
             const sorted = [...cards].sort((a, b) => Number(a.zoneIndex) - Number(b.zoneIndex));
-            const hosts = sorted.filter((c) => c.equippedToInstanceId === 0n);
+            const { hosts, accessoriesByHost } = splitLobCards(sorted);
             const renderOppLobCard = (
               card: CardInstance,
               anchor: { x: number; y: number },
@@ -5397,7 +5376,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
             for (const host of hosts) {
               const hostPos = opponentLobLayout.hostPositions.get(String(host.id));
               if (!hostPos) continue;
-              const attached = sorted.filter((c) => c.equippedToInstanceId === host.id);
+              const attached = accessoriesByHost.get(host.id) ?? [];
               for (const accessory of attached) {
                 const pos = opponentLobLayout.accessoryPositions.get(String(accessory.id));
                 if (!pos) continue;
@@ -5433,7 +5412,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
             const zone = mpLayout?.zones.sharedLob;
             if (!zone) return null;
             const sorted = [...cards].sort((a, b) => Number(a.zoneIndex) - Number(b.zoneIndex));
-            const hosts = sorted.filter((c) => c.equippedToInstanceId === 0n);
+            const { hosts, accessoriesByHost } = splitLobCards(sorted);
             const renderSharedLobCard = (card: CardInstance, overridePos: { x: number; y: number }) => {
               const gameCard = adaptCard(card, 'player1');
               const cardIdStr = String(card.id);
@@ -5468,7 +5447,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
             for (const host of hosts) {
               const hostPos = sharedLobLayout.hostPositions.get(String(host.id));
               if (!hostPos) continue;
-              const attached = sorted.filter((c) => c.equippedToInstanceId === host.id);
+              const attached = accessoriesByHost.get(host.id) ?? [];
               for (const accessory of attached) {
                 const pos = sharedLobLayout.accessoryPositions.get(String(accessory.id));
                 if (!pos) continue;

--- a/app/play/layout/__tests__/lobClassification.test.ts
+++ b/app/play/layout/__tests__/lobClassification.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { splitLobCards } from '../lobClassification';
+
+const soul = (id: bigint, equippedTo: bigint = 0n) => ({
+  id,
+  equippedToInstanceId: equippedTo,
+  cardType: 'Lost Soul',
+});
+const site = (id: bigint, equippedTo: bigint = 0n) => ({
+  id,
+  equippedToInstanceId: equippedTo,
+  cardType: 'Site',
+});
+
+describe('splitLobCards', () => {
+  it('splits a normal soul + attached site into host + accessory', () => {
+    const cards = [soul(1n), site(2n, 1n), soul(3n)];
+    const { hosts, accessoriesByHost } = splitLobCards(cards);
+    expect(hosts.map(c => c.id)).toEqual([1n, 3n]);
+    expect(accessoriesByHost.get(1n)?.map(c => c.id)).toEqual([2n]);
+  });
+
+  it('a Lost Soul with a stale equippedToInstanceId still renders as a host', () => {
+    // Regression: a soul carrying a bogus attachment must never be tucked
+    // behind another card (it rendered hidden below the opponent LOB strip).
+    const cards = [soul(1n), soul(2n, 1n)];
+    const { hosts, accessoriesByHost } = splitLobCards(cards);
+    expect(hosts.map(c => c.id)).toEqual([1n, 2n]);
+    expect(accessoriesByHost.size).toBe(0);
+  });
+
+  it('an accessory whose host is missing falls back to a host slot', () => {
+    // Orphaned site (host rescued/moved with a stale attachment left behind)
+    // must occupy its own slot instead of vanishing from the strip.
+    const cards = [site(5n, 999n), soul(6n)];
+    const { hosts, accessoriesByHost } = splitLobCards(cards);
+    expect(hosts.map(c => c.id)).toEqual([5n, 6n]);
+    expect(accessoriesByHost.size).toBe(0);
+  });
+
+  it('an accessory attached to another accessory falls back to a host slot', () => {
+    const cards = [soul(1n), site(2n, 1n), site(3n, 2n)];
+    const { hosts, accessoriesByHost } = splitLobCards(cards);
+    expect(hosts.map(c => c.id)).toEqual([1n, 3n]);
+    expect(accessoriesByHost.get(1n)?.map(c => c.id)).toEqual([2n]);
+  });
+
+  it('preserves input order for hosts and per-host accessories', () => {
+    const cards = [soul(3n), site(4n, 3n), soul(1n), site(5n, 3n), soul(2n)];
+    const { hosts, accessoriesByHost } = splitLobCards(cards);
+    expect(hosts.map(c => c.id)).toEqual([3n, 1n, 2n]);
+    expect(accessoriesByHost.get(3n)?.map(c => c.id)).toEqual([4n, 5n]);
+  });
+});

--- a/app/play/layout/lobClassification.ts
+++ b/app/play/layout/lobClassification.ts
@@ -1,0 +1,35 @@
+import { isLostSoulCard } from '@/lib/cards/cardAbilities';
+
+// ---------------------------------------------------------------------------
+// Land of Bondage host/accessory classification
+// A card renders as an accessory (tucked ~85% behind its host, peeking past
+// the strip) only when it is attached AND its host is present in the same LOB
+// list. Two guards keep bad/stale data from hiding cards (a soul once
+// rendered tucked below the opponent's strip until refresh):
+//   1. Lost Souls are ALWAYS hosts — souls are never accessories, whatever
+//      their equippedToInstanceId claims.
+//   2. An accessory whose host is missing falls back to a host slot instead
+//      of vanishing (orphaned sites).
+// Layout memos, render splits, marquee bounds, and the attach drag must all
+// classify through this helper so they stay consistent.
+// ---------------------------------------------------------------------------
+export function splitLobCards<
+  T extends { id: bigint; equippedToInstanceId: bigint; cardType: string },
+>(cards: T[]): { hosts: T[]; accessoriesByHost: Map<bigint, T[]> } {
+  const hostIds = new Set<bigint>();
+  for (const c of cards) {
+    if (c.equippedToInstanceId === 0n || isLostSoulCard(c)) hostIds.add(c.id);
+  }
+  const hosts: T[] = [];
+  const accessoriesByHost = new Map<bigint, T[]>();
+  for (const c of cards) {
+    if (hostIds.has(c.id) || !hostIds.has(c.equippedToInstanceId)) {
+      hosts.push(c);
+    } else {
+      const list = accessoriesByHost.get(c.equippedToInstanceId);
+      if (list) list.push(c);
+      else accessoriesByHost.set(c.equippedToInstanceId, [c]);
+    }
+  }
+  return { hosts, accessoriesByHost };
+}


### PR DESCRIPTION
## Symptom

Reported after the #171 deploy: a Lost Soul in the opponent's Land of Bondage occasionally renders **hidden below the strip** — tucked behind another card with only a sliver peeking — leaving a gap in the row. Intermittent; a page refresh fixes it.

## Root cause

LOB rendering splits cards into **hosts** (own slot in the row, clipped to the zone rect) and **accessories** (`equippedToInstanceId !== 0n` → rendered ~85% tucked behind their host in an **unclipped** group, peeking past the strip). Classification is decided entirely by `equippedToInstanceId`.

The decisive detail: the missing soul was **visibly peeking below** the strip. Hosts render inside a clip rect — a mispositioned host would be clipped invisible, not peeking. A visible peek can only come from the unclipped accessory path, which proves the soul was **classified as an accessory** because its row carried a stale/transient non-zero `equippedToInstanceId` client-side (refresh re-syncs clean data, which is why it self-heals). This also rules out the #171 animations — the deal/glide code can only move nodes, never re-classify them into the unclipped group.

Souls are never legitimately accessories (sites and Paragon enhancers attach **to** souls, never the reverse — both the drag path and `attach_card` always make the site the accessory).

## Fix

All six host/accessory split sites (3 layout memos, 3 render splits, plus marquee bounds and the attach-drag candidate list) now classify through one shared helper, `app/play/layout/lobClassification.ts`, with two guards:

1. **A Lost Soul is always a host** — whatever its `equippedToInstanceId` claims, it gets its own visible slot in the row.
2. **An accessory whose host is missing falls back to a host slot** — an orphaned site renders in the row instead of vanishing entirely (the same bug class, invisible variant).

Render-side guards are the right layer: client data can transiently lie (stale rows, races), and the board should never hide a card because of it.

## Verification

- 5 unit tests for the classifier, including the exact regression (stale-attached soul stays a host) and the orphan fallback.
- Live two-player game: souls route to both LOB strips and render in their row slots; normal site-attach tuck behavior unchanged (accessory positions only ever come from present hosts).
- `tsc --noEmit` clean; suite green except the pre-existing forge-lackey failure on `main`.

## Notes

- The trigger that leaves a stale `equippedToInstanceId` on a soul row client-side wasn't pinpointed (candidates: undo restoring an old row snapshot, or the known STDB shared-cache staleness class). The guard makes rendering immune regardless of trigger.
- Optional follow-up hardening: `attach_card` server-side reject when the accessory is a Lost Soul (requires module republish, so kept out of this client-only fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)