### PR TITLE
fix(battle): status-chrome and copy polish from the live UX review

### DIFF
--- a/app/play/components/BattleResolutionUI.tsx
+++ b/app/play/components/BattleResolutionUI.tsx
@@ -65,6 +65,11 @@ interface BattleResolutionUIProps {
   siteAttachedSoulIds: Set<string>;
   /** Forge card-art resolver, for Forge playtest games. */
   forgeResolver?: ForgeResolverMap | null;
+  /** True once the band holds at least one card. Win Battle / Battle Lost are
+   *  confirm-free and consequence-heavy (a misclicked 🏳 with souls at stake
+   *  goes straight into the surrender flow), so they stay hidden over an
+   *  empty band; ↩ End Battle remains the always-available escape hatch. */
+  bandHasCards: boolean;
   /** Both Win Battle and Battle Lost dispatch the same server reducer (resolve_battle) —
    *  the server decides win/loss from caller identity, not from which button was pressed. */
   onResolveBattle: () => void;
@@ -222,6 +227,13 @@ function AwaitingSoulUI({
   }
 
   const title = chooserSeat === attackerSeat ? 'Choose a Lost Soul to rescue' : 'Choose a Lost Soul to surrender';
+  // One line of context so the picker stands on its own for a chooser who
+  // wasn't watching the band (UX review F8): who won, where the soul goes.
+  const attackerName = attackerSeat === mySeat ? myPlayerName : opponentPlayerName;
+  const subtitle =
+    chooserSeat === attackerSeat
+      ? 'You won the battle — the soul you pick moves to your Land of Redemption.'
+      : `${attackerName} won the battle — the soul you pick goes to their Land of Redemption.`;
 
   const handlePick = (cardId: bigint) => {
     if (pendingSoulId !== null) return;
@@ -269,6 +281,17 @@ function AwaitingSoulUI({
         >
           {title}
         </h2>
+        <p
+          style={{
+            margin: '6px 0 0',
+            fontFamily: 'Georgia, serif',
+            fontSize: 12.5,
+            color: 'rgba(196, 149, 90, 0.75)',
+            flexShrink: 0,
+          }}
+        >
+          {subtitle}
+        </p>
 
         {eligibleSouls.length === 0 ? (
           <>
@@ -410,6 +433,7 @@ export default function BattleResolutionUI({
   eligibleSouls,
   siteAttachedSoulIds,
   forgeResolver,
+  bandHasCards,
   onResolveBattle,
   onEndBattle,
   onSurrenderSoul,
@@ -477,10 +501,10 @@ export default function BattleResolutionUI({
           pointerEvents: 'auto',
         }}
       >
-        {isAttacker && (
+        {isAttacker && bandHasCards && (
           <ResolutionButton label={BUTTON_COPY['claim-victory'].label} tone="gold" onClick={onResolveBattle} />
         )}
-        {isDefender && (
+        {isDefender && bandHasCards && (
           <ResolutionButton label={BUTTON_COPY['battle-lost'].label} tone="red" onClick={onResolveBattle} />
         )}
         <ResolutionButton label={BUTTON_COPY['end-battle'].label} tone="neutral" onClick={onEndBattle} />

--- a/app/play/components/ChatPanel.tsx
+++ b/app/play/components/ChatPanel.tsx
@@ -124,6 +124,13 @@ const ACTION_TYPE_LABELS: Record<string, string> = {
   GAME_CREATED: 'created the game',
   REMATCH_REQUESTED: 'wants to play again',
   REMATCH_RESPONSE: 'responded to rematch',
+  // Battle actions carry rich payloads rendered in formatActionType; these
+  // are the payload-parse-failure fallbacks (previously they fell through to
+  // the raw lowercased type: "resolve battle", "surrender soul", …).
+  ENTER_BATTLE: 'moved a card into battle',
+  RESOLVE_BATTLE: 'resolved the battle',
+  SURRENDER_SOUL: 'gave up a lost soul',
+  BATTLE_END: 'ended the battle',
 };
 
 function HoverableCard({ name, img }: { name: string; img?: string }) {
@@ -637,7 +644,50 @@ function formatActionType(actionType: string, payload?: string, playerNames?: Re
             ? <>moved <HoverableCard name={data.cardName} img={data.cardImgFile} /> to {targetName}&apos;s land of redemption</>
             : <>rescued <HoverableCard name={data.cardName} img={data.cardImgFile} /></>;
         }
+        if (data.to === 'battle') {
+          return <>moved {cardEl} into battle</>;
+        }
       }
+    } catch { /* fall through */ }
+  }
+  if (actionType === 'ENTER_BATTLE' && payload) {
+    try {
+      const data = JSON.parse(payload);
+      if (data.cardName) {
+        return <>moved <HoverableCard name={data.cardName} img={data.cardImgFile} /> into battle</>;
+      }
+    } catch { /* fall through */ }
+  }
+  if (actionType === 'RESOLVE_BATTLE' && payload) {
+    // Both ⚑ Win Battle (attacker) and 🏳 Battle Lost (defender) dispatch
+    // resolve_battle — the caller's seat tells the log which one happened.
+    try {
+      const data = JSON.parse(payload);
+      if (data.callerSeat && data.attackerSeat) {
+        return data.callerSeat === data.attackerSeat ? 'won the battle' : 'lost the battle';
+      }
+    } catch { /* fall through */ }
+  }
+  if (actionType === 'SURRENDER_SOUL' && payload) {
+    try {
+      const data = JSON.parse(payload);
+      if (data.cardName) {
+        const cardEl = <HoverableCard name={data.cardName} img={data.cardImgFile} />;
+        // T1: the defender surrenders one of their own souls; T2/Paragon: the
+        // attacker picks the soul they take (actor is also the destination).
+        return actorPlayerId && data.targetOwnerId === actorPlayerId
+          ? <>rescued {cardEl}</>
+          : <>surrendered {cardEl}</>;
+      }
+    } catch { /* fall through */ }
+  }
+  if (actionType === 'BATTLE_END' && payload) {
+    try {
+      const data = JSON.parse(payload);
+      const kept: string[] = Array.isArray(data.kept) ? data.kept : [];
+      return kept.length > 0
+        ? `ended the battle — kept in play: ${kept.join(', ')}`
+        : 'ended the battle';
     } catch { /* fall through */ }
   }
   if (actionType === 'MOVE_OPPONENT_CARD' && payload) {

--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -3864,6 +3864,29 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
             snapBack();
             return;
           }
+          // No Warrior under the drop — if it landed on a non-Warrior
+          // character, the refusal is rules-correct (only Warrior-class
+          // characters carry weapons) but used to be silent: the weapon just
+          // sat in the zone and got discarded at battle end, reading as "the
+          // game ate my sword" (UX review F10). Soft hint only — the move
+          // below still proceeds, nothing is blocked.
+          const nonWarriorCharacters = myHostCards.filter((c) => {
+            if (c.instanceId === card.instanceId) return false;
+            if (c.equippedTo) return false;
+            if (!isCharacterCard({ cardType: c.type })) return false;
+            return !isWarrior(findCard(c.cardName, c.cardSet, c.cardImgFile));
+          });
+          const hitNonWarrior = hitTestWarrior(
+            center.x,
+            center.y,
+            cardWidth,
+            cardHeight,
+            nonWarriorCharacters,
+            card.instanceId,
+          );
+          if (hitNonWarrior) {
+            showGameToast(`${hitNonWarrior.cardName} isn't a Warrior — ${card.cardName} won't attach`, 4000);
+          }
         }
       }
 
@@ -5269,7 +5292,11 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
     const myTotals = mySeatStr ? sideTotals(battleLikes, mySeatStr as BattleSeat) : { str: 0, tgh: 0, hasUnknown: false };
     const oppTotals = oppSeatStr ? sideTotals(battleLikes, oppSeatStr as BattleSeat) : { str: 0, tgh: 0, hasUnknown: false };
 
-    const headerText = `⚔ ${nameForSeat(attackerSeat)} attacking — ${stakesLostSoulCount >= 1 ? 'Rescue attempt' : 'Battle challenge'}`;
+    // No ⚔ prefixes anywhere in this chrome: Konva canvas text gets no emoji
+    // fallback, so U+2694 rendered as a bare "×"-looking glyph (PR #197 UX
+    // review F5). The HTML resolution buttons keep their glyphs — the DOM
+    // renders them fine.
+    const headerText = `${nameForSeat(attackerSeat)} attacking — ${stakesLostSoulCount >= 1 ? 'Rescue attempt' : 'Battle challenge'}`;
 
     const initiative = computeInitiative(
       battleLikes,
@@ -5278,24 +5305,39 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
     );
     let bannerMain = '';
     switch (initiative.kind) {
+      case 'empty':
+        // No characters on either side — the drag-guidance cue carries the
+        // instruction; a banner here contradicted it (UX review F2).
+        bannerMain = '';
+        break;
       case 'waiting-blocker':
-        bannerMain = 'Waiting for a blocker…';
+        // Side-neutral: also shown after the only blocker was defeated and
+        // dragged to discard, where "Waiting for a blocker…" wrongly implied
+        // the battle hadn't happened yet (UX review F3).
+        bannerMain = 'No blocker in battle';
         break;
       case 'no-attacker':
         bannerMain = 'No attacker in battle — End Battle?';
         break;
       case 'unknown':
-        bannerMain = '⚔ INITIATIVE: unknown (variable/face-down stats)';
+        bannerMain = 'INITIATIVE: unknown (variable/face-down stats)';
         break;
       case 'initiative': {
         const reasonLabel = initiative.reason === 'mutual-destruction' ? 'mutual destruction' : initiative.reason;
-        bannerMain = `⚔ INITIATIVE: ${nameForSeat(initiative.seat)} — ${reasonLabel}`;
+        bannerMain = `INITIATIVE: ${nameForSeat(initiative.seat)} — ${reasonLabel}`;
         break;
       }
     }
+    // The strip describes the ACTIVE fight. During 'awaiting-soul' it went
+    // stale ("Waiting for a blocker…") and collided with the HTML waiting
+    // pill anchored on the same band-bottom line (UX review F1).
+    if (gameState.battleState !== 'active') bannerMain = '';
 
     const chipWidth = 64 * fsGrowth(11);
     const chipHeight = 20;
+    // Two "0/0" chips over an empty band are noise — chips appear with the
+    // first card in the band (UX review F2).
+    const showChips = battleLikes.length > 0;
 
     return (
       <Group key="battle-chrome" listening={false}>
@@ -5323,38 +5365,42 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
             vertically centered). Halves are viewer-relative (spec §3: every
             player plays into their own right half), so the opponent's
             totals sit on my left. */}
-        <Group x={midX - 10 - chipWidth} y={band.y + band.height - 8 - chipHeight}>
-          <Rect width={chipWidth} height={chipHeight} fill="rgba(10,5,5,0.82)" stroke="#6496e0" strokeWidth={1} cornerRadius={4} perfectDrawEnabled={false} />
-          <Text
-            width={chipWidth}
-            height={chipHeight}
-            text={`⚔ ${oppTotals.str}/${oppTotals.tgh}${oppTotals.hasUnknown ? '?' : ''}`}
-            fontSize={fs(11)}
-            fontStyle="bold"
-            fill="#a3c5e8"
-            align="center"
-            verticalAlign="middle"
-            perfectDrawEnabled={false}
-          />
-        </Group>
+        {showChips && (
+          <Group x={midX - 10 - chipWidth} y={band.y + band.height - 8 - chipHeight}>
+            <Rect width={chipWidth} height={chipHeight} fill="rgba(10,5,5,0.82)" stroke="#6496e0" strokeWidth={1} cornerRadius={4} perfectDrawEnabled={false} />
+            <Text
+              width={chipWidth}
+              height={chipHeight}
+              text={`${oppTotals.str}/${oppTotals.tgh}${oppTotals.hasUnknown ? '?' : ''}`}
+              fontSize={fs(11)}
+              fontStyle="bold"
+              fill="#a3c5e8"
+              align="center"
+              verticalAlign="middle"
+              perfectDrawEnabled={false}
+            />
+          </Group>
+        )}
 
         {/* My-seat totals chip — flanks the vertical centerline on the
             right, anchored to the BOTTOM of the band, 8px above its bottom
             edge. My cards always render on my own right half. */}
-        <Group x={midX + 10} y={band.y + band.height - 8 - chipHeight}>
-          <Rect width={chipWidth} height={chipHeight} fill="rgba(10,5,5,0.82)" stroke="#c4955a" strokeWidth={1} cornerRadius={4} perfectDrawEnabled={false} />
-          <Text
-            width={chipWidth}
-            height={chipHeight}
-            text={`⚔ ${myTotals.str}/${myTotals.tgh}${myTotals.hasUnknown ? '?' : ''}`}
-            fontSize={fs(11)}
-            fontStyle="bold"
-            fill="#e8d5a3"
-            align="center"
-            verticalAlign="middle"
-            perfectDrawEnabled={false}
-          />
-        </Group>
+        {showChips && (
+          <Group x={midX + 10} y={band.y + band.height - 8 - chipHeight}>
+            <Rect width={chipWidth} height={chipHeight} fill="rgba(10,5,5,0.82)" stroke="#c4955a" strokeWidth={1} cornerRadius={4} perfectDrawEnabled={false} />
+            <Text
+              width={chipWidth}
+              height={chipHeight}
+              text={`${myTotals.str}/${myTotals.tgh}${myTotals.hasUnknown ? '?' : ''}`}
+              fontSize={fs(11)}
+              fontStyle="bold"
+              fill="#e8d5a3"
+              align="center"
+              verticalAlign="middle"
+              perfectDrawEnabled={false}
+            />
+          </Group>
+        )}
 
         {/* Status/initiative strip — horizontally centered, just below the
             band's bottom edge (outside the band; product direction,
@@ -5365,6 +5411,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
             but is capped narrow enough to never intersect it (verified by
             measurement at 1366x768 and 1920x1080 — see PR #197). */}
         {(() => {
+          if (!bannerMain) return null;
           const stripY = band.y + band.height + 6;
           const stripHeight = 16;
           const stripText = bannerMain;
@@ -5403,6 +5450,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
     mpLayout,
     battleCardEntries,
     stakesLostSoulCount,
+    gameState.battleState,
     gameState.battleAttackerSeat,
     gameState.lastBattlePlayBySeat,
     gameState.myPlayer,
@@ -8211,6 +8259,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
           eligibleSouls={stakesLostSoulRows}
           siteAttachedSoulIds={stakesSiteAttachedSoulIds}
           forgeResolver={forgeResolver}
+          bandHasCards={battleCardEntries.length > 0}
           onResolveBattle={gameState.resolveBattle}
           onEndBattle={gameState.endBattle}
           onSurrenderSoul={gameState.surrenderSoul}

--- a/app/play/lib/__tests__/battleMath.test.ts
+++ b/app/play/lib/__tests__/battleMath.test.ts
@@ -218,8 +218,8 @@ describe('computeInitiative — empty-side and unknown-stat states', () => {
     expect(computeInitiative(cards, '0', '')).toEqual({ kind: 'no-attacker' });
   });
 
-  it('both sides empty of characters -> waiting-blocker (band just opened)', () => {
-    expect(computeInitiative([], '0', '')).toEqual({ kind: 'waiting-blocker' });
+  it('both sides empty of characters -> empty (band just opened; no banner)', () => {
+    expect(computeInitiative([], '0', '')).toEqual({ kind: 'empty' });
   });
 
   it('non-character cards on both sides (e.g. Sites/Enhancements) still count as empty', () => {
@@ -227,7 +227,7 @@ describe('computeInitiative — empty-side and unknown-stat states', () => {
       mkCard({ ownerSeat: '0', cardType: 'GE', strength: '', toughness: '' }),
       mkCard({ ownerSeat: '1', cardType: 'Site', strength: '', toughness: '' }),
     ];
-    expect(computeInitiative(cards, '0', '')).toEqual({ kind: 'waiting-blocker' });
+    expect(computeInitiative(cards, '0', '')).toEqual({ kind: 'empty' });
   });
 
   it('either side hasUnknown (face-down card) -> unknown even with both sides populated', () => {

--- a/app/play/lib/battleMath.ts
+++ b/app/play/lib/battleMath.ts
@@ -116,6 +116,7 @@ export function parseMeekStats(strength: string, toughness: string): { strength:
 }
 
 export type InitiativeState =
+  | { kind: 'empty' }
   | { kind: 'waiting-blocker' }
   | { kind: 'no-attacker' }
   | { kind: 'unknown' }
@@ -155,7 +156,11 @@ export function computeInitiative(
   );
 
   if (!attackerHasCharacters) {
-    return defenderHasCharacters ? { kind: 'no-attacker' } : { kind: 'waiting-blocker' };
+    // Neither side has a character yet (band just opened, or only
+    // enhancements/sites are down): there is no fight to assess — callers
+    // suppress the status banner and let the drag-guidance cue do the
+    // talking instead of showing a contradictory "waiting for a blocker".
+    return defenderHasCharacters ? { kind: 'no-attacker' } : { kind: 'empty' };
   }
   if (!defenderHasCharacters) {
     return { kind: 'waiting-blocker' };


### PR DESCRIPTION
Stacked on #197 (base: `feat/battle-zone`). Applies the fix/polish findings from the two-client Playwright UX review; per owner direction, **F6 (chip STR/TGH labels) was skipped** and the post-battle summary toast stays removed.

## What changed

**Banner state machine** (`battleMath.ts` + chrome)
- New `'empty'` initiative kind: while neither side has a character, no banner renders — previously "Waiting for a blocker…" contradicted the "Drag attackers here" cue on the same screen.
- Banner hidden during `awaiting-soul` — it went stale and collided with the waiting pill + End Battle button on the same band-bottom line.
- "Waiting for a blocker…" → side-neutral **"No blocker in battle"** — the old copy read wrong at the claim-victory moment after the only blocker was defeated and discarded.

**Chrome cleanup** (`MultiplayerCanvas.tsx`)
- Totals chips only render once the band holds a card (no 0/0 noise at band-open).
- Dropped every `⚔` from Konva strings (header, chips, banner) — canvas text gets no emoji fallback, so U+2694 rendered as a bare "×". The HTML buttons keep their glyphs.

**Misclick guard** (`BattleResolutionUI.tsx`)
- `⚑ Win Battle` / `🏳 Battle Lost` render only once the band has at least one card — they're confirm-free and go straight into the soul flow. `↩ End Battle` stays always-available.
- Soul picker gains a context line: *"<attacker> won the battle — the soul you pick goes to their Land of Redemption."*

**Battle log** (`ChatPanel.tsx`, client-side only — no module republish)
- `moved <card> into battle` (MOVE_CARD `to: 'battle'` + ENTER_BATTLE), `won/lost the battle` (RESOLVE_BATTLE by caller seat), `surrendered/rescued <soul>` (SURRENDER_SOUL by destination), `ended the battle — kept in play: …` (BATTLE_END). Payloads already carried all the data; only the renderer lacked branches. Fallback labels added for parse failures.

**Attach feedback** (`MultiplayerCanvas.tsx`)
- Dropping a weapon on a non-Warrior character now toasts *"<host> isn't a Warrior — <weapon> won't attach"*. The refusal is rules-correct and unchanged; it was just silent, and the weapon's later auto-return discard read as "the game ate my sword".

## Verification
- `vitest app/play`: 167/167 (both-empty initiative tests updated first, watched fail, then implemented).
- `tsc --noEmit`: unchanged 7-error pre-existing baseline; none in touched files.
- Fresh two-client live battle on the dev module through every changed state: band-open (no banner/chips, End Battle only), non-Warrior weapon hint, defeated-blocker "No blocker in battle", awaiting-soul pill with no stale banner, picker subtitle, full log narrative, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)