### PR TITLE
feat(decklist): show search result count at the top of the builder

### DIFF
--- a/app/decklist/card-search/client.tsx
+++ b/app/decklist/card-search/client.tsx
@@ -1860,7 +1860,14 @@ export default function CardSearchClient({
             </div>
             {/* Desktop: centered buttons with filters right-aligned */}
             <div className="hidden sm:flex flex-row flex-wrap gap-2 w-full items-center">
-            <div className="hidden md:block flex-1" />
+            {/* Result count — fills the left spacer so it stays visible without scrolling */}
+            <div className="hidden md:flex flex-1 items-center">
+              {visibleCards.length > 0 && (
+                <span className="text-sm text-muted-foreground font-medium whitespace-nowrap">
+                  {filtered.length} {filtered.length === 1 ? 'card' : 'cards'}
+                </span>
+              )}
+            </div>
             <div className="flex items-center gap-2 mx-auto md:mx-0">
             <button
               className="px-4 shrink-0 rounded bg-primary/15 text-primary hover:bg-primary/25 border border-primary/30 transition font-medium shadow-sm text-center relative h-9 sm:h-11"
@@ -2179,6 +2186,12 @@ export default function CardSearchClient({
           </span>
         )}
         </div>
+        {/* Result count — mobile only; desktop shows it in the search header toolbar */}
+        {visibleCards.length > 0 && (
+          <span className="md:hidden shrink-0 pl-2 pr-3 text-xs font-medium text-muted-foreground whitespace-nowrap">
+            {filtered.length} {filtered.length === 1 ? 'card' : 'cards'}
+          </span>
+        )}
       </div>
       {/* Collapse/Expand Filter Grid Button — mobile only (on desktop it's in the search header) */}
       <div className={`flex-shrink-0 ${!filterGridCollapsed ? 'sticky top-0 z-30' : ''} flex md:hidden flex-row items-center justify-between px-3 py-1.5 bg-background border-b border-border`}>


### PR DESCRIPTION
## What

Surfaces the search result count at the **top** of the deck builder so you don't have to scroll to the bottom to see how many cards a search returned.

Previously the count only showed as *"Showing X of Y"* at the bottom of the results grid.

## How

Reuses existing empty space in the sticky header, so nothing grows taller and it only appears when a search has results:

- **Desktop** — fills the previously-empty left slot of the header toolbar (opposite the Sort / CSV / Filters controls). The header is sticky, so it stays visible while scrolling.
- **Mobile** — sits at the right end of the active-filter bar (the row with the search pill), which appears right below the search box. (The mobile sort/filter bar was too tight and truncated the label, so it went here instead.)

Reads `{count} card(s)` — the same total the bottom line reports — and is hidden when there are no results. Both the public deck builder and the Forge builder render this same component, so both are covered.

## Verification

Ran the dev server and drove standalone Playwright at 1280px and 390px against a real `angel` search (114 results): both widths render the full `114 cards` at the top, no truncation or crowding, no layout shift when idle.

### Desktop
Count appears top-left in the toolbar.

### Mobile
Count appears at the right of the active-filter bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)