### PR TITLE
fix(play): show Forge card names in the multiplayer game log

### DIFF
--- a/app/play/[code]/client.tsx
+++ b/app/play/[code]/client.tsx
@@ -1272,6 +1272,7 @@ function GameInner({ code, isConnected }: GameInnerProps) {
       playerNames={playerNameMap}
       chatScale={chatScale}
       unreadChatCount={unreadChatCount}
+      forgeResolver={forgeResolver}
       spectators={gameState.spectators as Array<{ id: bigint; identity: { toHexString: () => string }; displayName: string }>}
       myIdentityHex={gameState.identityHex}
       shareHandWithSpectators={gameState.myPlayer?.shareHandWithSpectators}

--- a/app/play/components/ChatPanel.tsx
+++ b/app/play/components/ChatPanel.tsx
@@ -2,6 +2,7 @@
 
 import { isValidElement, useEffect, useMemo, useRef, useState, type KeyboardEvent, type ReactNode, type CSSProperties } from 'react';
 import { useCardPreview } from '@/app/goldfish/state/CardPreviewContext';
+import { normalizeForgeLogPayload, type ForgeResolverMap } from '@/app/play/utils/forgeResolver';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -40,6 +41,8 @@ interface ChatPanelProps {
   chatScale?: number;
   /** When true, the chat input is disabled (read-only). Defaults to false. */
   chatDisabled?: boolean;
+  /** Viewer's granted forge resolver — re-hydrates blanked forge card names/art in the log. */
+  forgeResolver?: ForgeResolverMap | null;
   // ---- Spectator-controls subsection (player-mode only) ----
   /** Spectators in the current game. When provided, the Spectators tab renders. */
   spectators?: Array<{ id: bigint; identity: { toHexString: () => string }; displayName: string }>;
@@ -1034,6 +1037,7 @@ export default function ChatPanel({
   onActiveTabChange,
   chatScale = 1,
   chatDisabled = false,
+  forgeResolver,
   spectators,
   myIdentityHex,
   shareHandWithSpectators,
@@ -1114,11 +1118,11 @@ export default function ChatPanel({
     const map = new Map<string, string>();
     for (const a of visibleGameActions) {
       const playerName = playerNames[a.playerId.toString()] ?? `Player ${a.playerId}`;
-      const verb = formatActionType(a.actionType, a.payload, playerNames, a.playerId.toString(), myPlayerId.toString());
+      const verb = formatActionType(a.actionType, normalizeForgeLogPayload(a.payload, forgeResolver), playerNames, a.playerId.toString(), myPlayerId.toString());
       map.set(a.id.toString(), `${playerName} ${nodeToText(verb)} ${a.actionType}`.toLowerCase());
     }
     return map;
-  }, [visibleGameActions, playerNames, myPlayerId]);
+  }, [visibleGameActions, playerNames, myPlayerId, forgeResolver]);
 
   const matchesQuery = (text: string) => !isSearching || text.includes(normalizedQuery);
 
@@ -1792,7 +1796,7 @@ export default function ChatPanel({
                   const playerName =
                     playerNames[action.playerId.toString()] ??
                     `Player ${action.playerId}`;
-                  const verb = formatActionType(action.actionType, action.payload, playerNames, action.playerId.toString(), myPlayerId.toString());
+                  const verb = formatActionType(action.actionType, normalizeForgeLogPayload(action.payload, forgeResolver), playerNames, action.playerId.toString(), myPlayerId.toString());
                   const time = formatTimestamp(action.timestamp.microsSinceUnixEpoch);
                   const turn = Number(action.turnNumber);
                   return (
@@ -1968,7 +1972,7 @@ export default function ChatPanel({
                       const playerName =
                         playerNames[action.playerId.toString()] ??
                         `Player ${action.playerId}`;
-                      const verb = formatActionType(action.actionType, action.payload, playerNames, action.playerId.toString(), myPlayerId.toString());
+                      const verb = formatActionType(action.actionType, normalizeForgeLogPayload(action.payload, forgeResolver), playerNames, action.playerId.toString(), myPlayerId.toString());
                       const time = formatTimestamp(action.timestamp.microsSinceUnixEpoch);
                       const turn = Number(action.turnNumber);
 

--- a/app/play/components/RightPanel.tsx
+++ b/app/play/components/RightPanel.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useCardPreview } from '@/app/goldfish/state/CardPreviewContext';
 import ChatPanel from '@/app/play/components/ChatPanel';
 import { getCardImageUrl } from '@/app/shared/utils/cardImageUrl';
+import type { ForgeResolverMap } from '@/app/play/utils/forgeResolver';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -38,6 +39,8 @@ interface RightPanelProps {
   unreadChatCount?: number;
   /** When true, chat input is disabled (read-only chat). Used by spectators. */
   chatDisabled?: boolean;
+  /** Viewer's granted forge resolver — re-hydrates blanked forge card names/art in the log. */
+  forgeResolver?: ForgeResolverMap | null;
   // ---- Spectator-controls subsection (player-mode only) ----
   spectators?: Array<{ id: bigint; identity: { toHexString: () => string }; displayName: string }>;
   myIdentityHex?: string;
@@ -64,6 +67,7 @@ export default function RightPanel({
   chatScale,
   unreadChatCount = 0,
   chatDisabled = false,
+  forgeResolver,
   spectators,
   myIdentityHex,
   shareHandWithSpectators,
@@ -239,6 +243,7 @@ export default function RightPanel({
               onActiveTabChange={setChatTab}
               chatScale={chatScale}
               chatDisabled={chatDisabled}
+              forgeResolver={forgeResolver}
               spectators={spectators}
               myIdentityHex={myIdentityHex}
               shareHandWithSpectators={shareHandWithSpectators}

--- a/app/play/spectate/[code]/client.tsx
+++ b/app/play/spectate/[code]/client.tsx
@@ -547,6 +547,7 @@ function SpectatorInner({ code, isConnected, displayName }: SpectatorInnerProps)
               chatScale={chatScale}
               unreadChatCount={unreadChatCount}
               chatDisabled
+              forgeResolver={forgeResolver}
             />
           </div>
         )}

--- a/app/play/utils/__tests__/forgeResolver.test.ts
+++ b/app/play/utils/__tests__/forgeResolver.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { forgeCardIdFromImgFile, forgeProxyUrl, resolveCardImageUrl, mergeForgeDeckData } from "../forgeResolver";
+import { forgeCardIdFromImgFile, forgeProxyUrl, resolveCardImageUrl, mergeForgeDeckData, resolveLogCard, normalizeForgeLogPayload } from "../forgeResolver";
 import { getCardImageUrl, getCardImageUrlOrNull } from "@/app/shared/utils/cardImageUrl";
 
 const ID = "11111111-2222-3333-4444-555555555555";
@@ -44,6 +44,33 @@ describe("forge image seams", () => {
     expect(merged[1]).toBe(cards[1]);
   });
 
+  it("resolveLogCard leaves public cards untouched", () => {
+    expect(resolveLogCard("Angel of the Lord", "AngelOfTheLord.jpg", resolver)).toEqual({
+      name: "Angel of the Lord",
+      img: "AngelOfTheLord.jpg",
+    });
+    // Face-down sentinel is not a forge ref — pass it through unchanged.
+    expect(resolveLogCard("a face-down card", "", resolver)).toEqual({ name: "a face-down card", img: "" });
+    // Missing img still resolves to a defined img string.
+    expect(resolveLogCard("Some Source", undefined, resolver)).toEqual({ name: "Some Source", img: "" });
+  });
+  it("resolveLogCard re-hydrates a granted forge card's real name + proxy art", () => {
+    // The reserve log stores forge cards as { name: "", img: "forge:<uuid>" }
+    // (leak spine). A viewer holding the grant should see the real name.
+    expect(resolveLogCard("", `forge:${ID}`, resolver)).toEqual({
+      name: "Test Hero",
+      img: `/forge/api/art/${ID}?v=approved&kind=finished&t=v-1`,
+    });
+  });
+  it("resolveLogCard shows a granted forge card's name even when it has no art", () => {
+    const noArt = new Map([[ID, { ...entry, hasFinished: false, hasArt: false }]]);
+    expect(resolveLogCard("", `forge:${ID}`, noArt)).toEqual({ name: "Test Hero", img: "" });
+  });
+  it("resolveLogCard masks an ungranted forge card as 'a playtest card' (no leak)", () => {
+    expect(resolveLogCard("", `forge:${ID}`, new Map())).toEqual({ name: "a playtest card", img: "" });
+    expect(resolveLogCard("", `forge:${ID}`, null)).toEqual({ name: "a playtest card", img: "" });
+  });
+
   it("mergeForgeDeckData restores the searchable metadata (alignment/brigade/stats/identifier/reference)", () => {
     // Regression: the world-readable STDB row blanks these fields (leak spine),
     // so the owner's client must re-hydrate them — otherwise the in-game Search
@@ -63,5 +90,59 @@ describe("forge image seams", () => {
     expect(merged[0].toughness).toBe("6");
     expect(merged[0].identifier).toBe("Demon");
     expect(merged[0].reference).toBe("Revelation 8:11");
+  });
+});
+
+describe("normalizeForgeLogPayload", () => {
+  const PROXY = `/forge/api/art/${ID}?v=approved&kind=finished&t=v-1`;
+
+  it("resolves a forge card in a reserve/batch `cards` array (granted viewer)", () => {
+    const payload = JSON.stringify({
+      count: 1,
+      cards: [{ name: "", img: `forge:${ID}` }, { name: "Angel", img: "Angel.jpg" }],
+    });
+    const out = JSON.parse(normalizeForgeLogPayload(payload, resolver)!);
+    expect(out.cards[0]).toEqual({ name: "Test Hero", img: PROXY });
+    expect(out.cards[1]).toEqual({ name: "Angel", img: "Angel.jpg" }); // public card untouched
+  });
+
+  it("resolves cardName/cardImgFile and sourceCardName/sourceCardImgFile pairs", () => {
+    const payload = JSON.stringify({
+      cardName: "", cardImgFile: `forge:${ID}`,
+      sourceCardName: "", sourceCardImgFile: `forge:${ID}`,
+      to: "reserve",
+    });
+    const out = JSON.parse(normalizeForgeLogPayload(payload, resolver)!);
+    expect(out.cardName).toBe("Test Hero");
+    expect(out.cardImgFile).toBe(PROXY);
+    expect(out.sourceCardName).toBe("Test Hero");
+    expect(out.sourceCardImgFile).toBe(PROXY);
+    expect(out.to).toBe("reserve"); // unrelated fields preserved
+  });
+
+  it("resolves nested `card` / `drew` objects", () => {
+    const payload = JSON.stringify({ card: { name: "", img: `forge:${ID}` }, drew: { name: "", img: `forge:${ID}` } });
+    const out = JSON.parse(normalizeForgeLogPayload(payload, resolver)!);
+    expect(out.card.name).toBe("Test Hero");
+    expect(out.drew.name).toBe("Test Hero");
+  });
+
+  it("masks forge cards as 'a playtest card' for an ungranted viewer (no leak)", () => {
+    const payload = JSON.stringify({ cardName: "", cardImgFile: `forge:${ID}`, to: "reserve" });
+    for (const r of [new Map(), null, undefined] as const) {
+      const out = JSON.parse(normalizeForgeLogPayload(payload, r as any)!);
+      expect(out.cardName).toBe("a playtest card");
+      expect(out.cardImgFile).toBe("");
+    }
+  });
+
+  it("leaves non-forge, non-object, and non-JSON payloads untouched", () => {
+    const publicPayload = JSON.stringify({ cardName: "Angel", cardImgFile: "Angel.jpg" });
+    expect(normalizeForgeLogPayload(publicPayload, resolver)).toBe(publicPayload);
+    expect(normalizeForgeLogPayload("3", resolver)).toBe("3"); // bare count (LOOK_AT_TOP legacy)
+    expect(normalizeForgeLogPayload("[1,2,3]", resolver)).toBe("[1,2,3]"); // array payload (REVEAL_CARDS legacy)
+    expect(normalizeForgeLogPayload("not json", resolver)).toBe("not json");
+    expect(normalizeForgeLogPayload(undefined, resolver)).toBeUndefined();
+    expect(normalizeForgeLogPayload("", resolver)).toBe("");
   });
 });

--- a/app/play/utils/forgeResolver.ts
+++ b/app/play/utils/forgeResolver.ts
@@ -27,6 +27,99 @@ export function resolveCardImageUrl(imgFile: string, resolver?: ForgeResolverMap
   return getCardImageUrl(imgFile);
 }
 
+/**
+ * Resolve a `{ name, img }` pair for the GAME LOG. Server-generated log payloads
+ * copy the card's identity straight off the world-readable STDB row, where the
+ * leak spine has blanked forge cards to `{ name: "", img: "forge:<uuid>" }`. The
+ * board re-hydrates the real name/art client-side (see `cardInstanceToGameCard`);
+ * the log must do the same so reserved/moved forge cards aren't logged nameless.
+ *
+ * - Non-forge card → returned unchanged (name always resolved; blank img → '').
+ * - Granted forge card → real name + proxy art (or '' art when the card has none).
+ * - Ungranted forge card → neutral "a playtest card" placeholder; never leaks the
+ *   unreleased name to viewers without the RLS grant.
+ */
+export function resolveLogCard(
+  name: string,
+  img: string | undefined,
+  resolver?: ForgeResolverMap | null,
+): { name: string; img: string } {
+  const forgeId = img ? forgeCardIdFromImgFile(img) : null;
+  if (!forgeId) return { name, img: img ?? '' };
+  const e = resolver?.get(forgeId);
+  if (!e) return { name: 'a playtest card', img: '' };
+  return { name: e.name, img: forgeProxyUrl(e) };
+}
+
+function isForgeRef(img: unknown): img is string {
+  return typeof img === 'string' && img.startsWith('forge:');
+}
+
+// Resolve a { <nameKey>, <imgKey> } pair on `obj` in place, but only when the
+// img is a forge ref — normal cards are left byte-for-byte untouched.
+function resolveNamedCard(
+  obj: Record<string, unknown>,
+  nameKey: string,
+  imgKey: string,
+  resolver?: ForgeResolverMap | null,
+): void {
+  if (!isForgeRef(obj[imgKey])) return;
+  const name = typeof obj[nameKey] === 'string' ? (obj[nameKey] as string) : '';
+  const r = resolveLogCard(name, obj[imgKey], resolver);
+  obj[nameKey] = r.name;
+  obj[imgKey] = r.img;
+}
+
+/**
+ * Normalize a game-LOG payload string so every forge card it references carries
+ * the viewer's resolved name + proxy art (or the neutral "a playtest card"
+ * placeholder when ungranted) instead of the blanked `{ name:"", img:"forge:<uuid>" }`
+ * the server copies off the world-readable row.
+ *
+ * Applied once per action before `formatActionType` runs, this lets ChatPanel's
+ * existing handlers — many of which gate on a truthy card name and would drop a
+ * blank-named forge card to a generic label — treat forge cards like any named
+ * card, and makes the log searchable by the resolved name. Covers every card
+ * field the server emits (cardName/sourceCardName/tokenName + `{name,img}`
+ * arrays/objects). Leak-safe: ungranted viewers never receive the real name.
+ * Non-forge fields, non-object payloads (arrays, bare counts), and non-JSON
+ * payloads are returned untouched.
+ */
+export function normalizeForgeLogPayload(
+  payload: string | undefined,
+  resolver?: ForgeResolverMap | null,
+): string | undefined {
+  if (!payload) return payload;
+  // Fast path: forge refs are the only thing we rewrite, so a payload without one
+  // (every action in a non-forge game) skips the parse/stringify round-trip.
+  if (!payload.includes('forge:')) return payload;
+  let data: unknown;
+  try {
+    data = JSON.parse(payload);
+  } catch {
+    return payload;
+  }
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return payload;
+  const obj = data as Record<string, unknown>;
+
+  resolveNamedCard(obj, 'cardName', 'cardImgFile', resolver);
+  resolveNamedCard(obj, 'sourceCardName', 'sourceCardImgFile', resolver);
+  resolveNamedCard(obj, 'tokenName', 'tokenImgFile', resolver);
+
+  for (const key of ['cards', 'received', 'routedToLob', 'redirectedLostSouls']) {
+    const arr = obj[key];
+    if (!Array.isArray(arr)) continue;
+    for (const el of arr) {
+      if (el && typeof el === 'object') resolveNamedCard(el as Record<string, unknown>, 'name', 'img', resolver);
+    }
+  }
+  for (const key of ['card', 'drew', 'drewCard']) {
+    const el = obj[key];
+    if (el && typeof el === 'object') resolveNamedCard(el as Record<string, unknown>, 'name', 'img', resolver);
+  }
+  return JSON.stringify(obj);
+}
+
 export function mergeForgeDeckData(cards: GameCardData[], resolver?: ForgeResolverMap | null): GameCardData[] {
   if (!resolver || resolver.size === 0) return cards;
   return cards.map((c) => {


### PR DESCRIPTION
## The bug

Playtest (Forge) cards were logged **nameless** in the multiplayer chat/game log. Reserving or milling a Forge card showed a blank name — "sometimes it shows the card, sometimes not" — which BaboonyTim correctly guessed was specific to playtest cards.

## Root cause

Forge cards store `cardName = ""` on the world-readable SpacetimeDB row (the "leak spine" — unreleased card text must never persist to public rows); their identity rides only in `cardImgFile` as `forge:<uuid>`. Server log reducers copy that blank name into `GameAction.payload`.

The **board** rehydrates the real name per-viewer via the RLS-granted resolver ([`cardAdapter.ts`](../blob/main/app/play/utils/cardAdapter.ts)), but the **log renderer** never did — so it printed the blank verbatim. Normal cards carry their real name on the row and logged fine; hence the inconsistency.

## The fix (client-only)

`normalizeForgeLogPayload(payload, resolver)` — a pure transform that rewrites every forge `{name, img}` field in a log payload to the viewer's resolved name + hover art (or **"a playtest card"** when ungranted) **before** `ChatPanel`'s `formatActionType` renders it. Threaded via a new `forgeResolver` prop through `RightPanel` and both the play and spectate clients.

Because it normalizes the payload up front, every existing log handler — which gates on a truthy card name — treats Forge cards like any named card. This covers reserve, moves, meek/flip, counters, discards, shuffles, draws, etc. in one place, leaving the ~900-line `formatActionType` untouched, and it makes the log **searchable by Forge card name**.

- **Leak-safe:** fails closed to "a playtest card"; nothing is persisted, and the server still never emits the real name. Existing privacy layers (hand-mask, `isViewer` draw gates, face-down sentinel) are unaffected.
- **Free in normal games:** payloads without a `forge:` ref skip the parse/stringify via a fast-path.

## Why no server changes

An earlier iteration added server payload fields to cover `SET_CARD_OUTLINE` / `IMITATE_LOST_SOUL` / `REVEAL_CARDS`, then reverted them: those are **ability-sourced** log lines, and Forge cards have **no mechanized abilities** (dispatch resolves via the blanked name and throws `"No such ability"`), so they can never involve a Forge card. The reachable Forge log lines are the card-object fields this normalizer covers — no server/reducer change or module republish needed.

## Testing

- 16/16 unit tests (`forgeResolver.test.ts`): reserve arrays, name/img pairs, nested objects, ungranted-masking, and non-JSON/array/bare-count passthrough.
- `tsc --noEmit` clean on all changed files.
- Three independent adversarial reviews: leak-safe, no non-forge regression, revert clean, no dead/unreachable coverage of concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
