### PR TITLE
feat(forge): add Deckbuilder tab to the Forge nav

### DIFF
--- a/app/forge/components/ForgeNav.tsx
+++ b/app/forge/components/ForgeNav.tsx
@@ -18,13 +18,15 @@ export default function ForgeNav({ role }: { role: ForgeRole }) {
       ? [
           { href: "/forge/play", label: "Play", match: (p) => p === "/forge/play" || p.startsWith("/forge/play/games") },
           { href: "/forge/play/sets", label: "Sets", match: (p) => p.startsWith("/forge/play/sets") || (/^\/forge\/play\/[^/]+$/.test(p) && !p.startsWith("/forge/play/decks") && !p.startsWith("/forge/play/games")) },
-          { href: "/forge/play/decks", label: "Decks", match: (p) => p.startsWith("/forge/play/decks") },
+          { href: "/forge/play/decks", label: "Decks", match: (p) => p.startsWith("/forge/play/decks") && p !== "/forge/play/decks/new" },
+          { href: "/forge/play/decks/new", label: "Deckbuilder", match: (p) => p === "/forge/play/decks/new" },
         ]
       : [
           { href: "/forge/ideas", label: "Ideas", match: (p) => p.startsWith("/forge/ideas") },
           { href: "/forge/sets", label: "Sets", match: (p) => p.startsWith("/forge/sets") },
           { href: "/forge/play", label: "Play", match: (p) => p.startsWith("/forge/play") && !p.startsWith("/forge/play/decks") },
-          { href: "/forge/play/decks", label: "Decks", match: (p) => p.startsWith("/forge/play/decks") },
+          { href: "/forge/play/decks", label: "Decks", match: (p) => p.startsWith("/forge/play/decks") && p !== "/forge/play/decks/new" },
+          { href: "/forge/play/decks/new", label: "Deckbuilder", match: (p) => p === "/forge/play/decks/new" },
           { href: "/forge/announcements", label: "Announcements", match: (p) => p.startsWith("/forge/announcements") },
           ...(role === "superadmin" || role === "elder"
             ? [{ href: "/forge/admin", label: "Admin", match: (p: string) => p.startsWith("/forge/admin") }]


### PR DESCRIPTION
## What

Adds a top-level **Deckbuilder** tab to the Forge nav that links straight to `/forge/play/decks/new` — the existing route that boots the card-search + deck-panel builder (`CardSearchClient` + the Forge config) into a blank deck. This puts the builder view one click from anywhere in the Forge, instead of **Decks → + New deck**.

Requested so there's "a quick place to pull this up."

## Details

- Added to **both** nav branches — elder/superadmin (Ideas · Sets · Play · Decks · **Deckbuilder** · Announcements · Admin) and the reduced playtester branch (Play · Sets · Decks · **Deckbuilder**). Placed right after **Decks**.
- Narrowed the **Decks** tab's active-highlight match to exclude `/forge/play/decks/new`, so Decks and Deckbuilder don't both light up on the new-deck route. Once a new deck saves and the URL becomes `/forge/play/decks/<id>`, the highlight hands back from Deckbuilder → Decks.

## Scope / safety

- **One file changed** (`app/forge/components/ForgeNav.tsx`), ~2 lines net.
- No new routes, DB, persistence, or builder changes — `/forge/play/decks/new` already exists.
- The new-deck route only writes a deck on explicit save, so clicking the tab repeatedly never creates junk decks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)