### PR TITLE
Battle-zone polish: counters/notes fixes + duplicate-card race + open/close + auto-return

### DIFF
--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -116,6 +116,13 @@ const AUTO_ARRANGE_ZONES = ['land-of-bondage'] as const;
  *  both; the tween must never read the Rect's live value as a target). */
 const BAND_BG_OPACITY = 0.75;
 
+/** Field-of-Battle open/close fade timings (ms). Open only fades the chrome IN
+ *  (the background is placed opaque from frame 0 — flash-safe); close fades the
+ *  whole band OUT. Close matches the 200ms card-reflow glide so nothing is out
+ *  of step; the open wash is a touch quicker. */
+const BAND_CHROME_FADE_MS = 160;
+const BAND_CLOSE_FADE_MS = 200;
+
 /** Drag-target guidance cue pulse — amplitude and one-leg duration. `yoyo`
  *  doubles the duration for a full up/down cycle (~1.6s here, within the
  *  1.5-2s "slow gentle pulse" range). */
@@ -649,34 +656,70 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
   const lastBandRectRef = useRef<ZoneRect | null>(null);
   if (mpLayout?.zones.battle) lastBandRectRef.current = mpLayout.zones.battle;
   const [bandBgVisible, setBandBgVisible] = useState(battleActive);
-  const bandBgRectRef = useRef<Konva.Rect | null>(null);
+  // Refs to the two band-presentation Groups: `bg` (background rect + dashed
+  // centerline, rendered below card art) and `chrome` (header + totals chips,
+  // rendered above card art). Their opacity is driven imperatively by the
+  // tweens below; each Group's JSX `opacity` prop is a CONSTANT React never
+  // re-applies (same discipline as the guidance-cue tween), so a re-render
+  // can't fight an in-flight fade.
+  const bandBgGroupRef = useRef<Konva.Group | null>(null);
+  const bandChromeRef = useRef<Konva.Group | null>(null);
   const bandBgTweenRef = useRef<Konva.Tween | null>(null);
+  const bandChromeTweenRef = useRef<Konva.Tween | null>(null);
 
