### PR TITLE
fix(battle): meek persists across the battle-zone round trip

### DIFF
--- a/spacetimedb/__tests__/playField.test.ts
+++ b/spacetimedb/__tests__/playField.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+// Lives outside spacetimedb/src (the module's tsconfig `include`) so its vitest
+// import is never pulled into `spacetime publish`; root vitest still runs it via
+// the **/__tests__/** glob.
+import { isLeavingPlayField } from '../src/playField';
+
+// A card "leaves the play field" only when it moves from an on-field zone
+// (territory, land-of-bondage, battle) to an OFF-field zone (deck, hand,
+// discard, reserve, banish, soul-deck, land-of-redemption). Relocations that
+// keep the card in play — most importantly the battle-zone round trip — are
+// NOT leaving play. This predicate gates clearing the lasting `isMeek`
+// characteristic in leavePlayFieldOverrides.
+describe('isLeavingPlayField', () => {
+  it('does not count the battle round trip as leaving play (the meek bug)', () => {
+    // Entering battle from territory, and returning battle -> territory, keep
+    // the card on the field, so a meek hero must stay meek across both.
+    expect(isLeavingPlayField('territory', 'battle')).toBe(false);
+    expect(isLeavingPlayField('battle', 'territory')).toBe(false);
+  });
+
+  it('does not count moves between any two on-field zones as leaving play', () => {
+    expect(isLeavingPlayField('territory', 'land-of-bondage')).toBe(false);
+    expect(isLeavingPlayField('land-of-bondage', 'battle')).toBe(false);
+    expect(isLeavingPlayField('battle', 'land-of-bondage')).toBe(false);
+  });
+
+  it('counts a move to an off-field zone as leaving play', () => {
+    for (const to of ['deck', 'hand', 'discard', 'reserve', 'banish', 'soul-deck', 'land-of-redemption']) {
+      expect(isLeavingPlayField('territory', to)).toBe(true);
+      expect(isLeavingPlayField('battle', to)).toBe(true);
+      expect(isLeavingPlayField('land-of-bondage', to)).toBe(true);
+    }
+  });
+
+  it('is false when the card starts off-field, regardless of destination', () => {
+    expect(isLeavingPlayField('deck', 'territory')).toBe(false);
+    expect(isLeavingPlayField('hand', 'battle')).toBe(false);
+    expect(isLeavingPlayField('discard', 'discard')).toBe(false);
+  });
+
+  it('is false for a no-op move within the same on-field zone', () => {
+    expect(isLeavingPlayField('territory', 'territory')).toBe(false);
+    expect(isLeavingPlayField('battle', 'battle')).toBe(false);
+  });
+});

--- a/spacetimedb/src/index.ts
+++ b/spacetimedb/src/index.ts
@@ -4,6 +4,7 @@ import { DisconnectTimeout, setDisconnectTimeoutReducer, ChooseFirstTimeout, set
 import { t, SenderError } from 'spacetimedb/server';
 import { ScheduleAt, Timestamp } from 'spacetimedb';
 import { makeSeed, seededShuffle, seededDiceRoll, xorshift64, generateGameCode } from './utils';
+import { isLeavingPlayField } from './playField';
 import {
   getAbilitiesForCard,
   getEffectiveAbilities,
@@ -262,7 +263,14 @@ function leavePlayFieldOverrides(card: any, fromZone: string, toZone: string): {
   return {
     notes: leaving ? '' : card.notes,
     outlineColor: leaving ? '' : card.outlineColor,
-    isMeek: leaving ? false : card.isMeek,
+    // isMeek is a lasting hero characteristic (the card's meek-side stats), not
+    // battle-scoped state: a meek hero must stay meek across on-field
+    // relocations — above all the battle round trip (territory -> battle ->
+    // territory). Unlike notes/outline it clears only when the card genuinely
+    // leaves the play field (an off-field destination), so gate it on
+    // isLeavingPlayField rather than `leaving` (which fires on any move off an
+    // on-field zone, including battle <-> territory).
+    isMeek: isLeavingPlayField(fromZone, toZone) ? false : card.isMeek,
     imitatingName: wasImitating ? '' : card.imitatingName,
     cardImgFile: canonicalImg,
     ...battleClears,

--- a/spacetimedb/src/playField.ts
+++ b/spacetimedb/src/playField.ts
@@ -1,0 +1,20 @@
+// Pure play-field zone helpers. No SpacetimeDB runtime imports so this can be
+// unit tested in isolation (see __tests__/playField.test.ts) and shared by the
+// reducer write paths in index.ts.
+
+// The three zones where a card is "in play" on the field. Everything else
+// (deck, hand, discard, reserve, banish, soul-deck, land-of-redemption) is
+// off-field — the card has left play.
+export const ON_FIELD_ZONES = ['territory', 'land-of-bondage', 'battle'] as const;
+
+export function isOnFieldZone(zone: string): boolean {
+  return (ON_FIELD_ZONES as readonly string[]).includes(zone);
+}
+
+// True only when a card moves from an on-field zone to an off-field zone, i.e.
+// it genuinely leaves the play field. Relocations between on-field zones — most
+// importantly the battle-zone round trip (territory -> battle -> territory) —
+// are NOT leaving play, so lasting in-play characteristics must survive them.
+export function isLeavingPlayField(fromZone: string, toZone: string): boolean {
+  return isOnFieldZone(fromZone) && !isOnFieldZone(toZone);
+}


### PR DESCRIPTION
## Problem
`isMeek` is a lasting hero characteristic (renders the card on its meek side), but `leavePlayFieldOverrides` cleared it on **any** move off an on-field zone — its `leaving` flag only checked the origin zone. So a meek hero lost meek both **entering** the battle band (territory→battle) and **returning** from it (battle→territory).

Reported: a meek character removed from the battle zone converts back to not-meek (and the same on drag-in).

## Fix
Gate `isMeek` clearing on a new pure `isLeavingPlayField(from, to)` predicate (origin on-field **and** destination off-field). Meek now survives every on-field relocation (territory ↔ battle ↔ land-of-bondage) and clears only on a genuine exit (discard, deck, hand, reserve, banish, soul-deck, land-of-redemption). `notes`/`outline`/`imitate` keep their existing `leaving` behavior.

Both battle-entry paths (`enter_battle`→`writeBattleEntryMove` and `move_card` `toZone==='battle'`) and the battle-return path route through the fixed function; all 23 call sites reviewed.

## Tests
New `spacetimedb/__tests__/playField.test.ts` (5 cases) pins the invariant, incl. `isLeavingPlayField('territory','battle') === false` and `('battle','territory') === false`. Full suite green.

## Deploy
Module already republished to **dev** and **prod** (`redemption-multiplayer`) — pure reducer logic, empty migration plan, no `--clear`, no binding change (frontend unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)