### PR TITLE
fix(battle): stat-less cards count as 0/0 instead of poisoning totals

### DIFF
--- a/app/play/lib/__tests__/battleMath.test.ts
+++ b/app/play/lib/__tests__/battleMath.test.ts
@@ -118,6 +118,48 @@ describe('sideTotals', () => {
     const cards = [mkCard({ ownerSeat: '1' })];
     expect(sideTotals(cards, '0')).toEqual({ str: 0, tgh: 0, hasUnknown: false });
   });
+
+  it('a stat-less enhancement (blank strength/toughness) counts as 0/0 without setting hasUnknown', () => {
+    // Death of Unrighteous (Pat/FoM) prints no numbers — its Roots reprint
+    // prints the same card as 0/0. 524 official enhancements are stat-less;
+    // they must not poison the band totals with "?".
+    const cards = [
+      mkCard({ ownerSeat: '0', cardType: 'Evil Character', strength: '2', toughness: '1' }),
+      mkCard({ ownerSeat: '0', cardType: 'EE', strength: '', toughness: '' }),
+    ];
+    expect(sideTotals(cards, '0')).toEqual({ str: 2, tgh: 1, hasUnknown: false });
+  });
+
+  it('stat-less non-characters generally (Dominant/Artifact in the band) count as 0/0, no unknown', () => {
+    const cards = [
+      mkCard({ ownerSeat: '0', cardType: 'Hero', strength: '5', toughness: '5' }),
+      mkCard({ ownerSeat: '0', cardType: 'Dominant', strength: '', toughness: '' }),
+      mkCard({ ownerSeat: '0', cardType: 'Artifact', strength: '', toughness: '' }),
+    ];
+    expect(sideTotals(cards, '0')).toEqual({ str: 5, tgh: 5, hasUnknown: false });
+  });
+
+  it('a variable-stat enhancement ("X"/"*") still sets hasUnknown', () => {
+    const cards = [mkCard({ ownerSeat: '0', cardType: 'GE', strength: 'X', toughness: '*' })];
+    expect(sideTotals(cards, '0').hasUnknown).toBe(true);
+  });
+
+  it('a blank-stat CHARACTER still sets hasUnknown (hidden/ungranted forge row)', () => {
+    const cards = [mkCard({ ownerSeat: '0', cardType: 'Hero', strength: '', toughness: '' })];
+    expect(sideTotals(cards, '0').hasUnknown).toBe(true);
+  });
+
+  it('initiative resolves (not "unknown") with a stat-less enhancement in the band', () => {
+    // Screenshot repro: EC 2/1 + stat-less EE vs Heroes 17/9 — the blank EE
+    // must not force the "Initiative unknown" banner.
+    const cards = [
+      mkCard({ ownerSeat: '0', cardType: 'Evil Character', strength: '2', toughness: '1' }),
+      mkCard({ ownerSeat: '0', cardType: 'EE', strength: '', toughness: '' }),
+      mkCard({ ownerSeat: '1', cardType: 'Hero', strength: '17', toughness: '9' }),
+    ];
+    const result = computeInitiative(cards, '1', '');
+    expect(result).toEqual({ kind: 'initiative', seat: '0', reason: 'losing' });
+  });
 });
 
 describe('parseMeekStats', () => {

--- a/app/play/lib/battleMath.ts
+++ b/app/play/lib/battleMath.ts
@@ -54,11 +54,31 @@ export interface SideTotals {
 }
 
 /**
- * Sums strength/toughness for every card on `side`. Unparseable stat strings
- * ('', '*', 'X', ...) contribute 0 and set hasUnknown. Face-down cards are
- * excluded from the sum entirely (their stats are hidden information) and
- * also set hasUnknown, so the caller never asserts a rules conclusion from a
- * band with hidden cards in it.
+ * Parses one stat string for the band totals. A BLANK stat on a
+ * non-character means the card simply has no printed numbers — 524 official
+ * enhancements ship that way (Death of Unrighteous's Roots reprint prints
+ * the very same card as 0/0), and Dominants/Artifacts never have stats — so
+ * it counts as 0. A blank stat on a CHARACTER is hidden information (an
+ * ungranted forge row; official characters always print numbers) and a
+ * non-blank unparseable stat ('*', 'X') is genuinely variable — both return
+ * null so the caller sets hasUnknown.
+ */
+function parseBattleStat(raw: string, cardType: string): number | null {
+  const trimmed = raw.trim();
+  if (trimmed === '') {
+    return isCharacterType(cardType) ? null : 0;
+  }
+  const n = parseInt(trimmed, 10);
+  return Number.isNaN(n) ? null : n;
+}
+
+/**
+ * Sums strength/toughness for every card on `side`. Variable stat strings
+ * ('*', 'X', ...) contribute 0 and set hasUnknown; blank stats only do so on
+ * characters (see parseBattleStat). Face-down cards are excluded from the
+ * sum entirely (their stats are hidden information) and also set hasUnknown,
+ * so the caller never asserts a rules conclusion from a band with hidden
+ * cards in it.
  */
 export function sideTotals(cards: BattleCardLike[], side: BattleSeat): SideTotals {
   let str = 0;
@@ -71,14 +91,14 @@ export function sideTotals(cards: BattleCardLike[], side: BattleSeat): SideTotal
       hasUnknown = true;
       continue;
     }
-    const s = parseInt(c.strength, 10);
-    const t = parseInt(c.toughness, 10);
-    if (Number.isNaN(s)) {
+    const s = parseBattleStat(c.strength, c.cardType);
+    const t = parseBattleStat(c.toughness, c.cardType);
+    if (s === null) {
       hasUnknown = true;
     } else {
       str += s;
     }
-    if (Number.isNaN(t)) {
+    if (t === null) {
       hasUnknown = true;
     } else {
       tgh += t;


### PR DESCRIPTION
## Problem

Playing a stat-less enhancement (e.g. **Death of Unrighteous** — no printed numbers) into the battle band flips the side totals to `2/1?` and forces the **"Initiative unknown (face-down/variable stats)"** banner, even though every card's stats are perfectly known.

`sideTotals` treated any unparseable stat string as unknown — but a *blank* stat isn't variable, it just means the card has no numbers. 524 official enhancements ship with blank stats, and the Roots reprint of Death of Unrighteous prints the identical card as `0/0`.

## Fix

New `parseBattleStat` in `battleMath.ts`:

- **Blank stat on a non-character** (enhancements, Dominants, Artifacts, etc.) → counts as **0**, no unknown flag.
- **Blank stat on a character** → still unknown (only one official character is stat-less; blank there means a hidden/ungranted forge row, and the "?" cue must survive).
- **Non-blank variable stats** (`X`, `*`) and **face-down cards** → still unknown, unchanged.

`computeInitiative` consumes `sideTotals`, so the banner now resolves to a real initiative call in the screenshot scenario.

## Tests

5 new unit tests (failing-first): stat-less EE → 0/0 no flag; stat-less Dominant/Artifact → same; `X`/`*` still unknown; blank-stat character still unknown; screenshot repro resolves initiative. All 177 `app/play` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)