### PR TITLE
fix(forge): stop card-detail modal clipping the verse off Forge cards

### DIFF
--- a/app/decklist/card-search/ModalWithClose.tsx
+++ b/app/decklist/card-search/ModalWithClose.tsx
@@ -14,6 +14,32 @@ import type { Card } from "./utils";
 import type { DeckZone } from "./types/deck";
 
 /* ------------------------------------------------------------------ */
+/*  Card image contain-frame                                          */
+/* ------------------------------------------------------------------ */
+/**
+ * Constrains the card image to the largest 2.5:3.5 box that fits the parent in
+ * EITHER orientation (width- or height-bound), so a card is never clipped by the
+ * modal's fixed-height, overflow-hidden image column (which was cutting the verse
+ * off the bottom of Forge cards).
+ *
+ * `object-contain` alone can't fix it: Forge cards without a finished scan render
+ * as a composite <div> (ForgeCardPreview), which has no object-fit and so would
+ * stretch. Instead we make the parent a size container and size the frame with
+ * `min(100%, 71.4286cqh)` — 71.4286cqh is the card-aspect width derived from the
+ * container height — giving a true "contain" fit for both <img> and <div> cards.
+ */
+function CardImageFrame({ children, align = "center" }: { children: React.ReactNode; align?: "center" | "start" }) {
+  return (
+    <div
+      className={`flex h-full w-full justify-center ${align === "start" ? "items-start" : "items-center"}`}
+      style={{ containerType: "size" }}
+    >
+      <div style={{ width: "min(100%, 71.4286cqh)", aspectRatio: "2.5 / 3.5" }}>{children}</div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
 /*  Inline Edit Ruling (replaces a ruling's text with editable fields) */
 /* ------------------------------------------------------------------ */
 
@@ -884,24 +910,28 @@ export default function ModalWithClose({
               {hasNavigation && (() => {
                 const prev = getAdjacentCard('left');
                 return prev ? (
-                  <CardThumb
-                    card={prev}
-                    alt={prev.name}
-                    className="max-w-full max-h-full object-contain select-none rounded shadow-lg"
-                    draggable={false}
-                  />
+                  <CardImageFrame>
+                    <CardThumb
+                      card={prev}
+                      alt={prev.name}
+                      className="max-w-full max-h-full object-contain select-none rounded shadow-lg"
+                      draggable={false}
+                    />
+                  </CardImageFrame>
                 ) : null;
               })()}
             </div>
 
             {/* Current card */}
             <div className="w-full h-full flex-shrink-0 flex items-center justify-center px-2 py-1">
-              <CardThumb
-                card={modalCard}
-                alt={modalCard.name}
-                className="max-w-full max-h-full object-contain select-none rounded shadow-lg"
-                draggable={false}
-              />
+              <CardImageFrame>
+                <CardThumb
+                  card={modalCard}
+                  alt={modalCard.name}
+                  className="max-w-full max-h-full object-contain select-none rounded shadow-lg"
+                  draggable={false}
+                />
+              </CardImageFrame>
             </div>
 
             {/* Next card */}
@@ -909,12 +939,14 @@ export default function ModalWithClose({
               {hasNavigation && (() => {
                 const next = getAdjacentCard('right');
                 return next ? (
-                  <CardThumb
-                    card={next}
-                    alt={next.name}
-                    className="max-w-full max-h-full object-contain select-none rounded shadow-lg"
-                    draggable={false}
-                  />
+                  <CardImageFrame>
+                    <CardThumb
+                      card={next}
+                      alt={next.name}
+                      className="max-w-full max-h-full object-contain select-none rounded shadow-lg"
+                      draggable={false}
+                    />
+                  </CardImageFrame>
                 ) : null;
               })()}
             </div>
@@ -1283,23 +1315,25 @@ export default function ModalWithClose({
           /* Normal side-by-side layout: image left, details + rulings right */
           <div className="px-4 py-4 flex gap-6 flex-1 overflow-hidden">
             <div className="w-2/5 flex-shrink-0 flex items-start overflow-hidden">
-              <CardThumb
-                card={modalCard}
-                alt={modalCard.name}
-                className={`max-w-full max-h-full object-contain rounded shadow-lg ${canDragToDeck ? "cursor-grab active:cursor-grabbing" : ""}`}
-                draggable={canDragToDeck}
-                onDragStart={canDragToDeck ? (e) => {
-                  e.dataTransfer.setData(
-                    SEARCH_DRAG_MIME,
-                    JSON.stringify({ name: modalCard.name, set: modalCard.set }),
-                  );
-                  e.dataTransfer.effectAllowed = "copy";
-                  // Defer close one frame so the browser captures the drag-ghost
-                  // snapshot of the image first — closing synchronously can
-                  // cancel the drag in Firefox before the snapshot is taken.
-                  requestAnimationFrame(() => closeModal());
-                } : undefined}
-              />
+              <CardImageFrame align="start">
+                <CardThumb
+                  card={modalCard}
+                  alt={modalCard.name}
+                  className={`max-w-full max-h-full object-contain rounded shadow-lg ${canDragToDeck ? "cursor-grab active:cursor-grabbing" : ""}`}
+                  draggable={canDragToDeck}
+                  onDragStart={canDragToDeck ? (e) => {
+                    e.dataTransfer.setData(
+                      SEARCH_DRAG_MIME,
+                      JSON.stringify({ name: modalCard.name, set: modalCard.set }),
+                    );
+                    e.dataTransfer.effectAllowed = "copy";
+                    // Defer close one frame so the browser captures the drag-ghost
+                    // snapshot of the image first — closing synchronously can
+                    // cancel the drag in Firefox before the snapshot is taken.
+                    requestAnimationFrame(() => closeModal());
+                  } : undefined}
+                />
+              </CardImageFrame>
             </div>
             <div className="flex-1 overflow-auto pr-1">
               <div className="space-y-1">


### PR DESCRIPTION
## Problem

In the **Forge** deckbuilder, the card-detail modal was clipping the bottom (verse/reference) off cards — reported on the new EoT and Roots 2 finished scans.

Root cause is pure layout, not the images or the recent normalization backfill. The modal is the **only** card render site in the app without an `aspect-[2.5/3.5]` frame (grids/deck views all have one), and its image column is fixed-height + `overflow-hidden`. Public cards fit via `object-contain`, but [`CardThumb`](app/decklist/card-search/components/CardThumb.tsx) drops that className for Forge (`kind:"element"`) resolutions, and the Forge elements ([`forgeBuilderConfig.tsx`](app/forge/play/decks/[deckId]/forgeBuilderConfig.tsx)) size themselves `width:100%` + `aspectRatio:750/1050` with **no height cap**. On shorter viewports the aspect-driven height overflows the column and the bottom gets clipped — which is why it's Forge-only and viewport-height dependent.

## Fix

A new `CardImageFrame` helper wraps the modal image (desktop normal branch + all 3 mobile carousel cells). It's a true "contain" frame that works for both a finished `<img>` **and** the composite `<div>` (`ForgeCardPreview` has no `object-fit`, so `object-contain` can't save it):

```jsx
<div style={{ containerType: "size" }} className="flex h-full w-full ...">
  <div style={{ width: "min(100%, 71.4286cqh)", aspectRatio: "2.5 / 3.5" }}>{children}</div>
</div>
```

`71.4286cqh` is the card-aspect width derived from the container height, giving the largest 2.5:3.5 box that fits in either orientation. Entirely modal-side — no config or grid change.

## Why not the simpler options

Tested each candidate in isolated Playwright repros across both viewport orientations (target aspect = 0.714):

| Approach | Tall viewport | Short viewport |
|---|---|---|
| `h-full` frame | **0.46 (stretched)** | 0.714 ✓ |
| `max-height` clamp | 0.714 ✓ | **0.80 (stretched)** |
| **container-query `min()`** | **0.714 ✓** | **0.714 ✓** |

Only the container-query frame is correct in both orientations; the naive frames each distort in one.

## Scope note

The admin-only "Add Ruling" modal branch is intentionally left as-is — it stacks the image with text in one column, so a full-height frame doesn't apply there, and it's not the reported path.

## Verification

- Verified the exact shipped markup renders public `<img>`, Forge finished `<img>`, and composite `<div>` with zero clipping / no distortion in both orientations (Playwright geometry checks mirroring the real DOM, incl. `CardThumb`'s `display:contents` wrapper).
- 38/38 card-search + forge tests pass; `tsc --noEmit` clean on touched files.
- Not click-tested against the live Forge (local card data predates EoT/Roots 2 and the finished-image path needs auth) — worth a quick visual check once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)