### PR TITLE
feat(forge): share decks from the builder menu + default member display names

### DIFF
--- a/app/decklist/card-search/builderConfig.tsx
+++ b/app/decklist/card-search/builderConfig.tsx
@@ -132,6 +132,16 @@ export interface DeckBuilderConfig {
   persistence?: DeckBuilderPersistence;
   /** Feature toggles. Omit for all-public-defaults. */
   features?: DeckBuilderFeatures;
+  /** Replacement share modal. When provided, the builder shows its Share
+   *  controls even with `enableSharing` off and renders this instead of the
+   *  public ShareDeckModal (which writes public visibility — never for the
+   *  Forge). The Forge supplies its member-only share here. */
+  renderShareModal?: (props: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    deckId: string;
+    deckName?: string;
+  }) => ReactNode;
   /** Called after the Load Deck modal successfully loads a deck in place. The
    *  Forge rewrites /forge/play/decks/<id> via history.replaceState (its deck
    *  id lives in the URL; the public builder's does not). */

--- a/app/decklist/card-search/components/DeckBuilderPanel.tsx
+++ b/app/decklist/card-search/components/DeckBuilderPanel.tsx
@@ -249,6 +249,10 @@ export default function DeckBuilderPanel({
   // persistence hides Load Deck unless it supplies its own `listDecks`
   // (the Forge lists forge_decks).
   const canLoadDeckList = !builderConfig.persistence || !!builderConfig.persistence.listDecks;
+  // A config-supplied share modal (the Forge's member-only share) surfaces the
+  // Share controls even with the public share (`canShare`) off.
+  const renderShareModal = builderConfig.renderShareModal;
+  const canOpenShare = canShare || !!renderShareModal;
 
   const [activeTab, setActiveTab] = useState<TabType>(defaultTab ?? "main");
   const [isEditingName, setIsEditingName] = useState(false);
@@ -1169,7 +1173,7 @@ export default function DeckBuilderPanel({
             </button>
 
             {/* Share button (opens the share/visibility modal) */}
-            {canShare && isAuthenticated && deck.id && (
+            {canOpenShare && isAuthenticated && deck.id && (
               <button
                 onClick={() => setShowShareModal(true)}
                 className="w-8 h-8 rounded-lg flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
@@ -1300,7 +1304,7 @@ export default function DeckBuilderPanel({
                       Replace Evil…
                     </button>
                   )}
-                  {canShare && isAuthenticated && deck.id && (
+                  {canOpenShare && isAuthenticated && deck.id && (
                     <button
                       onClick={() => { setShowShareModal(true); setShowMenu(false); }}
                       className="w-full px-4 py-2.5 text-left hover:bg-muted flex items-center gap-2.5 text-foreground text-sm"
@@ -1677,7 +1681,7 @@ export default function DeckBuilderPanel({
             </button>
 
             {/* Share button (opens the share/visibility modal) */}
-            {canShare && isAuthenticated && deck.id && (
+            {canOpenShare && isAuthenticated && deck.id && (
               <button
                 onClick={() => setShowShareModal(true)}
                 className="px-3 py-1.5 rounded border border-border bg-card hover:bg-muted text-muted-foreground transition-colors flex items-center"
@@ -1832,7 +1836,7 @@ export default function DeckBuilderPanel({
               )}
 
               {/* Sharing Section */}
-              {canShare && isAuthenticated && deck.id && (
+              {canOpenShare && isAuthenticated && deck.id && (
                 <button
                   onClick={() => { setShowShareModal(true); setShowMenu(false); }}
                   className="w-full px-4 py-2 text-left hover:bg-muted flex items-center gap-2 text-foreground text-sm"
@@ -3648,8 +3652,17 @@ export default function DeckBuilderPanel({
         </div>
       )}
 
-      {/* Share / visibility modal */}
-      {canShare && deck.id && (
+      {/* Share / visibility modal. A config-supplied modal (the Forge's
+          member-only share) replaces the public one outright — the public
+          modal writes public visibility, which Forge decks must never do. */}
+      {renderShareModal && deck.id ? (
+        renderShareModal({
+          open: showShareModal,
+          onOpenChange: setShowShareModal,
+          deckId: deck.id,
+          deckName: deck.name,
+        })
+      ) : canShare && deck.id ? (
         <ShareDeckModal
           open={showShareModal}
           onOpenChange={setShowShareModal}
@@ -3658,7 +3671,7 @@ export default function DeckBuilderPanel({
           visibility={currentVisibility}
           onSetVisibility={handleSelectVisibility}
         />
-      )}
+      ) : null}
 
       {/* Username Modal */}
       {showUsernameModal && (

--- a/app/forge/components/ForgeBuilderShareModal.tsx
+++ b/app/forge/components/ForgeBuilderShareModal.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import ForgeShareDeckModal from "@/app/forge/components/ForgeShareDeckModal";
+import { getForgeDeckShared, setForgeDeckShared } from "@/app/forge/lib/forgeDecks";
+
+/**
+ * Hosts ForgeShareDeckModal for the deck builder, which doesn't track
+ * is_shared: fetches the current state when the modal opens and owns the
+ * server action on change. (The deck list page passes both from its
+ * server-rendered summaries instead.)
+ */
+export default function ForgeBuilderShareModal({
+  open,
+  onOpenChange,
+  deckId,
+  deckName,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  deckId: string;
+  deckName?: string;
+}) {
+  const [isShared, setIsShared] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    getForgeDeckShared(deckId).then((shared) => {
+      if (!cancelled) setIsShared(shared);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, deckId]);
+
+  return (
+    <ForgeShareDeckModal
+      open={open}
+      onOpenChange={onOpenChange}
+      deckId={deckId}
+      deckName={deckName}
+      isShared={isShared}
+      onSetShared={async (shared) => {
+        const res = await setForgeDeckShared(deckId, shared);
+        if (res.ok) setIsShared(shared);
+      }}
+    />
+  );
+}

--- a/app/forge/lib/forgeDecks.ts
+++ b/app/forge/lib/forgeDecks.ts
@@ -117,6 +117,19 @@ export async function copyForgeDeck(id: string): Promise<{ ok: true; id: string 
   return { ok: true, id: data.id };
 }
 
+// Just the share flag, for the builder's share modal (it doesn't track
+// is_shared, and pulling the full deck for one boolean is wasteful).
+export async function getForgeDeckShared(id: string): Promise<boolean> {
+  const ctx = await requireForge();
+  if (!ctx) return false;
+  const { data } = await ctx.supabase
+    .from("forge_decks")
+    .select("is_shared")
+    .eq("id", id)
+    .maybeSingle();
+  return data?.is_shared === true;
+}
+
 export async function setForgeDeckShared(id: string, shared: boolean): Promise<{ ok: boolean; error?: string }> {
   const ctx = await requireForge();
   if (!ctx) return { ok: false, error: "Not authorized" };

--- a/app/forge/play/decks/[deckId]/forgeBuilderConfig.tsx
+++ b/app/forge/play/decks/[deckId]/forgeBuilderConfig.tsx
@@ -33,6 +33,7 @@ import type { ForgeDeckEntry } from "@/app/forge/lib/deckTypes";
 import type { GrantedForgeCard } from "@/app/forge/lib/deckPool";
 import { saveForgeDeck, getForgeDeck, listForgeDecks, deleteForgeDeck } from "@/app/forge/lib/forgeDecks";
 import ForgeCardPreview from "@/app/forge/components/ForgeCardPreview";
+import ForgeBuilderShareModal from "@/app/forge/components/ForgeBuilderShareModal";
 
 export function makeForgeBuilderConfig(granted: GrantedForgeCard[]): DeckBuilderConfig {
   // Forge cards → Card[], with imgFile stamped to the forge dataLine so the cardId
@@ -214,6 +215,9 @@ export function makeForgeBuilderConfig(granted: GrantedForgeCard[]): DeckBuilder
     resolveCardImage,
     renderThumb,
     persistence: { save, loadById, resolveCard, listDecks, delete: deleteDeck },
+    // Member-only share (is_shared on forge_decks) in place of the public
+    // share modal — enableSharing stays off so nothing writes public data.
+    renderShareModal: (props) => <ForgeBuilderShareModal {...props} />,
     features: {
       localStoragePersist: false,
       syncFiltersToUrl: false,

--- a/supabase/migrations/077_forge_member_default_display_name.sql
+++ b/supabase/migrations/077_forge_member_default_display_name.sql
@@ -1,0 +1,46 @@
+-- Forge members: default display_name from the profile username.
+--
+-- forge_redeem_invite inserted the playtest_members row with no display_name,
+-- so invite-redeemed members rendered as "—" in the admin member list and
+-- set-access grid until they set a Forge profile. Default it to the member's
+-- site username at redeem time (still editable via forge_set_profile), and
+-- backfill members already missing one.
+
+-- 1) Redeem now seeds display_name from profiles.username. Body is identical
+--    to migration 068 except the playtest_members insert.
+create or replace function public.forge_redeem_invite(
+  p_token_hash text, p_nda_agreed boolean
+) returns text language plpgsql security definer set search_path = '' as $$
+declare v_invite public.forge_invites; v_set_id uuid;
+begin
+  if not coalesce(p_nda_agreed, false) then return null; end if;  -- must accept the NDA
+  select * into v_invite from public.forge_invites
+   where token_hash = p_token_hash and used_at is null and expires_at > now()
+   for update;
+  if not found then return null; end if;
+  if v_invite.email is not null and lower(v_invite.email) is distinct from lower(auth.email()) then
+    return null;  -- email-bound to someone else; Supabase lowercases auth emails
+  end if;
+  insert into public.playtest_members (user_id, role, invited_by, nda_agreed_at, display_name)
+  values (auth.uid(), v_invite.role, v_invite.invited_by, now(),
+          (select nullif(trim(p.username), '') from public.profiles p where p.id = auth.uid()))
+  on conflict (user_id) do nothing;
+  foreach v_set_id in array coalesce(v_invite.set_ids, '{}') loop
+    insert into public.forge_set_grants (set_id, user_id, granted_by)
+    select v_set_id, auth.uid(), v_invite.invited_by
+    where exists (select 1 from public.forge_sets s where s.id = v_set_id)
+    on conflict (set_id, user_id) do nothing;
+  end loop;
+  update public.forge_invites set used_at = now() where id = v_invite.id;
+  insert into public.forge_audit (actor, action, target)
+  values (auth.uid(), 'member_added', v_invite.id::text);
+  return v_invite.role::text;
+end; $$;
+
+-- 2) Backfill members with no display name from their profile username.
+update public.playtest_members pm
+set display_name = nullif(trim(p.username), '')
+from public.profiles p
+where p.id = pm.user_id
+  and nullif(btrim(pm.display_name), '') is null
+  and nullif(trim(p.username), '') is not null;


### PR DESCRIPTION
## What

Two bundled Forge quality-of-life changes:

### 1. Share Forge decks from the deck builder
Sharing a Forge deck was only reachable from the deck **list** page — the builder's Share controls were hidden because they open the public share/visibility modal, which writes to the public `decks` table (never allowed for Forge content).

- New `renderShareModal` seam on `DeckBuilderConfig`: when a config supplies its own share modal, the builder shows its Share controls (toolbar icon + "Share…" overflow-menu item, desktop and mobile) and renders that modal instead of the public `ShareDeckModal`. `enableSharing` stays hard-off for the Forge, so the public path remains unreachable.
- New `ForgeBuilderShareModal` wraps the existing member-only `ForgeShareDeckModal` (Private ↔ Shared with the Forge, auth-gated view link). The builder doesn't track `is_shared`, so it fetches the current flag when the modal opens via a new `getForgeDeckShared` action.
- Share appears once the deck is saved (needs a deck id), matching the public builder.

### 2. Migration 077: default Forge member display names
`forge_redeem_invite` created `playtest_members` rows with no `display_name`, so invite-redeemed members rendered as "—" in the admin member list and set-access grid until they set a Forge profile.

- Redeem now seeds `display_name` from the member's `profiles.username` (still editable via `forge_set_profile`).
- Backfills existing members missing a name.
- **Already applied to the live database** — merging just checks the migration into history.

## Testing

- `tsc --noEmit` clean on all touched files (only pre-existing, unrelated test-file errors remain).
- Backfill verified live: the one blank member now shows their username; no blank members remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)