### PR TITLE
feat(cards): canonical default card sort order everywhere cards are listed

### DIFF
--- a/app/collection/client.tsx
+++ b/app/collection/client.tsx
@@ -10,6 +10,7 @@ import { useCollectionState, cardFullKey } from "./hooks/useCollectionState";
 import { downloadCollectionTxt } from "./utils/collectionCsv";
 import ImportCsvModal from "./components/ImportCsvModal";
 import { useShowPrices } from "../../hooks/useShowPrices";
+import { compareCardsDefault } from "@/lib/cards/defaultSort";
 
 const BATCH_SIZE = 60;
 const RARITY_OPTIONS = ["Common", "Rare", "Ultra Rare", "Promo"];
@@ -95,8 +96,8 @@ export default function CollectionClient() {
   const [rarityFilter, setRarityFilter] = useState("");
   const [ownershipFilter, setOwnershipFilter] = useState<"all" | "owned" | "unowned">("all");
   const [sortBy, setSortBy] = useState<
-    "name" | "set" | "strength" | "toughness" | "type" | "brigade" | "quantity" | "price"
-  >("name");
+    "default" | "name" | "set" | "strength" | "toughness" | "type" | "brigade" | "quantity" | "price"
+  >("default");
   const [showPrices, setShowPrices] = useShowPrices();
   const [visibleCount, setVisibleCount] = useState(BATCH_SIZE);
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -196,8 +197,10 @@ export default function CollectionClient() {
           return bPrice - aPrice || a.name.localeCompare(b.name);
         }
         case "name":
-        default:
           return a.name.localeCompare(b.name) || a.set.localeCompare(b.set);
+        case "default":
+        default:
+          return compareCardsDefault(a, b) || a.set.localeCompare(b.set);
       }
     });
   }, [search, formatMode, typeFilter, brigadeFilter, alignmentFilter, rarityFilter, ownershipFilter, sortBy, quantities, getPrice]);
@@ -493,6 +496,7 @@ export default function CollectionClient() {
           title="Sort by"
           className="w-36 rounded-lg border border-border bg-background px-2 py-2 text-sm"
         >
+          <option value="default">Sort: Default</option>
           <option value="name">Sort: Name</option>
           <option value="set">Sort: Set</option>
           <option value="brigade">Sort: Brigade</option>

--- a/app/decklist/[deckId]/client.tsx
+++ b/app/decklist/[deckId]/client.tsx
@@ -23,6 +23,7 @@ import GeneratePDFModal from "../card-search/components/GeneratePDFModal";
 import GenerateDeckImageModal from "../card-search/components/GenerateDeckImageModal";
 import { Deck as DeckType } from "../card-search/types/deck";
 import { generateDeckText } from "../card-search/utils/deckImportExport";
+import { compareCardsDefault, compareTypeGroups, type SortableCard } from "@/lib/cards/defaultSort";
 
 interface PublicDeckData {
   id: string;
@@ -65,6 +66,19 @@ interface EnrichedCard extends DeckCardData {
   alignment: string;
   brigade: string;
   fullCard: Card | null;
+}
+
+// Adapt an enriched deck card for the canonical default comparator.
+// Strength/reference only live on the full card record when we resolved one.
+function toSortable(c: EnrichedCard): SortableCard {
+  return {
+    name: c.card_name,
+    type: c.type,
+    brigade: c.brigade,
+    alignment: c.alignment,
+    strength: c.fullCard?.strength,
+    reference: c.fullCard?.reference,
+  };
 }
 
 // Prettify raw type abbreviations
@@ -404,21 +418,11 @@ export default function PublicDeckClient({ deck, isOwner, isLoggedIn }: Props) {
   }, [mainCards, groupBy]);
 
   const sortedReserveCards = useMemo(() => {
-    return [...reserveCards].sort((a, b) => {
-      const typeA = prettifyTypeName(a.type);
-      const typeB = prettifyTypeName(b.type);
-      if (typeA !== typeB) return typeA.localeCompare(typeB);
-      return a.card_name.localeCompare(b.card_name);
-    });
+    return [...reserveCards].sort((a, b) => compareCardsDefault(toSortable(a), toSortable(b)));
   }, [reserveCards]);
 
   const sortedMaybeboardCards = useMemo(() => {
-    return [...maybeboardCards].sort((a, b) => {
-      const typeA = prettifyTypeName(a.type);
-      const typeB = prettifyTypeName(b.type);
-      if (typeA !== typeB) return typeA.localeCompare(typeB);
-      return a.card_name.localeCompare(b.card_name);
-    });
+    return [...maybeboardCards].sort((a, b) => compareCardsDefault(toSortable(a), toSortable(b)));
   }, [maybeboardCards]);
 
   // Build flat list of Card objects for modal navigation (main + reserve + maybeboard)
@@ -990,7 +994,7 @@ export default function PublicDeckClient({ deck, isOwner, isLoggedIn }: Props) {
             case "brigade":
               return (a.brigade || "").localeCompare(b.brigade || "") || a.card_name.localeCompare(b.card_name);
             default:
-              return 0;
+              return compareCardsDefault(toSortable(a), toSortable(b));
           }
         });
         const close = () => { setCoverEditorOpen(false); setCoverPickerSlot(null); };
@@ -1810,18 +1814,9 @@ function groupAndSortCards(
     grouped[key].push(card);
   }
 
-  // Sort within each group: alignment (Good > Evil > Neutral), then brigade, then name
-  const alignmentOrder = ["Good", "Evil", "Neutral"];
+  // Sort within each group with the canonical default order
   for (const key of Object.keys(grouped)) {
-    grouped[key].sort((a, b) => {
-      const aIdx = alignmentOrder.indexOf(a.alignment);
-      const bIdx = alignmentOrder.indexOf(b.alignment);
-      const aOrder = aIdx === -1 ? 999 : aIdx;
-      const bOrder = bIdx === -1 ? 999 : bIdx;
-      if (aOrder !== bOrder) return aOrder - bOrder;
-      if (a.brigade !== b.brigade) return a.brigade.localeCompare(b.brigade);
-      return a.card_name.localeCompare(b.card_name);
-    });
+    grouped[key].sort((a, b) => compareCardsDefault(toSortable(a), toSortable(b)));
   }
 
   // Order the groups
