### PR TITLE
feat(decklist): make the deck description editor taller and resizable

### DIFF
--- a/app/decklist/card-search/components/DeckBuilderPanel.tsx
+++ b/app/decklist/card-search/components/DeckBuilderPanel.tsx
@@ -3173,7 +3173,7 @@ export default function DeckBuilderPanel({
                 Add notes or strategy for your deck (supports Markdown).
               </p>
               {descriptionPreview ? (
-                <div className="w-full min-h-[8rem] p-3 text-sm border border-border rounded-lg bg-card text-card-foreground overflow-auto prose prose-sm dark:prose-invert max-w-none">
+                <div className="w-full min-h-[16rem] p-3 text-sm border border-border rounded-lg bg-card text-card-foreground overflow-auto prose prose-sm dark:prose-invert max-w-none">
                   {deck.description ? (
                     <ReactMarkdown>{deck.description}</ReactMarkdown>
                   ) : (
@@ -3185,7 +3185,7 @@ export default function DeckBuilderPanel({
                   value={deck.description || ""}
                   onChange={(e) => onDescriptionChange?.(e.target.value)}
                   placeholder="Deck strategy, card choices, matchup notes..."
-                  className="w-full h-32 p-3 text-sm border border-border rounded-lg bg-card text-card-foreground placeholder-muted-foreground resize-none focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
+                  className="w-full h-64 min-h-[16rem] p-3 text-sm border border-border rounded-lg bg-card text-card-foreground placeholder-muted-foreground resize-y focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
                 />
               )}
             </div>


### PR DESCRIPTION
## What

In the deck builder's **Details** tab, the Description editor was fixed at `h-32` (128px) with `resize-none`, so it was cramped and couldn't be grown for longer strategy notes.

- **Taller default** — `h-32` → `h-64` (128px → 256px)
- **Draggable** — `resize-none` → `resize-y`, so you can pull it as tall as you want
- **No layout jump** — bumped the Preview box's `min-h` to `16rem` to match the editor, so toggling Edit ↔ Preview stays put

Focus styling is left as-is to match the file's existing convention.

## Testing

Manual: open a deck → Details tab → Description. Editor now shows ~2× the lines by default and can be dragged taller; Edit/Preview toggle no longer resizes the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)