### PR TITLE
fix(battle): forge cards register stats + brigades in the battle zone

### DIFF
--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -83,7 +83,7 @@ import { LostSoulDealLayer, type SoulDeal } from '@/app/shared/components/LostSo
 import { computeDealFlight } from '@/app/shared/utils/lostSoulDeal';
 import { useCardEnterPlayPrompt } from '@/app/shared/hooks/useCardEnterPlayPrompt';
 import { cardInstanceToGameCard } from '../utils/cardAdapter';
-import { resolveCardImageUrl, type ForgeResolverMap } from '../utils/forgeResolver';
+import { resolveCardImageUrl, resolveBattleRowFields, type ForgeResolverMap } from '../utils/forgeResolver';
 import type { UndoStack, Captured } from '../hooks/useUndoStack';
 import { makeReverseAction, makeBatchReverseAction, reverseIsSafe } from '../hooks/useUndoStack';
 import {
@@ -5144,13 +5144,20 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
     const pushRows = (rows: CardInstance[] | undefined, owner: 'my' | 'opponent', seat: BattleSeat | null) => {
       if (!seat || !rows) return;
       for (const row of rows) {
+        // Forge rows carry blanked name/brigade/stats (leak spine) — the
+        // viewer's granted resolver re-hydrates them here or forge cards
+        // read as unknown stats and false brigade mismatches in the band.
+        // specialAbility stays the raw row value on purpose: the auto-return
+        // summary must predict the server, which only sees the blanked row
+        // (see resolveBattleRowFields).
+        const resolved = resolveBattleRowFields(row, forgeResolver);
         // Meek hero/character in battle must count its meek-side power/
         // toughness, not its normal-side stats (spec: Matthias converted to
         // meek is 7/7). The meek value lives in the row's own strength/
         // toughness string ("<normal>(<meek>)") — see parseMeekStats. Falls
         // through to the normal-side string unchanged when unresolvable
         // (non-meek card, blanked Forge field), matching existing ? handling.
-        const meekStats = row.isMeek ? parseMeekStats(row.strength, row.toughness) : null;
+        const meekStats = row.isMeek ? parseMeekStats(resolved.strength, resolved.toughness) : null;
         entries.push({
           row,
           owner,
@@ -5158,13 +5165,13 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
             ownerSeat: seat,
             dbX: parseFloat(row.posX || '0'),
             cardRelW,
-            strength: meekStats ? String(meekStats.strength) : row.strength,
-            toughness: meekStats ? String(meekStats.toughness) : row.toughness,
-            brigade: row.brigade,
+            strength: meekStats ? String(meekStats.strength) : resolved.strength,
+            toughness: meekStats ? String(meekStats.toughness) : resolved.toughness,
+            brigade: resolved.brigade,
             cardType: row.cardType,
             specialAbility: row.specialAbility,
             isFlipped: row.isFlipped,
-            cardName: row.cardName,
+            cardName: resolved.cardName,
             equippedToInstanceId: row.equippedToInstanceId,
             originZone: row.originZone,
           },
@@ -5174,7 +5181,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
     pushRows(myCards['battle'], 'my', mySeat);
     pushRows(opponentCards['battle'], 'opponent', oppSeat);
     return entries;
-  }, [battleActive, mpLayout, rawMain.cardWidth, gameState.myPlayer, gameState.opponentPlayer, myCards, opponentCards]);
+  }, [battleActive, mpLayout, rawMain.cardWidth, gameState.myPlayer, gameState.opponentPlayer, myCards, opponentCards, forgeResolver]);
 
   // Brigade soft-check (spec §6): every GE/EE-segment enhancement in the band
   // whose brigade has no match among same-side characters. Order follows

--- a/app/play/lib/__tests__/battleMath.test.ts
+++ b/app/play/lib/__tests__/battleMath.test.ts
@@ -303,6 +303,21 @@ describe('brigadeMismatch', () => {
     const enh = mkCard({ brigade: '' });
     expect(brigadeMismatch(enh, [])).toBe(false);
   });
