### PR TITLE
fix(decks): restore classic by-type sort for deck views

### DIFF
--- a/app/decklist/[deckId]/client.tsx
+++ b/app/decklist/[deckId]/client.tsx
@@ -24,7 +24,7 @@ import GenerateDeckImageModal from "../card-search/components/GenerateDeckImageM
 import AodCountCard from "../card-search/components/AodCountCard";
 import { Deck as DeckType } from "../card-search/types/deck";
 import { generateDeckText } from "../card-search/utils/deckImportExport";
-import { compareCardsDefault, compareTypeGroups, type SortableCard } from "@/lib/cards/defaultSort";
+import { compareCardsByType, compareCardsDefault, compareTypeGroups, type SortableCard } from "@/lib/cards/defaultSort";
 
 interface PublicDeckData {
   id: string;
@@ -419,11 +419,11 @@ export default function PublicDeckClient({ deck, isOwner, isLoggedIn }: Props) {
   }, [mainCards, groupBy]);
 
   const sortedReserveCards = useMemo(() => {
-    return [...reserveCards].sort((a, b) => compareCardsDefault(toSortable(a), toSortable(b)));
+    return [...reserveCards].sort((a, b) => compareCardsByType(toSortable(a), toSortable(b)));
   }, [reserveCards]);
 
   const sortedMaybeboardCards = useMemo(() => {
-    return [...maybeboardCards].sort((a, b) => compareCardsDefault(toSortable(a), toSortable(b)));
+    return [...maybeboardCards].sort((a, b) => compareCardsByType(toSortable(a), toSortable(b)));
   }, [maybeboardCards]);
 
   // Build flat list of Card objects for modal navigation (main + reserve + maybeboard)
@@ -1819,9 +1819,9 @@ function groupAndSortCards(
     grouped[key].push(card);
   }
 
-  // Sort within each group with the canonical default order
+  // Sort within each group by type, alignment, brigade, then name
   for (const key of Object.keys(grouped)) {
-    grouped[key].sort((a, b) => compareCardsDefault(toSortable(a), toSortable(b)));
+    grouped[key].sort((a, b) => compareCardsByType(toSortable(a), toSortable(b)));
   }
 
   // Order the groups

--- a/app/decklist/card-search/components/DeckBuilderPanel.tsx
+++ b/app/decklist/card-search/components/DeckBuilderPanel.tsx
@@ -25,7 +25,7 @@ import FullDeckView from "./FullDeckView";
 import DragGhost from "./DragGhost";
 import { Switch } from "@headlessui/react";
 import { Card, normalizeBrigadeField } from "../utils";
-import { compareCardsDefault, compareTypeGroups } from "@/lib/cards/defaultSort";
+import { compareCardsByType, compareCardsDefault, compareTypeGroups } from "@/lib/cards/defaultSort";
 import { validateDeck } from "../utils/deckValidation";
 import GeneratePDFModal from "./GeneratePDFModal";
 import AodCountCard from "./AodCountCard";
@@ -793,8 +793,8 @@ export default function DeckBuilderPanel({
       .sort(compareTypeGroups)
       .map((type) => ({
         type,
-        // Sort cards within each type with the canonical default order
-        cards: grouped[type].sort((a, b) => compareCardsDefault(a.card, b.card)),
+        // Sort cards within each type by alignment, brigade, then name
+        cards: grouped[type].sort((a, b) => compareCardsByType(a.card, b.card)),
         count: grouped[type].reduce((sum, dc) => sum + dc.quantity, 0),
       }));
   };
@@ -822,8 +822,8 @@ export default function DeckBuilderPanel({
       })
       .map((alignment) => ({
         type: alignment,
-        // Sort cards within each alignment with the canonical default order
-        cards: grouped[alignment].sort((a, b) => compareCardsDefault(a.card, b.card)),
+        // Sort cards within each alignment by type, brigade, then name
+        cards: grouped[alignment].sort((a, b) => compareCardsByType(a.card, b.card)),
         count: grouped[alignment].reduce((sum, dc) => sum + dc.quantity, 0),
       }));
   };

