### PR TITLE
fix(decklist): unclip Move-to submenu and make folder delete honest

### DIFF
--- a/app/decklist/actions.ts
+++ b/app/decklist/actions.ts
@@ -792,12 +792,13 @@ export async function deleteFolderAction(folderId: string) {
       };
     }
 
-    // Check if folder has decks
+    // Collect the decks in this folder so we can cascade-delete them and
+    // invalidate their public caches (card rows cascade-delete via FK).
     const { data: decksInFolder, error: checkError } = await supabase
       .from("decks")
       .select("id")
       .eq("folder_id", folderId)
-      .limit(1);
+      .eq("user_id", user.id);
 
     if (checkError) {
       console.error("Error checking folder contents:", checkError);
@@ -807,14 +808,24 @@ export async function deleteFolderAction(folderId: string) {
       };
     }
 
+    // Delete every deck inside the folder (their cards cascade-delete via FK).
     if (decksInFolder && decksInFolder.length > 0) {
-      return {
-        success: false,
-        error: "Cannot delete folder that contains decks. Move or delete the decks first.",
-      };
+      const { error: decksError } = await supabase
+        .from("decks")
+        .delete()
+        .eq("folder_id", folderId)
+        .eq("user_id", user.id);
+
+      if (decksError) {
+        console.error("Error deleting decks in folder:", decksError);
+        return {
+          success: false,
+          error: "Failed to delete folder",
+        };
+      }
     }
 
-    // Delete folder
+    // Delete the folder itself
     const { error } = await supabase
       .from("deck_folders")
       .delete()
@@ -830,10 +841,14 @@ export async function deleteFolderAction(folderId: string) {
     }
 
     revalidatePath("/decklist/my-decks");