+
+  it('forge "Good Gold" enhancement matches an official plain "Gold" character', () => {
+    // Official card data writes plain "Gold" for both good and evil gold;
+    // forge brigades keep them distinct ("Good Gold"/"Evil Gold"). The
+    // soft-check must not flag a forge/official pair over that naming gap.
+    const enh = mkCard({ brigade: 'Good Gold' });
+    const chars = [mkCard({ brigade: 'Gold' })];
+    expect(brigadeMismatch(enh, chars)).toBe(false);
+  });
+
+  it('official plain "Gold" enhancement matches a forge "Evil Gold" character', () => {
+    const enh = mkCard({ brigade: 'Gold' });
+    const chars = [mkCard({ brigade: 'Evil Gold' })];
+    expect(brigadeMismatch(enh, chars)).toBe(false);
+  });
 });
 
 describe('summarizeAutoReturn', () => {

--- a/app/play/lib/battleMath.ts
+++ b/app/play/lib/battleMath.ts
@@ -198,6 +198,10 @@ function brigadeTokens(brigade: string): string[] {
   return brigade
     .split('/')
     .map((s) => s.trim())
+    // Forge brigades keep good/evil gold distinct ("Good Gold"/"Evil Gold");
+    // official card data writes plain "Gold" for both. Fold them together so
+    // a forge/official pair isn't flagged over the naming gap.
+    .map((s) => (s === 'Good Gold' || s === 'Evil Gold' ? 'Gold' : s))
     .filter((s) => s.length > 0);
 }
 

--- a/app/play/utils/__tests__/forgeResolver.test.ts
+++ b/app/play/utils/__tests__/forgeResolver.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { forgeCardIdFromImgFile, forgeProxyUrl, resolveCardImageUrl, mergeForgeDeckData } from "../forgeResolver";
+import { forgeCardIdFromImgFile, forgeProxyUrl, resolveCardImageUrl, mergeForgeDeckData, resolveBattleRowFields } from "../forgeResolver";
 import { getCardImageUrl, getCardImageUrlOrNull } from "@/app/shared/utils/cardImageUrl";
 
 const ID = "11111111-2222-3333-4444-555555555555";
@@ -63,5 +63,35 @@ describe("forge image seams", () => {
     expect(merged[0].toughness).toBe("6");
     expect(merged[0].identifier).toBe("Demon");
     expect(merged[0].reference).toBe("Revelation 8:11");
+  });
+});
+
+describe("resolveBattleRowFields", () => {
+  // Battle-zone math (totals/initiative/brigade soft-check) reads CardInstance
+  // rows whose text fields the leak spine blanked for forge cards. The viewer's
+  // granted resolver must re-hydrate name/brigade/stats or forge cards read as
+  // unknown stats and false brigade mismatches.
+  const blankRow = { cardImgFile: `forge:${ID}`, cardName: "", brigade: "", strength: "", toughness: "" };
+
+  it("re-hydrates a granted forge row's name/brigade/stats", () => {
+    expect(resolveBattleRowFields(blankRow, resolver)).toEqual({
+      cardName: "Test Hero", brigade: "Blue", strength: "5", toughness: "4",
+    });
+  });
+
+  it("leaves an ungranted forge row blank (fail-closed)", () => {
+    expect(resolveBattleRowFields(blankRow, new Map())).toEqual({
+      cardName: "", brigade: "", strength: "", toughness: "",
+    });
+    expect(resolveBattleRowFields(blankRow, null)).toEqual({
+      cardName: "", brigade: "", strength: "", toughness: "",
+    });
+  });
+
+  it("passes public rows through untouched", () => {
+    const pub = { cardImgFile: "Moses.jpg", cardName: "Moses", brigade: "Blue", strength: "10", toughness: "10" };
+    expect(resolveBattleRowFields(pub, resolver)).toEqual({
+      cardName: "Moses", brigade: "Blue", strength: "10", toughness: "10",
+    });
   });
 });

