### PR TITLE
fix(play): drag the top card off the multiplayer deck, not the bottom

### DIFF
--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -5891,7 +5891,11 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
                   return (a.cardType ?? '').localeCompare(b.cardType ?? '') || (a.cardName ?? '').localeCompare(b.cardName ?? '');
                 })
               : cards;
-            const topCard = sortedCards[sortedCards.length - 1];
+            // For the deck, the top of the pile is the lowest zoneIndex (cards
+            // are sorted ascending), so the draggable "draw" card is the first
+            // element. For face-up piles (discard/reserve/banish/LOR) the last
+            // element renders on top, so that one is the visible top card.
+            const topCard = zoneKey === 'deck' ? sortedCards[0] : sortedCards[sortedCards.length - 1];
             const showFace = topCard && ((zoneKey === 'discard' || zoneKey === 'land-of-redemption' || zoneKey === 'banish') ? !topCard.isFlipped : (zoneKey === 'reserve' && canViewMyReserve));
 
             return (


### PR DESCRIPTION
## Problem

In multiplayer mode, clicking and dragging a card off your deck pile grabbed the **bottom** card of the deck instead of the **top** card. Because the drag moves that specific card instance, the wrong card was both shown on the pile and actually drawn on drop.

## Root cause

The deck pile's draggable "draw" card was selected as `sortedCards[sortedCards.length - 1]`. But deck cards are sorted **ascending** by `zoneIndex` (`useGameState.ts` `groupCardsByZone`), and the top of the deck is the lowest `zoneIndex` — i.e. `cards[0]`. This matches the authoritative SpacetimeDB convention (`index.ts`: *"Top is defined by ascending zoneIndex"*) and the goldfish reducer (draw = `deck.shift()`). So `length - 1` was the bottom card.

## Fix

Special-case the deck to use `sortedCards[0]`. Face-up piles (discard/reserve/banish/land-of-redemption) still use the last element, which correctly renders on top of the visual stack.

## Notes

- Goldfish mode is unaffected: its deck renders as a non-draggable card back (draw is via right-click / deck menu), so there is no wrong-card selection there.
- No automated test: the fix is inline render logic inside the Konva `MultiplayerCanvas` component, not a unit-testable pure function. Verified against the top-of-deck convention across `useGameState`, the SpacetimeDB module, and the goldfish reducer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)