### PR TITLE
fix(decklist): correct AoD tooltip wording for Soul figure

### DIFF
--- a/app/decklist/card-search/components/AodCountCard.tsx
+++ b/app/decklist/card-search/components/AodCountCard.tsx
@@ -20,9 +20,10 @@ const DECKLIST_TYPE: Record<AodCountCardProps["deckType"], string> = {
 };
 
 const AOD_TOOLTIP =
-  "Top-9 draw stats over a 10,000-iteration Monte Carlo. Non-Soul: avg non-soul " +
-  "Daniel cards in the top 9. Soul: avg Daniel Lost Souls (they trigger the chain " +
-  "but don't add to the count). Whiff: % of draws with no Daniel in the top 3.";
+  "Top-9 draw stats over a 10,000-iteration Monte Carlo, given a Daniel reference " +
+  "in the top 3. Non-Soul: avg Daniel cards in the top 9 excluding Lost Souls. " +
+  "Soul: the same average counting Daniel Lost Souls too. Whiff: % of draws with " +
+  "no Daniel in the top 3.";
 
 // One labeled figure within the revealed breakdown row.
 function Stat({ label, value }: { label: string; value: string }) {


### PR DESCRIPTION
## Summary
Follow-up to #199. The **Soul** breakdown figure is the AoD count **including** Daniel Lost Souls (paired with the souls-excluded Non-Soul number), not a souls-only tally. The tooltip previously said souls "don't add to the count," which is now inaccurate — this fixes the wording. Display/values are unchanged (the correction is server-side in the API's `soul_aod_count`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)