### PR TITLE
feat(decklist): show AoD count on the public deck view page

### DIFF
--- a/app/decklist/[deckId]/client.tsx
+++ b/app/decklist/[deckId]/client.tsx
@@ -21,6 +21,7 @@ import CollectionCheckModal from "../card-search/components/CollectionCheckModal
 import { aggregateOwnedByName } from "../card-search/utils/collectionCheck";
 import GeneratePDFModal from "../card-search/components/GeneratePDFModal";
 import GenerateDeckImageModal from "../card-search/components/GenerateDeckImageModal";
+import AodCountCard from "../card-search/components/AodCountCard";
 import { Deck as DeckType } from "../card-search/types/deck";
 import { generateDeckText } from "../card-search/utils/deckImportExport";
 import { compareCardsDefault, compareTypeGroups, type SortableCard } from "@/lib/cards/defaultSort";
@@ -1276,6 +1277,10 @@ export default function PublicDeckClient({ deck, isOwner, isLoggedIn }: Props) {
                     );
                   });
                 })()}
+                <AodCountCard
+                  deck={deckForModal}
+                  deckType={formatDeckType(deck.format) as "T1" | "T2" | "Paragon"}
+                />
               </div>
             </div>
 


### PR DESCRIPTION
Adds the AoD count card to the **community / public deck view** page (`/decklist/[deckId]`), filling the empty cell in the Alignment Breakdown grid — the same tap-to-reveal card that already lives in the deck builder.

### What
- Drops the existing `AodCountCard` into the view page's alignment grid (bottom-right cell, next to Good/Evil/Neutral).
- Reuses `deckForModal` — the `Deck` object already assembled for the PDF/image exports — and `formatDeckType(deck.format)` for the deck type. Same `Deck` type the card already consumes.
- **No new API call or data plumbing.** It hits the same `/v1/aod-count` endpoint on tap, exactly like the builder.

### Result
Browsing a shared deck now shows the four figures (Non-Soul / If Fires / Soul / Whiff) with the same tooltip disclaimer, not just when editing your own deck.

Follows #202 (which added the "If Fires" figure to that shared card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)