### PR TITLE
feat(decklist): sticky AB + 1st-print K/L filters across sessions

### DIFF
--- a/app/decklist/card-search/__tests__/stickyFilters.test.ts
+++ b/app/decklist/card-search/__tests__/stickyFilters.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_STICKY_FILTERS,
+  parseStickyFilters,
+  serializeStickyFilters,
+} from "../stickyFilters";
+
+describe("parseStickyFilters", () => {
+  it("returns defaults (hide both) when nothing is stored", () => {
+    expect(parseStickyFilters(null)).toEqual(DEFAULT_STICKY_FILTERS);
+    expect(parseStickyFilters(null)).toEqual({ noAltArt: true, noFirstPrint: true });
+  });
+
+  it("reads a full JSON blob", () => {
+    const raw = JSON.stringify({ noAltArt: false, noFirstPrint: false });
+    expect(parseStickyFilters(raw)).toEqual({ noAltArt: false, noFirstPrint: false });
+  });
+
+  it("preserves each key independently", () => {
+    expect(
+      parseStickyFilters(JSON.stringify({ noAltArt: false, noFirstPrint: true })),
+    ).toEqual({ noAltArt: false, noFirstPrint: true });
+  });
+
+  it("fills missing keys with defaults", () => {
+    expect(parseStickyFilters(JSON.stringify({ noAltArt: false }))).toEqual({
+      noAltArt: false,
+      noFirstPrint: true,
+    });
+  });
+
+  it("ignores non-boolean values and uses defaults for them", () => {
+    const raw = JSON.stringify({ noAltArt: "false", noFirstPrint: 0 });
+    expect(parseStickyFilters(raw)).toEqual(DEFAULT_STICKY_FILTERS);
+  });
+
+  it("falls back to defaults on corrupt / non-JSON input", () => {
+    expect(parseStickyFilters("not json")).toEqual(DEFAULT_STICKY_FILTERS);
+    expect(parseStickyFilters("[1,2,3")).toEqual(DEFAULT_STICKY_FILTERS);
+  });
+
+  it("falls back to defaults when JSON is not an object", () => {
+    expect(parseStickyFilters("true")).toEqual(DEFAULT_STICKY_FILTERS);
+    expect(parseStickyFilters("42")).toEqual(DEFAULT_STICKY_FILTERS);
+  });
+
+  describe("legacy deck-filter-noab migration", () => {
+    it("adopts legacy 'false' for noAltArt when the new key is absent", () => {
+      expect(parseStickyFilters(null, "false")).toEqual({
+        noAltArt: false,
+        noFirstPrint: true,
+      });
+    });
+
+    it("adopts legacy 'true' for noAltArt", () => {
+      expect(parseStickyFilters(null, "true")).toEqual({
+        noAltArt: true,
+        noFirstPrint: true,
+      });
+    });
+
+    it("prefers the new JSON blob over the legacy key", () => {
+      const raw = JSON.stringify({ noAltArt: true, noFirstPrint: false });
+      expect(parseStickyFilters(raw, "false")).toEqual({
+        noAltArt: true,
+        noFirstPrint: false,
+      });
+    });
+  });
+});
+
+describe("serializeStickyFilters", () => {
+  it("round-trips through parseStickyFilters", () => {
+    const filters = { noAltArt: false, noFirstPrint: true };
+    expect(parseStickyFilters(serializeStickyFilters(filters))).toEqual(filters);
+  });
+
+  it("only writes the two known keys", () => {
+    const serialized = serializeStickyFilters({
+      // extra field should not be persisted
+      noAltArt: false,
+      noFirstPrint: false,
+      // @ts-expect-error — guarding against accidental extra fields
+      somethingElse: true,
+    });
+    expect(JSON.parse(serialized)).toEqual({ noAltArt: false, noFirstPrint: false });
+  });
+});

--- a/app/decklist/card-search/client.tsx
+++ b/app/decklist/card-search/client.tsx
@@ -14,6 +14,7 @@ import {
   iconPredicates,
 } from "./utils";
 import { DeckBuilderConfig, PUBLIC_BUILDER_CONFIG, BuilderConfigProvider } from "./builderConfig";