@@ -1835,8 +1830,9 @@ function groupAndSortCards(
       if (!ordered[k]) ordered[k] = grouped[k];
     });
   } else {
+    // Order type buckets canonically (Dominants, Artifacts, Fortresses, …)
     Object.keys(grouped)
-      .sort((a, b) => a.localeCompare(b))
+      .sort(compareTypeGroups)
       .forEach((key) => {
         ordered[key] = grouped[key];
       });

--- a/app/decklist/card-search/client.tsx
+++ b/app/decklist/card-search/client.tsx
@@ -16,6 +16,7 @@ import {
 import { DeckBuilderConfig, PUBLIC_BUILDER_CONFIG, BuilderConfigProvider } from "./builderConfig";
 import { readStickyFilters, writeStickyFilters, type AltArtMode } from "./stickyFilters";
 import { hasAbReprint } from "@/lib/cards/lookup";
+import { compareCardsDefault } from "@/lib/cards/defaultSort";
 import { useDeckState } from "./hooks/useDeckState";
 import { useDeckCheck } from "./hooks/useDeckCheck";
 import { useCardImageUrl } from "./hooks/useCardImageUrl";
@@ -196,7 +197,7 @@ export default function CardSearchClient({
   // Card legality filter mode: Rotation, Classic (all), Banned, Scrolls (not Rotation or Banned), Paragon
   const [legalityMode, setLegalityMode] = useState<'Rotation'|'Classic'|'Banned'|'Scrolls'|'Paragon'>('Rotation');
   const [visibleCount, setVisibleCount] = useState(0); // Number of cards to show
-  const [sortBy, setSortBy] = useState<'name' | 'set' | 'strength' | 'toughness' | 'type' | 'brigade'>('name');
+  const [sortBy, setSortBy] = useState<'default' | 'name' | 'set' | 'strength' | 'toughness' | 'type' | 'brigade'>('default');
 
   const [modalCard, setModalCardRaw] = useState<Card | null>(null);
   const modalOpenedFromDeckRef = useRef(false);
@@ -1295,8 +1296,10 @@ export default function CardSearchClient({
         case 'brigade':
           return a.brigade.localeCompare(b.brigade) || a.name.localeCompare(b.name);
         case 'name':
-        default:
           return a.name.localeCompare(b.name);
+        case 'default':
+        default:
+          return compareCardsDefault(a, b);
       }
     });
   }, [filtered, sortBy]);
@@ -1941,6 +1944,7 @@ export default function CardSearchClient({
                 onChange={(e) => setSortBy(e.target.value as typeof sortBy)}
                 className="px-2 py-1.5 border rounded text-sm font-semibold bg-muted text-foreground border-border focus:outline-none h-9 sm:h-11"
               >
+                <option value="default">Default</option>
                 <option value="name">Name</option>
                 <option value="set">Set</option>
                 <option value="strength">Strength</option>
@@ -2223,6 +2227,7 @@ export default function CardSearchClient({
             onChange={(e) => setSortBy(e.target.value as typeof sortBy)}
             className="px-2 py-1 border rounded text-xs font-semibold bg-muted text-foreground border-border focus:outline-none"
           >
+            <option value="default">Default</option>
             <option value="name">Name</option>
             <option value="set">Set</option>
             <option value="strength">Strength</option>

--- a/app/decklist/card-search/components/DeckBuilderPanel.tsx
+++ b/app/decklist/card-search/components/DeckBuilderPanel.tsx
@@ -25,6 +25,7 @@ import FullDeckView from "./FullDeckView";
 import DragGhost from "./DragGhost";
 import { Switch } from "@headlessui/react";
 import { Card, normalizeBrigadeField } from "../utils";
+import { compareCardsDefault, compareTypeGroups } from "@/lib/cards/defaultSort";
 import { validateDeck } from "../utils/deckValidation";
 import GeneratePDFModal from "./GeneratePDFModal";
 import AodCountCard from "./AodCountCard";
@@ -783,29 +784,13 @@ export default function DeckBuilderPanel({
       return acc;
     }, {} as Record<string, typeof deck.cards>);
 
-    // Sort types alphabetically
+    // Order type buckets canonically (Dominants, Artifacts, Fortresses, …)
     return Object.keys(grouped)
-      .sort()
+      .sort(compareTypeGroups)
       .map((type) => ({
         type,
-        // Sort cards within each type by alignment, then by name
-        cards: grouped[type].sort((a, b) => {
-          const alignmentA = a.card.alignment || 'Neutral';
-          const alignmentB = b.card.alignment || 'Neutral';
-          
-          // Define alignment order: Good, Evil, Neutral
-          const alignmentOrder = ['Good', 'Evil', 'Neutral'];
-          const aIndex = alignmentOrder.indexOf(alignmentA);
-          const bIndex = alignmentOrder.indexOf(alignmentB);
-          
-          // Sort by alignment first
-          if (aIndex !== bIndex) {
-            return (aIndex === -1 ? 999 : aIndex) - (bIndex === -1 ? 999 : bIndex);
-          }
-          
-          // Then by card name
-          return a.card.name.localeCompare(b.card.name);
-        }),
+        // Sort cards within each type with the canonical default order
+        cards: grouped[type].sort((a, b) => compareCardsDefault(a.card, b.card)),
         count: grouped[type].reduce((sum, dc) => sum + dc.quantity, 0),
       }));
   };
@@ -833,15 +818,8 @@ export default function DeckBuilderPanel({
       })
       .map((alignment) => ({
         type: alignment,
-        // Sort cards within each alignment by type, then by name
-        cards: grouped[alignment].sort((a, b) => {
-          const typeA = a.card.type || '';
-          const typeB = b.card.type || '';
-          if (typeA !== typeB) {
-            return typeA.localeCompare(typeB);
-          }
-          return a.card.name.localeCompare(b.card.name);
-        }),
+        // Sort cards within each alignment with the canonical default order
+        cards: grouped[alignment].sort((a, b) => compareCardsDefault(a.card, b.card)),
         count: grouped[alignment].reduce((sum, dc) => sum + dc.quantity, 0),
       }));
   };
@@ -2929,7 +2907,7 @@ export default function DeckBuilderPanel({
                     case "brigade":
                       return (a.card.brigade || "").localeCompare(b.card.brigade || "") || a.card.name.localeCompare(b.card.name);
                     default:
-                      return 0;
+                      return compareCardsDefault(a.card, b.card);
                   }
                 });
                 return (

--- a/app/decklist/card-search/components/FullDeckView.tsx
+++ b/app/decklist/card-search/components/FullDeckView.tsx
@@ -10,6 +10,7 @@ import { createGlobalTagAction } from "../../../admin/tags/actions";
 import { HexColorPicker } from "react-colorful";
 import { useIsAdmin } from "../../../../hooks/useIsAdmin";
 import { useCardPrices } from "../hooks/useCardPrices";
+import { compareCardsDefault, compareTypeGroups } from "@/lib/cards/defaultSort";
 
 function getTagContrastColor(hex: string): string {
   const r = parseInt(hex.slice(1, 3), 16);
@@ -150,58 +151,9 @@ export default function FullDeckView({ deck, onViewCard, isAuthenticated = false
   const reserveCards = deck.cards.filter((dc) => dc.zone === 'reserve');
   const maybeboardCards = deck.cards.filter((dc) => dc.zone === 'maybeboard');
 
-    // Sort cards by type, then alignment, then name
-  const sortCards = (cards: typeof deck.cards, sortByAlignmentTypeBrigade = false) => {
-    return [...cards].sort((a, b) => {
-      if (sortByAlignmentTypeBrigade) {
-        // When grouping by type, sort by alignment first, then type, then brigade, then name
-        const alignmentA = a.card.alignment || 'Neutral';
-        const alignmentB = b.card.alignment || 'Neutral';
-        const alignmentOrder = ['Good', 'Evil', 'Neutral'];
-        const aAlignmentIndex = alignmentOrder.indexOf(alignmentA);
-        const bAlignmentIndex = alignmentOrder.indexOf(alignmentB);
-        if (aAlignmentIndex !== bAlignmentIndex) {
-          return (aAlignmentIndex === -1 ? 999 : aAlignmentIndex) - (bAlignmentIndex === -1 ? 999 : bAlignmentIndex);
-        }
-        
-        // Then by type
-        const typeA = a.card.type || 'Unknown';
-        const typeB = b.card.type || 'Unknown';
-        if (typeA !== typeB) {
-          return typeA.localeCompare(typeB);
-        }
-        
-        // Then by brigade
-        const brigadeA = a.card.brigade || 'None';
-        const brigadeB = b.card.brigade || 'None';
-        if (brigadeA !== brigadeB) {
-          return brigadeA.localeCompare(brigadeB);
-        }
-        
-        // Finally by name
-        return a.card.name.localeCompare(b.card.name);
-      }
-      
-      // Default sorting: First sort by type
-      const typeA = a.card.type || 'Unknown';
-      const typeB = b.card.type || 'Unknown';
-      if (typeA !== typeB) {
-        return typeA.localeCompare(typeB);
-      }
-      
-      // Then by alignment
-      const alignmentA = a.card.alignment || 'Neutral';
-      const alignmentB = b.card.alignment || 'Neutral';
-      const alignmentOrder = ['Good', 'Evil', 'Neutral'];
-      const aIndex = alignmentOrder.indexOf(alignmentA);
-      const bIndex = alignmentOrder.indexOf(alignmentB);
-      if (aIndex !== bIndex) {
-        return (aIndex === -1 ? 999 : aIndex) - (bIndex === -1 ? 999 : bIndex);
-      }
-      
-      // Finally by name
-      return a.card.name.localeCompare(b.card.name);
-    });
+  // Canonical default sort (sections → brigades → strength → name)
+  const sortCards = (cards: typeof deck.cards) => {
+    return [...cards].sort((a, b) => compareCardsDefault(a.card, b.card));
   };
 
   // Group cards by the selected grouping method
@@ -241,10 +193,9 @@ export default function FullDeckView({ deck, onViewCard, isAuthenticated = false
       grouped[key].push(deckCard);
     });
 
-    // Sort each group
+    // Sort each group with the canonical default order
     Object.keys(grouped).forEach((key) => {
-      // When grouping by type, sort by alignment, type, then brigade within each type group
-      grouped[key] = sortCards(grouped[key], groupBy === 'type');
+      grouped[key] = sortCards(grouped[key]);
     });
 
     // Return groups in a specific order
@@ -265,10 +216,10 @@ export default function FullDeckView({ deck, onViewCard, isAuthenticated = false
     }
 
     if (groupBy === 'type') {
-      // Sort type groups alphabetically
+      // Order type buckets canonically (Dominants, Artifacts, Fortresses, …)
       const orderedGroups: Record<string, typeof deck.cards> = {};
       Object.keys(grouped)
-        .sort((a, b) => a.localeCompare(b))
+        .sort(compareTypeGroups)
         .forEach((key) => {
           orderedGroups[key] = grouped[key];
         });

--- a/app/decklist/card-search/utils/deckImportExport.ts
+++ b/app/decklist/card-search/utils/deckImportExport.ts
@@ -1,5 +1,6 @@
 import { Card } from "../utils";
 import { Deck, DeckCard, DeckZone, ImportResult } from "../types/deck";
+import { compareCardsDefault } from "@/lib/cards/defaultSort";
 
 /**
  * Normalize card name for comparison by replacing various apostrophe types with standard apostrophe
@@ -252,9 +253,9 @@ export function generateDeckText(deck: Deck): string {
 
   const lines: string[] = [];
 
-  // Sort cards alphabetically by name
+  // Canonical default sort (sections → brigades → strength → name)
   const sortCards = (a: DeckCard, b: DeckCard) =>
-    a.card.name.localeCompare(b.card.name);
+    compareCardsDefault(a.card, b.card);
 
   // Add main deck cards
   mainCards.sort(sortCards).forEach((dc) => {

--- a/app/decklist/my-decks/QuickLookModal.tsx
+++ b/app/decklist/my-decks/QuickLookModal.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from "react";
 import { loadDeckByIdAction, DeckCardData } from "../actions";
-import { cardKey, buildTypeRanks } from "./cardTypeSort";
+import { buildSortInfo, compareDeckCards } from "./cardTypeSort";
+import type { SortableCard } from "@/lib/cards/defaultSort";
 
 // Mirror of the helper in client.tsx (kept local to avoid cross-file coupling).
 function getCardImageUrl(cardName: string | null | undefined): string | null {
@@ -26,7 +27,7 @@ export default function QuickLookModal({
   onOpenEditor: (deckId: string) => void;
 }) {
   const [cards, setCards] = useState<DeckCardData[]>([]);
-  const [rankByKey, setRankByKey] = useState<Record<string, number>>({});
+  const [sortInfo, setSortInfo] = useState<Record<string, SortableCard>>({});
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -37,10 +38,10 @@ export default function QuickLookModal({
         const list = (((result.deck as any).cards as DeckCardData[]) || []);
         setCards(list);
         setLoading(false);
-        // Enrich with card type for "group by type" sorting (lazy-loaded dataset).
-        const ranks = await buildTypeRanks(list);
+        // Enrich with card data for the default sort (lazy-loaded dataset).
+        const info = await buildSortInfo(list);
         if (!active) return;
-        setRankByKey(ranks);
+        setSortInfo(info);
       } else {
         setLoading(false);
       }
@@ -58,12 +59,11 @@ export default function QuickLookModal({
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [onClose]);
 
-  // Sort by card type (grouping same types together), then alphabetically.
-  const byTypeThenName = (a: DeckCardData, b: DeckCardData) =>
-    (rankByKey[cardKey(a)] ?? 99) - (rankByKey[cardKey(b)] ?? 99) ||
-    a.card_name.localeCompare(b.card_name);
-  const main = cards.filter((c) => c.zone === "main").sort(byTypeThenName);
-  const reserve = cards.filter((c) => c.zone === "reserve").sort(byTypeThenName);
+  // Canonical default sort (sections → brigades → strength → name).
+  const byDefaultOrder = (a: DeckCardData, b: DeckCardData) =>
+    compareDeckCards(sortInfo, a, b);
+  const main = cards.filter((c) => c.zone === "main").sort(byDefaultOrder);
+  const reserve = cards.filter((c) => c.zone === "reserve").sort(byDefaultOrder);
 
   const countCards = (list: DeckCardData[]) =>
     list.reduce((sum, c) => sum + (c.quantity || 0), 0);

--- a/app/decklist/my-decks/cardTypeSort.ts
+++ b/app/decklist/my-decks/cardTypeSort.ts
@@ -1,35 +1,40 @@
 import { DeckCardData } from "../actions";
-
-// Display order for grouping cards by type (good cards → evil → lands).
-// Combo types (e.g. "GE/EE", "Hero/Evil Character") rank by their leading type.
-export function typeRank(type: string | undefined): number {
-  const t = (type || "").toLowerCase();
-  if (t.includes("dominant")) return 0;
-  if (t.includes("hero")) return 1;
-  if (t.includes("good enhancement") || t.startsWith("ge")) return 2;
-  if (t.includes("artifact")) return 3;
-  if (t.includes("covenant")) return 4;
-  if (t.includes("lost soul")) return 5;
-  if (t.includes("evil character")) return 6;
-  if (t.includes("evil enhancement") || t.startsWith("ee")) return 7;
-  if (t.includes("curse")) return 8;
-  if (t.includes("site")) return 9;
-  if (t.includes("city")) return 10;
-  if (t.includes("fortress")) return 11;
-  return 99;
-}
+import { compareCardsDefault, type SortableCard } from "@/lib/cards/defaultSort";
 
 export function cardKey(c: DeckCardData): string {
   return `${c.card_name}|${c.card_set ?? ""}|${c.card_img_file ?? ""}`;
 }
 
-// Build a key→type-rank map for a card list, lazy-loading the (large) generated
-// card dataset so it stays out of route bundles until a card grid is opened.
-export async function buildTypeRanks(list: DeckCardData[]): Promise<Record<string, number>> {
+// Build a key→SortableCard map for a card list, lazy-loading the (large)
+// generated card dataset so it stays out of route bundles until a card grid is
+// opened. The stored deck rows only carry names, so type/brigade/strength/
+// reference come from the card database.
+export async function buildSortInfo(list: DeckCardData[]): Promise<Record<string, SortableCard>> {
   const { findCard } = await import("@/lib/cards/lookup");
-  const ranks: Record<string, number> = {};
+  const info: Record<string, SortableCard> = {};
   for (const c of list) {
-    ranks[cardKey(c)] = typeRank(findCard(c.card_name, c.card_set, c.card_img_file)?.type);
+    const found = findCard(c.card_name, c.card_set, c.card_img_file);
+    info[cardKey(c)] = {
+      name: c.card_name,
+      type: found?.type ?? "",
+      brigade: found?.brigade,
+      alignment: found?.alignment,
+      strength: found?.strength,
+      reference: found?.reference,
+    };
   }
-  return ranks;
+  return info;
+}
+
+// Canonical default order over deck rows, backed by a buildSortInfo map.
+// Before the map loads (or on a lookup miss) cards degrade to name-only
+// sortables, which the comparator still orders alphabetically.
+export function compareDeckCards(
+  info: Record<string, SortableCard>,
+  a: DeckCardData,
+  b: DeckCardData,
+): number {
+  const sa = info[cardKey(a)] ?? { name: a.card_name, type: "" };
+  const sb = info[cardKey(b)] ?? { name: b.card_name, type: "" };
+  return compareCardsDefault(sa, sb);
 }

--- a/app/decklist/my-decks/client.tsx
+++ b/app/decklist/my-decks/client.tsx
@@ -27,7 +27,8 @@ import DeleteDeckModal from "./DeleteDeckModal";
 import FolderModal from "./FolderModal";
 import UsernameModal from "./UsernameModal";
 import QuickLookModal from "./QuickLookModal";
-import { cardKey, buildTypeRanks } from "./cardTypeSort";
+import { buildSortInfo, compareDeckCards } from "./cardTypeSort";
+import type { SortableCard } from "@/lib/cards/defaultSort";
 import GeneratePDFModal from "../card-search/components/GeneratePDFModal";
 import GenerateDeckImageModal from "../card-search/components/GenerateDeckImageModal";
 import ShareDeckModal from "../card-search/components/ShareDeckModal";
@@ -2019,7 +2020,7 @@ function CoverPickerModal({
   onSaved: (deckId: string, card1: string | null, card2: string | null) => void;
 }) {
   const [cards, setCards] = useState<DeckCardData[]>([]);
-  const [rankByKey, setRankByKey] = useState<Record<string, number>>({});
+  const [sortInfo, setSortInfo] = useState<Record<string, SortableCard>>({});
   const [loading, setLoading] = useState(true);
   const [previewCard1, setPreviewCard1] = useState<string | null>(initialCard1);
   const [previewCard2, setPreviewCard2] = useState<string | null>(initialCard2);
@@ -2035,8 +2036,8 @@ function CoverPickerModal({
         const mainCards = ((result.deck as any).cards?.filter((c: DeckCardData) => c.zone === 'main') || []) as DeckCardData[];
         setCards(mainCards);
         setLoading(false);
-        const ranks = await buildTypeRanks(mainCards);
-        if (active) setRankByKey(ranks);
+        const info = await buildSortInfo(mainCards);
+        if (active) setSortInfo(info);
       } else {
         setLoading(false);
       }
@@ -2055,11 +2056,8 @@ function CoverPickerModal({
   const filteredCards = coverSearch.trim()
     ? cards.filter(c => c.card_name.toLowerCase().includes(coverSearch.trim().toLowerCase()))
     : cards;
-  // Sort by card type (grouping same types together), then alphabetically — consistent with quick look.
-  const sortedCards = [...filteredCards].sort((a, b) =>
-    (rankByKey[cardKey(a)] ?? 99) - (rankByKey[cardKey(b)] ?? 99) ||
-    a.card_name.localeCompare(b.card_name)
-  );
+  // Canonical default sort — consistent with quick look.
+  const sortedCards = [...filteredCards].sort((a, b) => compareDeckCards(sortInfo, a, b));
 
   async function handleSelect(imgFile: string) {
     const c1 = activeSlot === 1 ? imgFile : previewCard1;

--- a/app/forge/lib/__tests__/deckView.test.ts
+++ b/app/forge/lib/__tests__/deckView.test.ts
@@ -91,7 +91,7 @@ describe("grouping and sorting", () => {
     expect(getGroupDisplayName("Lost Soul")).toBe("Lost Souls");
   });
 
-  it("groups main items alphabetically and orders Good > Evil within a group", () => {
+  it("orders main-item groups canonically and known brigades before unknown within a group", () => {
     const catalog = [
       publicCard("Zeal", "I", "GE", "Good", "Silver"),
       publicCard("Guard", "I", "Hero", "Good", "Silver"),
@@ -102,9 +102,10 @@ describe("grouping and sorting", () => {
       source: "public" as const, name: c.name, set: c.set, qty: 1, zone: "main" as const,
     }));
     const groups = groupMainItems(resolveDeckEntries([], entries, catalog));
-    expect(groups.map(([g]) => g)).toEqual(["Evil Character", "Good Enhancement", "Hero"]);
+    expect(groups.map(([g]) => g)).toEqual(["Hero", "Good Enhancement", "Evil Character"]);
     const heroes = groups.find(([g]) => g === "Hero")![1];
-    expect(heroes.map((i) => i.name)).toEqual(["Guard", "Mixed"]); // Good before Evil
+    // Silver is a known good brigade; Brown isn't, so it sorts after.
+    expect(heroes.map((i) => i.name)).toEqual(["Guard", "Mixed"]);
   });
 
   it("groups by alignment in Good > Evil > Neutral order, blank alignment → Neutral", () => {
@@ -134,7 +135,7 @@ describe("grouping and sorting", () => {
     expect(groups[0][1].map((i) => i.name)).toEqual(["Guard", "Demon"]); // Good before Evil
   });
 
-  it("sorts side items by display type then name and counts quantities", () => {
+  it("sorts side items in the canonical default order and counts quantities", () => {
     const catalog = [
       publicCard("Bravery", "I", "GE"),
       publicCard("Axe", "I", "EE"),
@@ -144,7 +145,7 @@ describe("grouping and sorting", () => {
       { source: "public", name: "Axe", set: "I", qty: 1, zone: "reserve" },
     ];
     const items = sortSideItems(resolveDeckEntries([], entries, catalog));
-    expect(items.map((i) => i.name)).toEqual(["Axe", "Bravery"]); // Evil Enh. < Good Enh.
+    expect(items.map((i) => i.name)).toEqual(["Bravery", "Axe"]); // Good section before Evil
     expect(countItems(items)).toBe(3);
   });
 });

--- a/app/forge/lib/cardOrder.ts
+++ b/app/forge/lib/cardOrder.ts
@@ -1,27 +1,27 @@
-import { BRIGADES } from "@/app/forge/lib/designCard";
 import type { ForgeCardFull } from "@/app/forge/lib/cards";
+import { compareCardsDefault, type SortableCard } from "@/lib/cards/defaultSort";
 
-// Default set-card display order: by card type alphabetically, then brigade
-// (canonical BRIGADES order ascending), then title. Cards missing a primary type
-// sort last. Shared by the set grid (SetCardsBrowser) and the single-card detail
-// view's prev/next arrows so both walk the set in the same order.
+// Adapt a forge card snapshot (array-valued cardType/brigades, numeric-or-string
+// strength) to the canonical comparator's shape. Cards with no primary type get
+// an empty type string, which the comparator sends to the trailing misc section
+// — preserving the old "missing primary type sorts last" behavior, since every
+// typed forge card lands in an earlier section.
+function toSortable(c: ForgeCardFull): SortableCard {
+  const s = c.snapshot;
+  return {
+    name: c.title ?? "",
+    type: (s?.cardType ?? []).join("/"),
+    brigade: (s?.brigades ?? []).join("/"),
+    alignment: s?.alignment,
+    strength: s?.strength == null ? "" : String(s.strength),
+    reference: s?.reference,
+  };
+}
+
+// Default set-card display order: the canonical default card sort (sections →
+// brigades → strength → name). Shared by the set grid (SetCardsBrowser) and the
+// single-card detail view's prev/next arrows so both walk the set in the same
+// order.
 export function sortSetCards(cards: ForgeCardFull[]): ForgeCardFull[] {
-  const rank = (value: string | undefined, order: readonly string[]) => {
-    const i = value ? order.indexOf(value) : -1;
-    return i === -1 ? Number.MAX_SAFE_INTEGER : i;
-  };
-  const brigadeRank = (c: ForgeCardFull) => rank(c.snapshot?.brigades?.[0], BRIGADES);
-  const typeAlpha = (a: ForgeCardFull, b: ForgeCardFull) => {
-    const ta = a.snapshot?.cardType?.[0], tb = b.snapshot?.cardType?.[0];
-    if (ta === tb) return 0;
-    if (!ta) return 1; // no primary type → last
-    if (!tb) return -1;
-    return ta.localeCompare(tb);
-  };
-  return [...cards].sort(
-    (a, b) =>
-      typeAlpha(a, b) ||
-      brigadeRank(a) - brigadeRank(b) ||
-      (a.title ?? "").localeCompare(b.title ?? ""),
-  );
+  return [...cards].sort((a, b) => compareCardsDefault(toSortable(a), toSortable(b)));
 }

--- a/app/forge/lib/deckView.ts
+++ b/app/forge/lib/deckView.ts
@@ -13,6 +13,7 @@ import type { GrantedForgeCard } from "@/app/forge/lib/deckPool";
 import type { ForgeDeckEntry } from "@/app/forge/lib/deckTypes";
 import { designCardToCard } from "@/app/forge/lib/deckAdapter";
 import { ALL_CARDS } from "@/app/decklist/card-search/data/cardIndex";
+import { compareCardsDefault, compareTypeGroups } from "@/lib/cards/defaultSort";
 
 export type ResolvedDeckItem = {
   key: string;
@@ -22,6 +23,8 @@ export type ResolvedDeckItem = {
   type: string;      // display type ("Hero", "Good Enhancement", …)
   alignment: string;
   brigade: string;
+  strength: string;  // for the default sort (characters by strength desc)
+  reference: string; // for the default sort (Lost Souls in biblical order)
   // Present for forge entries; data null = ref the viewer can't resolve.
   forge: { cardId: string; data: DesignCard | null; hasArt: boolean; hasFinished: boolean } | null;
   imgFile: string;   // public card image file; "" for forge entries
@@ -98,6 +101,8 @@ export function resolveDeckEntries(
         type: card?.type ?? "Forge Card",
         alignment: card?.alignment ?? "",
         brigade: card?.brigade ?? "",
+        strength: card?.strength ?? "",
+        reference: card?.reference ?? "",
         forge: {
           cardId: e.cardId,
           data: g?.data ?? null,
@@ -116,6 +121,8 @@ export function resolveDeckEntries(
       type: pc?.type ?? "",
       alignment: pc?.alignment ?? "",
       brigade: pc?.brigade ?? "",
+      strength: pc?.strength ?? "",
+      reference: pc?.reference ?? "",
       forge: null,
       imgFile: pc?.imgFile ?? "",
     };
@@ -124,9 +131,10 @@ export function resolveDeckEntries(
 
 export type DeckGroupBy = "type" | "alignment" | "none";
 
-// Group main-deck items by display group, sorted within each group by
-// alignment (Good > Evil > Neutral) → brigade → name. Type groups sort
-// alphabetically; alignment groups follow the Good > Evil > Neutral order.
+// Group main-deck items by display group, sorted within each group by the
+// canonical default card order. Type groups follow the canonical bucket order
+// (Dominants, Artifacts, Fortresses, …); alignment groups follow the
+// Good > Evil > Neutral order.
 export function groupMainItems(
   items: ResolvedDeckItem[],
   groupBy: DeckGroupBy = "type",
@@ -143,15 +151,7 @@ export function groupMainItems(
     else grouped.set(key, [item]);
   }
   for (const bucket of grouped.values()) {
-    bucket.sort((a, b) => {
-      const aIdx = alignmentOrder.indexOf(a.alignment);
-      const bIdx = alignmentOrder.indexOf(b.alignment);
-      const aOrder = aIdx === -1 ? 999 : aIdx;
-      const bOrder = bIdx === -1 ? 999 : bIdx;
-      if (aOrder !== bOrder) return aOrder - bOrder;
-      if (a.brigade !== b.brigade) return a.brigade.localeCompare(b.brigade);
-      return a.name.localeCompare(b.name);
-    });
+    bucket.sort(compareCardsDefault);
   }
   return [...grouped.entries()].sort(([a], [b]) => {
     if (groupBy === "alignment") {
@@ -159,8 +159,9 @@ export function groupMainItems(
       const bIdx = alignmentOrder.indexOf(b);
       const diff = (aIdx === -1 ? 999 : aIdx) - (bIdx === -1 ? 999 : bIdx);
       if (diff !== 0) return diff;
+      return a.localeCompare(b);
     }
-    return a.localeCompare(b);
+    return compareTypeGroups(a, b);
   });
 }
 
@@ -197,14 +198,9 @@ export function splitStack(items: ResolvedDeckItem[], maxPerColumn = 17): Resolv
   return columns;
 }
 
-// Reserve/maybeboard: flat, sorted by display type then name (public page semantics).
+// Reserve/maybeboard: flat, in the canonical default order (public page semantics).
 export function sortSideItems(items: ResolvedDeckItem[]): ResolvedDeckItem[] {
-  return [...items].sort((a, b) => {
-    const typeA = prettifyTypeName(a.type);
-    const typeB = prettifyTypeName(b.type);
-    if (typeA !== typeB) return typeA.localeCompare(typeB);
-    return a.name.localeCompare(b.name);
-  });
+  return [...items].sort(compareCardsDefault);
 }
 
 export function countItems(items: ResolvedDeckItem[]): number {

--- a/app/goldfish/components/GoldfishCanvas.tsx
+++ b/app/goldfish/components/GoldfishCanvas.tsx
@@ -52,6 +52,7 @@ import { CardChoicePromptContainer } from '@/app/shared/components/CardChoicePro
 import { useRevealTick } from '@/app/shared/hooks/useRevealTick';
 import { computeEquipOffset, hitTestWarrior, MAX_EQUIPPED_WEAPONS_PER_WARRIOR } from '../utils/equipLayout';
 import { findCard, isWeapon, isWarrior } from '@/lib/cards/lookup';
+import { compareCardsDefault } from '@/lib/cards/defaultSort';
 import { getEffectiveAbilities, isLostSoulCard, isHeroCard, simplifyLostSoulName } from '@/lib/cards/cardAbilities';
 import { ResurrectHeroesModal } from '@/app/shared/components/ResurrectHeroesModal';
 import { Link2Off } from 'lucide-react';
@@ -2011,14 +2012,15 @@ export default function GoldfishCanvas({ containerWidth, containerHeight, scale,
               );
             }
 
-            // Reserve: overlap cards horizontally, sorted by type then name
+            // Reserve: overlap cards horizontally, in the canonical default order
             if (zoneId === 'reserve') {
               const zone = zoneLayout[zoneId];
               const pad = 8;
               const availW = zone.width - pad * 2;
-              const sorted = [...cards].sort((a, b) =>
-                a.type.localeCompare(b.type) || a.cardName.localeCompare(b.cardName)
-              );
+              const sorted = [...cards].sort((a, b) => compareCardsDefault(
+                { name: a.cardName, type: a.type, brigade: a.brigade, alignment: a.alignment, strength: a.strength, reference: a.reference },
+                { name: b.cardName, type: b.type, brigade: b.brigade, alignment: b.alignment, strength: b.strength, reference: b.reference },
+              ));
               const overlap = sorted.length <= 1
                 ? 0
                 : Math.min(sidebarCardWidth * 0.3, (availW - sidebarCardWidth) / (sorted.length - 1));

--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -69,6 +69,7 @@ import { preloadImitateSouls } from '@/app/shared/utils/preloadImitateSouls';
 import { useVirtualCanvas, VIRTUAL_WIDTH, VIRTUAL_HEIGHT, virtualToScreen } from '@/app/shared/layout/virtualCanvas';
 import { computeEquipOffset, hitTestWarrior, MAX_EQUIPPED_WEAPONS_PER_WARRIOR } from '@/app/goldfish/utils/equipLayout';
 import { findCard, isWarrior, isWeapon, isSite } from '@/lib/cards/lookup';
+import { compareCardsDefault } from '@/lib/cards/defaultSort';
 import { normalizeDeckFormat } from '@/lib/deck-format';
 import { SOUL_DECK_BACK_IMG } from '@/app/shared/paragon/soulDeck';
 import { Link2Off } from 'lucide-react';
@@ -5878,17 +5879,20 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
 
             // Discard, LOR, and Reserve show top card face-up; everything else shows card back
             // Reserve always shows face-up to the owner regardless of isFlipped
-            // Reserve sorts by type then name to match the browse modal order. While a
-            // per-card reveal is active (e.g. Herod's Temple), pin the revealed card
-            // to the end so it renders on top of the visual stack instead of being
-            // buried by the alphabetical sort.
+            // Reserve sorts in the canonical default order to match the browse modal.
+            // While a per-card reveal is active (e.g. Herod's Temple), pin the revealed
+            // card to the end so it renders on top of the visual stack instead of being
+            // buried by the sort.
             const nowMicrosForSort = BigInt(Date.now()) * 1000n;
             const sortedCards = zoneKey === 'reserve'
               ? [...cards].sort((a, b) => {
                   const aRevealed = a.revealExpiresAt !== undefined && a.revealExpiresAt.microsSinceUnixEpoch > nowMicrosForSort ? 1 : 0;
                   const bRevealed = b.revealExpiresAt !== undefined && b.revealExpiresAt.microsSinceUnixEpoch > nowMicrosForSort ? 1 : 0;
                   if (aRevealed !== bRevealed) return aRevealed - bRevealed;
-                  return (a.cardType ?? '').localeCompare(b.cardType ?? '') || (a.cardName ?? '').localeCompare(b.cardName ?? '');
+                  return compareCardsDefault(
+                    { name: a.cardName ?? '', type: a.cardType ?? '', brigade: a.brigade, alignment: a.alignment, strength: a.strength, reference: a.reference },
+                    { name: b.cardName ?? '', type: b.cardType ?? '', brigade: b.brigade, alignment: b.alignment, strength: b.strength, reference: b.reference },
+                  );
                 })
               : cards;
             // For the deck, the top of the pile is the lowest zoneIndex (cards

--- a/app/shared/components/OpponentBrowseModal.tsx
+++ b/app/shared/components/OpponentBrowseModal.tsx
@@ -9,6 +9,7 @@ import { useCardPreview } from '@/app/goldfish/state/CardPreviewContext';
 import { getCardImageUrl } from '@/app/shared/utils/cardImageUrl';
 import { useDraggableModal } from '@/app/shared/hooks/useDraggableModal';
 import { DraggableTitleBar } from './DraggableTitleBar';
+import { compareCardsDefault } from '@/lib/cards/defaultSort';
 
 const OPPONENT_ACTIONS = [
   { id: 'discard', label: 'Discard' },
@@ -185,7 +186,10 @@ export function OpponentBrowseModal({
   const isReserve = zoneName.toLowerCase().includes('reserve');
   const isDeck = zoneName.toLowerCase().includes('deck');
   const sortedCards = isReserve
-    ? [...cards].sort((a, b) => a.type.localeCompare(b.type) || a.cardName.localeCompare(b.cardName))
+    ? [...cards].sort((a, b) => compareCardsDefault(
+        { name: a.cardName, type: a.type, brigade: a.brigade, alignment: a.alignment, strength: a.strength, reference: a.reference },
+        { name: b.cardName, type: b.type, brigade: b.brigade, alignment: b.alignment, strength: b.strength, reference: b.reference },
+      ))
     : cards;
 
   const matchesSearch = (c: GameCard, term: string): boolean => {

--- a/app/shared/components/ZoneBrowseModal.tsx
+++ b/app/shared/components/ZoneBrowseModal.tsx
@@ -9,6 +9,7 @@ import { useCardPreview } from '@/app/goldfish/state/CardPreviewContext';
 import { getCardImageUrl } from '@/app/shared/utils/cardImageUrl';
 import { useDraggableModal } from '@/app/shared/hooks/useDraggableModal';
 import { DraggableTitleBar } from './DraggableTitleBar';
+import { compareCardsDefault } from '@/lib/cards/defaultSort';
 
 const MOVE_ZONES: { id: ZoneId; label: string }[] = [
   { id: 'hand', label: 'Hand' },
@@ -151,9 +152,12 @@ export function ZoneBrowseModal({ zoneId, onClose, onStartDrag, onStartMultiDrag
   const { zones, actions } = useModalGame();
   const { moveCard, moveCardsBatch, moveCardToTopOfDeck, moveCardToBottomOfDeck, shuffleCardIntoDeck, shuffleDeck } = actions;
   const rawCards = zones[zoneId] ?? [];
-  // Sort reserve by type then name (matches goldfish canvas convention)
+  // Sort reserve in the canonical default order (matches goldfish canvas convention)
   const cards = zoneId === 'reserve'
-    ? [...rawCards].sort((a, b) => a.type.localeCompare(b.type) || a.cardName.localeCompare(b.cardName))
+    ? [...rawCards].sort((a, b) => compareCardsDefault(
+        { name: a.cardName, type: a.type, brigade: a.brigade, alignment: a.alignment, strength: a.strength, reference: a.reference },
+        { name: b.cardName, type: b.type, brigade: b.brigade, alignment: b.alignment, strength: b.strength, reference: b.reference },
+      ))
     : rawCards;
   const { setPreviewCard, isLoupeVisible } = useCardPreview();
   const { hover, hoverProgress, hoveredCardId, onCardMouseEnter, onCardMouseLeave } = useModalCardHover(200, { setPreviewCard, isLoupeVisible });

--- a/lib/cards/__tests__/defaultSort.test.ts
+++ b/lib/cards/__tests__/defaultSort.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect } from "vitest";
+import {
+  compareCardsDefault,
+  compareTypeGroups,
+  defaultTypeGroupRank,
+  GOOD_BRIGADE_ORDER,
+  EVIL_BRIGADE_ORDER,
+  BIBLE_BOOK_ORDER,
+  type SortableCard,
+} from "../defaultSort";
+
+const card = (partial: Partial<SortableCard> & { name: string; type: string }): SortableCard => ({
+  brigade: "",
+  alignment: "",
+  strength: "",
+  reference: "",
+  ...partial,
+});
+
+const sortNames = (cards: SortableCard[]): string[] =>
+  [...cards].sort(compareCardsDefault).map((c) => c.name);
+
+describe("section ordering", () => {
+  it("orders all sections: dominants, artifacts, covenants, curses, fortresses, sites, lost souls, duals, good, evil, misc", () => {
+    const cards = [
+      card({ name: "Token", type: "Hero Token" }),
+      card({ name: "EvilChar", type: "Evil Character", brigade: "Brown", alignment: "Evil" }),
+      card({ name: "GoodEnh", type: "GE", brigade: "Blue", alignment: "Good" }),
+      card({ name: "Dual", type: "GE/EE", brigade: "Gold (Gold/Gold)" }),
+      card({ name: "Soul", type: "Lost Soul", reference: "Genesis 1:1" }),
+      card({ name: "Site", type: "Site", brigade: "Black" }),
+      card({ name: "Fort", type: "Fortress" }),
+      card({ name: "Curse", type: "Curse" }),
+      card({ name: "Cov", type: "Covenant" }),
+      card({ name: "Art", type: "Artifact" }),
+      card({ name: "Dom", type: "Dominant", alignment: "Good" }),
+    ];
+    expect(sortNames(cards)).toEqual([
+      "Dom", "Art", "Cov", "Curse", "Fort", "Site", "Soul", "Dual", "GoodEnh", "EvilChar", "Token",
+    ]);
+  });
+
+  it("first type part decides the section for mixed non-dual types", () => {
+    const cards = [
+      card({ name: "FortEC", type: "Fortress / Evil Character", brigade: "Black", alignment: "Evil" }),
+      card({ name: "ECFort", type: "Evil Character/Fortress", brigade: "Black", alignment: "Evil" }),
+    ];
+    // "Fortress / Evil Character" → Fortress section (4), before evil section (9)
+    expect(sortNames(cards)).toEqual(["FortEC", "ECFort"]);
+  });
+});
+
+describe("dominants", () => {
+  it("sorts dual/neutral first, then good, then evil, alpha within each", () => {
+    const cards = [
+      card({ name: "Death", type: "Dominant", alignment: "Evil" }),
+      card({ name: "Burial", type: "Dominant", alignment: "Evil" }),
+      card({ name: "Son of God", type: "Dominant", alignment: "Good" }),
+      card({ name: "Angel of the Lord", type: "Dominant", alignment: "Good" }),
+      card({ name: "Falling Away", type: "Dominant", alignment: "Neutral" }),
+      card({ name: "Ashes", type: "Dominant", alignment: "Neutral" }),
+    ];
+    expect(sortNames(cards)).toEqual([
+      "Ashes", "Falling Away", "Angel of the Lord", "Son of God", "Burial", "Death",
+    ]);
+  });
+});
+
+describe("artifacts / covenants / curses / fortresses", () => {
+  it("sorts artifacts, covenants, curses alphabetically within their sections", () => {
+    const cards = [
+      card({ name: "Zeal Cov", type: "Covenant" }),
+      card({ name: "Ark Cov", type: "Covenant" }),
+      card({ name: "Zeal Art", type: "Artifact" }),
+      card({ name: "Ark Art", type: "Artifact" }),
+      card({ name: "Zeal Curse", type: "Curse" }),
+      card({ name: "Ark Curse", type: "Curse" }),
+    ];
+    expect(sortNames(cards)).toEqual([
+      "Ark Art", "Zeal Art", "Ark Cov", "Zeal Cov", "Ark Curse", "Zeal Curse",
+    ]);
+  });
+
+  it("interleaves Cities with Fortresses alphabetically, Sites after", () => {
+    const cards = [
+      card({ name: "Aeneas Site", type: "Site" }),
+      card({ name: "Babylon", type: "City" }),
+      card({ name: "Ark Fortress", type: "Fortress" }),
+      card({ name: "City of Enoch", type: "City" }),
+      card({ name: "Zion Fortress", type: "Fortress" }),
+    ];
+    expect(sortNames(cards)).toEqual([
+      "Ark Fortress", "Babylon", "City of Enoch", "Zion Fortress", "Aeneas Site",
+    ]);
+  });
+});
+
+describe("lost souls — biblical reference order", () => {
+  it("orders by book, then chapter, then verse", () => {
+    const cards = [
+      card({ name: "E", type: "Lost Soul", reference: "Revelation 22:21" }),
+      card({ name: "D", type: "Lost Soul", reference: "Romans 3:23" }),
+      card({ name: "C", type: "Lost Soul", reference: "Matthew 5:5" }),
+      card({ name: "B", type: "Lost Soul", reference: "Ezekiel 34:16" }),
+      card({ name: "A", type: "Lost Soul", reference: "Genesis 3:19" }),
+      card({ name: "A2", type: "Lost Soul", reference: "Genesis 12:3" }),
+      card({ name: "A0", type: "Lost Soul", reference: "Genesis 3:6" }),
+    ];
+    expect(sortNames(cards)).toEqual(["A0", "A", "A2", "B", "C", "D", "E"]);
+  });
+
+  it("handles the roman-numeral prefix gotchas: II Kings vs I Kings, John vs I/II/III John", () => {
+    const cards = [
+      card({ name: "3John", type: "Lost Soul", reference: "III John 1:2" }),
+      card({ name: "1John", type: "Lost Soul", reference: "I John 4:8" }),
+      card({ name: "John", type: "Lost Soul", reference: "John 3:16" }),
+      card({ name: "2Kings", type: "Lost Soul", reference: "II Kings 4:8-37" }),
+      card({ name: "1Kings", type: "Lost Soul", reference: "I Kings 17:9" }),
+      card({ name: "2John", type: "Lost Soul", reference: "II John 1:1" }),
+    ];
+    // I Kings < II Kings < John (gospel) < I John < II John < III John
+    expect(sortNames(cards)).toEqual(["1Kings", "2Kings", "John", "1John", "2John", "3John"]);
+  });
+
+  it("accepts singular Psalm as Psalms and puts unknown/empty references last", () => {
+    const cards = [
+      card({ name: "NoRef", type: "Lost Soul", reference: "" }),
+      card({ name: "Odd", type: "Lost Soul", reference: "Apocrypha 1:1" }),
+      card({ name: "Psalm", type: "Lost Soul", reference: "Psalm 22:26" }),
+      card({ name: "Job", type: "Lost Soul", reference: "Job 30:25" }),
+      card({ name: "Prov", type: "Lost Soul", reference: "Proverbs 16:19" }),
+    ];
+    expect(sortNames(cards)).toEqual(["Job", "Psalm", "Prov", "NoRef", "Odd"]);
+  });
+
+  it("book list is the full 66-book canon in order", () => {
+    expect(BIBLE_BOOK_ORDER.length).toBe(66);
+    expect(BIBLE_BOOK_ORDER[0]).toBe("Genesis");
+    expect(BIBLE_BOOK_ORDER[39]).toBe("Matthew");
+    expect(BIBLE_BOOK_ORDER[65]).toBe("Revelation");
+  });
+});
+
+describe("dual characters and enhancements", () => {
+  it("puts type-spanning duals (GE/EE, Hero/Evil Character) in the dual section, alpha by name", () => {
+    const cards = [
+      card({ name: "Blue Hero", type: "Hero", brigade: "Blue", alignment: "Good", strength: "9" }),
+      card({ name: "Zeta Dual", type: "Hero/Evil Character", brigade: "Gold (Good Gold/Evil Gold)" }),
+      card({ name: "Alpha Dual", type: "GE/EE", brigade: "Green/White and Brown/Crimson" }),
+      card({ name: "Soul", type: "Lost Soul", reference: "Acts 2:21" }),
+    ];
+    expect(sortNames(cards)).toEqual(["Soul", "Alpha Dual", "Zeta Dual", "Blue Hero"]);
+  });
+
+  it("treats a single-type enhancement with brigades spanning both alignments as dual", () => {
+    const cards = [
+      card({ name: "Spanning", type: "GE", brigade: "Green/White and Brown/Crimson" }),
+      card({ name: "Plain", type: "GE", brigade: "Green", alignment: "Good" }),
+    ];
+    expect(sortNames(cards)).toEqual(["Spanning", "Plain"]);
+  });
+});
+
+describe("good and evil brigade sections", () => {
+  it("orders good brigades Blue → Clay → Gold → Green → Multi → Purple → Red → Silver → Teal → White", () => {
+    const brigades = ["White", "Teal", "Silver", "Red", "Purple", "Multi", "Green", "Gold", "Clay", "Blue"];
+    const cards = brigades.map((b) =>
+      card({ name: `${b} Hero`, type: "Hero", brigade: b, alignment: "Good", strength: "5" })
+    );
+    expect(sortNames(cards)).toEqual([
+      "Blue Hero", "Clay Hero", "Gold Hero", "Green Hero", "Multi Hero",
+      "Purple Hero", "Red Hero", "Silver Hero", "Teal Hero", "White Hero",
+    ]);
+    expect([...GOOD_BRIGADE_ORDER]).toEqual([
+      "Blue", "Clay", "Gold", "Green", "Multi", "Purple", "Red", "Silver", "Teal", "White",
+    ]);
+  });
+
+  it("orders evil brigades Black → Brown → Crimson → Gold → Gray → Multi → Orange → Pale Green", () => {
+    const brigades = ["Pale Green", "Orange", "Multi", "Gray", "Gold", "Crimson", "Brown", "Black"];
+    const cards = brigades.map((b) =>
+      card({ name: `${b} EC`, type: "Evil Character", brigade: b, alignment: "Evil", strength: "5" })
+    );
+    expect(sortNames(cards)).toEqual([
+      "Black EC", "Brown EC", "Crimson EC", "Gold EC", "Gray EC", "Multi EC", "Orange EC", "Pale Green EC",
+    ]);
+    expect([...EVIL_BRIGADE_ORDER]).toEqual([
+      "Black", "Brown", "Crimson", "Gold", "Gray", "Multi", "Orange", "Pale Green",
+    ]);
+  });
+
+  it("within a brigade: characters (strength desc) before enhancements (strength desc)", () => {
+    const cards = [
+      card({ name: "Enh Weak", type: "GE", brigade: "Green", alignment: "Good", strength: "1" }),
+      card({ name: "Enh Strong", type: "GE", brigade: "Green", alignment: "Good", strength: "4" }),
+      card({ name: "Hero Weak", type: "Hero", brigade: "Green", alignment: "Good", strength: "3" }),
+      card({ name: "Hero Strong", type: "Hero", brigade: "Green", alignment: "Good", strength: "10" }),
+    ];
+    expect(sortNames(cards)).toEqual(["Hero Strong", "Hero Weak", "Enh Strong", "Enh Weak"]);
+  });
+
+  it('sorts "X" / "*" / empty strength after numbered strength, alpha among themselves', () => {
+    const cards = [
+      card({ name: "Zed X", type: "Hero", brigade: "Red", alignment: "Good", strength: "X" }),
+      card({ name: "Alf Star", type: "Hero", brigade: "Red", alignment: "Good", strength: "*" }),
+      card({ name: "Empty", type: "Hero", brigade: "Red", alignment: "Good", strength: "" }),
+      card({ name: "Neg", type: "Hero", brigade: "Red", alignment: "Good", strength: "-1" }),
+      card({ name: "Paired", type: "Hero", brigade: "Red", alignment: "Good", strength: "4 (0)" }),
+    ];
+    expect(sortNames(cards)).toEqual(["Paired", "Neg", "Alf Star", "Empty", "Zed X"]);
+  });
+
+  it("parses primary brigade from parenthesized and multi forms", () => {
+    const cards = [
+      card({ name: "GreenTeal", type: "Hero", brigade: "Green/Teal", alignment: "Good", strength: "5" }),
+      card({ name: "GoldParen", type: "Hero", brigade: "Gold (Gold/Red)", alignment: "Good", strength: "5" }),
+      card({ name: "BlueFirst", type: "Hero", brigade: "Blue/Green (Multi)", alignment: "Good", strength: "5" }),
+    ];
+    // Primary brigades: Blue, Gold, Green
+    expect(sortNames(cards)).toEqual(["BlueFirst", "GoldParen", "GreenTeal"]);
+  });
+
+  it("disambiguates Gold by alignment: good Gold with good brigades, evil Gold with evil brigades", () => {
+    const cards = [
+      card({ name: "Evil Gray", type: "Evil Character", brigade: "Gray", alignment: "Evil", strength: "5" }),
+      card({ name: "Evil Gold", type: "Evil Character", brigade: "Gold", alignment: "Evil", strength: "5" }),
+      card({ name: "Evil Crimson", type: "Evil Character", brigade: "Crimson", alignment: "Evil", strength: "5" }),
+      card({ name: "Good Green", type: "Hero", brigade: "Green", alignment: "Good", strength: "5" }),
+      card({ name: "Good Gold", type: "Hero", brigade: "Gold", alignment: "Good", strength: "5" }),
+      card({ name: "Good Clay", type: "Hero", brigade: "Clay", alignment: "Good", strength: "5" }),
+    ];
+    // Good section: Clay < Gold < Green; evil section: Crimson < Gold < Gray
+    expect(sortNames(cards)).toEqual([
+      "Good Clay", "Good Gold", "Good Green", "Evil Crimson", "Evil Gold", "Evil Gray",
+    ]);
+  });
+
+  it("sorts unknown/empty brigades after all known brigades of the alignment", () => {
+    const cards = [
+      card({ name: "NoBrigade", type: "Hero", brigade: "", alignment: "Good", strength: "5" }),
+      card({ name: "White Hero", type: "Hero", brigade: "White", alignment: "Good", strength: "5" }),
+    ];
+    expect(sortNames(cards)).toEqual(["White Hero", "NoBrigade"]);
+  });
+});
+
+describe("degraded input (name + type only)", () => {
+  it("still yields section order then alphabetical", () => {
+    const cards = [
+      { name: "Zeal", type: "GE" },
+      { name: "Axe", type: "EE" },
+      { name: "Guard", type: "Hero" },
+      { name: "Demon", type: "Evil Character" },
+      { name: "Ark", type: "Artifact" },
+      { name: "Soul", type: "Lost Soul" },
+    ];
+    expect(sortNames(cards)).toEqual(["Ark", "Soul", "Guard", "Zeal", "Demon", "Axe"]);
+  });
+
+  it("handles forge-style compact type/brigade names", () => {
+    const cards = [
+      card({ name: "PG", type: "EvilCharacter", brigade: "PaleGreen", strength: "5" }),
+      card({ name: "Blk", type: "EvilCharacter", brigade: "Black", strength: "5" }),
+      card({ name: "LS", type: "LostSoul", reference: "John 3:16" }),
+      card({ name: "GG", type: "Hero", brigade: "GoodGold", strength: "5" }),
+    ];
+    expect(sortNames(cards)).toEqual(["LS", "GG", "Blk", "PG"]);
+  });
+});
+
+describe("grouped views — bucket ordering", () => {
+  it("ranks buckets Dominants, Artifacts, Fortresses, Lost Souls, Dual, Heroes, GE, EC, EE, misc", () => {
+    const buckets = [
+      "Evil Enhancement", "Evil Character", "Good Enhancement", "Hero",
+      "Dual-Type", "Lost Soul", "Fortress/Site", "Artifact/Covenant/Curse",
+      "Dominant", "Hero Token", "Forge Card",
+    ];
+    const sorted = [...buckets].sort(compareTypeGroups);
+    expect(sorted).toEqual([
+      "Dominant", "Artifact/Covenant/Curse", "Fortress/Site", "Lost Soul",
+      "Dual-Type", "Hero", "Good Enhancement", "Evil Character", "Evil Enhancement",
+      "Forge Card", "Hero Token",
+    ]);
+  });
+
+  it("ranks raw deck-builder type keys, including raw dual types", () => {
+    const buckets = ["GE/EE", "Site", "GE", "Curse", "Covenant", "Artifact", "Hero", "Lost Soul", "City", "Fortress"];
+    const sorted = [...buckets].sort(compareTypeGroups);
+    expect(sorted).toEqual([
+      "Artifact", "Covenant", "Curse", "City", "Fortress", "Site", "Lost Soul", "GE/EE", "Hero", "GE",
+    ]);
+    expect(defaultTypeGroupRank("GE/EE")).toBe(4);
+    expect(defaultTypeGroupRank("Hero/Evil Character")).toBe(4);
+  });
+
+  it("keeps token buckets in the trailing misc rank", () => {
+    expect(defaultTypeGroupRank("Lost Soul Token")).toBe(9);
+    expect(defaultTypeGroupRank("Hero Token")).toBe(9);
+    expect(defaultTypeGroupRank("Lost Soul")).toBe(3);
+  });
+});

--- a/lib/cards/defaultSort.ts
+++ b/lib/cards/defaultSort.ts
@@ -1,0 +1,327 @@
+/**
+ * Canonical "default" card sort order, shared by every surface that lists
+ * cards (deckbuilder, public deck view, exports, Forge, play-area reserve
+ * browsing, collection). Pure and dependency-free — no card data imports —
+ * so it can be bundled anywhere and mirrored 1:1 in the sister Python API.
+ *
+ * Order: Dominants, Artifacts, Covenants, Curses, Fortresses (+Cities),
+ * Sites, Lost Souls (biblical reference order), dual-alignment
+ * characters/enhancements, Good brigades (characters then enhancements,
+ * strength descending), Evil brigades (same), then everything else.
+ *
+ * The comparator degrades gracefully: given only `name` + `type` it still
+ * yields section order then alphabetical.
+ */
+
+export interface SortableCard {
+  name: string;
+  type: string;
+  brigade?: string;
+  alignment?: string;
+  strength?: string;
+  reference?: string;
+}
+
+// Alphabetical-by-color brigade orders. "Gold" covers Good Gold / Evil Gold
+// per the list it appears in; "Multi" sorts alphabetically within each list.
+export const GOOD_BRIGADE_ORDER = [
+  "Blue", "Clay", "Gold", "Green", "Multi", "Purple", "Red", "Silver", "Teal", "White",
+] as const;
+
+export const EVIL_BRIGADE_ORDER = [
+  "Black", "Brown", "Crimson", "Gold", "Gray", "Multi", "Orange", "Pale Green",
+] as const;
+
+// Books as they appear in card data (Roman numerals, "Psalms").
+export const BIBLE_BOOK_ORDER = [
+  "Genesis", "Exodus", "Leviticus", "Numbers", "Deuteronomy", "Joshua",
+  "Judges", "Ruth", "I Samuel", "II Samuel", "I Kings", "II Kings",
+  "I Chronicles", "II Chronicles", "Ezra", "Nehemiah", "Esther", "Job",
+  "Psalms", "Proverbs", "Ecclesiastes", "Song of Solomon", "Isaiah",
+  "Jeremiah", "Lamentations", "Ezekiel", "Daniel", "Hosea", "Joel", "Amos",
+  "Obadiah", "Jonah", "Micah", "Nahum", "Habakkuk", "Zephaniah", "Haggai",
+  "Zechariah", "Malachi", "Matthew", "Mark", "Luke", "John", "Acts",
+  "Romans", "I Corinthians", "II Corinthians", "Galatians", "Ephesians",
+  "Philippians", "Colossians", "I Thessalonians", "II Thessalonians",
+  "I Timothy", "II Timothy", "Titus", "Philemon", "Hebrews", "James",
+  "I Peter", "II Peter", "I John", "II John", "III John", "Jude",
+  "Revelation",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Section ranks
+// ---------------------------------------------------------------------------
+
+const SECTION_DOMINANT = 0;
+const SECTION_ARTIFACT = 1;
+const SECTION_COVENANT = 2;
+const SECTION_CURSE = 3;
+const SECTION_FORTRESS = 4; // Fortresses and Cities interleave alphabetically
+const SECTION_SITE = 5;
+const SECTION_LOST_SOUL = 6;
+const SECTION_DUAL = 7;
+const SECTION_GOOD = 8;
+const SECTION_EVIL = 9;
+const SECTION_MISC = 10;
+
+// Normalize a type/brigade token for matching: lowercase, drop spaces/hyphens.
+// Handles both raw carddata forms ("Evil Character", "Lost Soul", "Pale Green")
+// and Forge forms ("EvilCharacter", "LostSoul", "PaleGreen").
+function norm(s: string): string {
+  return s.toLowerCase().replace(/[\s-]+/g, "");
+}
+
+const GOOD_CHAR_TYPES = new Set(["hero", "heroes", "herocharacter", "hc", "goodcharacter", "gc"]);
+const GOOD_ENH_TYPES = new Set(["ge", "goodenhancement", "goodenhancements"]);
+const EVIL_CHAR_TYPES = new Set(["evilcharacter", "evilcharacters", "ec"]);
+const EVIL_ENH_TYPES = new Set(["ee", "evilenhancement", "evilenhancements"]);
+
+function isGoodSideType(part: string): boolean {
+  const n = norm(part);
+  if (GOOD_CHAR_TYPES.has(n) === true) return true;
+  return GOOD_ENH_TYPES.has(n);
+}
+
+function isEvilSideType(part: string): boolean {
+  const n = norm(part);
+  if (EVIL_CHAR_TYPES.has(n) === true) return true;
+  return EVIL_ENH_TYPES.has(n);
+}
+
+function typeParts(type: string): string[] {
+  // Split on "/" and trim — handles "Fortress / Evil Character".
+  return type.split("/").map((p) => p.trim()).filter((p) => p !== "");
+}
+
+// ---------------------------------------------------------------------------
+// Brigade parsing
+// ---------------------------------------------------------------------------
+
+// Unambiguously good/evil brigade tokens (normalized). "gold" and "multi"
+// appear in both alignments so they can't prove dual-ness on their own.
+const GOOD_ONLY_TOKENS = new Set(["blue", "clay", "goodgold", "green", "purple", "red", "silver", "teal", "white"]);
+const EVIL_ONLY_TOKENS = new Set(["black", "brown", "crimson", "evilgold", "gray", "orange", "palegreen"]);
+
+// Normalized token → canonical name as it appears in the order arrays.
+const CANONICAL_BRIGADE: Record<string, string> = {
+  blue: "Blue", clay: "Clay", gold: "Gold", goodgold: "Gold", evilgold: "Gold",
+  green: "Green", multi: "Multi", purple: "Purple", red: "Red", silver: "Silver",
+  teal: "Teal", white: "White", black: "Black", brown: "Brown", crimson: "Crimson",
+  gray: "Gray", orange: "Orange", palegreen: "Pale Green",
+};
+
+interface BrigadeInfo {
+  tokens: string[]; // trimmed raw tokens, paren segments stripped
+  spansAnd: boolean; // remainder contained " and " → spans both alignments
+}
+
+function parseBrigade(raw: string): BrigadeInfo {
+  const parenMatch = /\(([^)]*)\)/.exec(raw);
+  let stripped = raw.replace(/\([^)]*\)/g, "").trim();
+  // "(Gold/Red)" alone → fall back to the paren content.
+  if (stripped === "" && parenMatch !== null) stripped = parenMatch[1].trim();
+  const spansAnd = / and /i.test(stripped);
+  const tokens = stripped
+    .split(/\/|\band\b/i)
+    .map((t) => t.trim())
+    .filter((t) => t !== "");
+  return { tokens, spansAnd };
+}
+
+function brigadeSpansBothAlignments(info: BrigadeInfo): boolean {
+  if (info.spansAnd === true) return true;
+  let anyGood = false;
+  let anyEvil = false;
+  for (const t of info.tokens) {
+    const n = norm(t);
+    if (GOOD_ONLY_TOKENS.has(n) === true) anyGood = true;
+    if (EVIL_ONLY_TOKENS.has(n) === true) anyEvil = true;
+  }
+  return anyGood === true && anyEvil === true;
+}
+
+// ---------------------------------------------------------------------------
+// Per-section subkeys
+// ---------------------------------------------------------------------------
+
+// First integer in the strength string ("4 (0)" → 4, "-1" → -1);
+// null for "X" / "*" / "" — those sort after all numbered cards.
+function strengthValue(strength: string | undefined): number | null {
+  const m = /-?\d+/.exec(strength ?? "");
+  if (m === null) return null;
+  return parseInt(m[0], 10);
+}
+
+// Longest-prefix book match — required so "II Kings" doesn't half-match
+// "I Kings"-style confusions and "I John"/"II John"/"III John" win over "John".
+function referenceKey(reference: string | undefined): { book: number; chapter: number; verse: number } {
+  const ref = (reference ?? "").trim();
+  const refLower = ref.toLowerCase();
+  let bookIdx = -1;
+  let matchLen = 0;
+  for (let i = 0; i < BIBLE_BOOK_ORDER.length; i++) {
+    const book = BIBLE_BOOK_ORDER[i].toLowerCase();
+    if (refLower.startsWith(book) === true && book.length > matchLen) {
+      bookIdx = i;
+      matchLen = book.length;
+    }
+  }
+  // Singular "Psalm 23:1" counts as Psalms (only when "Psalms" itself missed).
+  if (bookIdx === -1 && refLower.startsWith("psalm") === true) {
+    bookIdx = BIBLE_BOOK_ORDER.indexOf("Psalms");
+    matchLen = "psalm".length;
+  }
+  if (bookIdx === -1) {
+    // Unknown book / empty reference → after all known books.
+    return { book: BIBLE_BOOK_ORDER.length, chapter: 0, verse: 0 };
+  }
+  const m = /(\d+)\s*:\s*(\d+)/.exec(ref.slice(matchLen));
+  return {
+    book: bookIdx,
+    chapter: m !== null ? parseInt(m[1], 10) : 0,
+    verse: m !== null ? parseInt(m[2], 10) : 0,
+  };
+}
+
+// Rank of the card's primary brigade within its alignment's order array.
+// Unknown/dirty/empty → after all known brigades, tie-broken by raw string.
+function brigadeRank(card: SortableCard, side: "good" | "evil"): { rank: number; tie: string } {
+  const order: readonly string[] = side === "good" ? GOOD_BRIGADE_ORDER : EVIL_BRIGADE_ORDER;
+  const info = parseBrigade(card.brigade ?? "");
+  const primary = info.tokens.length > 0 ? info.tokens[0] : "";
+  const canonical = CANONICAL_BRIGADE[norm(primary)];
+  if (canonical !== undefined) {
+    const idx = order.indexOf(canonical);
+    if (idx !== -1) return { rank: idx, tie: "" };
+  }
+  return { rank: order.length, tie: (card.brigade ?? "").toLowerCase() };
+}
+
+function dominantAlignmentRank(alignment: string | undefined): number {
+  if (alignment === "Good") return 1;
+  if (alignment === "Evil") return 2;
+  return 0; // Neutral / dual / missing first
+}
+
+// ---------------------------------------------------------------------------
+// Sort key
+// ---------------------------------------------------------------------------
+
+type SortKey = (string | number)[];
+
+function buildKey(card: SortableCard): SortKey {
+  const name = (card.name ?? "").toLowerCase();
+  const type = card.type ?? "";
+  const parts = typeParts(type);
+  const first = parts.length > 0 ? parts[0] : "";
+  const firstNorm = norm(first);
+
+  if (firstNorm === "dominant" || firstNorm === "dom") {
+    return [SECTION_DOMINANT, dominantAlignmentRank(card.alignment), name];
+  }
+  if (firstNorm === "artifact" || firstNorm === "art") return [SECTION_ARTIFACT, name];
+  if (firstNorm === "covenant" || firstNorm === "cov") return [SECTION_COVENANT, name];
+  if (firstNorm === "curse" || firstNorm === "cur") return [SECTION_CURSE, name];
+  if (firstNorm === "fortress" || firstNorm === "fort" || firstNorm === "city") {
+    return [SECTION_FORTRESS, name];
+  }
+  if (firstNorm === "site") return [SECTION_SITE, name];
+  if (firstNorm === "lostsoul" || firstNorm === "ls") {
+    const key = referenceKey(card.reference);
+    return [SECTION_LOST_SOUL, key.book, key.chapter, key.verse, (card.reference ?? "").toLowerCase(), name];
+  }
+
+  const hasGoodType = parts.some(isGoodSideType);
+  const hasEvilType = parts.some(isEvilSideType);
+  // Dual: type parts span both sides (GE/EE, Hero/Evil Character, …), or a
+  // character/enhancement whose brigades span both alignments
+  // ("Green/White and Brown/Crimson").
+  if (hasGoodType === true && hasEvilType === true) return [SECTION_DUAL, name];
+
+  if (hasGoodType === true || hasEvilType === true) {
+    if (brigadeSpansBothAlignments(parseBrigade(card.brigade ?? "")) === true) {
+      return [SECTION_DUAL, name];
+    }
+    const side: "good" | "evil" = hasGoodType === true ? "good" : "evil";
+    const { rank, tie } = brigadeRank(card, side);
+    const isCharacter =
+      side === "good" ? GOOD_CHAR_TYPES.has(firstNorm) : EVIL_CHAR_TYPES.has(firstNorm);
+    const str = strengthValue(card.strength);
+    return [
+      side === "good" ? SECTION_GOOD : SECTION_EVIL,
+      rank,
+      tie,
+      isCharacter === true ? 0 : 1,
+      str !== null ? 0 : 1, // numbered strength before X/*/empty
+      str !== null ? -str : 0, // strength descending
+      name,
+    ];
+  }
+
+  return [SECTION_MISC, type.toLowerCase(), name];
+}
+
+// Keys are pure functions of the card; cache per object so big lists don't
+// rebuild them O(n log n) times.
+const keyCache = new WeakMap<SortableCard, SortKey>();
+
+function keyOf(card: SortableCard): SortKey {
+  let key = keyCache.get(card);
+  if (key === undefined) {
+    key = buildKey(card);
+    keyCache.set(card, key);
+  }
+  return key;
+}
+
+export function compareCardsDefault(a: SortableCard, b: SortableCard): number {
+  const ka = keyOf(a);
+  const kb = keyOf(b);
+  const len = Math.min(ka.length, kb.length);
+  for (let i = 0; i < len; i++) {
+    const x = ka[i];
+    const y = kb[i];
+    if (x === y) continue;
+    if (typeof x === "number" && typeof y === "number") return x - y;
+    const r = String(x).localeCompare(String(y));
+    if (r !== 0) return r;
+  }
+  return ka.length - kb.length;
+}
+
+// ---------------------------------------------------------------------------
+// Grouped ("by type") views — bucket ordering
+// ---------------------------------------------------------------------------
+
+// Rank for a type-group bucket name. Accepts the various bucket keys the app
+// uses: pretty names ("Hero", "Good Enhancement"), merged buckets
+// ("Artifact/Covenant/Curse", "Fortress/Site"), dual buckets ("Dual-Type",
+// raw "GE/EE"), and raw type strings from the deck builder ("GE", "Lost Soul").
+// Unranked buckets get the same trailing rank; compareTypeGroups breaks ties
+// alphabetically.
+export function defaultTypeGroupRank(groupName: string): number {
+  const g = (groupName ?? "").toLowerCase();
+  const gNorm = norm(g);
+  if (g.includes("dominant") === true) return 0;
+  if (g.includes("artifact") === true || g.includes("covenant") === true || g.includes("curse") === true) return 1;
+  if (g.includes("fortress") === true || g.includes("site") === true || g.includes("city") === true) return 2;
+  // Exact match so "Lost Soul Token" buckets stay in the trailing misc rank.
+  if (gNorm === "lostsoul" || gNorm === "lostsouls" || gNorm === "ls") return 3;
+  if (g.includes("dual") === true) return 4;
+  const parts = typeParts(groupName ?? "");
+  const hasGood = parts.some(isGoodSideType);
+  const hasEvil = parts.some(isEvilSideType);
+  if (hasGood === true && hasEvil === true) return 4; // raw dual types ("GE/EE")
+  const first = parts.length > 0 ? norm(parts[0]) : "";
+  if (GOOD_CHAR_TYPES.has(first) === true) return 5;
+  if (GOOD_ENH_TYPES.has(first) === true) return 6;
+  if (EVIL_CHAR_TYPES.has(first) === true) return 7;
+  if (EVIL_ENH_TYPES.has(first) === true) return 8;
+  return 9;
+}
+
+export function compareTypeGroups(a: string, b: string): number {
+  const diff = defaultTypeGroupRank(a) - defaultTypeGroupRank(b);
+  if (diff !== 0) return diff;
+  return a.localeCompare(b);
+}


### PR DESCRIPTION
## What

Adds `lib/cards/defaultSort.ts` — a pure, dependency-free module defining the canonical "default" order for card lists — and wires it into every surface that lists cards. A sister PR in `redemption-tournament-api` will mirror the same order in Python.

## The order

| rank | section | within-section order |
|------|---------|----------------------|
| 0 | Dominants | dual/neutral → Good → Evil, alpha within each |
| 1 | Artifacts | alpha |
| 2 | Covenants | alpha |
| 3 | Curses | alpha |
| 4 | Fortresses + Cities | alpha (interleaved) |
| 5 | Sites | alpha |
| 6 | Lost Souls | biblical reference order (book → chapter → verse), longest-prefix book matching (II Kings, I/II/III John, singular Psalm) |
| 7 | Dual characters/enhancements | alpha (type spans good+evil, or brigades span both alignments e.g. `Green/White and Brown/Crimson`) |
| 8 | Good brigades | Blue → Clay → Gold → Green → Multi → Purple → Red → Silver → Teal → White; characters before enhancements; strength desc (X/*/empty last); name |
| 9 | Evil brigades | Black → Brown → Crimson → Gold → Gray → Multi → Orange → Pale Green; same sub-order |
| 10 | Tokens / misc | type alpha, then name |

Gold disambiguates by alignment; unknown/empty brigades sort after known ones. Grouped "by type" views order buckets: Dominants, Artifacts (merged), Fortresses (merged), Lost Souls, Dual-Type, Heroes, Good Enhancements, Evil Characters, Evil Enhancements, rest alphabetically. The comparator degrades gracefully with only `name`+`type` (section order, then alpha).

## Surfaces wired

- **Card search** (`app/decklist/card-search/client.tsx`): new "Default" option in both sort dropdowns, now the initial sort.
- **Deckbuilder** (`DeckBuilderPanel.tsx`): type buckets in canonical order, canonical sort within type/alignment groups, cover-picker "Default" option now meaningful.
- **FullDeckView**: canonical sort for main/reserve/maybeboard and within groups; type buckets in canonical order.
- **Text/PDF/image export** (`deckImportExport.ts` `generateDeckText`): decklists export in canonical order (`generateDeckTextBySet` untouched).
- **Public deck view** (`app/decklist/[deckId]/client.tsx`): groups, reserve, maybeboard, cover picker.
- **Forge**: `sortSetCards` (set grid + prev/next arrows) and `deckView.ts` (`groupMainItems`, `sortSideItems`; `ResolvedDeckItem` gains `strength`/`reference` so heroes and Lost Souls sort properly).
- **My decks**: quick-look and cover modal via reworked `cardTypeSort.ts` (now builds a key→SortableCard map instead of type ranks).
- **Collection** (`app/collection/client.tsx`): new "Sort: Default" option, now the initial sort.
- **Play areas** (goldfish canvas, multiplayer canvas, zone/opponent browse modals): reserve browsing uses the canonical order; the multiplayer revealed-card-pinned-last behavior is preserved. Game-state `zoneIndex` piles untouched.

## Tests

`lib/cards/__tests__/defaultSort.test.ts` (23 cases): full section ordering, dominant alignment order, fortress/city interleave, biblical ordering incl. prefix gotchas, dual rules, brigade orders, strength descending + X/empty handling, gold disambiguation, forge-style compact names, bucket ranking. Forge `deckView.test.ts` expectations updated to the canonical order. Also verified against the real 5,464-card dataset (sections monotonic, Blue heroes strength-descending, Lost Souls in biblical order).

Pre-existing failures not touched by this PR: `forge-lackey.test.ts` (one assertion), `forge-anon-leak`/`superuser-anon-leak` (need Supabase env), and tsc errors in `forge-anon-leak.test.ts` / `playDecksAuthorize.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)