### PR TITLE
fix(forge): surface Territory/Star/Cloud icons under the deckbuilder class filters

### DIFF
--- a/app/forge/lib/__tests__/deckAdapter.test.ts
+++ b/app/forge/lib/__tests__/deckAdapter.test.ts
@@ -36,6 +36,25 @@ describe("designCardToCard", () => {
     expect(c.type.toLowerCase()).toContain("dominant");
   });
 
+  it("folds Territory/Star/Cloud icons into the class string so the class filters match", () => {
+    // Regression: the deckbuilder's Territory/Warrior/Weapon-Class filters all read
+    // a single combined `class` string — public data keeps Warrior/Weapon AND the
+    // Territory/Star/Cloud icons together there. The forge model splits `class`
+    // (Warrior/Weapon) from `icons` (Territory/Star/Cloud), so the adapter must
+    // recombine them (like the Lackey export) or forge Territory Class cards are
+    // invisible to the Territory Class selector.
+    const territory: DesignCard = { name: "Hope", cardType: ["Hero"], icons: ["Territory"] };
+    expect(designCardToCard(territory, "t1", "EoT").class).toContain("Territory");
+
+    const both: DesignCard = { name: "Mixed", cardType: ["Hero"], class: ["Warrior"], icons: ["Star"] };
+    const mixed = designCardToCard(both, "m1", "EoT").class;
+    expect(mixed).toContain("Warrior");
+    expect(mixed).toContain("Star");
+
+    // No class/icons → empty string (unchanged).
+    expect(designCardToCard({ name: "Plain", cardType: ["Hero"] }, "p1", "S").class).toBe("");
+  });
+
   it("defaults an unset legality to 'Rotation' but preserves an explicit choice", () => {
     const unset: DesignCard = { name: "New", cardType: ["Hero"] };
     expect(designCardToCard(unset, "id3", "S").legality).toBe("Rotation");

--- a/app/forge/lib/deckAdapter.ts
+++ b/app/forge/lib/deckAdapter.ts
@@ -78,7 +78,11 @@ export function designCardToCard(data: DesignCard, cardId: string, setName: stri
     brigade: brigades.map((b) => BRIGADE_DISPLAY[b] ?? b).join("/") || "—",
     strength: data.strength != null ? String(data.strength) : "—",
     toughness: data.toughness != null ? String(data.toughness) : "—",
-    class: (data.class ?? []).join("/"),
+    // Public data keeps Warrior/Weapon AND the Territory/Star/Cloud icons in one
+    // combined `class` string (the deckbuilder's class filters substring-match it).
+    // The forge model splits them, so recombine here — mirroring the Lackey export
+    // (lackey.ts) — or forge Territory/Star/Cloud cards vanish from those filters.
+    class: [...(data.class ?? []), ...(data.icons ?? [])].join("/"),
     identifier: (data.identifiers ?? []).join(", "),
     // rawText-first (via cardRawText) — the studio edits rawText; a stale legacy
     // specialAbility must not shadow it (Heavenly Temple bug, 2026-07-06).


### PR DESCRIPTION
## Bug
Territory Class cards from the EoT forge set didn't show up under the deckbuilder's **Territory Class** filter — they appeared to be missing class information. Warrior Class cards worked fine.

## Root cause
The deckbuilder's Territory/Warrior/Weapon-Class filters substring-match a single combined `class` string (`c.class.includes("Territory")`). Public card data keeps Warrior/Weapon **and** the Territory/Star/Cloud icons together in that one `class` field. The Forge model, however, splits them into two fields — `class` (Warrior/Weapon) and `icons` (Territory/Star/Cloud).

The Forge→deckbuilder adapter `designCardToCard` mapped only `data.class` and **dropped `data.icons` entirely**, so forge Territory Class cards (and Star/Cloud) came through with an empty class and never matched the filters. The Forge's own Lackey export already recombines both fields into the single Class column — the adapter just forgot that half.

## Fix
Recombine `class` + `icons` into the adapter's `class` output, mirroring the Lackey export:
```ts
class: [...(data.class ?? []), ...(data.icons ?? [])].join("/"),
```
This also fixes the same latent gap for **Star** and **Cloud** icons.

## Testing
- Added a failing regression test in `deckAdapter.test.ts` first (reproduced `expected '' to contain 'Territory'`), then made it pass.
- Full suite green: **416 tests** across `app/forge`, `lib/cards`, `app/decklist/card-search`.
- No new type errors introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)