### PR TITLE
Fortress-filter fix, Forge builder share, folder-delete cascade, and member display-name default

### DIFF
--- a/app/decklist/actions.ts
+++ b/app/decklist/actions.ts
@@ -792,12 +792,13 @@ export async function deleteFolderAction(folderId: string) {
       };
     }
 
-    // Check if folder has decks
+    // Collect the decks in this folder so we can cascade-delete them and
+    // invalidate their public caches (card rows cascade-delete via FK).
     const { data: decksInFolder, error: checkError } = await supabase
       .from("decks")
       .select("id")
       .eq("folder_id", folderId)
-      .limit(1);
+      .eq("user_id", user.id);
 
     if (checkError) {
       console.error("Error checking folder contents:", checkError);
@@ -807,14 +808,24 @@ export async function deleteFolderAction(folderId: string) {
       };
     }
 
+    // Delete every deck inside the folder (their cards cascade-delete via FK).
     if (decksInFolder && decksInFolder.length > 0) {
-      return {
-        success: false,
-        error: "Cannot delete folder that contains decks. Move or delete the decks first.",
-      };
+      const { error: decksError } = await supabase
+        .from("decks")
+        .delete()
+        .eq("folder_id", folderId)
+        .eq("user_id", user.id);
+
+      if (decksError) {
+        console.error("Error deleting decks in folder:", decksError);
+        return {
+          success: false,
+          error: "Failed to delete folder",
+        };
+      }
     }
 
-    // Delete folder
+    // Delete the folder itself
     const { error } = await supabase
       .from("deck_folders")
       .delete()
@@ -830,10 +841,14 @@ export async function deleteFolderAction(folderId: string) {
     }
 
     revalidatePath("/decklist/my-decks");
