### PR TITLE
fix(forge): credit the proposer, not just the approver, on accepted proposals

### DIFF
--- a/app/forge/cards/[cardId]/CardHistory.tsx
+++ b/app/forge/cards/[cardId]/CardHistory.tsx
@@ -73,6 +73,12 @@ export default function CardHistory({ history }: { history: HistoryEvent[] }) {
                   {p.status === "accepted" && e.resultingVersionNumber != null && <> → v{e.resultingVersionNumber}</>}
                 </span>
               </div>
+              <p className="mt-0.5 text-muted-foreground">
+                Proposed by <span className="font-medium text-foreground">{p.proposerName ?? "Forge member"}</span>
+                {p.status === "accepted" && p.approverName && (
+                  <> · accepted by <span className="font-medium text-foreground">{p.approverName}</span></>
+                )}
+              </p>
               {p.status === "superseded" && (
                 <p className="mt-1 text-muted-foreground">
                   {e.supersededBy

--- a/app/forge/lib/proposals.ts
+++ b/app/forge/lib/proposals.ts
@@ -19,6 +19,13 @@ export type ProposalRow = {
   createdBy: string;
   createdAt: string;
   closedAt: string | null;
+  // Display names resolved from playtest_members (null until listProposals
+  // enriches them). proposerName = who authored the proposal; approverName =
+  // who closed it (the accepting elder on an accept). Preserves proposer
+  // credit in History even though the resulting version is stamped to the
+  // approver.
+  proposerName: string | null;
+  approverName: string | null;
 };
 
 export type ProposalDiffData = { proposal: ProposalRow; current: DesignCard };
@@ -39,7 +46,22 @@ function toProposal(row: any): ProposalRow {
     createdBy: row.created_by,
     createdAt: row.created_at,
     closedAt: row.closed_at ?? null,
+    proposerName: null,
+    approverName: null,
   };
+}
+
+// Resolve user UUIDs -> display names (member-readable). Same pattern as versions.ts / comments.ts.
+async function nameMap(
+  ctx: NonNullable<Awaited<ReturnType<typeof requireForge>>>,
+  ids: string[]
+): Promise<Map<string, string>> {
+  if (ids.length === 0) return new Map();
+  const { data } = await ctx.supabase
+    .from("playtest_members")
+    .select("user_id, display_name")
+    .in("user_id", [...new Set(ids)]);
+  return new Map((data ?? []).map((m: any) => [m.user_id, m.display_name]));
 }
 
 export async function createProposal(
@@ -128,7 +150,16 @@ export async function listProposals(cardId: string): Promise<ProposalRow[]> {
     .select(COLS)
     .eq("card_id", cardId)
     .order("created_at", { ascending: false });
-  return (data ?? []).map(toProposal);
+  const proposals = (data ?? []).map(toProposal);
+  const names = await nameMap(
+    ctx,
+    proposals.flatMap((p) => [p.createdBy, p.closedBy].filter((x): x is string => !!x))
+  );
+  return proposals.map((p) => ({
+    ...p,
+    proposerName: names.get(p.createdBy) ?? null,
+    approverName: p.closedBy ? names.get(p.closedBy) ?? null : null,
+  }));
 }
 
 export async function getOpenProposalDiffs(cardId: string): Promise<ProposalDiffData[]> {


### PR DESCRIPTION
## Why

From Forge card feedback (RedDragonThorn): when an elder accepts a proposal, the accepted change shows up in a card's **History** attributed entirely to the approver. The person who actually authored the proposal is captured in the data but never displayed, so their credit is lost.

> "this was originally my comment and proposal, then when Gabe accepted it his name overrode mine. For historical preservation having the name attached to the proposal stay and the approver also be mentioned would be ideal."

Root cause is structural, not a literal overwrite: `forge_accept_proposal` mints a new `card_versions` row stamped with `auth.uid()` (the accepter), and the proposal entry in History rendered only the summary + `Accepted → vN` — never the proposer (`created_by`).

## What

Surface both names on the proposal entry:

```
We talked last night about the animal theme…      Accepted → v2
Proposed by RedDragonThorn · accepted by Gabe
```

- `proposals.ts` — add `proposerName`/`approverName` to `ProposalRow`; resolve `created_by` / `closed_by` against `playtest_members` in `listProposals`, mirroring the existing `nameMap` pattern in `versions.ts` / `comments.ts`.
- `CardHistory.tsx` — render "Proposed by X · accepted by Y" on the proposal entry (approver shown only for accepted; denied/superseded already name the closer elsewhere).

**UI-only** — the proposer/approver ids already lived on the proposal row, so no migration and no change to version semantics.

## Scope

Left the *open* proposal review card (`ProposalDiff.tsx`) unchanged — it also omits the proposer name, but this PR is the smaller History-focused fix that directly answers the feedback. Easy follow-up if we want proposer attribution there too.

## Testing

- 13/13 history-view unit tests pass (`vitest run app/forge/lib/__tests__/historyView.test.ts`).
- Clean `tsc --noEmit` on the two touched files.
- Not driven in a live browser (local Node here is too old for the dev/test browser flow); verified by types + unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)