--- a/app/decklist/card-search/components/FullDeckView.tsx
+++ b/app/decklist/card-search/components/FullDeckView.tsx
@@ -10,7 +10,7 @@ import { createGlobalTagAction } from "../../../admin/tags/actions";
 import { HexColorPicker } from "react-colorful";
 import { useIsAdmin } from "../../../../hooks/useIsAdmin";
 import { useCardPrices } from "../hooks/useCardPrices";
-import { compareCardsDefault, compareTypeGroups } from "@/lib/cards/defaultSort";
+import { compareCardsByType, compareTypeGroups } from "@/lib/cards/defaultSort";
 
 function getTagContrastColor(hex: string): string {
   const r = parseInt(hex.slice(1, 3), 16);
@@ -151,9 +151,9 @@ export default function FullDeckView({ deck, onViewCard, isAuthenticated = false
   const reserveCards = deck.cards.filter((dc) => dc.zone === 'reserve');
   const maybeboardCards = deck.cards.filter((dc) => dc.zone === 'maybeboard');
 
-  // Canonical default sort (sections → brigades → strength → name)
+  // Classic deck order (type → alignment → brigade → name)
   const sortCards = (cards: typeof deck.cards) => {
-    return [...cards].sort((a, b) => compareCardsDefault(a.card, b.card));
+    return [...cards].sort((a, b) => compareCardsByType(a.card, b.card));
   };
 
   // Group cards by the selected grouping method

--- a/app/decklist/card-search/utils/deckImportExport.ts
+++ b/app/decklist/card-search/utils/deckImportExport.ts
@@ -1,6 +1,6 @@
 import { Card } from "../utils";
 import { Deck, DeckCard, DeckZone, ImportResult } from "../types/deck";
-import { compareCardsDefault } from "@/lib/cards/defaultSort";
+import { compareCardsByType } from "@/lib/cards/defaultSort";
 
 /**
  * Normalize card name for comparison by replacing various apostrophe types with standard apostrophe
@@ -253,9 +253,9 @@ export function generateDeckText(deck: Deck): string {
 
   const lines: string[] = [];
 
-  // Canonical default sort (sections → brigades → strength → name)
+  // Classic deck order (type → alignment → brigade → name)
   const sortCards = (a: DeckCard, b: DeckCard) =>
-    compareCardsDefault(a.card, b.card);
+    compareCardsByType(a.card, b.card);
 
   // Add main deck cards
   mainCards.sort(sortCards).forEach((dc) => {

--- a/app/decklist/my-decks/cardTypeSort.ts
+++ b/app/decklist/my-decks/cardTypeSort.ts
@@ -1,5 +1,5 @@
 import { DeckCardData } from "../actions";
-import { compareCardsDefault, type SortableCard } from "@/lib/cards/defaultSort";
+import { compareCardsByType, type SortableCard } from "@/lib/cards/defaultSort";
 
 export function cardKey(c: DeckCardData): string {
   return `${c.card_name}|${c.card_set ?? ""}|${c.card_img_file ?? ""}`;
@@ -26,7 +26,7 @@ export async function buildSortInfo(list: DeckCardData[]): Promise<Record<string
   return info;
 }
 
-// Canonical default order over deck rows, backed by a buildSortInfo map.
+// Classic by-type deck order over deck rows, backed by a buildSortInfo map.
 // Before the map loads (or on a lookup miss) cards degrade to name-only
 // sortables, which the comparator still orders alphabetically.
 export function compareDeckCards(
@@ -36,5 +36,5 @@ export function compareDeckCards(
 ): number {
   const sa = info[cardKey(a)] ?? { name: a.card_name, type: "" };
   const sb = info[cardKey(b)] ?? { name: b.card_name, type: "" };
-  return compareCardsDefault(sa, sb);
+  return compareCardsByType(sa, sb);
 }

--- a/app/forge/lib/__tests__/deckView.test.ts
+++ b/app/forge/lib/__tests__/deckView.test.ts
@@ -91,7 +91,7 @@ describe("grouping and sorting", () => {
     expect(getGroupDisplayName("Lost Soul")).toBe("Lost Souls");
   });
 
-  it("orders main-item groups canonically and known brigades before unknown within a group", () => {
+  it("orders main-item groups canonically and Good before Evil within a group", () => {
     const catalog = [
       publicCard("Zeal", "I", "GE", "Good", "Silver"),
       publicCard("Guard", "I", "Hero", "Good", "Silver"),
@@ -104,7 +104,7 @@ describe("grouping and sorting", () => {
     const groups = groupMainItems(resolveDeckEntries([], entries, catalog));
     expect(groups.map(([g]) => g)).toEqual(["Hero", "Good Enhancement", "Evil Character"]);
     const heroes = groups.find(([g]) => g === "Hero")![1];
-    // Silver is a known good brigade; Brown isn't, so it sorts after.
+    // Same type → Good alignment before Evil.
     expect(heroes.map((i) => i.name)).toEqual(["Guard", "Mixed"]);
   });
 
@@ -132,10 +132,10 @@ describe("grouping and sorting", () => {
     }));
     const groups = groupMainItems(resolveDeckEntries([], entries, catalog), "none");
     expect(groups.map(([g]) => g)).toEqual(["All Cards"]);
-    expect(groups[0][1].map((i) => i.name)).toEqual(["Guard", "Demon"]); // Good before Evil
+    expect(groups[0][1].map((i) => i.name)).toEqual(["Demon", "Guard"]); // "EC" before "Hero" by type
   });
 
-  it("sorts side items in the canonical default order and counts quantities", () => {
+  it("sorts side items in the classic deck order and counts quantities", () => {
     const catalog = [
       publicCard("Bravery", "I", "GE"),
       publicCard("Axe", "I", "EE"),
@@ -145,7 +145,7 @@ describe("grouping and sorting", () => {
       { source: "public", name: "Axe", set: "I", qty: 1, zone: "reserve" },
     ];
     const items = sortSideItems(resolveDeckEntries([], entries, catalog));
-    expect(items.map((i) => i.name)).toEqual(["Bravery", "Axe"]); // Good section before Evil
+    expect(items.map((i) => i.name)).toEqual(["Axe", "Bravery"]); // "EE" before "GE" by type
     expect(countItems(items)).toBe(3);
   });
 });

--- a/app/forge/lib/deckView.ts
+++ b/app/forge/lib/deckView.ts
@@ -13,7 +13,7 @@ import type { GrantedForgeCard } from "@/app/forge/lib/deckPool";
 import type { ForgeDeckEntry } from "@/app/forge/lib/deckTypes";
 import { designCardToCard } from "@/app/forge/lib/deckAdapter";
 import { ALL_CARDS } from "@/app/decklist/card-search/data/cardIndex";
-import { compareCardsDefault, compareTypeGroups } from "@/lib/cards/defaultSort";
+import { compareCardsByType, compareTypeGroups } from "@/lib/cards/defaultSort";
 
 export type ResolvedDeckItem = {
   key: string;
@@ -132,9 +132,9 @@ export function resolveDeckEntries(
 export type DeckGroupBy = "type" | "alignment" | "none";
 
 // Group main-deck items by display group, sorted within each group by the
-// canonical default card order. Type groups follow the canonical bucket order
-// (Dominants, Artifacts, Fortresses, …); alignment groups follow the
-// Good > Evil > Neutral order.
+// classic deck order (type → alignment → brigade → name). Type groups follow
+// the canonical bucket order (Dominants, Artifacts, Fortresses, …); alignment
+// groups follow the Good > Evil > Neutral order.
 export function groupMainItems(
   items: ResolvedDeckItem[],
   groupBy: DeckGroupBy = "type",
@@ -151,7 +151,7 @@ export function groupMainItems(
     else grouped.set(key, [item]);
   }
   for (const bucket of grouped.values()) {
-    bucket.sort(compareCardsDefault);
+    bucket.sort(compareCardsByType);
   }
   return [...grouped.entries()].sort(([a], [b]) => {
     if (groupBy === "alignment") {
@@ -198,9 +198,9 @@ export function splitStack(items: ResolvedDeckItem[], maxPerColumn = 17): Resolv
   return columns;
 }
 
-// Reserve/maybeboard: flat, in the canonical default order (public page semantics).
+// Reserve/maybeboard: flat, in the classic deck order (public page semantics).
 export function sortSideItems(items: ResolvedDeckItem[]): ResolvedDeckItem[] {
-  return [...items].sort(compareCardsDefault);
+  return [...items].sort(compareCardsByType);
 }
 
 export function countItems(items: ResolvedDeckItem[]): number {

--- a/lib/cards/__tests__/defaultSort.test.ts
+++ b/lib/cards/__tests__/defaultSort.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   compareCardsDefault,
+  compareCardsByType,
   compareTypeGroups,
   defaultTypeGroupRank,
   GOOD_BRIGADE_ORDER,
@@ -297,5 +298,50 @@ describe("grouped views — bucket ordering", () => {
     expect(defaultTypeGroupRank("Lost Soul Token")).toBe(9);
     expect(defaultTypeGroupRank("Hero Token")).toBe(9);
     expect(defaultTypeGroupRank("Lost Soul")).toBe(3);
+  });
+});
+
+describe("compareCardsByType", () => {
+  const sortByType = (cards: SortableCard[]): string[] =>
+    [...cards].sort(compareCardsByType).map((c) => c.name);
+
+  it("sorts by raw type alphabetically first", () => {
+    const cards = [
+      card({ name: "Soul", type: "Lost Soul" }),
+      card({ name: "HeroA", type: "Hero", brigade: "Blue", alignment: "Good" }),
+      card({ name: "EnhA", type: "GE", brigade: "Blue", alignment: "Good" }),
+      card({ name: "Dom", type: "Dominant", alignment: "Good" }),
+      card({ name: "Art", type: "Artifact" }),
+    ];
+    // Artifact < Dominant < GE < Hero < Lost Soul
+    expect(sortByType(cards)).toEqual(["Art", "Dom", "EnhA", "HeroA", "Soul"]);
+  });
+
+  it("breaks type ties by alignment Good > Evil > Neutral", () => {
+    const cards = [
+      card({ name: "Neutral", type: "Dominant", alignment: "Neutral" }),
+      card({ name: "Evil", type: "Dominant", alignment: "Evil" }),
+      card({ name: "Good", type: "Dominant", alignment: "Good" }),
+      card({ name: "Blank", type: "Dominant" }),
+    ];
+    // Missing alignment ranks with Neutral; "Blank" < "Neutral" by name
+    expect(sortByType(cards)).toEqual(["Good", "Evil", "Blank", "Neutral"]);
+  });
+
+  it("breaks alignment ties by brigade, then name case-insensitively", () => {
+    const cards = [
+      card({ name: "RedHero", type: "Hero", brigade: "Red", alignment: "Good" }),
+      card({ name: "blueB", type: "Hero", brigade: "Blue", alignment: "Good" }),
+      card({ name: "BlueA", type: "Hero", brigade: "Blue", alignment: "Good" }),
+    ];
+    expect(sortByType(cards)).toEqual(["BlueA", "blueB", "RedHero"]);
+  });
+
+  it("orders name-only sortables alphabetically within a type", () => {
+    const cards = [
+      card({ name: "Zeta", type: "" }),
+      card({ name: "Alpha", type: "" }),
+    ];
+    expect(sortByType(cards)).toEqual(["Alpha", "Zeta"]);
   });
 });

--- a/lib/cards/defaultSort.ts
+++ b/lib/cards/defaultSort.ts
@@ -325,3 +325,32 @@ export function compareTypeGroups(a: string, b: string): number {
   if (diff !== 0) return diff;
   return a.localeCompare(b);
 }
+
+// ---------------------------------------------------------------------------
+// "By type" deck-presentation order
+// ---------------------------------------------------------------------------
+
+function alignmentRank(alignment: string | undefined): number {
+  const a = alignment ?? "";
+  if (a === "Good") return 0;
+  if (a === "Evil") return 1;
+  if (a === "Neutral" || a === "") return 2;
+  return 3;
+}
+
+/**
+ * Classic decklist order for viewing whole decks: raw type alphabetically,
+ * then alignment (Good > Evil > Neutral), then brigade, then name. Mirrors
+ * the sister API's ["type", "alignment", "brigade", "name"] sort used for
+ * PDF/image output. Card-browsing surfaces (search results, collection,
+ * Forge set browser, play-area reserve browsing) use compareCardsDefault.
+ */
+export function compareCardsByType(a: SortableCard, b: SortableCard): number {
+  const typeDiff = (a.type ?? "").localeCompare(b.type ?? "");
+  if (typeDiff !== 0) return typeDiff;
+  const alignDiff = alignmentRank(a.alignment) - alignmentRank(b.alignment);
+  if (alignDiff !== 0) return alignDiff;
+  const brigadeDiff = (a.brigade ?? "").localeCompare(b.brigade ?? "");
+  if (brigadeDiff !== 0) return brigadeDiff;
+  return (a.name ?? "").toLowerCase().localeCompare((b.name ?? "").toLowerCase());
+}


### PR DESCRIPTION
## Why

PR #193 introduced the canonical default card sort and applied it everywhere. Player feedback: the new order (brigade-interleaved characters/enhancements) isn't optimal for viewing **entire decks** — it is nice for browsing card results. This PR splits the two categories.

## What

New `compareCardsByType` in `lib/cards/defaultSort.ts`: raw type alphabetical → alignment (Good > Evil > Neutral) → brigade → name. This mirrors the `["type", "alignment", "brigade", "name"]` sort the sister API used for deck PDFs/images before its own default-sort change.

**Swapped to by-type (deck presentations):**
- Deck builder type/alignment groups (`DeckBuilderPanel`)
- Full deck view (`FullDeckView`)
- Public deck page: groups, reserve, maybeboard (`[deckId]/client.tsx`)
- My-decks quick look + cover modal (`cardTypeSort.ts`)
- Forge deck view (`forge/lib/deckView.ts`)
- Text export (`generateDeckText`) — was alphabetical pre-#193; now by-type for consistency with deck views

**Kept on the canonical default order (card browsing):**
- Card search "Default" sort option
- Collection page
- Forge set browser
- Play-area reserve browsing (goldfish/multiplayer zone browse modals)
- Cover-picker "Default" dropdown option (pickers have their own sort selector that already includes a "type" choice)

Type-group **bucket** ordering (Dominants, Artifacts, Fortresses, …) is unchanged — only the card order within/across groups reverts.

## Companion PR

The API re-sorts decklist text server-side for PDF/WebP generation, so it needs the matching flip: timothestes/redemption-tournament-api#5.

## Verification

- `npm test`: 1437 passed; only pre-existing failures remain (forge-lackey brigade test + 2 env-dependent anon-leak suites, identical on main)
- 4 new unit tests for `compareCardsByType`
- 2 forge deckView test expectations updated to the restored classic order
- `tsc --noEmit`: same 7 pre-existing errors as main, none in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
