### PR TITLE
fix(play): keep opponent Land of Bondage souls in place during re-layout

### DIFF
--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -4352,12 +4352,19 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
     const m = new Map<string, { x: number; y: number; rotation: number }>();
     for (const [id, p] of myLobLayout.hostPositions) m.set(id, { x: p.x, y: p.y, rotation: 0 });
     for (const [id, p] of myLobLayout.accessoryPositions) m.set(id, { x: p.x, y: p.y, rotation: 0 });
-    for (const [id, p] of opponentLobLayout.hostPositions) m.set(id, { x: p.x, y: p.y, rotation: 180 });
+    // Opponent hosts render rotated 180° anchored at the slot's bottom-right
+    // corner (x+cardWidth, y+cardHeight) — see the opponent LoB render. The
+    // glide target must use that SAME anchor, or useHandLayoutTween drags each
+    // host a full card up-and-left of its slot; clipping to the zone then
+    // leaves only a sliver visible on the opponent's view. Opponent accessory
+    // positions already bake the rotated anchor in, so they pass through as-is.
+    for (const [id, p] of opponentLobLayout.hostPositions)
+      m.set(id, { x: p.x + lobCard.cardWidth, y: p.y + lobCard.cardHeight, rotation: 180 });
     for (const [id, p] of opponentLobLayout.accessoryPositions) m.set(id, { x: p.x, y: p.y, rotation: 180 });
     for (const [id, p] of sharedLobLayout.hostPositions) m.set(id, { x: p.x, y: p.y, rotation: 0 });
     for (const [id, p] of sharedLobLayout.accessoryPositions) m.set(id, { x: p.x, y: p.y, rotation: 0 });
     return m;
-  }, [myLobLayout, opponentLobLayout, sharedLobLayout]);
+  }, [myLobLayout, opponentLobLayout, sharedLobLayout, lobCard.cardWidth, lobCard.cardHeight]);
   useHandLayoutTween(lobSlots, cardNodeRefs);
 
   // ---- Derive per-accessory screen positions + seam (for detach overlay) ----


### PR DESCRIPTION
## P0: Lost Souls hiding on the opponent's view

Players reported that Lost Souls in the **Land of Bondage** kept "hiding themselves" on the **opponent's** screen — invisible, or with "only the tip showing, the rest mostly out of the LoB." Dragging the soul out and back fixed it temporarily; it came back whenever a new soul was added. The owner's own view always looked fine.

## Root cause — not the soul animation (#173), but the draw-deal glide (#171)

The smooth LoB re-layout glide (`useHandLayoutTween` + `lobSlots`) was added in **#171** ("the deal — cards fly from deck to hand"). Its target map gave the **opponent's** hosts the raw slot position `hostPos`. But the opponent LoB renders rotated **180°**, anchored at the slot's **bottom-right corner** (`hostPos + (cardWidth, cardHeight)`) — as it has since the original Online Play mode (#95).

So every time the strip re-laid out — i.e. whenever a soul was added or removed — the tween dragged each already-settled opponent soul a **full card up-and-left** of its slot. Hosts are clipped to the zone, leaving only a corner sliver visible.

This explains every symptom:
- **Opponent-only** — my-side and Paragon shared LoB render at rotation 0 / no offset, so their `lobSlots` entries already matched the render.
- **"Only the tip"** — a mispositioned + clipped card (not the deal animation's node-skip, which would make a card fully absent).
- **Recurs when a soul is added** — that's exactly when the re-layout tween fires on the *existing* souls.
- **Drag out & back fixes it** — dragging sets `isDragging()`, which the tween skips; the drop re-renders at the correct position until the next reflow.

Before #171 there was no LoB glide at all, so souls sat at their correct declarative positions — which is why this was never seen until the recent animation batch. Reverting the #173 soul flyer would **not** have fixed it.

## The fix

Align `lobSlots`' opponent-host target with the render anchor (one line + memo deps). My-side and Paragon shared LoB are untouched.

## Verification

- `tsc --noEmit` clean for the change (only pre-existing, unrelated Forge test-file errors remain).
- 15/15 soul/LoB unit tests pass (`lobClassification.test.ts`, `lostSoulDeal.test.ts`).
- Diagnosis independently reviewed by two agents and confirmed against git history (bug born in #171; no LoB glide before it).

## Follow-ups (latent, not this P0)

- `isLostSoulCard` doesn't recognize `cardType: 'TOKEN_LS'`, so a token soul with a stale equip pointer could still tuck as an accessory.
- The deal animation's settled-node skip has no time-bound release — a cheap defensive guardrail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)