### PR TITLE
fix(decklist): surface Cities under the Good/Evil Fortress filters

### DIFF
--- a/app/decklist/card-search/__tests__/iconPredicates.fortress.test.ts
+++ b/app/decklist/card-search/__tests__/iconPredicates.fortress.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { iconPredicates, type Card } from "../utils";
+
+// Minimal Card fixture — only the fields the Fortress/City predicates read matter.
+const card = (over: Partial<Card>): Card => ({
+  dataLine: "",
+  name: "",
+  set: "",
+  imgFile: "",
+  officialSet: "",
+  type: "",
+  brigade: "",
+  strength: "",
+  toughness: "",
+  class: "",
+  identifier: "",
+  specialAbility: "",
+  rarity: "",
+  reference: "",
+  alignment: "",
+  legality: "",
+  testament: "",
+  isGospel: false,
+  ...over,
+});
+
+const goodFortress = iconPredicates["Good Fortress"];
+const evilFortress = iconPredicates["Evil Fortress"];
+
+// In Redemption a City is a type of Fortress, so the Fortress filters should
+// surface Cities of the matching alignment (Bethlehem, City of Refuge, etc.).
+describe("Good/Evil Fortress filters include Cities", () => {
+  it("Good Fortress filter surfaces Good Cities", () => {
+    // Bethlehem (LoC) — a Good City
+    expect(goodFortress(card({ type: "City", alignment: "Good" }))).toBe(true);
+  });
+
+  it("Evil Fortress filter surfaces Evil Cities", () => {
+    // Sodom & Gomorrah — an Evil City
+    expect(evilFortress(card({ type: "City", alignment: "Evil" }))).toBe(true);
+  });
+
+  it("does not surface a City under the opposite alignment's Fortress filter", () => {
+    expect(evilFortress(card({ type: "City", alignment: "Good" }))).toBe(false);
+    expect(goodFortress(card({ type: "City", alignment: "Evil" }))).toBe(false);
+  });
+
+  it("still matches ordinary Fortresses (regression guard)", () => {
+    expect(goodFortress(card({ type: "Fortress", alignment: "Good" }))).toBe(true);
+    expect(evilFortress(card({ type: "Fortress", alignment: "Evil" }))).toBe(true);
+    // Dual-type fortress cards keep matching.
+    expect(evilFortress(card({ type: "Evil Character/Fortress", alignment: "Evil" }))).toBe(true);
+  });
+
+  it("does not surface non-Fortress, non-City cards", () => {
+    expect(goodFortress(card({ type: "Hero", alignment: "Good" }))).toBe(false);
+    expect(evilFortress(card({ type: "Site", alignment: "Evil" }))).toBe(false);
+  });
+});

--- a/app/decklist/card-search/utils.ts
+++ b/app/decklist/card-search/utils.ts
@@ -71,8 +71,9 @@ export const iconPredicates: Record<string, (c: Card) => boolean> = {
   Curse: (c) => c.type === "Curse",
   "Good Dominant": (c) => c.type.includes("Dominant") && (c.alignment.includes("Good") || c.alignment.includes("Neutral")),
   "Evil Dominant": (c) => c.type.includes("Dominant") && (c.alignment.includes("Evil") || c.alignment.includes("Neutral")),
-  "Good Fortress": (c) => c.type.includes("Fortress") && c.alignment.includes("Good"),
-  "Evil Fortress": (c) => c.type.includes("Fortress") && c.alignment.includes("Evil"),
+  // A City is a type of Fortress in Redemption, so surface Cities under the Fortress filters too.
+  "Good Fortress": (c) => (c.type.includes("Fortress") || c.type.includes("City")) && c.alignment.includes("Good"),
+  "Evil Fortress": (c) => (c.type.includes("Fortress") || c.type.includes("City")) && c.alignment.includes("Evil"),
   // other icons use existing category filters
   // Good Enhancements also surface Covenants (a good-side enhancement-like type)
   GE: (c) => c.type.includes("GE") || c.type === "Covenant",


### PR DESCRIPTION
## What & why

In Redemption a **City is a type of Fortress** (Bethlehem, City of Refuge, Sodom & Gomorrah, City of Enoch, …). Their own rules text even reads "Fortress holds …". But the **Good Fortress** / **Evil Fortress** icon filters only matched cards whose `type` contained the literal string `"Fortress"`. Since Cities have `type: "City"`, filtering for Good/Evil Fortresses **hid all Cities** — a Good City like Bethlehem never appeared under the Good Fortress filter, and an Evil City like Sodom & Gomorrah never appeared under Evil Fortress.

This addresses the report: *"can good cities show up when users filter for good fortresses, and evil cities for the evil fortress filter?"* — now they do.

## The change

`app/decklist/card-search/utils.ts` — broaden both predicates to also match `type.includes("City")` of the matching alignment:

```ts
"Good Fortress": (c) => (c.type.includes("Fortress") || c.type.includes("City")) && c.alignment.includes("Good"),
"Evil Fortress": (c) => (c.type.includes("Fortress") || c.type.includes("City")) && c.alignment.includes("Evil"),
```

This mirrors the existing precedent in the same table where a broad type filter surfaces a related subtype (`GE` also matches `Covenant`; `EE` also matches `Curse`).

## Scope

- **Both builders fixed by one change:** the deckbuilder and the Forge both render the shared `CardSearchClient`, which uses these `iconPredicates`. There is no separate Forge predicate.
- The standalone **City** filter is unchanged (still narrows to Cities of both alignments).
- Alignment is respected: a Good City does **not** appear under Evil Fortress and vice-versa. All 16 City cards in the data have a clean `Good`/`Evil` alignment.

## Tests

Added `app/decklist/card-search/__tests__/iconPredicates.fortress.test.ts` (5 tests, TDD — red before the fix, green after):
- Good City → Good Fortress ✅, Evil City → Evil Fortress ✅
- opposite-alignment City excluded, non-Fortress/City cards excluded
- regression guard: plain `Fortress` and dual-type `Evil Character/Fortress` still match

`npx vitest run app/decklist/card-search` → **41 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)