### PR TITLE
Name downloaded tournament PDF after the deck

### DIFF
--- a/app/decklist/card-search/components/GeneratePDFModal.tsx
+++ b/app/decklist/card-search/components/GeneratePDFModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Deck } from "../types/deck";
 import { generateDeckText } from "../utils/deckImportExport";
+import { decklistPdfDownloadUrl } from "../utils/pdfDownloadUrl";
 import {
   Dialog,
   DialogContent,
@@ -244,7 +245,7 @@ export default function GeneratePDFModal({ deck, onClose, isLegal }: GeneratePDF
                   Close
                 </button>
                 <a
-                  href={success.url}
+                  href={decklistPdfDownloadUrl(success.url, deck.name)}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="px-4 py-2 bg-foreground text-background rounded-lg text-sm font-medium hover:bg-foreground/90 transition-colors inline-flex items-center gap-2"

--- a/app/decklist/card-search/utils/__tests__/pdfDownloadUrl.test.ts
+++ b/app/decklist/card-search/utils/__tests__/pdfDownloadUrl.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { decklistPdfDownloadUrl, sanitizeDeckFilename } from "../pdfDownloadUrl";
+
+const SUPABASE_URL =
+  "https://dhxxsolhgvimxtusepht.supabase.co/storage/v1/object/public/decklists/cfc68382-413d-4a0a-bdd4-c04572f5a8c4?";
+
+describe("sanitizeDeckFilename", () => {
+  it("replaces whitespace with underscores", () => {
+    expect(sanitizeDeckFilename("My Cool Deck")).toBe("My_Cool_Deck");
+  });
+
+  it("strips filename-illegal characters", () => {
+    expect(sanitizeDeckFilename('Aggro/Control: "v2"?')).toBe("AggroControl_v2");
+  });
+
+  it("falls back to 'decklist' when empty or missing", () => {
+    expect(sanitizeDeckFilename("")).toBe("decklist");
+    expect(sanitizeDeckFilename("   ")).toBe("decklist");
+    expect(sanitizeDeckFilename(null)).toBe("decklist");
+    expect(sanitizeDeckFilename(undefined)).toBe("decklist");
+  });
+});
+
+describe("decklistPdfDownloadUrl", () => {
+  it("appends a download param named after the deck", () => {
+    const result = decklistPdfDownloadUrl(SUPABASE_URL, "My Cool Deck");
+    expect(new URL(result).searchParams.get("download")).toBe("My_Cool_Deck.pdf");
+  });
+
+  it("preserves the original object path and origin", () => {
+    const result = new URL(decklistPdfDownloadUrl(SUPABASE_URL, "Deck"));
+    expect(result.origin).toBe("https://dhxxsolhgvimxtusepht.supabase.co");
+    expect(result.pathname).toBe(
+      "/storage/v1/object/public/decklists/cfc68382-413d-4a0a-bdd4-c04572f5a8c4",
+    );
+  });
+
+  it("uses the fallback filename when no deck name is given", () => {
+    const result = decklistPdfDownloadUrl(SUPABASE_URL, null);
+    expect(new URL(result).searchParams.get("download")).toBe("decklist.pdf");
+  });
+
+  it("returns the raw string unchanged when it is not a valid URL", () => {
+    expect(decklistPdfDownloadUrl("not a url", "Deck")).toBe("not a url");
+  });
+});

--- a/app/decklist/card-search/utils/pdfDownloadUrl.ts
+++ b/app/decklist/card-search/utils/pdfDownloadUrl.ts
@@ -1,0 +1,37 @@
+/**
+ * Turn a card/deck name into a safe download filename (no extension).
+ * Mirrors the whitespace-to-underscore convention used by the .txt exports,
+ * and additionally strips characters that are illegal in filenames.
+ */
+export function sanitizeDeckFilename(deckName: string | null | undefined): string {
+  const cleaned = (deckName ?? "")
+    .trim()
+    .replace(/[/\\?%*:|"<>]/g, "") // strip filename-illegal characters
+    .replace(/\s+/g, "_");
+  return cleaned || "decklist";
+}
+
+/**
+ * The tournament PDF service stores generated decklists in Supabase Storage,
+ * whose public object URLs end in a random UUID (e.g. `.../decklists/<uuid>`).
+ * Downloading that URL as-is saves a file named after the UUID.
+ *
+ * Supabase Storage honors a `download` query param that sets
+ * `Content-Disposition: attachment; filename=<name>` on the response, so we
+ * append the deck name here to give the saved PDF a meaningful name.
+ * See: https://supabase.com/docs/guides/storage/serving/downloads
+ */
+export function decklistPdfDownloadUrl(
+  rawUrl: string,
+  deckName: string | null | undefined,
+): string {
+  const filename = `${sanitizeDeckFilename(deckName)}.pdf`;
+  try {
+    const url = new URL(rawUrl);
+    url.searchParams.set("download", filename);
+    return url.toString();
+  } catch {
+    // Not a parseable absolute URL — leave the link untouched rather than break it.
+    return rawUrl;
+  }
+}

--- a/app/decklist/generate/page.tsx
+++ b/app/decklist/generate/page.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { Button } from "flowbite-react";
 import ToastNotification from "../../../components/ui/toast-notification";
 import DeckSourcePicker from "./DeckSourcePicker";
+import { decklistPdfDownloadUrl } from "../card-search/utils/pdfDownloadUrl";
 
 async function checkLegality(decklist: string, deckType: string, deckId?: string | null): Promise<boolean | null> {
   // The PDF/image generator omits the legal/illegal seal entirely (renders `?`)
@@ -506,7 +507,7 @@ export default function GenerateDeckList() {
                 </div>
               </div>
               <Button
-                onClick={() => window.open(success.url, '_blank')}
+                onClick={() => window.open(decklistPdfDownloadUrl(success.url, loadedDeckName), '_blank')}
                 gradientDuoTone="greenToBlue"
                 size="lg"
                 className="font-semibold"


### PR DESCRIPTION
## What & why

Downloading a deck's tournament PDF saved the file under a random UUID (e.g. `cfc68382-413d-4a0a-bdd4-c04572f5a8c4.pdf`) — the "jibberish" name. That UUID is the Supabase Storage object key the external tournament API generates the PDF into; nothing on our side was naming the file.

This names the saved file after the deck instead, e.g. **`My_Cool_Deck.pdf`**.

## How

The `downloadUrl` returned by the tournament API is a **Supabase Storage** public object URL. Supabase Storage honors a [`download` query param](https://supabase.com/docs/guides/storage/serving/downloads) that sets `Content-Disposition: attachment; filename=<name>` on the response. So we just append `?download=<sanitized deck name>.pdf` to the URL.

Verified against a live generated object:

```
$ curl -sI '<supabase object url>?download=My_Deck.pdf' | grep -i content-disposition
content-disposition: attachment; filename=My_Deck.pdf; filename*=UTF-8''My_Deck.pdf
```

No fetch/blob dance needed — the server sets the filename, so it works cross-origin and in a new tab. If the URL is ever unparseable the helper returns it untouched (no regression).

New shared helper `decklistPdfDownloadUrl()` / `sanitizeDeckFilename()` in `app/decklist/card-search/utils/pdfDownloadUrl.ts`, wired into both download entry points:
- The deck-view **Generate Tournament PDF** modal (`GeneratePDFModal.tsx`) — uses `deck.name`.
- The standalone **/decklist/generate** page — uses the loaded deck name, falling back to `decklist.pdf` for pasted-text decks.

Filename sanitization mirrors the existing `.txt` export convention (whitespace → `_`) and additionally strips filename-illegal characters.

## Testing

- New unit tests (`pdfDownloadUrl.test.ts`, 7 cases) — all pass.
- `tsc --noEmit` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)