### PR TITLE
fix(app): auto-reload once on stale-build ChunkLoadError

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Cinzel } from "next/font/google";
 import { ThemeProvider } from "next-themes";
 import Background from "../components/ui/background"; // Using the improved background
 import { AdminProvider } from "../components/providers/AdminProvider";
+import ChunkErrorReloader from "../components/ChunkErrorReloader";
 import "./globals.css";
 
 const cinzel = Cinzel({ subsets: ["latin"], variable: "--font-cinzel" });
@@ -31,6 +32,7 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${GeistSans.className} ${cinzel.variable}`} suppressHydrationWarning>
       <body className="bg-background text-foreground">
+        <ChunkErrorReloader />
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/components/ChunkErrorReloader.tsx
+++ b/components/ChunkErrorReloader.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect } from "react";
+import { isChunkLoadError } from "@/lib/chunkReload";
+
+// One-time recovery for stale-build chunk failures.
+//
+// When a client running an older build fails to load a code-split chunk (see
+// isChunkLoadError), the current navigation is already broken, so reload once to
+// pull the current build. The timestamp guard prevents a reload loop if the
+// failure persists (e.g. the origin is genuinely unreachable) while still
+// allowing recovery from a separate incident later in the same session.
+const RELOAD_KEY = "chunk-reload-at";
+const RELOAD_COOLDOWN_MS = 10_000;
+
+function recover(err: unknown) {
+  if (!isChunkLoadError(err)) return;
+
+  let last = 0;
+  try {
+    last = Number(sessionStorage.getItem(RELOAD_KEY)) || 0;
+  } catch {
+    // sessionStorage can throw in private mode / sandboxed iframes; if we can't
+    // read the guard, fall through and reload once (last stays 0).
+  }
+  if (Date.now() - last < RELOAD_COOLDOWN_MS) return;
+
+  try {
+    sessionStorage.setItem(RELOAD_KEY, String(Date.now()));
+  } catch {
+    // Best-effort guard; a reload without it is still preferable to a broken page.
+  }
+  window.location.reload();
+}
+
+export default function ChunkErrorReloader() {
+  useEffect(() => {
+    const onError = (e: ErrorEvent) => recover(e.error ?? e.message);
+    const onRejection = (e: PromiseRejectionEvent) => recover(e.reason);
+
+    window.addEventListener("error", onError);
+    window.addEventListener("unhandledrejection", onRejection);
+    return () => {
+      window.removeEventListener("error", onError);
+      window.removeEventListener("unhandledrejection", onRejection);
+    };
+  }, []);
+
+  return null;
+}

--- a/lib/__tests__/chunkReload.test.ts
+++ b/lib/__tests__/chunkReload.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { isChunkLoadError } from "@/lib/chunkReload";
+
+describe("isChunkLoadError", () => {
+  it("detects a webpack ChunkLoadError by name", () => {
+    const err = Object.assign(new Error("Loading chunk 6791 failed."), {
+      name: "ChunkLoadError",
+    });
+    expect(isChunkLoadError(err)).toBe(true);
+  });
+
+  it("detects the failed-chunk message form", () => {
+    expect(isChunkLoadError(new Error("Loading chunk 6791 failed."))).toBe(true);
+    expect(isChunkLoadError(new Error("Loading CSS chunk 42 failed"))).toBe(true);
+    expect(
+      isChunkLoadError("ChunkLoadError: Loading chunk app/register/page failed"),
+    ).toBe(true);
+  });
+
+  it("ignores unrelated errors", () => {
+    expect(isChunkLoadError(null)).toBe(false);
+    expect(isChunkLoadError(undefined)).toBe(false);
+    expect(isChunkLoadError(new Error("Something else went wrong"))).toBe(false);
+    // A generic fetch NetworkError is recovered by Next's router fallback and must
+    // NOT trigger a reload, or ordinary API/RSC hiccups would reload the page.
+    expect(
+      isChunkLoadError(new TypeError("NetworkError when attempting to fetch resource")),
+    ).toBe(false);
+  });
+});

--- a/lib/chunkReload.ts
+++ b/lib/chunkReload.ts
@@ -1,0 +1,24 @@
+// Detection for Next.js code-split chunk load failures.
+//
+// These happen when a client is running an *older* build (a stale tab) and the
+// router tries to lazy-load a code-split chunk whose content-hashed filename no
+// longer exists on the origin — e.g. after a new deploy, or when a long-lived
+// tab outlives Vercel's skew-protection window. Webpack surfaces this as a
+// `ChunkLoadError` (usually via an unhandled promise rejection from `import()`),
+// with a message of the form "Loading chunk <id> failed" (or "Loading CSS
+// chunk <id> failed").
+//
+// Deliberately narrow: a generic `TypeError: NetworkError when attempting to
+// fetch resource` (e.g. a failed RSC payload or API call) is NOT treated as a
+// chunk error — Next's router already falls back to a browser navigation for
+// those, and reloading on every transient fetch hiccup would be far too eager.
+export function isChunkLoadError(err: unknown): boolean {
+  if (!err) return false;
+  const name = (err as { name?: unknown }).name;
+  if (name === "ChunkLoadError") return true;
+  const message =
+    typeof (err as { message?: unknown }).message === "string"
+      ? (err as { message: string }).message
+      : String(err);
+  return /ChunkLoadError/.test(message) || /Loading (?:CSS )?chunk .+ failed/i.test(message);
+}


### PR DESCRIPTION
## Problem

Production clients were logging a cascade of chunk failures:

```
Loading failed for the <script> ... 6791-a6b621f86d0f2f2e.js?dpl=dpl_...
Uncaught ChunkLoadError: Loading chunk 6791 failed.
Failed to fetch RSC payload for .../decklist/... Falling back to browser navigation.
```

This is **deployment skew**, not a code bug: a client running an *older* build tries to lazy-load a code-split chunk whose content-hashed filename no longer exists on the origin. It happens when a tab was opened on a prior deploy and either a new deploy shipped or the tab outlived Vercel's skew-protection window. Webpack throws these as an uncaught `ChunkLoadError` / unhandled rejection that **escapes React error boundaries** (note the `Uncaught` in the logs), so a route-level `error.tsx` wouldn't catch them — client navigation just breaks.

## Fix

A tiny `"use client"` component (`ChunkErrorReloader`) mounted at the top of the root layout listens on `window` for `error` + `unhandledrejection`, detects a chunk-load failure, and reloads **once** onto the current build.

Two guards keep it safe:

- **Loop-safe** — a `sessionStorage` timestamp (10s cooldown) prevents reload spin if the origin is genuinely unreachable, while still allowing recovery from a *separate* incident later in the session.
- **Narrow detection** — only real `ChunkLoadError`s trigger a reload. A generic `TypeError: NetworkError when attempting to fetch resource` (e.g. the failed RSC payloads above, which Next already recovers via its browser-navigation fallback) is **deliberately ignored**, so ordinary API/RSC hiccups never reload the page. There's a test asserting exactly that.

## Files

- `lib/chunkReload.ts` — pure `isChunkLoadError()` predicate (the only branching logic)
- `lib/__tests__/chunkReload.test.ts` — locks detection + the no-false-positive-on-NetworkError contract
- `components/ChunkErrorReloader.tsx` — window listeners + one-time guarded reload
- `app/layout.tsx` — mounts it globally

## Test

```
npx vitest run lib/__tests__/chunkReload.test.ts  →  3 passed
```

## Complementary knob (not in this PR)

Raising the **Skew Protection** window in Vercel project settings reduces how often this fires in the first place; this PR handles the recovery when it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
