### PR TITLE
fix(forge): make add-to-set selects controlled so the top option stays pickable

### DIFF
--- a/app/forge/cards/[cardId]/LifecycleControls.tsx
+++ b/app/forge/cards/[cardId]/LifecycleControls.tsx
@@ -122,7 +122,7 @@ export default function LifecycleControls({ card, sets }: { card: ForgeCardFull;
       ) : (
         <div className="ml-auto">
           {picking ? (
-            <select autoFocus disabled={pending} defaultValue="" onChange={(e) => e.target.value && run(() => shareToSet(card.id, e.target.value))} className="rounded-md border bg-background px-2 py-1">
+            <select autoFocus disabled={pending} value="" onChange={(e) => e.target.value && run(() => shareToSet(card.id, e.target.value))} className="rounded-md border bg-background px-2 py-1">
               <option value="" disabled>Share into set…</option>
               {sets.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
             </select>

--- a/app/forge/sets/[setId]/progress/SetEldersPanel.tsx
+++ b/app/forge/sets/[setId]/progress/SetEldersPanel.tsx
@@ -29,7 +29,7 @@ export default function SetEldersPanel({ setId, elders, addable }: { setId: stri
         ))}
       </ul>
       {addable.length > 0 && (
-        <select disabled={busy} defaultValue="" onChange={(e) => e.target.value && run(() => addSetElder(setId, e.target.value))} className="mt-2 rounded-md border bg-background px-2 py-1 text-xs">
+        <select disabled={busy} value="" onChange={(e) => e.target.value && run(() => addSetElder(setId, e.target.value))} className="mt-2 rounded-md border bg-background px-2 py-1 text-xs">
           <option value="" disabled>Add a designer…</option>
           {addable.map((m) => <option key={m.userId} value={m.userId}>{m.displayName ?? m.userId}</option>)}
         </select>


### PR DESCRIPTION
## Problem

Reported: when adding an elder/designer to a private set, after you've already added someone, the top name in the dropdown (e.g. ChrisF) shows as selected by default but **can't be added** — the UI won't act on it. Refreshing the page resets the list and lets you add them.

## Root cause

The "add a designer" select in `SetEldersPanel` was **uncontrolled** (`defaultValue=""` + add-on-`onChange`):

1. You pick a designer → `onChange` → `addSetElder` → `router.refresh()`.
2. The refresh re-renders with the just-added person filtered out of the options. Because the select is uncontrolled, React keeps the same DOM node and only drops that one `<option>`.
3. Per the HTML spec, when the *currently-selected* option is removed the browser auto-selects the first non-disabled option — the top remaining designer (ChrisF). That's the phantom "checked by default."
4. Clicking ChrisF does nothing: `onChange` only fires on a *change*, and ChrisF is already the select's value.
5. A full page refresh remounts the component (`defaultValue=""` → placeholder), which is why refreshing "fixed" it.

## Fix

Bind `value=""` so the select is **controlled** — React forces it back to the placeholder after every render, so the top option is never left phantom-selected and each pick is a real change. This mirrors the controlled pattern already used in the sibling `PlaytesterGrants` component.

Applied to both selects with the identical bug:
- `SetEldersPanel.tsx` — the reported "add a designer" dropdown.
- `LifecycleControls.tsx` — the "share a card to a set" dropdown (`run()` there never closes the picker, so it was vulnerable to the same auto-select-on-refresh issue).

## Verification

Verified by code analysis and by matching the proven-correct controlled pattern in `PlaytesterGrants`. This is native browser `<select>` behavior (auto-select on option removal) that a jsdom unit test would not reproduce, and the repo has no DOM test harness. Change is a single attribute per select.

🤖 Generated with [Claude Code](https://claude.com/claude-code)