+import { readStickyFilters, writeStickyFilters } from "./stickyFilters";
 import { useDeckState } from "./hooks/useDeckState";
 import { useDeckCheck } from "./hooks/useDeckCheck";
 import { useCardImageUrl } from "./hooks/useCardImageUrl";
@@ -214,8 +215,11 @@ export default function CardSearchClient({
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [selectedTestaments, setSelectedTestaments] = useState<string[]>([]);
   const [isGospel, setIsGospel] = useState(false);
-  const [noAltArt, setnoAltArt] = useState(true);
-  const [noFirstPrint, setnoFirstPrint] = useState(true);
+  // Seed the two print/art filters from the user's per-device sticky preference
+  // (default "hide" for both when unset). Applies in all modes, including deck
+  // editing and the Forge, where a deckId is always present.
+  const [noAltArt, setnoAltArt] = useState(() => readStickyFilters().noAltArt);
+  const [noFirstPrint, setnoFirstPrint] = useState(() => readStickyFilters().noFirstPrint);
   const [nativityOnly, setNativityOnly] = useState(false);
   const [hasStarOnly, setHasStarOnly] = useState(false);
   const [cloudOnly, setCloudOnly] = useState(false);
@@ -707,15 +711,15 @@ export default function CardSearchClient({
         setToughnessOp(searchParams.get('toughnessOp') || 'eq');
       }
 
-      // Explicit shared-link intent wins; otherwise fall back to the user's
-      // saved per-device preference, defaulting to "hide AB versions" (true).
+      // Explicit shared-link intent overrides the sticky default; otherwise the
+      // values keep their initial state seeded from the saved per-device
+      // preference (see the useState initializers above).
       if (searchParams.get('showAltArt') === 'true') {
         setnoAltArt(false);
-      } else {
-        const savedNoAltArt = localStorage.getItem('deck-filter-noab');
-        setnoAltArt(savedNoAltArt === null ? true : savedNoAltArt === 'true');
       }
-      setnoFirstPrint(searchParams.get('showFirstPrint') !== 'true');
+      if (searchParams.get('showFirstPrint') === 'true') {
+        setnoFirstPrint(false);
+      }
       setNativityOnly(searchParams.get('nativity') === 'true');
       setNativityNot(searchParams.get('nativityNot') === 'true');
       setHasStarOnly(searchParams.get('hasStar') === 'true');
@@ -740,13 +744,14 @@ export default function CardSearchClient({
     }
   }, [searchParams, isInitialized]);
 
-  // Persist the "No AB Versions" toggle as a per-device default so the user's
-  // choice sticks across visits. Skipped until initialized so we don't clobber
-  // the saved value with the initial render default.
+  // Persist the two print/art filters as per-device defaults so the user's
+  // choice sticks across sessions (public builder and the Forge alike). Skipped
+  // until initialized so we don't clobber the saved value with the mount default
+  // before any shared-link URL params have been applied.
   useEffect(() => {
     if (!isInitialized) return;
-    localStorage.setItem('deck-filter-noab', String(noAltArt));
-  }, [noAltArt, isInitialized]);
+    writeStickyFilters({ noAltArt, noFirstPrint });
+  }, [noAltArt, noFirstPrint, isInitialized]);
 
   // Update URL whenever filters change
   useEffect(() => {
@@ -1391,8 +1396,8 @@ export default function CardSearchClient({
     setSelectedRarityFilters([]);
     setSelectedTestaments([]);
     setIsGospel(false);
-    setnoAltArt(true);
-    setnoFirstPrint(true);
+    // Keep the sticky print/art preferences on reset (don't force "hide" back
+    // on) — they mirror the persisted per-device default, like legalityMode above.
     setNativityOnly(false);
     setHasStarOnly(false);
     setCloudOnly(false);

--- a/app/decklist/card-search/stickyFilters.ts
+++ b/app/decklist/card-search/stickyFilters.ts
@@ -1,0 +1,83 @@
+// Per-device "sticky" defaults for the two print/art filters in the card-search
+// deckbuilder ("No AB Versions" and "No 1st Print K/L Starters"). The user's
+// last-used choice is remembered across sessions and survives a filter reset,
+// in both the public builder and the Forge.
+//
+// Design: docs/superpowers/specs/2026-07-10-sticky-print-filters-design.md
+
+const STORAGE_KEY = "deck-sticky-filters";
+// Legacy key that only ever persisted noAltArt (and never applied while a deckId
+// was present). Read once for a seamless migration into STORAGE_KEY.
+const LEGACY_NOAB_KEY = "deck-filter-noab";
+
+export type StickyFilters = {
+  /** true = hide AB (alternate art) versions. */
+  noAltArt: boolean;
+  /** true = hide 1st-print K/L starter variants. */
+  noFirstPrint: boolean;
+};
+
+// Default to "hide" for both, matching the historical hardcoded defaults so
+// users who have never touched these filters see no behavior change.
+export const DEFAULT_STICKY_FILTERS: StickyFilters = {
+  noAltArt: true,
+  noFirstPrint: true,
+};
+
+/**
+ * Resolve sticky filters from raw storage values. Prefers the JSON blob under
+ * `deck-sticky-filters`; falls back to the legacy `deck-filter-noab` value
+ * (noAltArt only) for a one-time migration; otherwise returns defaults. Pure —
+ * takes the stored strings as arguments so it stays unit-testable without a DOM.
+ */
+export function parseStickyFilters(
+  raw: string | null,
+  legacyNoAb: string | null = null,
+): StickyFilters {
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object") {
+        return {
+          noAltArt:
+            typeof parsed.noAltArt === "boolean"
+              ? parsed.noAltArt
+              : DEFAULT_STICKY_FILTERS.noAltArt,
+          noFirstPrint:
+            typeof parsed.noFirstPrint === "boolean"
+              ? parsed.noFirstPrint
+              : DEFAULT_STICKY_FILTERS.noFirstPrint,
+        };
+      }
+    } catch {
+      // Corrupt / non-JSON value — fall through to legacy/defaults.
+    }
+  }
+  return {
+    noAltArt:
+      legacyNoAb === null ? DEFAULT_STICKY_FILTERS.noAltArt : legacyNoAb === "true",
+    noFirstPrint: DEFAULT_STICKY_FILTERS.noFirstPrint,
+  };
+}
+
+export function serializeStickyFilters(filters: StickyFilters): string {
+  return JSON.stringify({
+    noAltArt: filters.noAltArt,
+    noFirstPrint: filters.noFirstPrint,
+  });
+}
+
+/** SSR-safe read from localStorage. Returns defaults on the server. */
+export function readStickyFilters(): StickyFilters {
+  if (typeof window === "undefined") return DEFAULT_STICKY_FILTERS;
+  return parseStickyFilters(
+    localStorage.getItem(STORAGE_KEY),
+    localStorage.getItem(LEGACY_NOAB_KEY),
+  );
+}
+
+/** SSR-safe write to localStorage. No-op on the server. */
+export function writeStickyFilters(filters: StickyFilters): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(STORAGE_KEY, serializeStickyFilters(filters));
+}