+  // Whole-band open/close animation. OPEN washes the chrome IN over the
+  // instantly-placed background — the bg stays opaque from frame 0 so it can
+  // never expose raw board art (the flash the old grow-tween caused; see the
+  // BAND_BG_OPACITY note). CLOSE fades BOTH groups out together, so the dashed
+  // centerline no longer hangs at full strength while everything else
+  // dissolves. Every transition destroys the in-flight tweens FIRST so a rapid
+  // open⇄close can't leave a stale fade driving a group toward 0.
   useEffect(() => {
     bandBgTweenRef.current?.destroy();
     bandBgTweenRef.current = null;
+    bandChromeTweenRef.current?.destroy();
+    bandChromeTweenRef.current = null;
+    const bg = bandBgGroupRef.current;
+    const chrome = bandChromeRef.current;
     if (battleActive) {
       setBandBgVisible(true);
-      // Reopen while a close tween was mid-fade: restore the full layout
-      // values it had been dragging toward 0. On a fresh open this is a
-      // no-op — the Rect just mounted with these exact JSX attrs.
-      const rect = bandBgRectRef.current;
-      const band = lastBandRectRef.current;
-      if (rect && band) {
-        rect.height(band.height);
-        rect.opacity(BAND_BG_OPACITY);
+      // Background present at full opacity immediately (a reopen mid-close
+      // snaps it back from a fade the close tween had driven toward 0).
+      bg?.opacity(1);
+      // Chrome washes in from transparent so header/chips don't pop.
+      if (chrome) {
+        chrome.opacity(0);
+        const t = new KonvaLib.Tween({
+          node: chrome,
+          duration: BAND_CHROME_FADE_MS / 1000,
+          opacity: 1,
+          easing: KonvaLib.Easings.EaseOut,
+          onFinish: () => { bandChromeTweenRef.current = null; },
+        });
+        bandChromeTweenRef.current = t;
+        t.play();
       }
       return;
     }
-    const rect = bandBgRectRef.current;
-    if (!rect || !rect.getStage()) {
+    // CLOSE — fade both groups out, then unmount once the bg fade lands.
+    if (chrome) {
+      const ct = new KonvaLib.Tween({
+        node: chrome,
+        duration: BAND_CLOSE_FADE_MS / 1000,
+        opacity: 0,
+        easing: KonvaLib.Easings.EaseOut,
+        onFinish: () => { bandChromeTweenRef.current = null; },
+      });
+      bandChromeTweenRef.current = ct;
+      ct.play();
+    }
+    if (!bg || !bg.getStage()) {
       setBandBgVisible(false);
       return;
     }
     const tween = new KonvaLib.Tween({
-      node: rect,
-      duration: 0.2,
-      height: 0,
+      node: bg,
+      duration: BAND_CLOSE_FADE_MS / 1000,
       opacity: 0,
       easing: KonvaLib.Easings.EaseOut,
       onFinish: () => {
@@ -689,7 +732,10 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
   }, [battleActive]);
 
   useEffect(() => {
-    return () => { bandBgTweenRef.current?.destroy(); };
+    return () => {
+      bandBgTweenRef.current?.destroy();
+      bandChromeTweenRef.current?.destroy();
+    };
   }, []);
 
   // Card scale preference
@@ -5253,8 +5299,19 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
   // battleCardEntries, etc.) — avoids rebuilding ~15 Konva primitives on
   // unrelated re-renders, e.g. the per-frame ticks MultiplayerCanvas gets
   // from useRevealTick while any card's post-draw reveal flash is active.
+  // Snapshot of the last rendered chrome element, replayed verbatim during the
+  // close fade: once battleActive drops the battle rows are gone (totals would
+  // read 0/0) and mpLayout has no battle rect, but the fade tween needs a
+  // stable node to animate. The cached element carries the same "battle-chrome"
+  // key, so react-konva keeps the same Konva node and the tween runs on it.
+  const lastBattleChromeRef = useRef<React.ReactNode>(null);
   const battleChromeNode = useMemo(() => {
-    if (!battleActive || gameStatus !== 'playing' || !mpLayout?.zones.battle) return null;
+    if (gameStatus !== 'playing') return null;
+    // Closing fade: replay the last snapshot while bandBgVisible keeps the
+    // band mounted; otherwise there's nothing to show.
+    if (!battleActive || !mpLayout?.zones.battle) {
+      return bandBgVisible ? lastBattleChromeRef.current : null;
+    }
     const band = mpLayout.zones.battle;
     const midX = band.x + band.width / 2;
 
@@ -5338,8 +5395,11 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
     // first card in the band (UX review F2).
     const showChips = battleLikes.length > 0;
 
-    return (
-      <Group key="battle-chrome" listening={false}>
+    // opacity={0} is a CONSTANT — the fade tweens (in on open, out on close)
+    // mutate the Group's opacity imperatively; React never re-applies this
+    // literal, so it can't fight an in-flight fade (guidance-cue discipline).
+    const node = (
+      <Group key="battle-chrome" ref={bandChromeRef} opacity={0} listening={false}>
         {/* Header — attacker + stakes type, top edge of the band */}
         <Rect x={band.x} y={band.y} width={band.width} height={18} fill="rgba(10,5,5,0.72)" perfectDrawEnabled={false} />
         <Text
@@ -5403,6 +5463,8 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
 
       </Group>
     );
+    lastBattleChromeRef.current = node;
+    return node;
     // fs/fsGrowth are derived purely from `scale` (see their definitions
     // near the top of the component) — depending on `scale` directly keeps
     // this memo correct across window resizes without needing to list the
@@ -5410,6 +5472,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     battleActive,
+    bandBgVisible,
     gameStatus,
     mpLayout,
     battleCardEntries,
@@ -6070,10 +6133,14 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
           {(battleActive || bandBgVisible) && gameStatus === 'playing' && lastBandRectRef.current && (() => {
             const band = lastBandRectRef.current!;
             const midX = band.x + band.width / 2;
+            // opacity={1} is a CONSTANT — the close-fade tween mutates the
+            // Group's opacity imperatively; React never re-applies this literal,
+            // so it can't fight the fade (guidance-cue discipline). The Rect
+            // keeps its own resting BAND_BG_OPACITY, which the Group opacity
+            // multiplies down to 0 on close.
             return (
-              <Group key="battle-band-bg" listening={false}>
+              <Group key="battle-band-bg" ref={bandBgGroupRef} opacity={1} listening={false}>
                 <Rect
-                  ref={bandBgRectRef}
                   x={band.x}
                   y={band.y}
                   width={band.width}

--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -3731,6 +3731,31 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
       draggedCardIdRef.current = null;
       setBattleActive(rawBattleActiveRef.current);
 
+      // Destroy a reparented drag node that react-konva failed to clean up.
+      // At drag-start the dragged card is lifted out of its clipped zone Group
+      // onto the game layer (handleCardDragStart: node.moveTo(layer)). Both
+      // early returns below fire when the card's row left its drag-start zone
+      // server-side mid-drag; normally react-konva destroys this node as it
+      // remounts the card in the new zone. But a battle "courtesy drag" (the
+      // opponent moving the very card you're dragging) can desync react-konva's
+      // child bookkeeping so the reparented node SURVIVES on the layer while a
+      // fresh authoritative node mounts in the new zone — a client-only
+      // duplicate the user can nudge within the zone but never re-zone. Destroy
+      // the survivor, but ONLY when a DIFFERENT live node is registered for this
+      // id (authoritative node confirmed present elsewhere); destroying the sole
+      // node for an id is the ghost-card class — see
+      // reference_konva_destroy_ghost_cards.
+      const destroyOrphanedDragNode = () => {
+        const dragNode: Konva.Node = e.target;
+        // react-konva already destroyed it → getStage() is null, nothing to do.
+        if (!dragNode || dragNode.getStage() == null) return;
+        const authoritative: Konva.Node | undefined = cardNodeRefs.current.get(card.instanceId);
+        if (authoritative && authoritative !== dragNode) {
+          dragNode.destroy();
+          gameLayerRef.current?.batchDraw();
+        }
+      };
+
       if (dragCancelledRef.current) {
         // The mid-drag zone-change guard (below) already called
         // node.stopDrag() because the row's zone changed server-side while
@@ -3739,6 +3764,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
         // row's new zone/position is already authoritative from the server,
         // and resolving one here would race a stale drop target against it.
         dragCancelledRef.current = false;
+        destroyOrphanedDragNode();
         return;
       }
 
@@ -3764,6 +3790,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
       // mutation phase — it is always fresh when this fires.
       const liveLeadRow = findAnyCardByIdRef.current(card.instanceId);
       if (!liveLeadRow || liveLeadRow.zone !== sourceZone) {
+        destroyOrphanedDragNode();
         return;
       }
 

--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -663,29 +663,59 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
   // re-applies (same discipline as the guidance-cue tween), so a re-render
   // can't fight an in-flight fade.
   const bandBgGroupRef = useRef<Konva.Group | null>(null);
+  const bandBgRectRef = useRef<Konva.Rect | null>(null);
   const bandChromeRef = useRef<Konva.Group | null>(null);
   const bandBgTweenRef = useRef<Konva.Tween | null>(null);
   const bandChromeTweenRef = useRef<Konva.Tween | null>(null);
 
-  // Whole-band open/close animation. OPEN washes the chrome IN over the
-  // instantly-placed background — the bg stays opaque from frame 0 so it can
-  // never expose raw board art (the flash the old grow-tween caused; see the
-  // BAND_BG_OPACITY note). CLOSE fades BOTH groups out together, so the dashed
-  // centerline no longer hangs at full strength while everything else
+  // Whole-band open/close animation. OPEN: the background rect "settles" from
+  // fully opaque down to its resting BAND_BG_OPACITY while the chrome washes
+  // IN — the bg is only ever MORE opaque than rest during the settle, so it
+  // can never expose raw board art (the flash the old grow-tween caused; see
+  // the BAND_BG_OPACITY note). CLOSE fades BOTH groups out together, so the
+  // dashed centerline no longer hangs at full strength while everything else
   // dissolves. Every transition destroys the in-flight tweens FIRST so a rapid
-  // open⇄close can't leave a stale fade driving a group toward 0.
+  // open⇄close can't leave a stale fade driving a node toward 0. `bandBgTweenRef`
+  // holds whichever bg animation is live (open = rect settle, close = group
+  // fade) — the two branches are mutually exclusive so they never overlap.
+  // Reduced motion: skip every tween and snap to the end state (mirrors
+  // useHandLayoutTween, which gates the territory/battle card glides the same
+  // way).
   useEffect(() => {
     bandBgTweenRef.current?.destroy();
     bandBgTweenRef.current = null;
     bandChromeTweenRef.current?.destroy();
     bandChromeTweenRef.current = null;
     const bg = bandBgGroupRef.current;
+    const rect = bandBgRectRef.current;
     const chrome = bandChromeRef.current;
+    const reduceMotion =
+      typeof window !== 'undefined' &&
+      !!window.matchMedia &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     if (battleActive) {
       setBandBgVisible(true);
-      // Background present at full opacity immediately (a reopen mid-close
-      // snaps it back from a fade the close tween had driven toward 0).
+      // Group opacity at full immediately (a reopen mid-close snaps it back
+      // from a fade the close tween had driven toward 0).
       bg?.opacity(1);
+      if (reduceMotion) {
+        rect?.opacity(BAND_BG_OPACITY);
+        chrome?.opacity(1);
+        return;
+      }
+      // BG settle: materialize from fully opaque to resting opacity.
+      if (rect) {
+        rect.opacity(1);
+        const rt = new KonvaLib.Tween({
+          node: rect,
+          duration: BAND_CHROME_FADE_MS / 1000,
+          opacity: BAND_BG_OPACITY,
+          easing: KonvaLib.Easings.EaseOut,
+          onFinish: () => { bandBgTweenRef.current = null; },
+        });
+        bandBgTweenRef.current = rt;
+        rt.play();
+      }
       // Chrome washes in from transparent so header/chips don't pop.
       if (chrome) {
         chrome.opacity(0);
@@ -702,6 +732,12 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
       return;
     }
     // CLOSE — fade both groups out, then unmount once the bg fade lands.
+    if (reduceMotion || !bg || !bg.getStage()) {
+      chrome?.opacity(0);
+      bg?.opacity(0);
+      setBandBgVisible(false);
+      return;
+    }
     if (chrome) {
       const ct = new KonvaLib.Tween({
         node: chrome,
@@ -712,10 +748,6 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
       });
       bandChromeTweenRef.current = ct;
       ct.play();
-    }
-    if (!bg || !bg.getStage()) {
-      setBandBgVisible(false);
-      return;
     }
     const tween = new KonvaLib.Tween({
       node: bg,
@@ -6141,6 +6173,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
             return (
               <Group key="battle-band-bg" ref={bandBgGroupRef} opacity={1} listening={false}>
                 <Rect
+                  ref={bandBgRectRef}
                   x={band.x}
                   y={band.y}
                   width={band.width}

--- a/app/shared/components/CardContextMenu.tsx
+++ b/app/shared/components/CardContextMenu.tsx
@@ -368,8 +368,8 @@ export function CardContextMenu({ card: initialCard, x, y, actions, onClose, onE
         </>
       )}
 
-      {/* Counter swatches — territory and land-of-bondage always; land-of-redemption only when counters already exist */}
-      {(card.zone === 'territory' || card.zone === 'land-of-bondage' || (card.zone === 'land-of-redemption' && card.counters.some(c => c.count > 0))) && (
+      {/* Counter swatches — territory, land-of-bondage and battle always; land-of-redemption only when counters already exist */}
+      {(card.zone === 'territory' || card.zone === 'land-of-bondage' || card.zone === 'battle' || (card.zone === 'land-of-redemption' && card.counters.some(c => c.count > 0))) && (
         <>
           <div style={labelStyle}>Counters</div>
           <div style={{ display: 'flex', gap: 6, padding: '4px 16px 2px', alignItems: 'center' }}>

--- a/docs/superpowers/specs/2026-07-14-battle-zone-polish-design.md
+++ b/docs/superpowers/specs/2026-07-14-battle-zone-polish-design.md
@@ -1,0 +1,113 @@
+# Battle Zone Polish — Design Spec
+
+Date: 2026-07-14
+Status: Approved for implementation.
+Scope: Two targeted fixes to the shipped Field of Battle feature (PR #197). No
+schema changes, no new reducers. Builds on `2026-07-12-battle-zone-design.md`.
+
+## Problem statement
+
+1. **Jerky/abrupt open & close.** When the band opens or closes the transition
+   reads as a hard cut in places.
+2. **"Willy-nilly" card placement on auto-return.** When the battle closes,
+   some cards land stacked on top of / overlapping cards already sitting in the
+   territory.
+
+## Fix 1 — Occupancy-aware auto-return placement (server)
+
+### Root cause
+`autoReturnBattleCards` (`spacetimedb/src/index.ts` ~2250) returns
+origin-territory survivors to their exact pre-battle spot, but routes three
+kinds of card through `nextFreeSpot` instead:
+- characters whose `originZone !== 'territory'` (drafted attackers, characters
+  played straight into battle),
+- kept `place` enhancements,
+- the rule-5 fallback (Dominants/Artifacts/etc. with no stored origin).
+
+`nextFreeSpot` (~2285) fans from the top-left corner `(0.03, 0.05)` on a fresh
+per-owner counter that is **blind to what is already on the board** — neither
+the cards that never entered the battle, nor the survivors that just reclaimed
+their origin spots. So fanned cards pile onto whatever occupies the top-left.
+
+### Design
+Make free-spot selection occupancy-aware, contained to this one routine:
+
+1. **Build a per-owner occupied set** of normalized territory positions before
+   any fanning:
+   - every card currently in that owner's `territory` that is **not** in the
+     battle (it stayed put), plus
+   - the origin positions (`originPosX/originPosY`) of battle cards that will
+     return via `originZone === 'territory'` (they reclaim those exact spots).
+2. **Greedy placement** replaces the blind counter: walk the existing fan-grid
+   candidate cells in reading order, skip any candidate within a collision
+   radius (~one card footprint in normalized units) of an occupied position,
+   place at the first free cell, then add that cell to the occupied set so
+   fanned cards do not stack on each other either.
+
+Structure: compute the occupied set up front (origin-return positions are
+deterministic — just the origin fields of the origin-territory battle cards), so
+the single routing pass is preserved; only `nextFreeSpot` changes from a blind
+counter into an occupancy-aware scan seeded with that set.
+
+Philosophy unchanged ("app computes, players decide") — everything stays
+draggable afterward; this only stops the initial drop from landing on top of
+existing cards.
+
+### Out of scope (mentioned, not touched)
+`move_cards_batch`'s territory auto-fan (the `~2982` reference `nextFreeSpot`
+mirrors) is blind the same way. That is a pre-existing issue outside the
+reported bug and is left alone.
+
+### Tests
+Extend the auto-return routing unit test with a "territory already occupied"
+case: a survivor returning from a non-territory origin must be placed clear of a
+pre-existing territory card and clear of an origin-returning survivor.
+
+## Fix 2 — Animation polish (client, `MultiplayerCanvas.tsx`)
+
+### Root cause
+- The band **background pops in instantly** on open (deliberately un-tweened to
+  avoid exposing raw board art as a bright flash — see the comment at ~627) but
+  **fades out** on close: asymmetric.
+- The band **chrome** (header bar, STR/TGH chips, dashed centerline) mounts and
+  unmounts with `battleActive`, so it **pops** in and out with the layout flip.
+- (Explicitly deferred, per owner: cards crossing territory↔battle teleport
+  because each zone renders in its own clipped Konva group. That cross-zone
+  glide — via the `DealLayer` overlay-sprite pattern — is the next lever if this
+  pass is not enough. Not in this scope.)
+
+### Design
+Quick, low-risk, flash-safe polish reusing the band-bg lifecycle already in the
+file (`bandBgVisible` + `lastBandRectRef` + node-ref tween):
+
+1. **BG open "settle."** On open, start the bg rect at full opacity (1.0) and
+   tween down to the resting `BAND_BG_OPACITY` (0.75) over ~160ms. Because it
+   only ever gets *more* opaque than rest during the transition, it can never
+   expose the bright-flash the hard cut was avoiding — but the eye catches a
+   soft materialize instead of a hard pop. Close keeps its existing 200ms fade.
+2. **Chrome fade in/out.** Give the chrome group a node ref and drive its
+   opacity with a tween: 0→1 on open (~160ms), 1→0 on close (200ms), managed in
+   the same effect as the bg so the whole band presentation shares one
+   lifecycle. Keep the chrome mounted through the close (gate on
+   `battleActive || bandBgVisible`, geometry from `lastBandRectRef`, content
+   from a last-value snapshot ref) so the fade-out renders stable content
+   instead of recomputing from emptied battle rows. The chrome sits above the
+   opaque bg, so fading it is always flash-safe.
+3. **Consistent timing.** BG close, chrome fade, and the existing card reflow
+   (`useHandLayoutTween`, 200ms EaseOut) all share the 200ms/EaseOut curve;
+   the open settle uses ~160ms EaseOut.
+
+### Optional stretch (not in this scope unless requested)
+- Hand-card **size tween** (removes the accepted ~13% resize snap).
+- Territory **background-rect glide** (so the shrink/grow reads as cohesive as
+  the cards).
+
+### Tests
+Manual/visual (Konva canvas animation is not unit-tested in this codebase). The
+existing battle E2E and layout-invariant tests must still pass.
+
+## Deployment
+Fix 1 changes `spacetimedb/src/index.ts` logic only (no schema change), so it
+needs a module republish via the `spacetimedb-deploy` skill — a normal publish,
+**no `--clear`** (no schema migration). Bindings need no regeneration (no
+signature change). Fix 2 is client-only.

--- a/spacetimedb/__tests__/battlePlacement.test.ts
+++ b/spacetimedb/__tests__/battlePlacement.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+// Lives outside spacetimedb/src (the module's tsconfig `include`) so its vitest
+// import is never pulled into `spacetime publish`; root vitest still runs it
+// via the **/__tests__/** glob.
+import {
+  makeFreeSpotAllocator,
+  BATTLE_PLACE_COLLISION_R,
+  type Pos,
+} from '../src/battlePlacement';
+
+const overlaps = (a: Pos, b: Pos): boolean =>
+  Math.abs(a.x - b.x) < BATTLE_PLACE_COLLISION_R &&
+  Math.abs(a.y - b.y) < BATTLE_PLACE_COLLISION_R;
+
+describe('makeFreeSpotAllocator (battle auto-return placement)', () => {
+  it('hands out the top-left grid cell first on an empty board', () => {
+    const alloc = makeFreeSpotAllocator([]);
+    expect(alloc()).toEqual({ x: 0.03, y: 0.05 });
+  });
+
+  it('does not stack successive returns on top of each other', () => {
+    const alloc = makeFreeSpotAllocator([]);
+    const spots = Array.from({ length: 12 }, () => alloc());
+    for (let i = 0; i < spots.length; i++) {
+      for (let j = i + 1; j < spots.length; j++) {
+        expect(overlaps(spots[i], spots[j])).toBe(false);
+      }
+    }
+  });
+
+  it('avoids a pre-existing territory card sitting in the top-left', () => {
+    // A card that never entered the battle occupies the first grid cell.
+    const existing: Pos = { x: 0.03, y: 0.05 };
+    const alloc = makeFreeSpotAllocator([existing]);
+    const spot = alloc();
+    expect(overlaps(spot, existing)).toBe(false);
+  });
+
+  it('avoids the origin spots reclaimed by returning survivors', () => {
+    // Survivors returned to a cluster of exact origin positions; a drafted
+    // attacker fanning in must land clear of all of them.
+    const reclaimed: Pos[] = [
+      { x: 0.03, y: 0.05 },
+      { x: 0.07, y: 0.05 },
+      { x: 0.5, y: 0.4 },
+    ];
+    const alloc = makeFreeSpotAllocator(reclaimed);
+    const spot = alloc();
+    for (const r of reclaimed) expect(overlaps(spot, r)).toBe(false);
+  });
+
+  it('keeps every allocation clear of seed occupancy and of each other', () => {
+    const seed: Pos[] = [
+      { x: 0.03, y: 0.05 },
+      { x: 0.11, y: 0.05 },
+      { x: 0.5, y: 0.33 },
+    ];
+    const alloc = makeFreeSpotAllocator(seed);
+    const handed: Pos[] = [];
+    for (let n = 0; n < 8; n++) {
+      const spot = alloc();
+      for (const s of seed) expect(overlaps(spot, s)).toBe(false);
+      for (const h of handed) expect(overlaps(spot, h)).toBe(false);
+      handed.push(spot);
+    }
+  });
+
+  it('returns positions inside the normalized 0-1 range for a modest count', () => {
+    const alloc = makeFreeSpotAllocator([]);
+    for (let n = 0; n < 10; n++) {
+      const spot = alloc();
+      expect(spot.x).toBeGreaterThanOrEqual(0);
+      expect(spot.x).toBeLessThanOrEqual(1);
+      expect(spot.y).toBeGreaterThanOrEqual(0);
+      expect(spot.y).toBeLessThanOrEqual(1);
+    }
+  });
+});

--- a/spacetimedb/__tests__/playField.test.ts
+++ b/spacetimedb/__tests__/playField.test.ts
@@ -9,7 +9,7 @@ import { isLeavingPlayField } from '../src/playField';
 // discard, reserve, banish, soul-deck, land-of-redemption). Relocations that
 // keep the card in play — most importantly the battle-zone round trip — are
 // NOT leaving play. This predicate gates clearing the lasting `isMeek`
-// characteristic in leavePlayFieldOverrides.
+// characteristic and manual `notes` in leavePlayFieldOverrides.
 describe('isLeavingPlayField', () => {
   it('does not count the battle round trip as leaving play (the meek bug)', () => {
     // Entering battle from territory, and returning battle -> territory, keep

--- a/spacetimedb/src/battlePlacement.ts
+++ b/spacetimedb/src/battlePlacement.ts
@@ -1,0 +1,68 @@
+// Pure placement helper for the battle auto-return routine (index.ts,
+// autoReturnBattleCards). Extracted so the occupancy-aware free-spot logic can
+// be unit-tested without a full reducer harness (same split as playField.ts).
+// No spacetimedb imports — safe to bundle into `spacetime publish`.
+
+export interface Pos {
+  x: number;
+  y: number;
+}
+
+/**
+ * Collision radius in normalized (0–1) Territory units — roughly one card
+ * footprint; nearer than this two cards visibly overlap. Kept below the fan
+ * grid's 0.04 column pitch so distinct grid cells never reject each other.
+ */
+export const BATTLE_PLACE_COLLISION_R = 0.035;
+
+const CARDS_PER_ROW = 10;
+
+/** The i-th cell of the auto-fan grid (reading order), in normalized units.
+ *  Geometry is unchanged from the old blind fan (mirrors move_cards_batch's
+ *  territory auto-fan ~2982-2992). */
+function gridCell(i: number): Pos {
+  const col = i % CARDS_PER_ROW;
+  const row = Math.floor(i / CARDS_PER_ROW);
+  return { x: 0.03 + col * 0.04 + row * 0.02, y: 0.05 + row * 0.28 };
+}
+
+function collides(a: Pos, taken: Pos[]): boolean {
+  return taken.some(
+    (p) =>
+      Math.abs(p.x - a.x) < BATTLE_PLACE_COLLISION_R &&
+      Math.abs(p.y - a.y) < BATTLE_PLACE_COLLISION_R,
+  );
+}
+
+/**
+ * Occupancy-aware auto-fan allocator for cards returning to an owner's
+ * Territory when a battle closes. Seed it with the positions already occupied
+ * there — cards that never entered the battle, plus the exact origin spots the
+ * origin-Territory survivors will reclaim. Each call walks the fan grid from a
+ * running counter, skips any cell that collides with an occupied point, and
+ * records the spot it hands out so successive returns don't stack on each
+ * other either. Replaces the old blind counter that dropped every non-origin
+ * return onto the top-left corner regardless of what was already there.
+ *
+ * The scan is capped so a pathologically full board can't loop forever; past
+ * the cap it falls back to the last raw grid cell tried.
+ */
+export function makeFreeSpotAllocator(occupied: Pos[] = []): () => Pos {
+  const taken: Pos[] = [...occupied];
+  let i = 0;
+  return () => {
+    let chosen: Pos | null = null;
+    let last: Pos = gridCell(0);
+    for (let tries = 0; tries < 200; tries++) {
+      last = gridCell(i);
+      i++;
+      if (!collides(last, taken)) {
+        chosen = last;
+        break;
+      }
+    }
+    const spot = chosen ?? last;
+    taken.push(spot);
+    return spot;
+  };
+}

--- a/spacetimedb/src/index.ts
+++ b/spacetimedb/src/index.ts
@@ -262,7 +262,13 @@ function leavePlayFieldOverrides(card: any, fromZone: string, toZone: string): {
     ? { originZone: '', originPosX: '', originPosY: '' }
     : {};
   return {
-    notes: leaving ? '' : card.notes,
+    // notes are manual player annotations on the card while it's in play: like
+    // isMeek they must survive on-field relocations — above all the battle round
+    // trip (territory -> battle -> territory) — and clear only when the card
+    // genuinely leaves the play field. Gate on isLeavingPlayField rather than
+    // `leaving` (which fires on any move off an on-field zone, incl. battle <->
+    // territory).
+    notes: isLeavingPlayField(fromZone, toZone) ? '' : card.notes,
     outlineColor: leaving ? '' : card.outlineColor,
     // isMeek is a lasting hero characteristic (the card's meek-side stats), not
     // battle-scoped state: a meek hero must stay meek across on-field

--- a/spacetimedb/src/index.ts
+++ b/spacetimedb/src/index.ts
@@ -5,6 +5,7 @@ import { t, SenderError } from 'spacetimedb/server';
 import { ScheduleAt, Timestamp } from 'spacetimedb';
 import { makeSeed, seededShuffle, seededDiceRoll, xorshift64, generateGameCode } from './utils';
 import { isLeavingPlayField } from './playField';
+import { makeFreeSpotAllocator } from './battlePlacement';
 import {
   getAbilitiesForCard,
   getEffectiveAbilities,
@@ -2276,31 +2277,71 @@ function runBattleAutoReturn(ctx: any, gameId: bigint, actingPlayerId: bigint) {
     return idx;
   };
 
-  // Free-spot auto-fan per owner — mirrors move_cards_batch's territory
-  // auto-fan grid (~2982-2992). Fresh counter for this call only (matching
-  // that reducer's behavior), shared by every branch that needs "a free
-  // Territory spot": surviving characters with a non-Territory origin, kept
-  // enhancements, and the rule-5 fallback.
-  const fanIdx = new Map<string, number>();
-  const nextFreeSpot = (ownerId: bigint): { posX: string; posY: string } => {
-    const key = ownerId.toString();
-    const i = fanIdx.get(key) ?? 0;
-    fanIdx.set(key, i + 1);
-    const cardsPerRow = 10;
-    const col = i % cardsPerRow;
-    const row = Math.floor(i / cardsPerRow);
-    return { posX: String(0.03 + col * 0.04 + row * 0.02), posY: String(0.05 + row * 0.28) };
-  };
-
-  // Lost-soul check per the idiom at index.ts ~4479 (surrender_lost_soul) —
-  // includes TOKEN_LS, unlike the narrower two-part check used inline by the
-  // move reducers' discard/reserve/banish redirect.
+  // Precedence predicates (used by both the occupancy seed below and
+  // computeDestination). Lost-soul check per the idiom at index.ts ~4479
+  // (surrender_lost_soul) — includes TOKEN_LS, unlike the narrower two-part
+  // check used inline by the move reducers' discard/reserve/banish redirect.
   const isLostSoulCard = (c: any): boolean =>
     c.cardType === 'LS' || c.cardType === 'TOKEN_LS' || c.cardName.toLowerCase().includes('lost soul');
   const isPlaceKeep = (sa: string): boolean =>
     /\bplace\b/i.test(sa) && !/\bin (the )?place of\b/i.test(sa) && !/take the place of/i.test(sa);
   const enhSegment = (ct: string): boolean =>
     ct.split('/').map((s: string) => s.trim()).some((s: string) => s === 'GE' || s === 'EE');
+
+  // Occupancy-aware free-spot auto-fan per owner. The blind top-left fan this
+  // replaced dropped every non-origin return onto (0.03, 0.05) regardless of
+  // what already sat in the Territory, stacking drafted attackers / kept
+  // enhancements on top of existing cards ("willy-nilly" placement). Seed a
+  // per-owner occupied set with (a) the owner's Territory cards that never
+  // entered the battle and (b) the exact origin spots the origin-Territory
+  // returns will reclaim (deterministic — just their origin fields), then hand
+  // out grid cells that clear both, and clear each other. Grid geometry is
+  // unchanged from the old fan (still mirrors move_cards_batch ~2982-2992);
+  // only the occupancy skip is new.
+  const inBattleIds = new Set(inBattle.map((c: any) => c.id.toString()));
+  const occupied = new Map<string, Array<{ x: number; y: number }>>();
+  const addOccupied = (ownerId: bigint, posX: string, posY: string): void => {
+    const x = parseFloat(posX);
+    const y = parseFloat(posY);
+    if (Number.isNaN(x) || Number.isNaN(y)) return;
+    const key = ownerId.toString();
+    const arr = occupied.get(key);
+    if (arr) arr.push({ x, y });
+    else occupied.set(key, [{ x, y }]);
+  };
+  // (a) Territory cards that stay put through the battle.
+  for (const c of all) {
+    if (c.zone === 'territory' && !inBattleIds.has(c.id.toString())) {
+      addOccupied(c.ownerId, c.posX, c.posY);
+    }
+  }
+  // (b) Battle cards that will reclaim their exact Territory origin spot: a
+  // character with a Territory origin (rule 3) or a rule-5 card with a
+  // Territory origin. Enhancements never reclaim an origin, and accessories
+  // follow their host (pass 2), so neither seeds occupancy here.
+  for (const c of inBattle) {
+    if (c.equippedToInstanceId !== 0n) continue;
+    if (isLostSoulCard(c)) continue;
+    const reclaimsOrigin =
+      c.originZone === 'territory' &&
+      (isCharacterCard({ cardType: c.cardType }) || !enhSegment(c.cardType));
+    if (reclaimsOrigin) addOccupied(c.ownerId, c.originPosX, c.originPosY);
+  }
+
+  // One occupancy-aware allocator per owner, lazily seeded from that owner's
+  // occupied set (grid geometry + collision live in the pure, unit-tested
+  // battlePlacement helper).
+  const allocators = new Map<string, () => { x: number; y: number }>();
+  const nextFreeSpot = (ownerId: bigint): { posX: string; posY: string } => {
+    const key = ownerId.toString();
+    let alloc = allocators.get(key);
+    if (!alloc) {
+      alloc = makeFreeSpotAllocator(occupied.get(key) ?? []);
+      allocators.set(key, alloc);
+    }
+    const spot = alloc();
+    return { posX: String(spot.x), posY: String(spot.y) };
+  };
 
   // Precedence rules 2-5 (rule 1, attached accessories, is handled by the
   // caller routing them in pass 2 below via their host's result instead).


### PR DESCRIPTION
Battle-zone polish. Four commits on this branch.

## Bug fixes (this session)
- **Counters addable in battle.** The right-click counter swatches were gated to an allow-list of zones that omitted `battle`; the `add_counter` reducer was already zone-agnostic, so this was purely a client UI gate.
- **Notes persist across the battle round trip.** `leavePlayFieldOverrides` still gated `notes` on the old `leaving` predicate (true for `territory<->battle`), wiping notes on both legs. Now gated on `isLeavingPlayField`, mirroring the `isMeek` fix from #201 — notes clear only on a genuine leave-play.
- **Duplicate/ghost card race.** When both players drag the same card out of battle simultaneously (courtesy drag), the reparented drag node can survive react-konva reconciliation and orphan on the game layer as a client-only duplicate. `handleCardDragEnd`'s early returns now destroy that node, but **only** when a different authoritative node is registered for the same id (never the sole node — that's the ghost-card class).

## Prior battle-polish commits on this branch
- Smooth band open/close + occupancy-aware auto-return
- Restore approved bg open-settle + respect reduced-motion
- Design spec doc for the above

## Verification
- SpacetimeDB module `tsc --noEmit`: clean; `playField` unit tests pass (5).
- App `tsc --noEmit`: no errors in changed files.

## Deploy notes
- Client fixes ship with the Vercel deploy.
- The notes fix is **server-side** (`spacetimedb/src/index.ts`, reducer logic only, no schema/binding change) and needs a SpacetimeDB module republish (incremental — **no `--clear`**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)