### PR TITLE
feat(decklist): add "If Fires" (non-whiff EV) to AoD count card

### DIFF
--- a/app/decklist/card-search/components/AodCountCard.tsx
+++ b/app/decklist/card-search/components/AodCountCard.tsx
@@ -20,10 +20,12 @@ const DECKLIST_TYPE: Record<AodCountCardProps["deckType"], string> = {
 };
 
 const AOD_TOOLTIP =
-  "Top-9 draw stats over a 10,000-iteration Monte Carlo, given a Daniel reference " +
-  "in the top 3. Non-Soul: avg Daniel cards in the top 9 excluding Lost Souls. " +
-  "Soul: the same average counting Daniel Lost Souls too. Whiff: % of draws with " +
-  "no Daniel in the top 3.";
+  "Top-9 draw stats from a 10,000-iteration Monte Carlo. " +
+  "Non-Soul is the true expected value: average non-Soul Daniel cards in your top 9 " +
+  "across every draw, counting whiffs as 0. If Fires is that same average over only " +
+  "the draws that don't whiff — the expected haul when the Ancient of Days actually " +
+  "goes off — so it is always ≥ Non-Soul. Soul is Non-Soul plus Daniel Lost Souls. " +
+  "Whiff is the % of draws with no Daniel reference in the top 3, where the chain never fires.";
 
 // One labeled figure within the revealed breakdown row.
 function Stat({ label, value }: { label: string; value: string }) {
@@ -124,6 +126,12 @@ export default function AodCountCard({ deck, deckType }: AodCountCardProps) {
   // Revealed result — mirrors the alignment cells' label + big-number layout.
   if (status === "done") {
     const tooFewCards = mainDeckCount < 9;
+    // EV of the Non-Soul count given the chain fires — whiff draws removed from
+    // the denominator, so it's the expected haul when it actually goes off.
+    // Derived from the returned figures (unconditional / P(fires)); always
+    // >= the unconditional Non-Soul number.
+    const nonWhiffFraction = 1 - whiff / 100;
+    const ifFires = nonWhiffFraction > 0 ? nonSoul / nonWhiffFraction : 0;
     return (
       <button
         type="button"
@@ -138,8 +146,9 @@ export default function AodCountCard({ deck, deckType }: AodCountCardProps) {
             &#9432;
           </span>
         </div>
-        <div className="grid grid-cols-3 gap-1.5">
+        <div className="grid grid-cols-2 gap-1.5">
           <Stat label="Non-Soul" value={nonSoul.toFixed(2)} />
+          <Stat label="If Fires" value={ifFires.toFixed(2)} />
           <Stat label="Soul" value={soul.toFixed(2)} />
           <Stat label="Whiff" value={`${whiff.toFixed(1)}%`} />
         </div>


### PR DESCRIPTION
Adds a fourth figure to the AoD count card: **If Fires** — the expected non-Soul haul on the draws where the Ancient of Days actually goes off (i.e. the count conditioned on *not* whiffing).

### Why
The existing **Non-Soul** figure is the true expected value: it averages non-Soul Daniel references over *every* top-9 draw, counting whiff draws as `0`. That is the correct long-run EV of the card, but it is always lower than what you experience on the draws that fire — which is the number some players want to build around. Now both are shown, so nobody has to argue about which one the count "should" be.

### What
- New **If Fires** figure = `Non-Soul / P(fires)` = `nonSoul / (1 - whiff/100)`, derived client-side from the values the `/v1/aod-count` endpoint already returns. No API change, no new Monte Carlo.
- Card figures relaid out **2×2** (`Non-Soul / If Fires` over `Soul / Whiff`) so each number has more room than the old 3-across row — and the true-EV vs. conditional-EV pair sits together on the top row.
- Tooltip expanded to spell out the distinction: Non-Soul = true EV (whiffs as 0); If Fires = EV given it does not whiff (always ≥ Non-Soul).

Guarded against divide-by-zero when whiff% = 100 (no Daniel references), where it shows `0.00`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)