### PR TITLE
fix(goldfish): use the forge background for forge decks

### DIFF
--- a/app/goldfish/[deckId]/client.tsx
+++ b/app/goldfish/[deckId]/client.tsx
@@ -42,6 +42,11 @@ function GoldfishGameArea({ deck, onLoadDeck }: { deck: DeckDataForGoldfish; onL
 
   const { isReady, progress } = useImagePreloader(imageUrls);
 
+  // Forge decks play against the forge background; everything else the cave.
+  const backgroundImage = deck.isForge
+    ? 'url(/gameplay/forge_background.png)'
+    : 'url(/gameplay/cave_background.png)';
+
   // Warm the canvas chunk while the loading screen is up — GoldfishCanvas is
   // dynamically imported, and without this it only starts downloading after
   // isReady flips, leaving the cave background briefly unshaded.
@@ -64,7 +69,7 @@ function GoldfishGameArea({ deck, onLoadDeck }: { deck: DeckDataForGoldfish; onL
   );
 
   if (!isReady) {
-    return <LoadingScreen progress={progress} />;
+    return <LoadingScreen progress={progress} isForge={deck.isForge} />;
   }
 
   return (
@@ -81,13 +86,13 @@ function GoldfishGameArea({ deck, onLoadDeck }: { deck: DeckDataForGoldfish; onL
         flexDirection: 'row',
       }}
     >
-      {/* Cave background image — shared across game area and loupe */}
+      {/* Cave (or Forge) background image — shared across game area and loupe */}
       <div
         className="cave-bg"
         style={{
           position: 'absolute',
           inset: 0,
-          backgroundImage: 'url(/gameplay/cave_background.png)',
+          backgroundImage,
           backgroundSize: 'cover',
           backgroundPosition: 'center 70%',
           backgroundRepeat: 'no-repeat',

--- a/app/goldfish/components/LoadingScreen.tsx
+++ b/app/goldfish/components/LoadingScreen.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { LOADING_MESSAGES } from '@/app/shared/constants/loadingMessages';
 
-export function LoadingScreen({ progress }: { progress: number }) {
+export function LoadingScreen({ progress, isForge }: { progress: number; isForge?: boolean }) {
   // Randomize only after mount: picking during render runs on the server too,
   // and a different pick on the client is a hydration text mismatch.
   const [message, setMessage] = useState(LOADING_MESSAGES[0]);
@@ -27,12 +27,12 @@ export function LoadingScreen({ progress }: { progress: number }) {
         gap: 24,
       }}
     >
-      {/* Cave background */}
+      {/* Cave (or Forge) background */}
       <div
         style={{
           position: 'absolute',
           inset: 0,
-          backgroundImage: 'url(/gameplay/cave_background.png)',
+          backgroundImage: `url(/gameplay/${isForge ? 'forge_background' : 'cave_background'}.png)`,
           backgroundSize: 'cover',
           backgroundPosition: 'center 70%',
           backgroundRepeat: 'no-repeat',


### PR DESCRIPTION
## What

Goldfish (single-player practice) mode hardcoded `cave_background.png` in both the game area and the loading screen. Decks loaded from the Forge already carry an `isForge` flag (set by `loadForgeDeckGoldfish`), so when it's set we now render `forge_background.png` instead — matching the toggle the multiplayer play mode already uses.

## Changes

- [`app/goldfish/[deckId]/client.tsx`](app/goldfish/[deckId]/client.tsx) — derive the game-area `backgroundImage` from `deck.isForge`; pass `isForge` to `LoadingScreen`.
- [`app/goldfish/components/LoadingScreen.tsx`](app/goldfish/components/LoadingScreen.tsx) — accept an optional `isForge` prop and pick the background accordingly.

Non-forge goldfish decks are unchanged (still the cave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)