--- a/app/play/utils/forgeResolver.ts
+++ b/app/play/utils/forgeResolver.ts
@@ -27,6 +27,25 @@ export function resolveCardImageUrl(imgFile: string, resolver?: ForgeResolverMap
   return getCardImageUrl(imgFile);
 }
 
+// Re-hydrate the battle-math fields the leak spine blanked on a forge
+// CardInstance row (name/brigade/strength/toughness), from the viewer's
+// granted resolver. Deliberately NOT specialAbility: the auto-return summary
+// must predict the server's routing, and the server only ever sees the
+// blanked row (a forge "place" enhancement goes to discard server-side, so
+// the client summary has to say the same). Ungranted forge rows come back
+// unchanged — blank stats read as "unknown" in the band, fail-closed.
+export function resolveBattleRowFields(
+  row: { cardImgFile: string; cardName: string; brigade: string; strength: string; toughness: string },
+  resolver?: ForgeResolverMap | null,
+): { cardName: string; brigade: string; strength: string; toughness: string } {
+  const forgeId = forgeCardIdFromImgFile(row.cardImgFile);
+  const e = forgeId ? resolver?.get(forgeId) : undefined;
+  if (!e) {
+    return { cardName: row.cardName, brigade: row.brigade, strength: row.strength, toughness: row.toughness };
+  }
+  return { cardName: e.name, brigade: e.brigade, strength: e.strength, toughness: e.toughness };
+}
+
 export function mergeForgeDeckData(cards: GameCardData[], resolver?: ForgeResolverMap | null): GameCardData[] {
   if (!resolver || resolver.size === 0) return cards;
   return cards.map((c) => {


### PR DESCRIPTION
## Problem

Playtester report (Kurt, via Discord): in playtest games, forge cards in the new battle zone "don't register their stats, and sometimes enhancements don't register as matching their brigades."

## Root causes

**1. Battle math read the blanked STDB rows.** The leak spine (`playSerialize.ts`) deliberately blanks `cardName`/`brigade`/`strength`/`toughness` on world-readable forge CardInstance rows. Everywhere else in the client (`cardAdapter`, `mergeForgeDeckData`) the viewer's RLS-granted forge resolver re-hydrates those fields — but `battleCardEntries` in `MultiplayerCanvas` built its `BattleCardLike` inputs straight from the raw rows. Result: forge stats parse as NaN (totals show unknown, initiative reads "unknown"), and a forge character's blank brigade can never match an official enhancement's brigade, so the red mismatch glow fires falsely.

**2. Gold brigade naming divergence.** Forge brigades keep good/evil gold distinct (`"Good Gold"` / `"Evil Gold"`); official card data writes plain `"Gold"` for both (581 cards). Even with resolved fields, a forge gold card could never brigade-match an official gold card.

## Fix

- New pure helper `resolveBattleRowFields` in `forgeResolver.ts` re-hydrates name/brigade/stats from the viewer's granted resolver; `battleCardEntries` now feeds battle math through it. Ungranted forge rows stay blank — fail-closed, same "unknown" rendering as today.
- `brigadeTokens` in `battleMath.ts` folds `Good Gold`/`Evil Gold`/`Gold` to one token for the soft-check (matches official data's inability to distinguish them).
- `specialAbility` intentionally stays the raw row value: the pre-resolve auto-return summary must predict the **server's** routing, and the server only ever sees the blanked row (a forge "place" enhancement goes to discard server-side).

Client-only change — no STDB module or schema touch, no new data exposed (the resolver already ships these fields to granted viewers for deck search).

## Tests

- `brigadeMismatch`: forge `Good Gold` enhancement ↔ official `Gold` character (both directions) no longer flags.
- `resolveBattleRowFields`: granted row re-hydrates; ungranted row stays blank; public rows pass through untouched.
- All 172 existing `app/play` tests pass; `tsc --noEmit` clean for touched files (7 pre-existing errors in unrelated test files).

Manual check for reviewers: playtest game with forge decks → battle phase → totals chips show real numbers and a matching-brigade enhancement gets no red glow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)