+    revalidateTag("public-decks-list");
+    for (const deck of decksInFolder ?? []) {
+      revalidateTag(`public-deck:${deck.id}`);
+    }
 
     return {
       success: true,
-      message: "Folder deleted successfully",
+      message: "Folder and its decks deleted successfully",
     };
   } catch (error) {
     console.error("Error in deleteFolderAction:", error);

--- a/app/decklist/my-decks/DeleteFolderModal.tsx
+++ b/app/decklist/my-decks/DeleteFolderModal.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import ConfirmationDialog from "@/components/ui/confirmation-dialog";
+
+interface DeleteFolderModalProps {
+  folderName: string;
+  deckCount: number;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export default function DeleteFolderModal({ folderName, deckCount, onConfirm, onClose }: DeleteFolderModalProps) {
+  const hasDecks = deckCount > 0;
+  const deckWord = deckCount === 1 ? "deck" : "decks";
+
+  return (
+    <ConfirmationDialog
+      open={true}
+      onOpenChange={(open) => { if (!open) onClose(); }}
+      onConfirm={onConfirm}
+      variant="destructive"
+      title="Delete Folder"
+      description="This action cannot be undone"
+      confirmLabel={hasDecks ? `Delete folder & ${deckCount} ${deckWord}` : "Delete folder"}
+      cancelLabel="Cancel"
+      icon={
+        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+        </svg>
+      }
+    >
+      <p className="text-foreground mb-2">
+        Are you sure you want to delete this folder?
+      </p>
+      <div className="bg-muted rounded-lg px-4 py-3 mt-3">
+        <p className="text-sm text-muted-foreground mb-1">Folder name:</p>
+        <p className="font-semibold text-foreground break-words">
+          {folderName}
+        </p>
+      </div>
+      {hasDecks ? (
+        <div className="mt-3 rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3">
+          <p className="text-sm text-red-600 dark:text-red-400">
+            This folder contains <span className="font-semibold">{deckCount} {deckWord}</span>. The folder and all{" "}
+            {deckWord} inside it — including their card data — will be permanently deleted.
+          </p>
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground mt-3">
+          This folder is empty. It will be permanently deleted.
+        </p>
+      )}
+    </ConfirmationDialog>
+  );
+}

--- a/app/decklist/my-decks/client.tsx
+++ b/app/decklist/my-decks/client.tsx
@@ -24,6 +24,7 @@ import {
 } from "../actions";
 import { GoldfishButton } from "../../goldfish/components/GoldfishButton";
 import DeleteDeckModal from "./DeleteDeckModal";
+import DeleteFolderModal from "./DeleteFolderModal";
 import FolderModal from "./FolderModal";
 import UsernameModal from "./UsernameModal";
 import QuickLookModal from "./QuickLookModal";
@@ -316,6 +317,8 @@ export default function MyDecksClient() {
     const result = await deleteFolderAction(folderId);
     if (result.success) {
       setFolders(folders.filter((f) => f.id !== folderId));
+      // Decks inside the folder are cascade-deleted server-side; drop them locally too.
+      setDecks((prev) => prev.filter((d) => d.folder_id !== folderId));
       if (selectedFolder === folderId) {
         setSelectedFolder(null); // Go back to "My Decks"
       }
@@ -1193,8 +1196,9 @@ export default function MyDecksClient() {
 
       {/* Delete Folder Confirmation */}
       {folderToDelete && (
-        <DeleteDeckModal
-          deckName={folderToDelete.name}
+        <DeleteFolderModal
+          folderName={folderToDelete.name}
+          deckCount={decks.filter((d) => d.folder_id === folderToDelete.id).length}
           onConfirm={() => handleDeleteFolder(folderToDelete.id)}
           onClose={() => setFolderToDelete(null)}
         />
@@ -1757,11 +1761,9 @@ function DropdownMenu({
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const [showMoveMenu, setShowMoveMenu] = useState(false);
-  const [submenuOnLeft, setSubmenuOnLeft] = useState(false);
   const [menuStyle, setMenuStyle] = useState<React.CSSProperties>({});
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
-  const moveItemRef = useRef<HTMLDivElement>(null);
 
   function handleToggle() {
     if (!isOpen && buttonRef.current) {
@@ -1781,14 +1783,6 @@ function DropdownMenu({
     }
     setIsOpen(!isOpen);
   }
-
-  // Flip submenu to left side when it would overflow the right edge of the viewport
-  useEffect(() => {
-    if (!showMoveMenu || !moveItemRef.current) return;
-    const rect = moveItemRef.current.getBoundingClientRect();
-    const submenuWidth = 192; // w-48
-    setSubmenuOnLeft(rect.right + 8 + submenuWidth > window.innerWidth);
-  }, [showMoveMenu]);
 
   // Reposition on scroll/resize while open
   useEffect(() => {
@@ -1930,59 +1924,57 @@ function DropdownMenu({
               Share…
             </button>
 
-            {/* Move to Folder submenu */}
+            {/* Move to Folder submenu (expands inline so it isn't clipped by the menu's scroll container) */}
             <div className="border-t border-border my-1"></div>
-            <div className="relative" ref={moveItemRef}>
-              <button
-                onClick={() => setShowMoveMenu(!showMoveMenu)}
-                className="w-full text-left px-4 py-2 hover:bg-muted flex items-center gap-2"
-              >
-                <svg className="w-4 h-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-                </svg>
-                <span className="flex-1">Move to...</span>
-                <svg className={`w-4 h-4 ${submenuOnLeft ? "rotate-180" : ""}`} fill="currentColor" viewBox="0 0 20 20">
-                  <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
-                </svg>
-              </button>
+            <button
+              onClick={() => setShowMoveMenu(!showMoveMenu)}
+              className="w-full text-left px-4 py-2 hover:bg-muted flex items-center gap-2"
+            >
+              <svg className="w-4 h-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+              </svg>
+              <span className="flex-1">Move to...</span>
+              <svg className={`w-4 h-4 transition-transform ${showMoveMenu ? "rotate-90" : ""}`} fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
+              </svg>
+            </button>
 
-              {showMoveMenu && (
-                <div className={`absolute top-0 w-48 bg-card rounded-md shadow-lg border border-border max-h-60 overflow-y-auto ${submenuOnLeft ? "right-full mr-1" : "left-full ml-1"}`}>
+            {showMoveMenu && (
+              <div className="bg-muted/40">
+                <button
+                  onClick={() => {
+                    onMove(null);
+                    setIsOpen(false);
+                    setShowMoveMenu(false);
+                  }}
+                  className={`w-full text-left pl-11 pr-4 py-2 text-sm hover:bg-muted ${
+                    !currentFolderId ? "bg-primary/10" : ""
+                  }`}
+                >
+                  My Decks
+                </button>
+                {folders.map((folder) => (
                   <button
+                    key={folder.id}
                     onClick={() => {
-                      onMove(null);
+                      onMove(folder.id!);
                       setIsOpen(false);
                       setShowMoveMenu(false);
                     }}
-                    className={`w-full text-left px-4 py-2 hover:bg-muted first:rounded-t-md ${
-                      !currentFolderId ? "bg-primary/10" : ""
+                    className={`w-full text-left pl-11 pr-4 py-2 text-sm truncate hover:bg-muted ${
+                      currentFolderId === folder.id ? "bg-primary/10" : ""
                     }`}
                   >
-                    My Decks
+                    {folder.name}
                   </button>
-                  {folders.map((folder) => (
-                    <button
-                      key={folder.id}
-                      onClick={() => {
-                        onMove(folder.id!);
-                        setIsOpen(false);
-                        setShowMoveMenu(false);
-                      }}
-                      className={`w-full text-left px-4 py-2 hover:bg-muted last:rounded-b-md ${
-                        currentFolderId === folder.id ? "bg-primary/10" : ""
-                      }`}
-                    >
-                      {folder.name}
-                    </button>
-                  ))}
-                  {folders.length === 0 && (
-                    <div className="px-4 py-2 text-sm text-muted-foreground">
-                      No folders available
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
+                ))}
+                {folders.length === 0 && (
+                  <div className="pl-11 pr-4 py-2 text-sm text-muted-foreground">
+                    No folders available
+                  </div>
+                )}
+              </div>
+            )}
 
             <div className="border-t border-border my-1"></div>
             <button


### PR DESCRIPTION
## Summary

Fixes three related issues in **My Decks** reported from the deck-card kebab menu and folder management.

### 1. "Move to…" submenu was visually broken
The submenu was an absolutely-positioned **sideways flyout**, but its parent menu uses `overflow-y-auto` so tall menus can scroll. Per the CSS spec, once `overflow-y` is non-visible, `overflow-x` computes to `auto` too — so the flyout got **clipped and spawned a horizontal scrollbar** instead of escaping. There's no one-line CSS fix.

**Fix:** "Move to…" now **expands inline** within the menu (accordion — indented, tinted, chevron rotates down), pushing "Delete" below it. Clip-proof, and better on touch. Removed the now-dead left/right flip logic (`submenuOnLeft`, `moveItemRef`, the flip effect) and added `truncate` for long folder names.

### 2. "Delete folder" dialog was misleading
Deleting a *folder* popped the *deck* modal ("Delete Deck… all card and deck data will be permanently deleted"), while the server action actually **refused to delete any non-empty folder**. So it warned about a deletion that would just fail.

**Fix:** New `DeleteFolderModal` with honest, folder-specific copy — a destructive red warning showing the deck count and a **"Delete folder & N decks"** confirm button (empty folders get a simpler message).

### 3. Folder delete now cascades (intended behavior)
`deleteFolderAction` now **cascade-deletes the decks inside the folder** (scoped to `user_id`; card rows cascade via DB FK, mirroring `deleteDeckAction`), revalidates the public-deck caches, then removes the folder. `handleDeleteFolder` drops the deleted decks from local state so they vanish from the UI immediately.

> ⚠️ This is a **destructive cascade** with no undo. The deck-count-in-button and red warning are the guardrails.

## Test plan
- [x] `tsc --noEmit` clean on all three touched files
- [ ] Manual: open a deck's kebab → "Move to…" expands inline, no horizontal scrollbar, moves work
- [ ] Manual: delete an empty folder (simple confirm) and a non-empty folder (warns with deck count, decks are removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)