--- a/docs/superpowers/specs/2026-07-10-sticky-print-filters-design.md
+++ b/docs/superpowers/specs/2026-07-10-sticky-print-filters-design.md
@@ -1,0 +1,129 @@
+# Sticky Print/Art Filters (AB + 1st Print K/L)
+
+**Date:** 2026-07-10
+**Status:** Approved design, pending implementation plan
+**Surfaces:** Public deckbuilder (`/decklist/card-search`) and the Forge deck builder (both render the shared `CardSearchClient`)
+
+## Problem
+
+The card-search filters reset to hardcoded defaults every session. A user who prefers to
+always see **AB (alternate art) versions** and **1st-print K/L starter variants** must re-enable
+those two filters on every visit and after every filter reset. The preference should be
+remembered ("sticky") across sessions per device, and a filter reset should restore the user's
+remembered preference rather than snapping back to the hardcoded default.
+
+Scope was deliberately narrowed (during brainstorming) to **two filters only**:
+
+- **"No AB Versions"** — `noAltArt` ([`client.tsx:217`](../../../app/decklist/card-search/client.tsx))
+- **"No 1st Print K/L Starters"** — `noFirstPrint` ([`client.tsx:218`](../../../app/decklist/card-search/client.tsx))
+
+Legality mode (Rotation / Classic / "Unlimited") is **out of scope** for this change.
+
+## Current State (as-is)
+
+- Both filters are flat `useState` hooks in `app/decklist/card-search/client.tsx`, hardcoded to
+  `true`. Semantics are **inverted**: `true` HIDES the cards. The user's desired state is
+  `false` for both (show AB / show 1st-print K/L).
+- Filter application:
+  - `noAltArt` → `.filter((c) => !noAltArt || !c.set.includes("AB"))` (`client.tsx:1156`)
+  - `noFirstPrint` → `.filter((c) => !noFirstPrint || (!c.set.includes("K1P") && !c.set.includes("L1P")))` (`client.tsx:1157-1159`)
+- `handleResetFilters()` (`client.tsx:1384-1425`) currently forces both back to `true`
+  (`client.tsx:1394-1395`). It already **preserves** `legalityMode` on reset
+  (`client.tsx:1387-1388`) — the precedent this change extends to the two print filters.
+- There is an **existing, broken** persistence attempt for `noAltArt` only:
+  - Key `deck-filter-noab`, written on every change (`client.tsx:746-749`), but read only in
+    browse mode. The init effect early-returns whenever a `deckId` is present
+    (`client.tsx:658-661`). Because normal deck-editing and the **entire Forge** always carry a
+    `deckId`, the saved value is written but **never applied while building a deck**.
+- Both surfaces render the same `CardSearchClient`, so a single change covers both. The Forge
+  config sets `syncFiltersToUrl: false` and `localStoragePersist: false`
+  (`forgeBuilderConfig.tsx`), but the existing `deck-filter-noab` write is un-gated and already
+  fires in the Forge, so localStorage persistence needs no feature flag.
+
+## Design
+
+### Behavior model: implicit "last-used"
+
+No new "save as default" UI. The two toggles *are* their own preference: whatever the user last
+set them to is persisted and seeds the initial value next session. Consequences:
+
+- **First-time / never-touched users:** unchanged. Both still default to `true` (hide AB / hide
+  1st-print). No behavior change for anyone who has never flipped them.
+- **After flipping "No AB Versions" off:** it stays off across sessions and survives Reset, in
+  both the public builder and the Forge.
+- **Reset** restores these two filters to the saved preference (i.e. leaves them where the user
+  set them) instead of forcing `true` — mirroring how `legalityMode` already behaves on reset.
+
+### Storage
+
+- Single namespaced localStorage key: `deck-sticky-filters`
+- Value: JSON `{ "noAltArt": boolean, "noFirstPrint": boolean }`
+- Read via lazy `useState` initializers, SSR-guarded (`typeof window !== "undefined"`), matching
+  the established `app/shared/hooks/useCardScale.ts` pattern. Reading at initializer time (rather
+  than in a post-mount effect) avoids a visible flicker from default→saved and makes the value
+  correct on first render.
+- Persist on change via a `useEffect` keyed on the two values.
+- When no saved value exists, fall back to the current hardcoded default `true` for each key, so
+  existing behavior is preserved for untouched users.
+
+### Changes
+
+1. **Seed initial state from storage.** Replace the hardcoded `useState(true)` initializers for
+   `noAltArt` and `noFirstPrint` with lazy initializers that read `deck-sticky-filters` (SSR-safe,
+   default `true` per key). Encapsulate in a small helper/hook (e.g. `useStickyFilters`) to keep
+   `client.tsx` readable and the read/write logic in one place.
+2. **Persist on change.** Single `useEffect` writes `{ noAltArt, noFirstPrint }` to
+   `deck-sticky-filters`. Must run regardless of `deckId` (so it works in the Forge and in
+   deck-editing).
+3. **Fix reset.** In `handleResetFilters()`, remove the `setnoAltArt(true)` / `setnoFirstPrint(true)`
+   lines and instead restore both from the saved preference (which, since they haven't changed,
+   is effectively "leave as-is").
+4. **Remove the old mechanism.** Delete the `deck-filter-noab` write effect (`client.tsx:746-749`)
+   and its browse-only read (`client.tsx:715-716`) so there is exactly one persistence path.
+   Optionally, one-time migrate an existing `deck-filter-noab` value into `deck-sticky-filters`
+   for `noAltArt`.
+
+### Data flow
+
+```
+localStorage["deck-sticky-filters"]
+   │  (lazy useState init, SSR-guarded, default true per key)
+   ▼
+noAltArt / noFirstPrint state  ──►  filter useMemo (client.tsx:1156-1159)
+   │
+   ├─ on change ──► useEffect ──► write localStorage["deck-sticky-filters"]
+   │
+   └─ handleResetFilters() ──► restore from saved prefs (not hardcoded true)
+```
+
+## Edge Cases
+
+- **Existing `deck-filter-noab` users:** users who previously toggled AB off in browse mode had
+  the value saved but never applied in the builder. After this change the read runs regardless of
+  deck mode, so their saved preference will now take effect in the builder too. This is the
+  intended fix, but it is a **visible behavior change** for those specific users — call it out in
+  the PR description.
+- **SSR / hydration:** lazy initializers must guard `typeof window` and tolerate the server
+  rendering the default (`true`) while the client hydrates to the saved value, consistent with
+  how `useCardScale`/`useChatScale` already behave in this codebase.
+- **Corrupt / non-JSON stored value:** parse defensively; on parse failure fall back to defaults
+  and overwrite on next persist.
+- **Paragon decks:** unaffected — this change touches only `noAltArt`/`noFirstPrint`, not
+  `legalityMode` (which is auto-forced to Paragon for Paragon decks).
+
+## Testing / Verification
+
+- Toggle "No AB Versions" off in the public builder, reload the page → it stays off.
+- Same in the Forge builder (has a `deckId`) → it stays off (proves the old `deckId` early-return
+  bug is fixed).
+- Click Reset with the preference set to "show AB" → AB stays shown (not re-hidden).
+- Fresh browser / cleared localStorage → both default to `true` (hide), matching today's behavior.
+- Repeat all four for "No 1st Print K/L Starters".
+- Confirm no lingering writes to `deck-filter-noab`.
+
+## Out of Scope
+
+- Cross-device / account-level persistence (Supabase). Chosen storage is per-device localStorage;
+  an account-synced version is a possible future follow-up.
+- Making `legalityMode` (Rotation/Classic/"Unlimited") sticky.
+- Any new settings UI or "save as default" control.