+    revalidateTag("public-decks-list");
+    for (const deck of decksInFolder ?? []) {
+      revalidateTag(`public-deck:${deck.id}`);
+    }
 
     return {
       success: true,
-      message: "Folder deleted successfully",
+      message: "Folder and its decks deleted successfully",
     };
   } catch (error) {
     console.error("Error in deleteFolderAction:", error);

--- a/app/decklist/card-search/__tests__/iconPredicates.fortress.test.ts
+++ b/app/decklist/card-search/__tests__/iconPredicates.fortress.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { iconPredicates, type Card } from "../utils";
+
+// Minimal Card fixture — only the fields the Fortress/City predicates read matter.
+const card = (over: Partial<Card>): Card => ({
+  dataLine: "",
+  name: "",
+  set: "",
+  imgFile: "",
+  officialSet: "",
+  type: "",
+  brigade: "",
+  strength: "",
+  toughness: "",
+  class: "",
+  identifier: "",
+  specialAbility: "",
+  rarity: "",
+  reference: "",
+  alignment: "",
+  legality: "",
+  testament: "",
+  isGospel: false,
+  ...over,
+});
+
+const goodFortress = iconPredicates["Good Fortress"];
+const evilFortress = iconPredicates["Evil Fortress"];
+
+// In Redemption a City is a type of Fortress, so the Fortress filters should
+// surface Cities of the matching alignment (Bethlehem, City of Refuge, etc.).
+describe("Good/Evil Fortress filters include Cities", () => {
+  it("Good Fortress filter surfaces Good Cities", () => {
+    // Bethlehem (LoC) — a Good City
+    expect(goodFortress(card({ type: "City", alignment: "Good" }))).toBe(true);
+  });
+
+  it("Evil Fortress filter surfaces Evil Cities", () => {
+    // Sodom & Gomorrah — an Evil City
+    expect(evilFortress(card({ type: "City", alignment: "Evil" }))).toBe(true);
+  });
+
+  it("does not surface a City under the opposite alignment's Fortress filter", () => {
+    expect(evilFortress(card({ type: "City", alignment: "Good" }))).toBe(false);
+    expect(goodFortress(card({ type: "City", alignment: "Evil" }))).toBe(false);
+  });
+
+  it("still matches ordinary Fortresses (regression guard)", () => {
+    expect(goodFortress(card({ type: "Fortress", alignment: "Good" }))).toBe(true);
+    expect(evilFortress(card({ type: "Fortress", alignment: "Evil" }))).toBe(true);
+    // Dual-type fortress cards keep matching.
+    expect(evilFortress(card({ type: "Evil Character/Fortress", alignment: "Evil" }))).toBe(true);
+  });
+
+  it("does not surface non-Fortress, non-City cards", () => {
+    expect(goodFortress(card({ type: "Hero", alignment: "Good" }))).toBe(false);
+    expect(evilFortress(card({ type: "Site", alignment: "Evil" }))).toBe(false);
+  });
+});

--- a/app/decklist/card-search/builderConfig.tsx
+++ b/app/decklist/card-search/builderConfig.tsx
@@ -132,6 +132,16 @@ export interface DeckBuilderConfig {
   persistence?: DeckBuilderPersistence;
   /** Feature toggles. Omit for all-public-defaults. */
   features?: DeckBuilderFeatures;
+  /** Replacement share modal. When provided, the builder shows its Share
+   *  controls even with `enableSharing` off and renders this instead of the
+   *  public ShareDeckModal (which writes public visibility — never for the
+   *  Forge). The Forge supplies its member-only share here. */
+  renderShareModal?: (props: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    deckId: string;
+    deckName?: string;
+  }) => ReactNode;
   /** Called after the Load Deck modal successfully loads a deck in place. The
    *  Forge rewrites /forge/play/decks/<id> via history.replaceState (its deck
    *  id lives in the URL; the public builder's does not). */

--- a/app/decklist/card-search/components/DeckBuilderPanel.tsx
+++ b/app/decklist/card-search/components/DeckBuilderPanel.tsx
@@ -249,6 +249,10 @@ export default function DeckBuilderPanel({
   // persistence hides Load Deck unless it supplies its own `listDecks`
   // (the Forge lists forge_decks).
   const canLoadDeckList = !builderConfig.persistence || !!builderConfig.persistence.listDecks;
+  // A config-supplied share modal (the Forge's member-only share) surfaces the
+  // Share controls even with the public share (`canShare`) off.
+  const renderShareModal = builderConfig.renderShareModal;
+  const canOpenShare = canShare || !!renderShareModal;
 
   const [activeTab, setActiveTab] = useState<TabType>(defaultTab ?? "main");
   const [isEditingName, setIsEditingName] = useState(false);
@@ -1169,7 +1173,7 @@ export default function DeckBuilderPanel({
             </button>
 
             {/* Share button (opens the share/visibility modal) */}
-            {canShare && isAuthenticated && deck.id && (
+            {canOpenShare && isAuthenticated && deck.id && (
               <button
                 onClick={() => setShowShareModal(true)}
                 className="w-8 h-8 rounded-lg flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
@@ -1300,7 +1304,7 @@ export default function DeckBuilderPanel({
                       Replace Evil…
                     </button>
                   )}
-                  {canShare && isAuthenticated && deck.id && (
+                  {canOpenShare && isAuthenticated && deck.id && (
                     <button
                       onClick={() => { setShowShareModal(true); setShowMenu(false); }}
                       className="w-full px-4 py-2.5 text-left hover:bg-muted flex items-center gap-2.5 text-foreground text-sm"
@@ -1677,7 +1681,7 @@ export default function DeckBuilderPanel({
             </button>
 
             {/* Share button (opens the share/visibility modal) */}
-            {canShare && isAuthenticated && deck.id && (
+            {canOpenShare && isAuthenticated && deck.id && (
               <button
                 onClick={() => setShowShareModal(true)}
                 className="px-3 py-1.5 rounded border border-border bg-card hover:bg-muted text-muted-foreground transition-colors flex items-center"
@@ -1832,7 +1836,7 @@ export default function DeckBuilderPanel({
               )}
 
               {/* Sharing Section */}
-              {canShare && isAuthenticated && deck.id && (
+              {canOpenShare && isAuthenticated && deck.id && (
                 <button
                   onClick={() => { setShowShareModal(true); setShowMenu(false); }}
                   className="w-full px-4 py-2 text-left hover:bg-muted flex items-center gap-2 text-foreground text-sm"
@@ -3648,8 +3652,17 @@ export default function DeckBuilderPanel({
         </div>
       )}
 
-      {/* Share / visibility modal */}
-      {canShare && deck.id && (
+      {/* Share / visibility modal. A config-supplied modal (the Forge's
+          member-only share) replaces the public one outright — the public
+          modal writes public visibility, which Forge decks must never do. */}
+      {renderShareModal && deck.id ? (
+        renderShareModal({
+          open: showShareModal,
+          onOpenChange: setShowShareModal,
+          deckId: deck.id,
+          deckName: deck.name,
+        })
+      ) : canShare && deck.id ? (
         <ShareDeckModal
           open={showShareModal}
           onOpenChange={setShowShareModal}
@@ -3658,7 +3671,7 @@ export default function DeckBuilderPanel({
           visibility={currentVisibility}
           onSetVisibility={handleSelectVisibility}
         />
-      )}
+      ) : null}
 
       {/* Username Modal */}
       {showUsernameModal && (

--- a/app/decklist/card-search/utils.ts
+++ b/app/decklist/card-search/utils.ts
@@ -71,8 +71,9 @@ export const iconPredicates: Record<string, (c: Card) => boolean> = {
   Curse: (c) => c.type === "Curse",
   "Good Dominant": (c) => c.type.includes("Dominant") && (c.alignment.includes("Good") || c.alignment.includes("Neutral")),
   "Evil Dominant": (c) => c.type.includes("Dominant") && (c.alignment.includes("Evil") || c.alignment.includes("Neutral")),
-  "Good Fortress": (c) => c.type.includes("Fortress") && c.alignment.includes("Good"),
-  "Evil Fortress": (c) => c.type.includes("Fortress") && c.alignment.includes("Evil"),
+  // A City is a type of Fortress in Redemption, so surface Cities under the Fortress filters too.
+  "Good Fortress": (c) => (c.type.includes("Fortress") || c.type.includes("City")) && c.alignment.includes("Good"),
+  "Evil Fortress": (c) => (c.type.includes("Fortress") || c.type.includes("City")) && c.alignment.includes("Evil"),
   // other icons use existing category filters
   // Good Enhancements also surface Covenants (a good-side enhancement-like type)
   GE: (c) => c.type.includes("GE") || c.type === "Covenant",

--- a/app/decklist/my-decks/DeleteFolderModal.tsx
+++ b/app/decklist/my-decks/DeleteFolderModal.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import ConfirmationDialog from "@/components/ui/confirmation-dialog";
+
+interface DeleteFolderModalProps {
+  folderName: string;
+  deckCount: number;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export default function DeleteFolderModal({ folderName, deckCount, onConfirm, onClose }: DeleteFolderModalProps) {
+  const hasDecks = deckCount > 0;
+  const deckWord = deckCount === 1 ? "deck" : "decks";
+
+  return (
+    <ConfirmationDialog
+      open={true}
+      onOpenChange={(open) => { if (!open) onClose(); }}
+      onConfirm={onConfirm}
+      variant="destructive"
+      title="Delete Folder"
+      description="This action cannot be undone"
+      confirmLabel={hasDecks ? `Delete folder & ${deckCount} ${deckWord}` : "Delete folder"}
+      cancelLabel="Cancel"
+      icon={
+        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+        </svg>
+      }
+    >
+      <p className="text-foreground mb-2">
+        Are you sure you want to delete this folder?
+      </p>
+      <div className="bg-muted rounded-lg px-4 py-3 mt-3">
+        <p className="text-sm text-muted-foreground mb-1">Folder name:</p>
+        <p className="font-semibold text-foreground break-words">
+          {folderName}
+        </p>
+      </div>
+      {hasDecks ? (
+        <div className="mt-3 rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3">
+          <p className="text-sm text-red-600 dark:text-red-400">
+            This folder contains <span className="font-semibold">{deckCount} {deckWord}</span>. The folder and all{" "}
+            {deckWord} inside it — including their card data — will be permanently deleted.
+          </p>
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground mt-3">
+          This folder is empty. It will be permanently deleted.
+        </p>
+      )}
+    </ConfirmationDialog>
+  );
+}

--- a/app/decklist/my-decks/client.tsx
+++ b/app/decklist/my-decks/client.tsx
@@ -24,6 +24,7 @@ import {
 } from "../actions";
 import { GoldfishButton } from "../../goldfish/components/GoldfishButton";
 import DeleteDeckModal from "./DeleteDeckModal";
+import DeleteFolderModal from "./DeleteFolderModal";
 import FolderModal from "./FolderModal";
 import UsernameModal from "./UsernameModal";
 import QuickLookModal from "./QuickLookModal";
@@ -316,6 +317,8 @@ export default function MyDecksClient() {
     const result = await deleteFolderAction(folderId);
     if (result.success) {
       setFolders(folders.filter((f) => f.id !== folderId));
+      // Decks inside the folder are cascade-deleted server-side; drop them locally too.
+      setDecks((prev) => prev.filter((d) => d.folder_id !== folderId));
       if (selectedFolder === folderId) {
         setSelectedFolder(null); // Go back to "My Decks"
       }
@@ -1193,8 +1196,9 @@ export default function MyDecksClient() {
 
       {/* Delete Folder Confirmation */}
       {folderToDelete && (
-        <DeleteDeckModal
-          deckName={folderToDelete.name}
+        <DeleteFolderModal
+          folderName={folderToDelete.name}
+          deckCount={decks.filter((d) => d.folder_id === folderToDelete.id).length}
           onConfirm={() => handleDeleteFolder(folderToDelete.id)}
           onClose={() => setFolderToDelete(null)}
         />
@@ -1757,11 +1761,9 @@ function DropdownMenu({
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const [showMoveMenu, setShowMoveMenu] = useState(false);
-  const [submenuOnLeft, setSubmenuOnLeft] = useState(false);
   const [menuStyle, setMenuStyle] = useState<React.CSSProperties>({});
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
-  const moveItemRef = useRef<HTMLDivElement>(null);
 
   function handleToggle() {
     if (!isOpen && buttonRef.current) {
@@ -1781,14 +1783,6 @@ function DropdownMenu({
     }
     setIsOpen(!isOpen);
   }
-
-  // Flip submenu to left side when it would overflow the right edge of the viewport
-  useEffect(() => {
-    if (!showMoveMenu || !moveItemRef.current) return;
-    const rect = moveItemRef.current.getBoundingClientRect();
-    const submenuWidth = 192; // w-48
-    setSubmenuOnLeft(rect.right + 8 + submenuWidth > window.innerWidth);
-  }, [showMoveMenu]);
 
   // Reposition on scroll/resize while open
   useEffect(() => {
@@ -1930,59 +1924,57 @@ function DropdownMenu({
               Share…
             </button>
 
-            {/* Move to Folder submenu */}
+            {/* Move to Folder submenu (expands inline so it isn't clipped by the menu's scroll container) */}
             <div className="border-t border-border my-1"></div>
-            <div className="relative" ref={moveItemRef}>
-              <button
-                onClick={() => setShowMoveMenu(!showMoveMenu)}
-                className="w-full text-left px-4 py-2 hover:bg-muted flex items-center gap-2"
-              >
-                <svg className="w-4 h-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-                </svg>
-                <span className="flex-1">Move to...</span>
-                <svg className={`w-4 h-4 ${submenuOnLeft ? "rotate-180" : ""}`} fill="currentColor" viewBox="0 0 20 20">
-                  <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
-                </svg>
-              </button>
+            <button
+              onClick={() => setShowMoveMenu(!showMoveMenu)}
+              className="w-full text-left px-4 py-2 hover:bg-muted flex items-center gap-2"
+            >
+              <svg className="w-4 h-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+              </svg>
+              <span className="flex-1">Move to...</span>
+              <svg className={`w-4 h-4 transition-transform ${showMoveMenu ? "rotate-90" : ""}`} fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
+              </svg>
+            </button>
 
-              {showMoveMenu && (
-                <div className={`absolute top-0 w-48 bg-card rounded-md shadow-lg border border-border max-h-60 overflow-y-auto ${submenuOnLeft ? "right-full mr-1" : "left-full ml-1"}`}>
+            {showMoveMenu && (
+              <div className="bg-muted/40">
+                <button
+                  onClick={() => {
+                    onMove(null);
+                    setIsOpen(false);
+                    setShowMoveMenu(false);
+                  }}
+                  className={`w-full text-left pl-11 pr-4 py-2 text-sm hover:bg-muted ${
+                    !currentFolderId ? "bg-primary/10" : ""
+                  }`}
+                >
+                  My Decks
+                </button>
+                {folders.map((folder) => (
                   <button
+                    key={folder.id}
                     onClick={() => {
-                      onMove(null);
+                      onMove(folder.id!);
                       setIsOpen(false);
                       setShowMoveMenu(false);
                     }}
-                    className={`w-full text-left px-4 py-2 hover:bg-muted first:rounded-t-md ${
-                      !currentFolderId ? "bg-primary/10" : ""
+                    className={`w-full text-left pl-11 pr-4 py-2 text-sm truncate hover:bg-muted ${
+                      currentFolderId === folder.id ? "bg-primary/10" : ""
                     }`}
                   >
-                    My Decks
+                    {folder.name}
                   </button>
-                  {folders.map((folder) => (
-                    <button
-                      key={folder.id}
-                      onClick={() => {
-                        onMove(folder.id!);
-                        setIsOpen(false);
-                        setShowMoveMenu(false);
-                      }}
-                      className={`w-full text-left px-4 py-2 hover:bg-muted last:rounded-b-md ${
-                        currentFolderId === folder.id ? "bg-primary/10" : ""
-                      }`}
-                    >
-                      {folder.name}
-                    </button>
-                  ))}
-                  {folders.length === 0 && (
-                    <div className="px-4 py-2 text-sm text-muted-foreground">
-                      No folders available
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
+                ))}
+                {folders.length === 0 && (
+                  <div className="pl-11 pr-4 py-2 text-sm text-muted-foreground">
+                    No folders available
+                  </div>
+                )}
+              </div>
+            )}
 
             <div className="border-t border-border my-1"></div>
             <button

--- a/app/forge/components/ForgeBuilderShareModal.tsx
+++ b/app/forge/components/ForgeBuilderShareModal.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import ForgeShareDeckModal from "@/app/forge/components/ForgeShareDeckModal";
+import { getForgeDeckShared, setForgeDeckShared } from "@/app/forge/lib/forgeDecks";
+
+/**
+ * Hosts ForgeShareDeckModal for the deck builder, which doesn't track
+ * is_shared: fetches the current state when the modal opens and owns the
+ * server action on change. (The deck list page passes both from its
+ * server-rendered summaries instead.)
+ */
+export default function ForgeBuilderShareModal({
+  open,
+  onOpenChange,
+  deckId,
+  deckName,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  deckId: string;
+  deckName?: string;
+}) {
+  const [isShared, setIsShared] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    getForgeDeckShared(deckId).then((shared) => {
+      if (!cancelled) setIsShared(shared);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, deckId]);
+
+  return (
+    <ForgeShareDeckModal
+      open={open}
+      onOpenChange={onOpenChange}
+      deckId={deckId}
+      deckName={deckName}
+      isShared={isShared}
+      onSetShared={async (shared) => {
+        const res = await setForgeDeckShared(deckId, shared);
+        if (res.ok) setIsShared(shared);
+      }}
+    />
+  );
+}

--- a/app/forge/lib/forgeDecks.ts
+++ b/app/forge/lib/forgeDecks.ts
@@ -117,6 +117,19 @@ export async function copyForgeDeck(id: string): Promise<{ ok: true; id: string 
   return { ok: true, id: data.id };
 }
 
+// Just the share flag, for the builder's share modal (it doesn't track
+// is_shared, and pulling the full deck for one boolean is wasteful).
+export async function getForgeDeckShared(id: string): Promise<boolean> {
+  const ctx = await requireForge();
+  if (!ctx) return false;
+  const { data } = await ctx.supabase
+    .from("forge_decks")
+    .select("is_shared")
+    .eq("id", id)
+    .maybeSingle();
+  return data?.is_shared === true;
+}
+
 export async function setForgeDeckShared(id: string, shared: boolean): Promise<{ ok: boolean; error?: string }> {
   const ctx = await requireForge();
   if (!ctx) return { ok: false, error: "Not authorized" };

--- a/app/forge/play/decks/[deckId]/forgeBuilderConfig.tsx
+++ b/app/forge/play/decks/[deckId]/forgeBuilderConfig.tsx
@@ -33,6 +33,7 @@ import type { ForgeDeckEntry } from "@/app/forge/lib/deckTypes";
 import type { GrantedForgeCard } from "@/app/forge/lib/deckPool";
 import { saveForgeDeck, getForgeDeck, listForgeDecks, deleteForgeDeck } from "@/app/forge/lib/forgeDecks";
 import ForgeCardPreview from "@/app/forge/components/ForgeCardPreview";
+import ForgeBuilderShareModal from "@/app/forge/components/ForgeBuilderShareModal";
 
 export function makeForgeBuilderConfig(granted: GrantedForgeCard[]): DeckBuilderConfig {
   // Forge cards → Card[], with imgFile stamped to the forge dataLine so the cardId
@@ -214,6 +215,9 @@ export function makeForgeBuilderConfig(granted: GrantedForgeCard[]): DeckBuilder
     resolveCardImage,
     renderThumb,
     persistence: { save, loadById, resolveCard, listDecks, delete: deleteDeck },
+    // Member-only share (is_shared on forge_decks) in place of the public
+    // share modal — enableSharing stays off so nothing writes public data.
+    renderShareModal: (props) => <ForgeBuilderShareModal {...props} />,
     features: {
       localStoragePersist: false,
       syncFiltersToUrl: false,

--- a/supabase/migrations/077_forge_member_default_display_name.sql
+++ b/supabase/migrations/077_forge_member_default_display_name.sql
@@ -1,0 +1,46 @@
+-- Forge members: default display_name from the profile username.
+--
+-- forge_redeem_invite inserted the playtest_members row with no display_name,
+-- so invite-redeemed members rendered as "—" in the admin member list and
+-- set-access grid until they set a Forge profile. Default it to the member's
+-- site username at redeem time (still editable via forge_set_profile), and
+-- backfill members already missing one.
+
+-- 1) Redeem now seeds display_name from profiles.username. Body is identical
+--    to migration 068 except the playtest_members insert.
+create or replace function public.forge_redeem_invite(
+  p_token_hash text, p_nda_agreed boolean
+) returns text language plpgsql security definer set search_path = '' as $$
+declare v_invite public.forge_invites; v_set_id uuid;
+begin
+  if not coalesce(p_nda_agreed, false) then return null; end if;  -- must accept the NDA
+  select * into v_invite from public.forge_invites
+   where token_hash = p_token_hash and used_at is null and expires_at > now()
+   for update;
+  if not found then return null; end if;
+  if v_invite.email is not null and lower(v_invite.email) is distinct from lower(auth.email()) then
+    return null;  -- email-bound to someone else; Supabase lowercases auth emails
+  end if;
+  insert into public.playtest_members (user_id, role, invited_by, nda_agreed_at, display_name)
+  values (auth.uid(), v_invite.role, v_invite.invited_by, now(),
+          (select nullif(trim(p.username), '') from public.profiles p where p.id = auth.uid()))
+  on conflict (user_id) do nothing;
+  foreach v_set_id in array coalesce(v_invite.set_ids, '{}') loop
+    insert into public.forge_set_grants (set_id, user_id, granted_by)
+    select v_set_id, auth.uid(), v_invite.invited_by
+    where exists (select 1 from public.forge_sets s where s.id = v_set_id)
+    on conflict (set_id, user_id) do nothing;
+  end loop;
+  update public.forge_invites set used_at = now() where id = v_invite.id;
+  insert into public.forge_audit (actor, action, target)
+  values (auth.uid(), 'member_added', v_invite.id::text);
+  return v_invite.role::text;
+end; $$;
+
+-- 2) Backfill members with no display name from their profile username.
+update public.playtest_members pm
+set display_name = nullif(trim(p.username), '')
+from public.profiles p
+where p.id = pm.user_id
+  and nullif(btrim(pm.display_name), '') is null
+  and nullif(trim(p.username), '') is not null;


### PR DESCRIPTION
Bundles four independent changes (one commit each) that were in flight together on this branch.

## 1. `fix(decklist)` — Cities under the Fortress filters
Surfaces Cities cards under the Good/Evil **Fortress** filters where they were previously missing.

## 2. `feat(forge)` — member-only share modal in the deck builder
The Forge deck builder reused the public `ShareDeckModal`, which writes **public** visibility — something Forge decks must never do. Adds a `renderShareModal` config hook: when supplied, the builder shows its Share controls (even with public sharing off) and renders the config's modal instead of the public one. The Forge wires in `ForgeBuilderShareModal`, toggling `is_shared` on `forge_decks` via `getForgeDeckShared` / `setForgeDeckShared`.

## 3. `feat(decklist)` — delete a folder together with its decks
`deleteFolderAction` previously refused to delete a non-empty folder. It now cascade-deletes every deck the user owns in that folder (card rows cascade via FK) and invalidates the affected `public-deck` caches. A dedicated `DeleteFolderModal` replaces the deck-delete dialog (shows the deck count in its confirm label), the client drops removed decks from local state, and the "Move to Folder" submenu now expands inline so it isn't clipped by the menu's scroll container.

## 4. `fix(forge)` — default member display_name from profile username (migration 077)
Invite-redeemed members were inserted with no `display_name`, rendering as "—" in the admin member list and set-access grid until they set a Forge profile. Seeds `display_name` from `profiles.username` at redeem time (still editable via `forge_set_profile`) and backfills existing members missing one.

## Testing
Manual. Note: migration 077 must be applied to the database on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)