### PR TITLE
fix(play): invisible "ghost" Lost Souls after dragging to discard/banish/reserve

### DIFF
--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -3904,18 +3904,42 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
         }
         holdOnPile();
       } else {
+        // Lost Souls dropped on a graveyard pile (discard/reserve/banish) are
+        // redirected by the server back into the Land of Bondage. When the
+        // drag started in a LoB the card re-renders in the SAME parent Group
+        // with the same key, so its element never unmounts — destroying the
+        // node here would orphan the row (React-Konva still thinks the node
+        // exists and never recreates it), leaving an invisible "ghost" soul
+        // holding a slot. Mirrors the server predicate at moveCard's
+        // lost-soul redirect (token souls are deleted there, not redirected).
+        const GRAVEYARD_PILE_ZONES = ['discard', 'reserve', 'banish'];
+        const staysInLobAfterPileDrop = (id: string): boolean => {
+          if (!GRAVEYARD_PILE_ZONES.includes(targetZone)) return false;
+          const inst = findAnyCardById(id);
+          if (!inst || inst.isToken) return false;
+          if (inst.zone !== 'land-of-bondage') return false;
+          return inst.cardType === 'LS' || inst.cardName.toLowerCase().includes('lost soul');
+        };
         // Non-deck zone: destroy the reparented node so React-Konva creates
         // a fresh node in the correct parent Group with correct dimensions.
         const draggedNode = cardNodeRefs.current.get(card.instanceId);
         if (draggedNode) {
-          cardNodeRefs.current.delete(card.instanceId);
-          draggedNode.destroy();
+          if (staysInLobAfterPileDrop(card.instanceId)) {
+            // Node must survive — the subscription update repositions it.
+            snapBack();
+          } else {
+            cardNodeRefs.current.delete(card.instanceId);
+            draggedNode.destroy();
+          }
         }
         // Also clean up any follower nodes that were reparented
         if (followerOffsets) {
           for (const [id] of followerOffsets) {
             const fNode = cardNodeRefs.current.get(id);
             if (fNode) {
+              // Redirected souls keep their node (it never left its parent);
+              // the group-settle microtask re-shows it in place.
+              if (staysInLobAfterPileDrop(id)) continue;
               cardNodeRefs.current.delete(id);
               fNode.destroy();
             }


### PR DESCRIPTION
## Problem

Dragging a Lost Soul from the Land of Bondage onto a graveyard pile (discard, reserve, or banish) left an invisible "ghost" soul: the card still existed in state — holding a slot and spreading the LOB strip — but nothing rendered it. Game log showed e.g.:

> banished Lost Soul "Lawless" [Hebrews 12:8] … but went to land of bondage instead

## Root cause

On a cross-zone drop, `handleCardDragEnd` destroys the dragged Konva node, relying on the row changing render blocks so React-Konva mounts a fresh node in the new zone group. But the server redirects Lost Souls dropped on discard/reserve/banish back into the Land of Bondage (`moveCard` redirect in `spacetimedb/src/index.ts`). Since the soul starts and ends in the LOB, its React element never unmounts — same key, same parent Group — so React-Konva never recreates the node it still thinks is alive. Row with no canvas node = invisible soul. (The recent deal-flyer animation was not involved.)

## Fix

When the drop matches the server's redirect predicate (LS type or "lost soul" name, non-token, dragged from a LOB, target is a graveyard pile), snap the node back instead of destroying it. The subscription update then repositions it at the end of the strip. Token souls still delete (matching the server), and group-drag followers matching the predicate keep their nodes so the settle pass re-shows them in place.

Covers both players' piles and Paragon's shared LOB.

## Verification

- `tsc --noEmit` clean for the changed file (remaining repo errors pre-exist in unrelated test files)
- 177 play/shared unit tests pass
- Manual check suggested: drag a soul from LOB → discard and → banish; it should snap back and slide to the end of the strip with no gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)