### PR DESCRIPTION
## What

Makes the two print/art filters in the card-search deckbuilder **sticky** — remembered per-device across sessions, in both the public builder and the Forge:

- **No AB Versions** (`noAltArt`)
- **No 1st Print K/L Starters** (`noFirstPrint`)

Whatever you last set them to is your default next session, and a filter **Reset keeps them** (mirroring how `legalityMode` already behaves) instead of forcing "hide" back on. First-time users are unchanged — both still default to hide.

Legality mode was intentionally left out of scope.

## Why / bug fixed

There was already a half-built persistence for `noAltArt` (`deck-filter-noab`) that **wrote on every change but only read in browse mode** — it early-returned whenever a `deckId` was present. Since deck-editing and the *entire Forge* always carry a `deckId`, the saved AB preference silently did nothing in the builder. This PR replaces that path with one localStorage key (`deck-sticky-filters`) read via lazy initializers, so the preference applies in every mode. Existing `deck-filter-noab` values are migrated on first read.

## How

- New pure module `app/decklist/card-search/stickyFilters.ts` (read/write + testable `parse`/`serialize`, SSR-guarded, legacy migration).
- `client.tsx`: seed `noAltArt`/`noFirstPrint` from `readStickyFilters()`; persist both on change; shared-link URL params (`showAltArt`/`showFirstPrint`) still override; reset no longer forces `true`.
- Removed the old `deck-filter-noab` read/write.

## Behavior-change note for reviewers

Users who previously toggled AB off *in browse mode* had the value saved but never applied in the builder. After this change it now takes effect in the builder too — the intended fix, but a visible change for those specific users.

## Testing

- 12 unit tests for `parseStickyFilters`/`serializeStickyFilters` (defaults, per-key preservation, non-boolean/corrupt input, legacy migration, round-trip) — all green.
- `tsc --noEmit` clean for changed files (the 7 pre-existing errors are in unrelated test files on `main`).

Manual verification checklist:
- Toggle "No AB Versions" off in the public builder → reload → stays off.
- Same in the Forge (has a `deckId`) → stays off (proves the `deckId` bug is fixed).
- Reset with "show AB" set → AB stays shown.
- Fresh browser / cleared storage → both default to hide (today's behavior).
- Repeat for "No 1st Print K/L Starters".

Spec: `docs/superpowers/specs/2026-07-10-sticky-print-filters-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)