### PR TITLE
feat(tournament): static seats + seat-numbering mode

### DIFF
--- a/app/tracker/tournaments/[id]/page.tsx
+++ b/app/tracker/tournaments/[id]/page.tsx
@@ -47,6 +47,7 @@ export default function TournamentPage({
   const [tournament, setTournament] = useState<any>(null);
   const [currentParticipant, setCurrentParticipant] = useState<any>(null);
   const [newParticipantName, setNewParticipantName] = useState<string>("");
+  const [newParticipantSeat, setNewParticipantSeat] = useState<string>("");
   const [isEditTournamentModalOpen, setIsEditTournamentModalOpen] =
     useState<boolean>(false);
   const [activeTab, setActiveTab] = useState(0);
@@ -184,15 +185,27 @@ export default function TournamentPage({
 
   const updateParticipant = async () => {
     if (!currentParticipant || !newParticipantName.trim()) return;
-
+    const trimmedSeat = newParticipantSeat.trim();
+    const seatNum = trimmedSeat === "" ? null : Number(trimmedSeat);
+    if (seatNum !== null && (!Number.isInteger(seatNum) || seatNum < 1)) {
+      showToast("Static assignment must be a positive whole number.", "error");
+      return;
+    }
     try {
       const { error } = await supabase
         .from("participants")
-        .update({ name: newParticipantName })
+        .update({ name: newParticipantName, assigned_seat: seatNum })
         .eq("id", currentParticipant.id);
-
-      if (error) throw error;
-
+      if (error) {
+        if ((error as { code?: string }).code === "23505") {
+          showToast(
+            `${numberingMode === "seats" ? "Seat" : "Table"} ${seatNum} is already assigned to another player.`,
+            "error",
+          );
+          return;
+        }
+        throw error;
+      }
       fetchParticipants();
       setIsEditParticipantModalOpen(false);
       showToast("Participant updated successfully!", "success");
@@ -646,6 +659,8 @@ export default function TournamentPage({
   }, [id]);
 
   const isHost = !!(tournament?.host_id && currentUserId && tournament.host_id === currentUserId);
+  const numberingMode: "tables" | "seats" =
+    tournament?.numbering_mode === "seats" ? "seats" : "tables";
 
   return (
     <div className="flex min-h-screen px-3 sm:px-5 w-full jayden-gradient-bg">
@@ -899,10 +914,12 @@ export default function TournamentPage({
             isModalOpen={isModalOpen}
             setIsModalOpen={setIsModalOpen}
             isHost={isHost}
+            numberingMode={numberingMode}
             onAddParticipant={handleAddParticipant}
             onEdit={(participant) => {
               setCurrentParticipant(participant);
               setNewParticipantName(participant.name);
+              setNewParticipantSeat(participant.assigned_seat != null ? String(participant.assigned_seat) : "");
               setIsEditParticipantModalOpen(true);
             }}
             setLatestRound={setLatestRound}
@@ -1074,6 +1091,9 @@ export default function TournamentPage({
           onSave={updateParticipant}
           newParticipantName={newParticipantName}
           setNewParticipantName={setNewParticipantName}
+          numberingMode={numberingMode}
+          seatValue={newParticipantSeat}
+          setSeatValue={setNewParticipantSeat}
         />
         <TournamentStartModal
           isOpen={showStartModal}

--- a/app/tracker/tournaments/repair-actions.ts
+++ b/app/tracker/tournaments/repair-actions.ts
@@ -79,11 +79,16 @@ export async function regenerateCurrentRoundPairingsAction(input: {
     mode: state.numberingMode ?? "tables",
   });
 
+  // Persist the override decision now — it must not be re-derived later
+  // from a pin that may have changed since (spec: "Overridden pins" §).
+  const overridden = new Set(assigned.overriddenPins);
   const pairings = assigned.matches.map((m, idx) => ({
     player1_id: m.player1Id,
     player2_id: m.player2Id,
     match_order: m.matchOrder ?? idx + 1,
     table_number: m.tableNumber,
+    player1_pin_overridden: overridden.has(m.player1Id),
+    player2_pin_overridden: overridden.has(m.player2Id),
   }));
 
   const { data, error } = await supabase.rpc("regenerate_current_round_pairings", {

--- a/app/tracker/tournaments/repair-actions.ts
+++ b/app/tracker/tournaments/repair-actions.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from "next/cache";
 import { buildStateFromSupabase } from "@/utils/tournament/stateAdapter";
 import { pairFirstRound, pairLaterRound } from "@/lib/tournament/pairing";
 import { mulberry32 } from "@/lib/tournament/rng";
+import { assignTables } from "@/lib/tournament/tableAssignment";
 
 export interface RepairResult {
   ok: boolean;
@@ -67,10 +68,22 @@ export async function regenerateCurrentRoundPairingsAction(input: {
       ? pairFirstRound(state.participants.filter((p) => !p.droppedOut), rng)
       : pairLaterRound(state, round, rng);
 
-  const pairings = result.matches.map((m, idx) => ({
+  // Static seats: honor pins when placing regenerated matches (spec
+  // 2026-07-15-static-seats-design.md).
+  const pins = new Map<string, number>();
+  for (const p of state.participants) {
+    if (!p.droppedOut && p.assignedSeat != null) pins.set(p.id, p.assignedSeat);
+  }
+  const assigned = assignTables(result.matches, pins, {
+    startingTableNumber: state.startingTableNumber ?? 1,
+    mode: state.numberingMode ?? "tables",
+  });
+
+  const pairings = assigned.matches.map((m, idx) => ({
     player1_id: m.player1Id,
     player2_id: m.player2Id,
     match_order: m.matchOrder ?? idx + 1,
+    table_number: m.tableNumber,
   }));
 
   const { data, error } = await supabase.rpc("regenerate_current_round_pairings", {

--- a/components/ui/EditParticipantModal.tsx
+++ b/components/ui/EditParticipantModal.tsx
@@ -16,6 +16,9 @@ interface EditParticipantModalProps {
   onSave: () => void;
   newParticipantName: string;
   setNewParticipantName: (name: string) => void;
+  numberingMode: "tables" | "seats";
+  seatValue: string;
+  setSeatValue: (v: string) => void;
 }
 
 const EditParticipantModal: React.FC<EditParticipantModalProps> = ({
@@ -25,6 +28,9 @@ const EditParticipantModal: React.FC<EditParticipantModalProps> = ({
   onSave,
   newParticipantName,
   setNewParticipantName,
+  numberingMode,
+  seatValue,
+  setSeatValue,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -61,6 +67,27 @@ const EditParticipantModal: React.FC<EditParticipantModalProps> = ({
                 ref={inputRef}
                 className="w-full rounded-lg border border-border bg-card text-foreground px-3 py-2 text-sm focus:outline-none"
               />
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="assigned-seat" className="text-sm font-medium text-foreground">
+                Static {numberingMode === "seats" ? "seat" : "table"} #{" "}
+                <span className="text-muted-foreground font-normal">(optional)</span>
+              </label>
+              <input
+                id="assigned-seat"
+                name="assigned-seat"
+                type="number"
+                min={1}
+                step={1}
+                value={seatValue}
+                onChange={(e) => setSeatValue(e.target.value)}
+                placeholder="None"
+                className="w-full rounded-lg border border-border bg-card text-foreground px-3 py-2 text-sm focus:outline-none"
+              />
+              <p className="text-xs text-muted-foreground">
+                Always placed at this {numberingMode === "seats" ? "seat" : "table"} when
+                pairings are generated. Leave empty for automatic placement.
+              </p>
             </div>
           </DialogBody>
           <DialogFooter className="justify-end">

--- a/components/ui/ParticipantTable.tsx
+++ b/components/ui/ParticipantTable.tsx
@@ -13,6 +13,7 @@ interface Participant {
   match_points: number;
   differential: number;
   dropped_out: boolean;
+  assigned_seat?: number | null;
 }
 
 interface ParticipantTableProps {
@@ -26,6 +27,7 @@ interface ParticipantTableProps {
   tournamentId: string;
   decklists: TournamentDecklistRow[];
   onDecklistsChange: () => void;
+  numberingMode: "tables" | "seats";
 }
 
 const ParticipantTable: React.FC<ParticipantTableProps> = ({
@@ -39,6 +41,7 @@ const ParticipantTable: React.FC<ParticipantTableProps> = ({
   tournamentId,
   decklists,
   onDecklistsChange,
+  numberingMode,
 }) => {
   const [attachDialogOpen, setAttachDialogOpen] = useState(false);
   const [attachTarget, setAttachTarget] = useState<Participant | null>(null);
@@ -209,6 +212,15 @@ const ParticipantTable: React.FC<ParticipantTableProps> = ({
                         Dropped
                       </span>
                     )}
+                    {participant.assigned_seat != null && (
+                      <span
+                        className="text-[11px] font-semibold tabular-nums rounded px-1.5 py-0.5 bg-muted text-muted-foreground border border-border flex-shrink-0"
+                        title={`Static ${numberingMode === "seats" ? "seat" : "table"} ${participant.assigned_seat}`}
+                      >
+                        {numberingMode === "seats" ? "S" : "T"}
+                        {participant.assigned_seat}
+                      </span>
+                    )}
                   </div>
                   <div className="mt-2">{renderDeckCell(participant)}</div>
                 </div>
@@ -267,6 +279,15 @@ const ParticipantTable: React.FC<ParticipantTableProps> = ({
                       <span className="truncate">{participant.name}</span>
                       {participant.dropped_out && (
                         <span className="text-destructive text-[11px] flex-shrink-0 uppercase tracking-wide">Dropped</span>
+                      )}
+                      {participant.assigned_seat != null && (
+                        <span
+                          className="text-[11px] font-semibold tabular-nums rounded px-1.5 py-0.5 bg-muted text-muted-foreground border border-border flex-shrink-0"
+                          title={`Static ${numberingMode === "seats" ? "seat" : "table"} ${participant.assigned_seat}`}
+                        >
+                          {numberingMode === "seats" ? "S" : "T"}
+                          {participant.assigned_seat}
+                        </span>
                       )}
                     </div>
                   </Table.Cell>

--- a/components/ui/RepairPairingModal.tsx
+++ b/components/ui/RepairPairingModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { ArrowUpDown } from "lucide-react";
 import { createClient } from "../../utils/supabase/client";
+import { reassignRoundTables } from "../../utils/tournament/reassignTables";
 import { Button } from "./button";
 import {
   Dialog,
@@ -188,6 +189,8 @@ export default function RepairPairingModal({
           differential: (otherPlayer.differential || 0) + tournament.bye_differential,
         });
       }
+
+      await reassignRoundTables(client, tournamentId, roundNumber);
 
       fetchCurrentRoundData();
       onClose();

--- a/components/ui/TournamentRounds.tsx
+++ b/components/ui/TournamentRounds.tsx
@@ -6,6 +6,7 @@ import { createClient } from "../../utils/supabase/client";
 import { recomputeTotalsFromHistory } from "../../lib/tournament/results";
 import { gameScoreForMatch, differentialForMatch } from "../../lib/tournament/standingsScoring";
 import { buildStateFromSupabase } from "../../utils/tournament/stateAdapter";
+import { reassignRoundTables } from "../../utils/tournament/reassignTables";
 import MatchEditModal from "./match-edit";
 import RepairPairingModal from "./RepairPairingModal";
 import { ArrowDown, ArrowUp, ArrowUpDown, MoreHorizontal, Printer } from "lucide-react";
@@ -713,8 +714,10 @@ export default function TournamentRounds({
         }).eq("id", sourceMatch.id);
       }
 
+      await reassignRoundTables(client, tournamentId, currentPage);
+
       await fetchCurrentRoundData();
-      
+
     } catch (error) {
       console.error("Error swapping players:", error);
       showToast("Error swapping players. Please try again.", "error");
@@ -819,6 +822,8 @@ export default function TournamentRounds({
         { p_tournament_id: tournamentId },
       );
       if (recomputeError) throw recomputeError;
+
+      await reassignRoundTables(client, tournamentId, currentPage);
 
       await fetchCurrentRoundData();
     } catch (error) {

--- a/components/ui/TournamentRounds.tsx
+++ b/components/ui/TournamentRounds.tsx
@@ -405,7 +405,7 @@ export default function TournamentRounds({
     const { data, error } = await client
       .from("matches")
       .select(
-        "id, match_order, table_number, player1_match_points, player2_match_points, differential, differential2, player1_id:participants!matches_player1_id_fkey(name,id,assigned_seat), player2_id:participants!matches_player2_id_fkey(name,id,assigned_seat), player1_score, player2_score"
+        "id, match_order, table_number, player1_pin_overridden, player2_pin_overridden, player1_match_points, player2_match_points, differential, differential2, player1_id:participants!matches_player1_id_fkey(name,id,assigned_seat), player2_id:participants!matches_player2_id_fkey(name,id,assigned_seat), player1_score, player2_score"
       )
       .eq("tournament_id", tournamentId)
       .eq("round", currentPage)
@@ -914,15 +914,14 @@ export default function TournamentRounds({
   const displayTable = (match: any, index: number): number =>
     match.table_number ?? index + (tournamentInfo.starting_table_number || 1);
 
-  /** True when a player's static pin was not honored this round. */
-  const pinOverridden = (match: any, side: 1 | 2, tableNum: number): boolean => {
-    const pin = side === 1 ? match.player1_id?.assigned_seat : match.player2_id?.assigned_seat;
-    if (pin == null || match.table_number == null) return false;
-    if (isSeatsMode) {
-      return pin !== (side === 1 ? 2 * tableNum - 1 : 2 * tableNum);
-    }
-    return pin !== tableNum;
-  };
+  /**
+   * True when a player's static pin was not honored this round. Reads the
+   * flag persisted at generation time (assignTables' overriddenPins), not a
+   * live comparison against the current pin — a pin edited mid-round would
+   * otherwise produce a false badge here (spec: "Overridden pins" §).
+   */
+  const pinOverridden = (match: any, side: 1 | 2): boolean =>
+    side === 1 ? !!match.player1_pin_overridden : !!match.player2_pin_overridden;
 
   // In repair mode player names read as click-to-swap links — primary color
   // with an underline — without changing the row size. The selected source is
@@ -1142,11 +1141,11 @@ export default function TournamentRounds({
                                     ) : (
                                       <span>{match.player1_id.name}</span>
                                     )}
-                                    {pinOverridden(match, 1, displayTable(match, index)) && (
+                                    {pinOverridden(match, 1) && (
                                       <span
-                                        title="Static seat not honored this round (conflicting pins)"
+                                        title="Static assignment couldn't be honored this round"
                                         className="text-amber-500 text-xs flex-shrink-0"
-                                        aria-label="Static seat not honored this round"
+                                        aria-label="Static assignment couldn't be honored this round"
                                       >⚠</span>
                                     )}
                                   </span>
@@ -1181,11 +1180,11 @@ export default function TournamentRounds({
                                     ) : (
                                       <span>{match.player2_id.name}</span>
                                     )}
-                                    {pinOverridden(match, 2, displayTable(match, index)) && (
+                                    {pinOverridden(match, 2) && (
                                       <span
-                                        title="Static seat not honored this round (conflicting pins)"
+                                        title="Static assignment couldn't be honored this round"
                                         className="text-amber-500 text-xs flex-shrink-0"
-                                        aria-label="Static seat not honored this round"
+                                        aria-label="Static assignment couldn't be honored this round"
                                       >⚠</span>
                                     )}
                                   </span>
@@ -1411,11 +1410,11 @@ export default function TournamentRounds({
                                       </span>
                                     )}
                                     <span className="truncate min-w-0">{match.player1_id.name}</span>
-                                    {pinOverridden(match, 1, displayTable(match, index)) && (
+                                    {pinOverridden(match, 1) && (
                                       <span
-                                        title="Static seat not honored this round (conflicting pins)"
+                                        title="Static assignment couldn't be honored this round"
                                         className="text-amber-500 text-xs flex-shrink-0"
-                                        aria-label="Static seat not honored this round"
+                                        aria-label="Static assignment couldn't be honored this round"
                                       >⚠</span>
                                     )}
                                   </p>
@@ -1445,11 +1444,11 @@ export default function TournamentRounds({
                                       </span>
                                     )}
                                     <span className="truncate min-w-0">{match.player2_id.name}</span>
-                                    {pinOverridden(match, 2, displayTable(match, index)) && (
+                                    {pinOverridden(match, 2) && (
                                       <span
-                                        title="Static seat not honored this round (conflicting pins)"
+                                        title="Static assignment couldn't be honored this round"
                                         className="text-amber-500 text-xs flex-shrink-0"
-                                        aria-label="Static seat not honored this round"
+                                        aria-label="Static assignment couldn't be honored this round"
                                       >⚠</span>
                                     )}
                                   </p>

--- a/components/ui/TournamentRounds.tsx
+++ b/components/ui/TournamentRounds.tsx
@@ -106,6 +106,7 @@ interface TournamentInfo {
   max_score: number | null;
   starting_table_number: number | null;
   name: string | null;
+  numbering_mode: string | null;
 }
 
 interface RoundInfo {
@@ -146,6 +147,7 @@ export default function TournamentRounds({
     max_score: null,
     starting_table_number: 1,
     name: tournamentName || null,
+    numbering_mode: null,
   });
   // Tracks whether we've completed the initial tournament fetch and synced
   // currentPage to tournamentInfo.current_round. Used as a render gate so the
@@ -260,7 +262,7 @@ export default function TournamentRounds({
       const [tournamentResult, roundResult] = await Promise.all([
         client
           .from("tournaments")
-          .select("id, n_rounds, current_round, has_ended, max_score, starting_table_number, name")
+          .select("id, n_rounds, current_round, has_ended, max_score, starting_table_number, name, numbering_mode")
           .eq("id", tournamentId)
           .single(),
         client
@@ -403,10 +405,11 @@ export default function TournamentRounds({
     const { data, error } = await client
       .from("matches")
       .select(
-        "id, match_order, player1_match_points, player2_match_points, differential, differential2, player1_id:participants!matches_player1_id_fkey(name,id), player2_id:participants!matches_player2_id_fkey(name,id), player1_score, player2_score"
+        "id, match_order, table_number, player1_match_points, player2_match_points, differential, differential2, player1_id:participants!matches_player1_id_fkey(name,id,assigned_seat), player2_id:participants!matches_player2_id_fkey(name,id,assigned_seat), player1_score, player2_score"
       )
       .eq("tournament_id", tournamentId)
       .eq("round", currentPage)
+      .order("table_number", { ascending: true, nullsFirst: true })
       .order("match_order", { ascending: true });
     
     if (error) console.log(error);
@@ -903,6 +906,22 @@ export default function TournamentRounds({
     currentPage === tournamentInfo.current_round &&
     (!roundInfo.started_at || noScoresEntered);
 
+  const isSeatsMode = tournamentInfo.numbering_mode === "seats";
+
+  /** Persisted table with legacy fallback to positional numbering. */
+  const displayTable = (match: any, index: number): number =>
+    match.table_number ?? index + (tournamentInfo.starting_table_number || 1);
+
+  /** True when a player's static pin was not honored this round. */
+  const pinOverridden = (match: any, side: 1 | 2, tableNum: number): boolean => {
+    const pin = side === 1 ? match.player1_id?.assigned_seat : match.player2_id?.assigned_seat;
+    if (pin == null || match.table_number == null) return false;
+    if (isSeatsMode) {
+      return pin !== (side === 1 ? 2 * tableNum - 1 : 2 * tableNum);
+    }
+    return pin !== tableNum;
+  };
+
   // In repair mode player names read as click-to-swap links — primary color
   // with an underline — without changing the row size. The selected source is
   // bold with a solid underline; the other selectable players get a dotted
@@ -1096,7 +1115,9 @@ export default function TournamentRounds({
                             <Fragment key={match.id}>
                               <tr className={`border-b border-border ${matchErrorIndex.includes(index) ? "bg-red-600/20" : "bg-muted/50"}`}>
                                 <td className={`px-4 py-2 text-center border-r ${matchErrorIndex.includes(index) ? "border-red-400" : "border-border"}`}>
-                                  {index + (tournamentInfo.starting_table_number || 1)}
+                                  {isSeatsMode
+                                    ? `${2 * displayTable(match, index) - 1}·${2 * displayTable(match, index)}`
+                                    : displayTable(match, index)}
                                 </td>
                                 <td
                                   className={`px-4 py-2 text-center border-r text-foreground ${matchErrorIndex.includes(index) ? "border-red-400" : "border-border"} ${
@@ -1106,13 +1127,27 @@ export default function TournamentRounds({
                                   role={repairMode ? "button" : undefined}
                                   tabIndex={repairMode ? 0 : undefined}
                                 >
-                                  {repairMode ? (
-                                    <span className={swapTargetClass(repairSourceMatch?.match?.id === match.id && !repairSourceMatch?.isPlayer2 && !repairSourceMatch?.isBye)}>
-                                      {match.player1_id.name}
-                                    </span>
-                                  ) : (
-                                    match.player1_id.name
-                                  )}
+                                  <span className="inline-flex items-center justify-center gap-1">
+                                    {isSeatsMode && (
+                                      <span className="text-xs text-muted-foreground tabular-nums">
+                                        {2 * displayTable(match, index) - 1}
+                                      </span>
+                                    )}
+                                    {repairMode ? (
+                                      <span className={swapTargetClass(repairSourceMatch?.match?.id === match.id && !repairSourceMatch?.isPlayer2 && !repairSourceMatch?.isBye)}>
+                                        {match.player1_id.name}
+                                      </span>
+                                    ) : (
+                                      <span>{match.player1_id.name}</span>
+                                    )}
+                                    {pinOverridden(match, 1, displayTable(match, index)) && (
+                                      <span
+                                        title="Static seat not honored this round (conflicting pins)"
+                                        className="text-amber-500 text-xs flex-shrink-0"
+                                        aria-label="Static seat not honored this round"
+                                      >⚠</span>
+                                    )}
+                                  </span>
                                 </td>
                                 <td className={`px-4 py-2 text-center border-r tabular-nums ${matchErrorIndex.includes(index) ? "border-red-400" : "border-border"}`}>
                                   {hasResult ? (
@@ -1131,13 +1166,27 @@ export default function TournamentRounds({
                                   role={repairMode ? "button" : undefined}
                                   tabIndex={repairMode ? 0 : undefined}
                                 >
-                                  {repairMode ? (
-                                    <span className={swapTargetClass(repairSourceMatch?.match?.id === match.id && repairSourceMatch?.isPlayer2 && !repairSourceMatch?.isBye)}>
-                                      {match.player2_id.name}
-                                    </span>
-                                  ) : (
-                                    match.player2_id.name
-                                  )}
+                                  <span className="inline-flex items-center justify-center gap-1">
+                                    {isSeatsMode && (
+                                      <span className="text-xs text-muted-foreground tabular-nums">
+                                        {2 * displayTable(match, index)}
+                                      </span>
+                                    )}
+                                    {repairMode ? (
+                                      <span className={swapTargetClass(repairSourceMatch?.match?.id === match.id && repairSourceMatch?.isPlayer2 && !repairSourceMatch?.isBye)}>
+                                        {match.player2_id.name}
+                                      </span>
+                                    ) : (
+                                      <span>{match.player2_id.name}</span>
+                                    )}
+                                    {pinOverridden(match, 2, displayTable(match, index)) && (
+                                      <span
+                                        title="Static seat not honored this round (conflicting pins)"
+                                        className="text-amber-500 text-xs flex-shrink-0"
+                                        aria-label="Static seat not honored this round"
+                                      >⚠</span>
+                                    )}
+                                  </span>
                                 </td>
                                 <td className={`px-4 py-2 text-center border-r tabular-nums ${matchErrorIndex.includes(index) ? "border-red-400" : "border-border"}`}>
                                   {perRound ? `${perRound.p1Mp} / ${perRound.p2Mp}` : "N/A"}
@@ -1273,7 +1322,8 @@ export default function TournamentRounds({
                     <div className="md:hidden space-y-2">
                       {matches.map((match, index) => {
                         const isError = matchErrorIndex.includes(index);
-                        const tableNum = index + (tournamentInfo.starting_table_number || 1);
+                        const tableNum = displayTable(match, index);
+                        const tableLabel = isSeatsMode ? `Seats ${2 * tableNum - 1}·${2 * tableNum}` : `Table ${tableNum}`;
                         const repairEnabled = canRepairCurrentRound;
                         const perRound = perRoundScores(match, tournamentInfo.max_score ?? 5);
                         const isP1Selected =
@@ -1307,7 +1357,7 @@ export default function TournamentRounds({
                           >
                             <div className="flex items-center justify-between gap-2 mb-2">
                               <span className="text-xs uppercase tracking-wide text-muted-foreground whitespace-nowrap">
-                                Table {tableNum}
+                                {tableLabel}
                               </span>
                               <div className="flex items-center gap-1 flex-shrink-0">
                                 {/* See desktop note: hide the disabled edit
@@ -1352,8 +1402,20 @@ export default function TournamentRounds({
                             <div className="space-y-2">
                               <div className="flex items-center gap-2">
                                 <div className="flex-1 min-w-0">
-                                  <p className="font-medium text-foreground truncate">
-                                    {match.player1_id.name}
+                                  <p className="font-medium text-foreground flex items-center gap-1">
+                                    {isSeatsMode && (
+                                      <span className="text-xs text-muted-foreground tabular-nums flex-shrink-0">
+                                        {2 * displayTable(match, index) - 1}
+                                      </span>
+                                    )}
+                                    <span className="truncate min-w-0">{match.player1_id.name}</span>
+                                    {pinOverridden(match, 1, displayTable(match, index)) && (
+                                      <span
+                                        title="Static seat not honored this round (conflicting pins)"
+                                        className="text-amber-500 text-xs flex-shrink-0"
+                                        aria-label="Static seat not honored this round"
+                                      >⚠</span>
+                                    )}
                                   </p>
                                   <p className="text-xs text-muted-foreground tabular-nums">
                                     Match Pts {perRound ? perRound.p1Mp : "N/A"} · Diff {perRound ? perRound.p1Diff : "N/A"}
@@ -1374,8 +1436,20 @@ export default function TournamentRounds({
                               </div>
                               <div className="flex items-center gap-2 pt-2 border-t border-border">
                                 <div className="flex-1 min-w-0">
-                                  <p className="font-medium text-foreground truncate">
-                                    {match.player2_id.name}
+                                  <p className="font-medium text-foreground flex items-center gap-1">
+                                    {isSeatsMode && (
+                                      <span className="text-xs text-muted-foreground tabular-nums flex-shrink-0">
+                                        {2 * displayTable(match, index)}
+                                      </span>
+                                    )}
+                                    <span className="truncate min-w-0">{match.player2_id.name}</span>
+                                    {pinOverridden(match, 2, displayTable(match, index)) && (
+                                      <span
+                                        title="Static seat not honored this round (conflicting pins)"
+                                        className="text-amber-500 text-xs flex-shrink-0"
+                                        aria-label="Static seat not honored this round"
+                                      >⚠</span>
+                                    )}
                                   </p>
                                   <p className="text-xs text-muted-foreground tabular-nums">
                                     Match Pts {perRound ? perRound.p2Mp : "N/A"} · Diff {perRound ? perRound.p2Diff : "N/A"}

--- a/components/ui/TournamentRounds.tsx
+++ b/components/ui/TournamentRounds.tsx
@@ -839,11 +839,12 @@ export default function TournamentRounds({
 
   const handlePrintPairings = () => {
     printTournamentPairings(
-      matches, 
-      byes, 
-      currentPage, 
+      matches,
+      byes,
+      currentPage,
       tournamentInfo.starting_table_number || 1,
-      tournamentName || tournamentInfo.name // Use prop value first if available
+      tournamentName || tournamentInfo.name, // Use prop value first if available
+      tournamentInfo.numbering_mode === "seats" ? "seats" : "tables",
     );
   };
 
@@ -852,7 +853,8 @@ export default function TournamentRounds({
       matches,
       currentPage,
       tournamentInfo.starting_table_number || 1,
-      tournamentName || tournamentInfo.name
+      tournamentName || tournamentInfo.name,
+      tournamentInfo.numbering_mode === "seats" ? "seats" : "tables",
     );
   };
   

--- a/components/ui/TournamentRounds.tsx
+++ b/components/ui/TournamentRounds.tsx
@@ -1079,7 +1079,7 @@ export default function TournamentRounds({
                     <thead className="sticky top-0 z-10 text-xs uppercase font-normal text-foreground bg-muted border-b-2 border-border rounded-t-lg">
                       <tr>
                         <th scope="col" className="px-4 py-2 text-center">
-                          Table
+                          {isSeatsMode ? "Seats" : "Table"}
                         </th>
                         <th scope="col" className="px-4 py-2 text-center">
                           Player 1
@@ -1546,7 +1546,7 @@ export default function TournamentRounds({
                       <thead className="text-xs uppercase font-normal text-foreground bg-muted border-b-2 border-border rounded-t-lg">
                         <tr>
                           <th scope="col" className="px-4 py-2 text-center">
-                            Table
+                            {isSeatsMode ? "Seats" : "Table"}
                           </th>
                           <th scope="col" className="px-4 py-2 text-center">
                             Name

--- a/components/ui/TournamentSettings.tsx
+++ b/components/ui/TournamentSettings.tsx
@@ -14,6 +14,7 @@ interface TournamentInfo {
   bye_differential: number | null;
   starting_table_number: number | null;
   sound_notifications: boolean | null;
+  numbering_mode: string | null;
   has_started: boolean | null;
   has_ended: boolean | null;
 }
@@ -34,6 +35,7 @@ const EMPTY_INFO: TournamentInfo = {
   bye_differential: null,
   starting_table_number: null,
   sound_notifications: null,
+  numbering_mode: "tables",
   has_started: null,
   has_ended: null,
 };
@@ -47,6 +49,7 @@ const EDITABLE_KEYS = [
   "bye_points",
   "bye_differential",
   "sound_notifications",
+  "numbering_mode",
 ] as const;
 
 export default function TournamentSettings({
@@ -57,6 +60,7 @@ export default function TournamentSettings({
   // Baseline reflecting what's persisted in the DB, used for dirty tracking.
   const [savedInfo, setSavedInfo] = useState<TournamentInfo>(EMPTY_INFO);
   const [round1Started, setRound1Started] = useState(false);
+  const [pinnedCount, setPinnedCount] = useState(0);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
   const savedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -70,7 +74,7 @@ export default function TournamentSettings({
       const { data, error } = await client
         .from("tournaments")
         .select(
-          "n_rounds, current_round, round_length, max_score, bye_points, bye_differential, starting_table_number, sound_notifications, has_started, has_ended",
+          "n_rounds, current_round, round_length, max_score, bye_points, bye_differential, starting_table_number, sound_notifications, has_started, has_ended, numbering_mode",
         )
         .eq("id", tournamentId)
         .single();
@@ -90,6 +94,13 @@ export default function TournamentSettings({
         .eq("round_number", 1)
         .maybeSingle();
       setRound1Started(!!round1?.started_at);
+
+      const { count } = await client
+        .from("participants")
+        .select("id", { count: "exact", head: true })
+        .eq("tournament_id", tournamentId)
+        .not("assigned_seat", "is", null);
+      setPinnedCount(count ?? 0);
     };
 
     fetchTournamentInfo();
@@ -394,6 +405,30 @@ export default function TournamentSettings({
                 <option value="4">+4</option>
                 <option value="5">+5</option>
               </select>
+            </label>
+
+            <label className="block">
+              <span className="text-sm font-medium text-foreground mb-1.5 block">
+                Numbering
+              </span>
+              <select
+                value={tournamentInfo.numbering_mode ?? "tables"}
+                onChange={(e) =>
+                  setTournamentInfo((prev) => ({ ...prev, numbering_mode: e.target.value }))
+                }
+                disabled={editingDisabled}
+                className={inputClasses}
+              >
+                <option value="tables">Tables — one number per match</option>
+                <option value="seats">Seats — numbered chairs, two per table</option>
+              </select>
+              {pinnedCount > 0 && tournamentInfo.numbering_mode !== savedInfo.numbering_mode && (
+                <p className="text-xs text-amber-500 mt-1">
+                  {pinnedCount} player{pinnedCount === 1 ? " has" : "s have"} a static
+                  assignment — the number keeps its value but is reinterpreted under the
+                  new mode. Review assignments after saving.
+                </p>
+              )}
             </label>
           </div>
 

--- a/components/ui/TournamentSettings.tsx
+++ b/components/ui/TournamentSettings.tsx
@@ -150,6 +150,7 @@ export default function TournamentSettings({
 
   const editingDisabled = !!tournamentInfo.has_ended;
   const maxScoreLocked = round1Started || editingDisabled;
+  const numberingModeLocked = !!tournamentInfo.has_started || editingDisabled;
   const minRounds = Math.max(1, tournamentInfo.current_round || 1);
 
   const inputClasses =
@@ -408,20 +409,28 @@ export default function TournamentSettings({
             </label>
 
             <label className="block">
-              <span className="text-sm font-medium text-foreground mb-1.5 block">
+              <span className="text-sm font-medium text-foreground mb-1.5 flex items-center gap-1.5">
                 Numbering
+                {numberingModeLocked && !editingDisabled && (
+                  <Lock className="w-3.5 h-3.5 text-muted-foreground" aria-label="Locked" />
+                )}
               </span>
               <select
                 value={tournamentInfo.numbering_mode ?? "tables"}
                 onChange={(e) =>
                   setTournamentInfo((prev) => ({ ...prev, numbering_mode: e.target.value }))
                 }
-                disabled={editingDisabled}
+                disabled={numberingModeLocked}
                 className={inputClasses}
               >
                 <option value="tables">Tables — one number per match</option>
                 <option value="seats">Seats — numbered chairs, two per table</option>
               </select>
+              {numberingModeLocked && !editingDisabled && (
+                <p className="text-xs text-muted-foreground mt-1">
+                  Locked once the tournament starts.
+                </p>
+              )}
               {pinnedCount > 0 && tournamentInfo.numbering_mode !== savedInfo.numbering_mode && (
                 <p className="text-xs text-amber-500 mt-1">
                   {pinnedCount} player{pinnedCount === 1 ? " has" : "s have"} a static

--- a/components/ui/TournamentTabs.tsx
+++ b/components/ui/TournamentTabs.tsx
@@ -48,6 +48,7 @@ interface TournamentTabsProps {
   decklists: TournamentDecklistRow[];
   onDecklistsChange: () => void;
   isHost?: boolean;
+  numberingMode: "tables" | "seats";
   onRepairCompleted?: () => void;
   matchesRefreshNonce?: number;
   onRoundEnded?: () => void | Promise<void>;
@@ -85,6 +86,7 @@ export default function TournamentTabs({
   decklists,
   onDecklistsChange,
   isHost = false,
+  numberingMode,
   onRepairCompleted,
   matchesRefreshNonce,
   onRoundEnded,
@@ -237,6 +239,7 @@ export default function TournamentTabs({
               tournamentId={tournamentId}
               decklists={decklists}
               onDecklistsChange={onDecklistsChange}
+              numberingMode={numberingMode}
             />
           </div>
         )}

--- a/docs/superpowers/plans/2026-07-16-static-seats.md
+++ b/docs/superpowers/plans/2026-07-16-static-seats.md
@@ -1,0 +1,1296 @@
+# Static Seats & Seat-Numbering Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hosts can pin a participant to a static table (or chair, in seat-numbering mode); every pairing generation places that player's match at their pin, with deterministic conflict handling.
+
+**Architecture:** Pure post-pairing assignment function (`assignTables`) in `lib/tournament/`, persisted to a new `matches.table_number` column by all three match-writing paths (createPairing, regenerate RPC, repair handlers). Display and print read the persisted number with an index-math fallback for legacy rounds. Spec: `docs/superpowers/specs/2026-07-15-static-seats-design.md`.
+
+**Tech Stack:** Next.js 15 / React 19 / TypeScript (strict:false), Supabase (Postgres + RLS), vitest.
+
+## Global Constraints
+
+- All work in the worktree `/Users/timestes/projects/rtt-seats` on branch `feat/static-seats`. Use absolute paths. Never touch `/Users/timestes/projects/redemption-tournament-tracker` (a sibling agent owns it).
+- `git add` only the specific files you changed — never `-A`/`.`.
+- tsconfig has `strict: false`: union narrowing via `if (x.ok)` does not narrow — use explicit comparisons (`=== null`, `=== "seats"`).
+- No `focus:ring-2 focus:ring-ring` on form controls (project convention).
+- Type gate is `npx tsc --noEmit -p tsconfig.json` (pre-existing errors exist in `__tests__/forge-anon-leak.test.ts` and `app/forge/lib/__tests__/playDecksAuthorize.test.ts` — ignore those two files only).
+- Tests: `npx vitest run <path>` (vitest, not jest).
+- Seat math: table *k* ↔ seats *2k−1* (player1 chair) and *2k* (player2 chair). A pin is a table number in `tables` mode, a seat number in `seats` mode.
+
+---
+
+### Task 1: Migration `078_static_seats.sql`
+
+**Files:**
+- Create: `supabase/migrations/078_static_seats.sql`
+
+**Interfaces:**
+- Consumes: existing `regenerate_current_round_pairings` definition (migration 036).
+- Produces: columns `tournaments.numbering_mode`, `participants.assigned_seat`, `matches.table_number`; RPC now inserts `table_number` from each `p_pairings` element (JSON key `table_number`, may be absent → NULL).
+
+- [ ] **Step 1: Write the migration file**
+
+```sql
+-- Static seats & seat-numbering mode.
+-- Spec: docs/superpowers/specs/2026-07-15-static-seats-design.md
+--
+-- 1. tournaments.numbering_mode: 'tables' (default, current behavior) or
+--    'seats' (numbered chairs, two per table: table k = seats 2k-1, 2k).
+-- 2. participants.assigned_seat: optional static pin. Interpreted per mode
+--    (table number in tables mode, seat number in seats mode).
+-- 3. matches.table_number: the match's physical table, persisted at pairing
+--    time. NULL for legacy rounds (display falls back to index math).
+-- 4. regenerate_current_round_pairings: accepts table_number per pairing.
+
+ALTER TABLE tournaments
+  ADD COLUMN numbering_mode text NOT NULL DEFAULT 'tables'
+  CHECK (numbering_mode IN ('tables', 'seats'));
+
+ALTER TABLE participants
+  ADD COLUMN assigned_seat integer
+  CHECK (assigned_seat IS NULL OR assigned_seat >= 1);
+
+-- One pin value per tournament. Blocks two players pinned to the same
+-- table/seat. Seats-mode couples sharing a table use different values (9, 10).
+CREATE UNIQUE INDEX participants_assigned_seat_unique
+  ON participants (tournament_id, assigned_seat)
+  WHERE assigned_seat IS NOT NULL;
+
+ALTER TABLE matches ADD COLUMN table_number integer;
+
+-- Redefine the regenerate RPC (body from migration 036) with table_number
+-- added to the INSERT. ->> yields NULL when the key is absent, so old
+-- callers keep working.
+CREATE OR REPLACE FUNCTION regenerate_current_round_pairings(
+  p_tournament_id  UUID,
+  p_pairings       JSONB,
+  p_bye_id         UUID DEFAULT NULL,
+  p_unlock         BOOLEAN DEFAULT FALSE
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_host_id      UUID;
+  v_current_rnd  INT;
+  v_round_id     UUID;
+  v_is_completed BOOLEAN;
+  v_scored_count INT;
+  v_inserted     INT := 0;
+  v_pair         JSONB;
+BEGIN
+  SELECT host_id, current_round INTO v_host_id, v_current_rnd
+  FROM tournaments
+  WHERE id = p_tournament_id
+  FOR UPDATE;
+
+  IF v_host_id IS NULL THEN
+    RAISE EXCEPTION 'regenerate_current_round_pairings: tournament % not found', p_tournament_id;
+  END IF;
+
+  IF auth.uid() IS NULL OR auth.uid() <> v_host_id THEN
+    RAISE EXCEPTION 'regenerate_current_round_pairings: not the tournament host';
+  END IF;
+
+  SELECT id, is_completed INTO v_round_id, v_is_completed
+  FROM rounds
+  WHERE tournament_id = p_tournament_id
+    AND round_number = v_current_rnd;
+
+  IF v_round_id IS NULL THEN
+    RAISE EXCEPTION 'regenerate_current_round_pairings: no rounds row for round % (tournament state inconsistent)', v_current_rnd;
+  END IF;
+
+  IF v_is_completed THEN
+    RAISE EXCEPTION 'regenerate_current_round_pairings: round % is already completed', v_current_rnd;
+  END IF;
+
+  SELECT COUNT(*) INTO v_scored_count
+  FROM matches
+  WHERE tournament_id = p_tournament_id
+    AND round = v_current_rnd
+    AND player1_score IS NOT NULL;
+
+  IF v_scored_count > 0 AND NOT p_unlock THEN
+    RAISE EXCEPTION 'regenerate_current_round_pairings: % match(es) already scored; pass p_unlock=true to override', v_scored_count;
+  END IF;
+
+  DELETE FROM matches
+   WHERE tournament_id = p_tournament_id
+     AND round = v_current_rnd;
+  DELETE FROM byes
+   WHERE tournament_id = p_tournament_id
+     AND round_number = v_current_rnd;
+
+  FOR v_pair IN SELECT * FROM jsonb_array_elements(p_pairings)
+  LOOP
+    INSERT INTO matches (
+      tournament_id, round, player1_id, player2_id,
+      player1_score, player2_score, match_order, table_number
+    ) VALUES (
+      p_tournament_id,
+      v_current_rnd,
+      (v_pair->>'player1_id')::UUID,
+      (v_pair->>'player2_id')::UUID,
+      NULL, NULL,
+      (v_pair->>'match_order')::INT,
+      (v_pair->>'table_number')::INT
+    );
+    v_inserted := v_inserted + 1;
+  END LOOP;
+
+  IF p_bye_id IS NOT NULL THEN
+    INSERT INTO byes (
+      tournament_id, round_number, participant_id,
+      match_points, differential
+    ) VALUES (
+      p_tournament_id, v_current_rnd, p_bye_id, 3, 0
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'tournament_id', p_tournament_id,
+    'round', v_current_rnd,
+    'matches_inserted', v_inserted,
+    'bye_id', p_bye_id
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION regenerate_current_round_pairings(UUID, JSONB, UUID, BOOLEAN) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION regenerate_current_round_pairings(UUID, JSONB, UUID, BOOLEAN) FROM anon;
+GRANT EXECUTE ON FUNCTION regenerate_current_round_pairings(UUID, JSONB, UUID, BOOLEAN) TO authenticated;
+```
+
+- [ ] **Step 2: Sanity-check against 036**
+
+Run: `diff <(sed -n '/^CREATE OR REPLACE FUNCTION/,/^\$\$;/p' /Users/timestes/projects/rtt-seats/supabase/migrations/036_regenerate_pairings_require_rounds_row.sql) <(sed -n '/^CREATE OR REPLACE FUNCTION/,/^\$\$;/p' /Users/timestes/projects/rtt-seats/supabase/migrations/078_static_seats.sql)`
+Expected: the only differences are the `table_number` column in the INSERT column list and `(v_pair->>'table_number')::INT` in VALUES.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/timestes/projects/rtt-seats
+git add supabase/migrations/078_static_seats.sql
+git commit -m "feat(db): static seats schema + regenerate RPC accepts table_number"
+```
+
+**Note:** Do NOT apply the migration to the live DB in this task; the coordinator applies it via Supabase MCP during final verification (Task 10), keeping schema changes paired with the code that uses them.
+
+---
+
+### Task 2: Pure assignment function `assignTables` (TDD)
+
+**Files:**
+- Modify: `lib/tournament/types.ts` (add `NumberingMode`, `Participant.assignedSeat`, `TournamentState.startingTableNumber/numberingMode`)
+- Create: `lib/tournament/tableAssignment.ts`
+- Test: `lib/tournament/__tests__/tableAssignment.test.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces (used by Tasks 3, 4, 5):
+
+```ts
+export type NumberingMode = 'tables' | 'seats';                    // types.ts
+export interface AssignOptions { startingTableNumber: number; mode: NumberingMode; }
+export interface AssignableMatch { player1Id: string; player2Id: string; matchOrder: number; }
+export function assignTables<M extends AssignableMatch>(
+  matches: M[],
+  pins: Map<string, number>,          // participantId -> assigned_seat
+  opts: AssignOptions,
+): { matches: Array<M & { tableNumber: number }>; overriddenPins: string[] };
+// Returned matches are in matchOrder order; player1Id/player2Id may be
+// swapped relative to input (seats-mode chair sides).
+```
+
+- [ ] **Step 1: Add types to `lib/tournament/types.ts`**
+
+In the `Participant` interface, after `dropAfterRound?: number;` add:
+
+```ts
+  /** Static table (tables mode) or seat (seats mode) pin. Undefined = none. */
+  assignedSeat?: number;
+```
+
+After the `Bye` interface, add:
+
+```ts
+/** How a tournament numbers physical locations: one number per match
+ * ('tables') or one number per chair, two per table ('seats'). */
+export type NumberingMode = "tables" | "seats";
+```
+
+In `TournamentState`, after `startedRounds?: number[];` add:
+
+```ts
+  /** First table number used by unpinned fill. Optional for back-compat with
+   * hand-built test states; defaults to 1. */
+  startingTableNumber?: number;
+  /** Defaults to 'tables' when absent. */
+  numberingMode?: NumberingMode;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `lib/tournament/__tests__/tableAssignment.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { assignTables } from '../tableAssignment';
+import type { NumberingMode } from '../types';
+
+const m = (order: number, p1: string, p2: string) => ({
+  matchOrder: order, player1Id: p1, player2Id: p2,
+});
+const opts = (start = 1, mode: NumberingMode = 'tables') => ({
+  startingTableNumber: start, mode,
+});
+const tableOf = (r: ReturnType<typeof assignTables>, id: string) =>
+  r.matches.find(x => x.player1Id === id || x.player2Id === id)!.tableNumber;
+
+describe('assignTables — tables mode', () => {
+  it('no pins → identity fill from startingTableNumber in rank order', () => {
+    const r = assignTables([m(1, 'A', 'B'), m(2, 'C', 'D'), m(3, 'E', 'F')], new Map(), opts(5));
+    expect(r.matches.map(x => x.tableNumber)).toEqual([5, 6, 7]);
+    expect(r.overriddenPins).toEqual([]);
+  });
+
+  it('single pin places that match at the pinned table; fill skips it', () => {
+    const r = assignTables([m(1, 'A', 'B'), m(2, 'C', 'D'), m(3, 'E', 'F')],
+      new Map([['C', 2]]), opts(1));
+    expect(tableOf(r, 'C')).toBe(2);
+    expect(tableOf(r, 'A')).toBe(1);
+    expect(tableOf(r, 'E')).toBe(3);
+  });
+
+  it('sparse pin beyond match count is honored', () => {
+    const r = assignTables([m(1, 'A', 'B'), m(2, 'C', 'D')], new Map([['A', 50]]), opts(1));
+    expect(tableOf(r, 'A')).toBe(50);
+    expect(tableOf(r, 'C')).toBe(1);
+  });
+
+  it('pin below startingTableNumber is honored', () => {
+    const r = assignTables([m(1, 'A', 'B'), m(2, 'C', 'D')], new Map([['C', 3]]), opts(5));
+    expect(tableOf(r, 'C')).toBe(3);
+    expect(tableOf(r, 'A')).toBe(5);
+  });
+
+  it('two pinned players in one match: lower value wins, other overridden', () => {
+    const r = assignTables([m(1, 'A', 'B')], new Map([['A', 7], ['B', 4]]), opts(1));
+    expect(r.matches[0].tableNumber).toBe(4);
+    expect(r.overriddenPins).toEqual(['A']);
+  });
+});
+
+describe('assignTables — seats mode', () => {
+  it('even-seat pin maps to table ceil(s/2) and forces the player2 chair', () => {
+    // B pinned to seat 10 → table 5, even → player2 slot (input has B as player1).
+    const r = assignTables([m(1, 'B', 'A')], new Map([['B', 10]]), opts(1, 'seats'));
+    expect(r.matches[0].tableNumber).toBe(5);
+    expect(r.matches[0].player1Id).toBe('A');
+    expect(r.matches[0].player2Id).toBe('B');
+  });
+
+  it('odd-seat pin keeps/forces the player1 chair', () => {
+    const r = assignTables([m(1, 'A', 'B')], new Map([['A', 9]]), opts(1, 'seats'));
+    expect(r.matches[0].tableNumber).toBe(5);
+    expect(r.matches[0].player1Id).toBe('A');
+  });
+
+  it('seats 9+10 pinned and paired together: both honored, no override', () => {
+    const r = assignTables([m(1, 'X', 'Y')], new Map([['X', 10], ['Y', 9]]), opts(1, 'seats'));
+    expect(r.matches[0].tableNumber).toBe(5);
+    expect(r.matches[0].player1Id).toBe('Y'); // seat 9 = odd chair
+    expect(r.matches[0].player2Id).toBe('X');
+    expect(r.overriddenPins).toEqual([]);
+  });
+
+  it('cross-match same-table claims: lower seat wins, other bumped + overridden', () => {
+    // A pinned seat 9, C pinned seat 10 — both table 5, different matches.
+    const r = assignTables([m(1, 'A', 'B'), m(2, 'C', 'D')],
+      new Map([['A', 9], ['C', 10]]), opts(1, 'seats'));
+    expect(tableOf(r, 'A')).toBe(5);
+    expect(tableOf(r, 'C')).toBe(1); // bumped to normal fill
+    expect(r.overriddenPins).toEqual(['C']);
+  });
+});
+
+describe('assignTables — general', () => {
+  it('pin of a player not in any match (bye/dropped) claims nothing', () => {
+    const r = assignTables([m(1, 'A', 'B')], new Map([['Z', 1]]), opts(1));
+    expect(r.matches[0].tableNumber).toBe(1);
+  });
+
+  it('deterministic: identical inputs → identical outputs', () => {
+    const ms = [m(1, 'A', 'B'), m(2, 'C', 'D'), m(3, 'E', 'F')];
+    const pins = new Map([['E', 2], ['B', 7]]);
+    expect(assignTables(ms, pins, opts(1))).toEqual(assignTables(ms, pins, opts(1)));
+  });
+
+  it('returns matches in matchOrder order regardless of claims', () => {
+    const r = assignTables([m(1, 'A', 'B'), m(2, 'C', 'D')], new Map([['C', 1]]), opts(1));
+    expect(r.matches.map(x => x.matchOrder)).toEqual([1, 2]);
+  });
+
+  it('does not mutate its inputs', () => {
+    const ms = [m(1, 'B', 'A')];
+    const pins = new Map([['B', 10]]);
+    assignTables(ms, pins, opts(1, 'seats'));
+    expect(ms[0].player1Id).toBe('B'); // swap happened on a copy
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd /Users/timestes/projects/rtt-seats && npx vitest run lib/tournament/__tests__/tableAssignment.test.ts`
+Expected: FAIL — cannot resolve `../tableAssignment`.
+
+- [ ] **Step 4: Implement `lib/tournament/tableAssignment.ts`**
+
+```ts
+// lib/tournament/tableAssignment.ts
+//
+// Post-pairing table/seat assignment. Pure: no IO, no RNG. Decides WHERE each
+// match happens; never changes who plays whom.
+// Spec: docs/superpowers/specs/2026-07-15-static-seats-design.md
+//
+// Seat math (seats mode): table k holds seats 2k-1 (player1 chair) and 2k
+// (player2 chair). A pin is a table number in tables mode, a seat number in
+// seats mode.
+
+import type { NumberingMode } from "./types";
+
+export interface AssignOptions {
+  startingTableNumber: number;
+  mode: NumberingMode;
+}
+
+export interface AssignableMatch {
+  player1Id: string;
+  player2Id: string;
+  matchOrder: number;
+}
+
+export interface AssignResult<M extends AssignableMatch> {
+  /** In matchOrder order. player1Id/player2Id may be swapped vs input
+   * (seats-mode chair sides). */
+  matches: Array<M & { tableNumber: number }>;
+  /** Participants whose pin was not honored this round. */
+  overriddenPins: string[];
+}
+
+/** Table a pin points to: identity in tables mode, ceil(seat/2) in seats mode. */
+function pinTable(pin: number, mode: NumberingMode): number {
+  return mode === "seats" ? Math.ceil(pin / 2) : pin;
+}
+
+export function assignTables<M extends AssignableMatch>(
+  matches: M[],
+  pins: Map<string, number>,
+  opts: AssignOptions,
+): AssignResult<M> {
+  const { startingTableNumber, mode } = opts;
+  const overridden = new Set<string>();
+
+  // Rank order (matchOrder asc); input order isn't guaranteed.
+  const ranked = [...matches].sort((a, b) => a.matchOrder - b.matchOrder);
+
+  // Step 1: per-match claims. A match with two pins keeps the lower value
+  // (both, when they resolve to the same table — the seats 9+10 happy case).
+  interface Claim {
+    match: M;
+    table: number;
+    pinValue: number;
+    pinnedIds: string[];
+  }
+  const claims: Claim[] = [];
+  const unclaimed: M[] = [];
+  for (const match of ranked) {
+    const p1Pin = pins.get(match.player1Id);
+    const p2Pin = pins.get(match.player2Id);
+    if (p1Pin === undefined && p2Pin === undefined) {
+      unclaimed.push(match);
+      continue;
+    }
+    let pinValue: number;
+    let pinnedIds: string[];
+    if (p1Pin !== undefined && p2Pin !== undefined) {
+      if (pinTable(p1Pin, mode) === pinTable(p2Pin, mode)) {
+        pinValue = Math.min(p1Pin, p2Pin);
+        pinnedIds = [match.player1Id, match.player2Id];
+      } else if (p1Pin <= p2Pin) {
+        pinValue = p1Pin;
+        pinnedIds = [match.player1Id];
+        overridden.add(match.player2Id);
+      } else {
+        pinValue = p2Pin;
+        pinnedIds = [match.player2Id];
+        overridden.add(match.player1Id);
+      }
+    } else if (p1Pin !== undefined) {
+      pinValue = p1Pin;
+      pinnedIds = [match.player1Id];
+    } else {
+      pinValue = p2Pin as number;
+      pinnedIds = [match.player2Id];
+    }
+    claims.push({ match, table: pinTable(pinValue, mode), pinValue, pinnedIds });
+  }
+
+  // Step 2: resolve cross-match claims to the same table — (pin value asc,
+  // matchOrder asc); first claimant keeps it, the rest drop to fill.
+  claims.sort((a, b) => a.pinValue - b.pinValue || a.match.matchOrder - b.match.matchOrder);
+  const taken = new Set<number>();
+  const placed: Array<{ match: M; tableNumber: number; pinnedIds: string[] }> = [];
+  for (const c of claims) {
+    if (taken.has(c.table)) {
+      for (const id of c.pinnedIds) overridden.add(id);
+      unclaimed.push(c.match);
+      continue;
+    }
+    taken.add(c.table);
+    placed.push({ match: c.match, tableNumber: c.table, pinnedIds: c.pinnedIds });
+  }
+
+  // Step 3: fill — bumped + unpinned matches take the lowest free tables
+  // >= startingTableNumber in rank order, skipping claimed tables.
+  unclaimed.sort((a, b) => a.matchOrder - b.matchOrder);
+  let next = startingTableNumber;
+  for (const match of unclaimed) {
+    while (taken.has(next)) next++;
+    taken.add(next);
+    placed.push({ match, tableNumber: next, pinnedIds: [] });
+  }
+
+  // Step 4: seats-mode chair sides — an honored pin to an even seat sits in
+  // the player2 slot, odd in player1. Swaps a copy, never the input.
+  const out = placed.map(({ match, tableNumber, pinnedIds }) => {
+    let result: M = match;
+    if (mode === "seats") {
+      for (const id of pinnedIds) {
+        const pin = pins.get(id) as number;
+        const wantsPlayer1 = pin % 2 === 1;
+        const isPlayer1 = result.player1Id === id;
+        if (wantsPlayer1 !== isPlayer1) {
+          result = { ...result, player1Id: result.player2Id, player2Id: result.player1Id };
+        }
+      }
+    }
+    return { ...result, tableNumber };
+  });
+
+  out.sort((a, b) => a.matchOrder - b.matchOrder);
+  return { matches: out, overriddenPins: [...overridden] };
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/timestes/projects/rtt-seats && npx vitest run lib/tournament/__tests__/tableAssignment.test.ts`
+Expected: PASS (12 tests).
+
+- [ ] **Step 6: Run the full tournament suite (no regressions)**
+
+Run: `cd /Users/timestes/projects/rtt-seats && npx vitest run lib/tournament`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/timestes/projects/rtt-seats
+git add lib/tournament/types.ts lib/tournament/tableAssignment.ts lib/tournament/__tests__/tableAssignment.test.ts
+git commit -m "feat(tournament): pure assignTables — static pins, seat math, conflict rules"
+```
+
+---
+
+### Task 3: Persist table numbers from `createPairing`
+
+**Files:**
+- Modify: `utils/tournament/stateAdapter.ts` (selects + mapping)
+- Modify: `utils/tournament/pairingUtilsV2.ts` (assign + persist)
+
+**Interfaces:**
+- Consumes: `assignTables` from Task 2.
+- Produces: `TournamentState` now carries `startingTableNumber`, `numberingMode`, and `Participant.assignedSeat` (Task 4 relies on this); `matches` rows inserted by `createPairing` include `table_number`.
+
+- [ ] **Step 1: Extend `stateAdapter.ts`**
+
+Tournament select (line ~53) becomes:
+
+```ts
+    .select("id, n_rounds, current_round, max_score, has_started, has_ended, starting_table_number, numbering_mode")
+```
+
+Participants select (line ~61) becomes:
+
+```ts
+    .select("id, name, joined_at, dropped_out, assigned_seat")
+```
+
+Participant mapping gains:
+
+```ts
+    assignedSeat: p.assigned_seat ?? undefined,
+```
+
+The returned state object gains (after `startedRounds`):
+
+```ts
+    startingTableNumber: t.starting_table_number ?? 1,
+    numberingMode: t.numbering_mode === "seats" ? "seats" : "tables",
+```
+
+- [ ] **Step 2: Update `pairingUtilsV2.ts`**
+
+Add import:
+
+```ts
+import { assignTables } from "../../lib/tournament/tableAssignment";
+```
+
+Replace `persistMatches` with:
+
+```ts
+/** Insert match records for a round. */
+async function persistMatches(
+  client: AnyClient,
+  tournamentId: string,
+  matches: Array<{
+    round: number;
+    player1Id: string;
+    player2Id: string;
+    matchOrder: number;
+    tableNumber: number;
+  }>,
+) {
+  if (matches.length === 0) return;
+  const rows = matches.map(m => ({
+    tournament_id: tournamentId,
+    round: m.round,
+    player1_id: m.player1Id,
+    player2_id: m.player2Id,
+    player1_score: null,
+    player2_score: null,
+    match_order: m.matchOrder,
+    table_number: m.tableNumber,
+  }));
+  await client.from("matches").insert(rows);
+}
+```
+
+In `createPairing`, between computing `result` and persisting, add:
+
+```ts
+    // Static seats: place each match at a physical table, honoring pins.
+    // Chair-side swaps (seats mode) happen here, before insert, while the
+    // match has no scores. Spec: 2026-07-15-static-seats-design.md
+    const pins = new Map<string, number>();
+    for (const p of state.participants) {
+      if (!p.droppedOut && p.assignedSeat != null) pins.set(p.id, p.assignedSeat);
+    }
+    const assigned = assignTables(result.matches, pins, {
+      startingTableNumber: state.startingTableNumber ?? 1,
+      mode: state.numberingMode ?? "tables",
+    });
+```
+
+and change the persist call to:
+
+```ts
+    await persistMatches(client, tournamentId, assigned.matches);
+```
+
+- [ ] **Step 3: Type-check + full suite**
+
+Run: `cd /Users/timestes/projects/rtt-seats && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -v "forge-anon-leak\|playDecksAuthorize" | grep "error TS" ; npx vitest run lib/tournament utils`
+Expected: no new type errors; all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/timestes/projects/rtt-seats
+git add utils/tournament/stateAdapter.ts utils/tournament/pairingUtilsV2.ts
+git commit -m "feat(tournament): createPairing assigns and persists table numbers"
+```
+
+---
+
+### Task 4: Regenerate path passes `table_number` through the RPC
+
+**Files:**
+- Modify: `app/tracker/tournaments/repair-actions.ts:50-87` (`regenerateCurrentRoundPairingsAction`)
+
+**Interfaces:**
+- Consumes: `assignTables` (Task 2), extended state (Task 3), RPC accepting `table_number` (Task 1).
+- Produces: regenerated rounds have `matches.table_number` set.
+
+- [ ] **Step 1: Update the action**
+
+Add import at the top of the file:
+
+```ts
+import { assignTables } from "@/lib/tournament/tableAssignment";
+```
+
+(Match the file's existing import style — if it uses relative paths, use `../../../lib/tournament/tableAssignment`.)
+
+In `regenerateCurrentRoundPairingsAction`, replace the `const pairings = ...` block with:
+
+```ts
+  // Static seats: honor pins when placing regenerated matches (spec
+  // 2026-07-15-static-seats-design.md).
+  const pins = new Map<string, number>();
+  for (const p of state.participants) {
+    if (!p.droppedOut && p.assignedSeat != null) pins.set(p.id, p.assignedSeat);
+  }
+  const assigned = assignTables(result.matches, pins, {
+    startingTableNumber: state.startingTableNumber ?? 1,
+    mode: state.numberingMode ?? "tables",
+  });
+
+  const pairings = assigned.matches.map((m, idx) => ({
+    player1_id: m.player1Id,
+    player2_id: m.player2Id,
+    match_order: m.matchOrder ?? idx + 1,
+    table_number: m.tableNumber,
+  }));
+```
+
+- [ ] **Step 2: Type-check + existing repair tests**
+
+Run: `cd /Users/timestes/projects/rtt-seats && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -v "forge-anon-leak\|playDecksAuthorize" | grep "error TS" ; npx vitest run app/tracker/tournaments/__tests__/repair-actions.test.ts`
+Expected: no new type errors; repair tests pass (they mock the RPC — extra payload key is inert).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/timestes/projects/rtt-seats
+git add app/tracker/tournaments/repair-actions.ts
+git commit -m "feat(tournament): regenerate pairings persists table numbers via RPC"
+```
+
+---
+
+### Task 5: `reassignRoundTables` helper + wire into repair swaps
+
+**Files:**
+- Create: `utils/tournament/reassignTables.ts`
+- Modify: `components/ui/TournamentRounds.tsx` (`handleSwapPlayers` ~line 656, `handleSwapPlayerWithBye` ~line 768)
+- Modify: `components/ui/RepairPairingModal.tsx` (`handleRepair` ~lines 83-199)
+
+**Interfaces:**
+- Consumes: `assignTables` (Task 2).
+- Produces: `reassignRoundTables(client, tournamentId, round): Promise<void>` — reloads the round's matches + pins, recomputes placement, updates `matches.table_number` (and swaps chair sides + their sibling columns where seats mode demands it).
+
+- [ ] **Step 1: Create the helper**
+
+`utils/tournament/reassignTables.ts`:
+
+```ts
+// Recompute a round's table numbers after a manual repair (player swap,
+// bye swap, re-pair). Deterministic: same helper the pairing paths use.
+// Safe only pre-results — all repair flows are already gated to rounds
+// with no scores entered.
+
+import { assignTables } from "../../lib/tournament/tableAssignment";
+
+type AnyClient = {
+  from: (table: string) => any;
+};
+
+export async function reassignRoundTables(
+  client: AnyClient,
+  tournamentId: string,
+  round: number,
+): Promise<void> {
+  const [{ data: t }, { data: parts }, { data: ms }] = await Promise.all([
+    client
+      .from("tournaments")
+      .select("starting_table_number, numbering_mode")
+      .eq("id", tournamentId)
+      .single(),
+    client
+      .from("participants")
+      .select("id, assigned_seat")
+      .eq("tournament_id", tournamentId)
+      .not("assigned_seat", "is", null),
+    client
+      .from("matches")
+      .select(
+        "id, player1_id, player2_id, match_order, player1_match_points, player2_match_points, differential, differential2",
+      )
+      .eq("tournament_id", tournamentId)
+      .eq("round", round),
+  ]);
+  if (!t || !ms || ms.length === 0) return;
+
+  const pins = new Map<string, number>(
+    (parts || []).map((p: any) => [p.id as string, p.assigned_seat as number]),
+  );
+  const rows = (ms || []).map((m: any) => ({
+    id: m.id as string,
+    player1Id: m.player1_id as string,
+    player2Id: m.player2_id as string,
+    matchOrder: (m.match_order ?? 0) as number,
+  }));
+  const byId = new Map((ms || []).map((m: any) => [m.id as string, m]));
+
+  const { matches: assigned } = assignTables(rows, pins, {
+    startingTableNumber: t.starting_table_number ?? 1,
+    mode: t.numbering_mode === "seats" ? "seats" : "tables",
+  });
+
+  for (const m of assigned) {
+    const orig = byId.get((m as any).id);
+    if (!orig) continue;
+    const swapped = orig.player1_id !== m.player1Id;
+    const patch: Record<string, unknown> = { table_number: m.tableNumber };
+    if (swapped) {
+      // Chair-side swap: mirror handleSwapPlayers' same-match flip — swap the
+      // per-side sibling columns along with the ids. Scores are null here
+      // (repairs are pre-results), so they don't need swapping.
+      patch.player1_id = m.player1Id;
+      patch.player2_id = m.player2Id;
+      patch.player1_match_points = orig.player2_match_points;
+      patch.player2_match_points = orig.player1_match_points;
+      patch.differential = orig.differential2;
+      patch.differential2 = orig.differential;
+    }
+    await client.from("matches").update(patch).eq("id", (m as any).id);
+  }
+}
+```
+
+- [ ] **Step 2: Wire into `TournamentRounds.tsx`**
+
+Add import (top of file, alongside the other `../../utils` imports):
+
+```ts
+import { reassignRoundTables } from "../../utils/tournament/reassignTables";
+```
+
+In `handleSwapPlayers` (~line 656) and `handleSwapPlayerWithBye` (~line 768): after the last `await client.from(...)`/`await client.rpc(...)` write of each handler and **before** `await fetchCurrentRoundData()`, insert:
+
+```ts
+      await reassignRoundTables(client, tournamentId, currentPage);
+```
+
+(`currentPage` is the round being viewed/repaired in this component; both handlers already operate on it. Do NOT add this to `handleSwapPlayersWithBye` (~line 726) — that one swaps two bye holders and touches no matches.)
+
+- [ ] **Step 3: Wire into `RepairPairingModal.tsx`**
+
+Add the same import (path from `components/ui/`: `../../utils/tournament/reassignTables`). In `handleRepair`, after its final DB write and before the success callback/refresh call at the end of the function, insert the same call, using the modal's existing tournament-id and round values (read the surrounding code for their prop/variable names — the handler already filters matches by round).
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd /Users/timestes/projects/rtt-seats && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -v "forge-anon-leak\|playDecksAuthorize" | grep "error TS"`
+Expected: no new errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/timestes/projects/rtt-seats
+git add utils/tournament/reassignTables.ts components/ui/TournamentRounds.tsx components/ui/RepairPairingModal.tsx
+git commit -m "feat(tournament): repairs recompute table numbers (pins follow players)"
+```
+
+---
+
+### Task 6: Rounds view — persisted tables, seat display, overridden-pin badge
+
+**Files:**
+- Modify: `components/ui/TournamentRounds.tsx` (TournamentInfo type ~106, initial state ~146, tournament fetch ~262, matches fetch ~402-409, desktop table cell ~1094, mobile card ~1271)
+
+**Interfaces:**
+- Consumes: `matches.table_number`, `participants.assigned_seat`, `tournaments.numbering_mode` (Tasks 1, 3).
+- Produces: `matches` state rows now carry `table_number` and joined `assigned_seat`; print handlers (Task 7) read them.
+
+- [ ] **Step 1: Fetch the new columns**
+
+TournamentInfo type (~line 106): add `numbering_mode: string | null;` — initial state (~146): add `numbering_mode: null,`.
+
+Tournament select (~line 262): append `, numbering_mode`:
+
+```ts
+          .select("id, n_rounds, current_round, has_ended, max_score, starting_table_number, name, numbering_mode")
+```
+
+Matches select (~line 404): add `table_number` and `assigned_seat` on both joins, and sort by table first:
+
+```ts
+      .select(
+        "id, match_order, table_number, player1_match_points, player2_match_points, differential, differential2, player1_id:participants!matches_player1_id_fkey(name,id,assigned_seat), player2_id:participants!matches_player2_id_fkey(name,id,assigned_seat), player1_score, player2_score"
+      )
+      .eq("tournament_id", tournamentId)
+      .eq("round", currentPage)
+      .order("table_number", { ascending: true, nullsFirst: true })
+      .order("match_order", { ascending: true });
+```
+
+(A round is either all-legacy (`table_number` null → match_order sort, identical to today) or all-new (table sort); the two never mix within one round.)
+
+- [ ] **Step 2: Display helpers**
+
+Near the other derived consts in the component body (after `noScoresEntered`, ~line 896), add:
+
+```ts
+  const isSeatsMode = tournamentInfo.numbering_mode === "seats";
+
+  /** Persisted table with legacy fallback to positional numbering. */
+  const displayTable = (match: any, index: number): number =>
+    match.table_number ?? index + (tournamentInfo.starting_table_number || 1);
+
+  /** True when a player's static pin was not honored this round. */
+  const pinOverridden = (match: any, side: 1 | 2, tableNum: number): boolean => {
+    const pin = side === 1 ? match.player1_id?.assigned_seat : match.player2_id?.assigned_seat;
+    if (pin == null || match.table_number == null) return false;
+    if (isSeatsMode) {
+      return pin !== (side === 1 ? 2 * tableNum - 1 : 2 * tableNum);
+    }
+    return pin !== tableNum;
+  };
+```
+
+- [ ] **Step 3: Use them at the two display sites**
+
+Desktop table-number cell (~line 1094): replace `{index + (tournamentInfo.starting_table_number || 1)}` with:
+
+```tsx
+{isSeatsMode
+  ? `${2 * displayTable(match, index) - 1}·${2 * displayTable(match, index)}`
+  : displayTable(match, index)}
+```
+
+Mobile card (~line 1271): replace `const tableNum = index + (tournamentInfo.starting_table_number || 1);` with:
+
+```tsx
+const tableNum = displayTable(match, index);
+const tableLabel = isSeatsMode ? `Seats ${2 * tableNum - 1}·${2 * tableNum}` : `Table ${tableNum}`;
+```
+
+and use `tableLabel` where the card currently renders `Table {tableNum}` (keep the raw `tableNum` variable for anything else that uses it).
+
+Next to each player-name render inside the desktop row and mobile card (both `matches.map` blocks), append after the name span:
+
+```tsx
+{pinOverridden(match, 1, displayTable(match, index)) && (
+  <span
+    title="Static seat not honored this round (conflicting pins)"
+    className="text-amber-500 text-xs flex-shrink-0"
+    aria-label="Static seat not honored this round"
+  >⚠</span>
+)}
+```
+
+(and the `side: 2` twin after the player-2 name). In seats mode also prefix each name with its seat number:
+
+```tsx
+{isSeatsMode && (
+  <span className="text-xs text-muted-foreground tabular-nums mr-1">
+    {2 * displayTable(match, index) - 1}
+  </span>
+)}
+```
+
+(player 2 uses `2 * displayTable(match, index)`).
+
+- [ ] **Step 4: Type-check + eyeball**
+
+Run: `cd /Users/timestes/projects/rtt-seats && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -v "forge-anon-leak\|playDecksAuthorize" | grep "error TS"`
+Expected: no new errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/timestes/projects/rtt-seats
+git add components/ui/TournamentRounds.tsx
+git commit -m "feat(tournament): rounds view reads persisted tables, seats mode + pin badges"
+```
+
+---
+
+### Task 7: Print pairings + match slips read persisted numbers, seat-aware
+
+**Files:**
+- Modify: `utils/printUtils.ts` (`printTournamentPairings` ~166, `printMatchSlips` ~312)
+- Modify: `components/ui/TournamentRounds.tsx` (`handlePrintPairings` ~832, `handlePrintMatchSlips` ~842)
+
+**Interfaces:**
+- Consumes: `matches` rows carrying `table_number` (Task 6 fetch), `numbering_mode`.
+- Produces: both print functions gain a trailing `numberingMode: 'tables' | 'seats' = 'tables'` parameter.
+
+- [ ] **Step 1: `printTournamentPairings`**
+
+Signature becomes:
+
+```ts
+export const printTournamentPairings = (
+  matches: any[],
+  byes: any[],
+  roundNumber: number,
+  startingTableNumber: number = 1,
+  tournamentName?: string | null,
+  numberingMode: 'tables' | 'seats' = 'tables',
+): void => {
+```
+
+Replace the `pairingsHtml` builder with:
+
+```ts
+  const pairingsHtml = (matches || [])
+    .map((match, index) => {
+      const table = match.table_number ?? index + startingTableNumber;
+      if (numberingMode === 'seats') {
+        // Per-chair numbers replace the single table badge.
+        return `
+        <li class="pair pair-seats">
+          <span class="names">
+            <span class="seat">${2 * table - 1}</span>
+            <span class="p">${escapeHtml(match.player1_id?.name)}</span>
+            <span class="vs">vs</span>
+            <span class="seat">${2 * table}</span>
+            <span class="p">${escapeHtml(match.player2_id?.name)}</span>
+          </span>
+        </li>`;
+      }
+      return `
+        <li class="pair">
+          <span class="t">${table}</span>
+          <span class="names">
+            <span class="p">${escapeHtml(match.player1_id?.name)}</span>
+            <span class="vs">vs</span>
+            <span class="p">${escapeHtml(match.player2_id?.name)}</span>
+          </span>
+        </li>`;
+    })
+    .join('');
+```
+
+In the `<style>` block, after the `.pair .vs` rule, add:
+
+```css
+          .pair.pair-seats { grid-template-columns: 1fr; }
+          .pair .seat {
+            font-weight: 800; color: #555;
+            font-variant-numeric: tabular-nums; font-size: 13px;
+          }
+```
+
+- [ ] **Step 2: `printMatchSlips`**
+
+Signature gains the same trailing parameter:
+
+```ts
+export const printMatchSlips = (
+  matches: any[],
+  roundNumber: number,
+  startingTableNumber: number = 1,
+  tournamentName?: string | null,
+  numberingMode: 'tables' | 'seats' = 'tables',
+): void => {
+```
+
+Inside the per-slip map, replace `const tableNumber = index + startingTableNumber;` with:
+
+```ts
+    const tableNumber = match.table_number ?? index + startingTableNumber;
+    const locationLabel = numberingMode === 'seats'
+      ? `Seats ${2 * tableNumber - 1} &amp; ${2 * tableNumber}`
+      : `Table ${tableNumber}`;
+    const p1Seat = numberingMode === 'seats' ? `<span class="slip-seat">${2 * tableNumber - 1}</span> ` : '';
+    const p2Seat = numberingMode === 'seats' ? `<span class="slip-seat">${2 * tableNumber}</span> ` : '';
+```
+
+Header line uses the label (replace `Table ${tableNumber}`):
+
+```html
+          <strong>${escapeHtml(tournamentName || 'Tournament')}</strong> - Round ${roundNumber} - ${locationLabel}
+```
+
+Player-name cells gain the seat prefix and escaping (replace the two `${match.playerN_id.name}` interpolations):
+
+```html
+            <td class="player-name">${p1Seat}${escapeHtml(match.player1_id?.name)}</td>
+            ...
+            <td class="player-name">${p2Seat}${escapeHtml(match.player2_id?.name)}</td>
+```
+
+Add to the slips `<style>` block (after `.player-name`):
+
+```css
+          .slip-seat { color: #888; font-weight: normal; }
+```
+
+- [ ] **Step 3: Callers pass the mode**
+
+In `TournamentRounds.tsx`, both handlers gain a final argument:
+
+```ts
+      tournamentInfo.numbering_mode === "seats" ? "seats" : "tables",
+```
+
+(`handlePrintPairings` after the tournament-name arg; same for `handlePrintMatchSlips`.)
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd /Users/timestes/projects/rtt-seats && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -v "forge-anon-leak\|playDecksAuthorize" | grep "error TS"`
+Expected: no new errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/timestes/projects/rtt-seats
+git add utils/printUtils.ts components/ui/TournamentRounds.tsx
+git commit -m "feat(print): pairings + match slips read persisted tables, seat-aware"
+```
+
+---
+
+### Task 8: Assign pins — edit modal, save handler, roster badge
+
+**Files:**
+- Modify: `components/ui/EditParticipantModal.tsx`
+- Modify: `app/tracker/tournaments/[id]/page.tsx` (state ~49, `updateParticipant` ~185-203, modal-open handler ~905, modal props ~1074-1076, TournamentTabs props ~897)
+- Modify: `components/ui/ParticipantTable.tsx` (interface ~10-30, name renders in mobile ~200 + desktop ~263)
+- Modify: `components/ui/TournamentTabs.tsx` (pass-through prop ~229)
+
+**Interfaces:**
+- Consumes: `participants.assigned_seat` column (page participants fetch is `select("*")` so the field flows automatically); tournament `numbering_mode` (page's tournament fetch — if it selects explicit columns, add `numbering_mode`; if `select("*")`, nothing to add).
+- Produces: `EditParticipantModal` props gain `numberingMode: "tables" | "seats"`, `seatValue: string`, `setSeatValue: (v: string) => void`; `ParticipantTable`/`TournamentTabs` props gain `numberingMode: "tables" | "seats"`.
+
+- [ ] **Step 1: Modal field**
+
+In `EditParticipantModal.tsx`, extend the props interface:
+
+```ts
+  numberingMode: "tables" | "seats";
+  seatValue: string;
+  setSeatValue: (v: string) => void;
+```
+
+destructure them, and add below the name field inside `DialogBody`:
+
+```tsx
+            <div className="space-y-1">
+              <label htmlFor="assigned-seat" className="text-sm font-medium text-foreground">
+                Static {numberingMode === "seats" ? "seat" : "table"} #{" "}
+                <span className="text-muted-foreground font-normal">(optional)</span>
+              </label>
+              <input
+                id="assigned-seat"
+                name="assigned-seat"
+                type="number"
+                min={1}
+                step={1}
+                value={seatValue}
+                onChange={(e) => setSeatValue(e.target.value)}
+                placeholder="None"
+                className="w-full rounded-lg border border-border bg-card text-foreground px-3 py-2 text-sm focus:outline-none"
+              />
+              <p className="text-xs text-muted-foreground">
+                Always placed at this {numberingMode === "seats" ? "seat" : "table"} when
+                pairings are generated. Leave empty for automatic placement.
+              </p>
+            </div>
+```
+
+- [ ] **Step 2: Page state + save**
+
+In `app/tracker/tournaments/[id]/page.tsx`, next to the `newParticipantName` state (~line 49):
+
+```ts
+  const [newParticipantSeat, setNewParticipantSeat] = useState<string>("");
+```
+
+Where the edit modal is opened (~line 905, right after `setNewParticipantName(participant.name)`):
+
+```ts
+    setNewParticipantSeat(participant.assigned_seat != null ? String(participant.assigned_seat) : "");
+```
+
+Derive the mode near the modal render (the page already holds the tournament row):
+
+```ts
+  const numberingMode: "tables" | "seats" =
+    tournament?.numbering_mode === "seats" ? "seats" : "tables";
+```
+
+Replace the body of `updateParticipant` (~185-203) with:
+
+```ts
+  const updateParticipant = async () => {
+    if (!currentParticipant || !newParticipantName.trim()) return;
+    const trimmedSeat = newParticipantSeat.trim();
+    const seatNum = trimmedSeat === "" ? null : Number(trimmedSeat);
+    if (seatNum !== null && (!Number.isInteger(seatNum) || seatNum < 1)) {
+      showToast("Static assignment must be a positive whole number.", "error");
+      return;
+    }
+    try {
+      const { error } = await supabase
+        .from("participants")
+        .update({ name: newParticipantName, assigned_seat: seatNum })
+        .eq("id", currentParticipant.id);
+      if (error) {
+        if ((error as { code?: string }).code === "23505") {
+          showToast(
+            `${numberingMode === "seats" ? "Seat" : "Table"} ${seatNum} is already assigned to another player.`,
+            "error",
+          );
+          return;
+        }
+        throw error;
+      }
+      fetchParticipants();
+      setIsEditParticipantModalOpen(false);
+      showToast("Participant updated successfully!", "success");
+    } catch (error) {
+      showToast("Error updating participant.", "error");
+      console.error("Error updating participant:", error);
+    }
+  };
+```
+
+Modal usage (~1074-1076) gains:
+
+```tsx
+        numberingMode={numberingMode}
+        seatValue={newParticipantSeat}
+        setSeatValue={setNewParticipantSeat}
+```
+
+`TournamentTabs` usage (~897) gains `numberingMode={numberingMode}`.
+
+- [ ] **Step 3: Roster badge**
+
+`TournamentTabs.tsx`: add `numberingMode: "tables" | "seats";` to its props and forward `numberingMode={numberingMode}` to `<ParticipantTable ...>` (~line 229).
+
+`ParticipantTable.tsx`: `Participant` interface gains `assigned_seat?: number | null;`; props gain `numberingMode: "tables" | "seats";`. In both the mobile name row (inside the flex-wrap div, ~line 204) and the desktop name cell (~line 267), after the dropped-out span add:
+
+```tsx
+                    {participant.assigned_seat != null && (
+                      <span
+                        className="text-[11px] font-semibold tabular-nums rounded px-1.5 py-0.5 bg-muted text-muted-foreground border border-border flex-shrink-0"
+                        title={`Static ${numberingMode === "seats" ? "seat" : "table"} ${participant.assigned_seat}`}
+                      >
+                        {numberingMode === "seats" ? "S" : "T"}
+                        {participant.assigned_seat}
+                      </span>
+                    )}
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd /Users/timestes/projects/rtt-seats && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -v "forge-anon-leak\|playDecksAuthorize" | grep "error TS"`
+Expected: no new errors. If the page's tournament fetch selects explicit columns (not `*`), add `numbering_mode` to that select in this task.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/timestes/projects/rtt-seats
+git add components/ui/EditParticipantModal.tsx "app/tracker/tournaments/[id]/page.tsx" components/ui/ParticipantTable.tsx components/ui/TournamentTabs.tsx
+git commit -m "feat(tournament): assign static seats from the players tab"
+```
+
+---
+
+### Task 9: Settings — numbering-mode toggle with pin warning
+
+**Files:**
+- Modify: `components/ui/TournamentSettings.tsx` (interface ~8-19, EMPTY_INFO ~35, EDITABLE_KEYS ~42-50, fetch select ~70-76, form controls)
+
+**Interfaces:**
+- Consumes: `tournaments.numbering_mode`, pinned-participant count.
+- Produces: hosts can switch modes; the existing dirty-tracking/patch save handles persistence automatically once the key is registered.
+
+- [ ] **Step 1: Register the field**
+
+- `TournamentInfo` interface: add `numbering_mode: string | null;`
+- `EMPTY_INFO`: add `numbering_mode: "tables",`
+- `EDITABLE_KEYS`: add `"numbering_mode",`
+- Fetch select string: append `, numbering_mode`
+
+- [ ] **Step 2: Pinned-count state**
+
+```ts
+  const [pinnedCount, setPinnedCount] = useState(0);
+```
+
+In the existing fetch effect, after the tournament info loads:
+
+```ts
+      const { count } = await client
+        .from("participants")
+        .select("id", { count: "exact", head: true })
+        .eq("tournament_id", tournamentId)
+        .not("assigned_seat", "is", null);
+      setPinnedCount(count ?? 0);
+```
+
+- [ ] **Step 3: Control**
+
+Add alongside the existing numeric settings fields, following the file's field markup/classes exactly (read a neighboring field first and clone its structure):
+
+```tsx
+        <div>
+          <label className="text-sm font-medium text-foreground" htmlFor="numbering-mode">
+            Numbering
+          </label>
+          <select
+            id="numbering-mode"
+            value={tournamentInfo.numbering_mode ?? "tables"}
+            onChange={(e) =>
+              setTournamentInfo((prev) => ({ ...prev, numbering_mode: e.target.value }))
+            }
+            className="w-full rounded-lg border border-border bg-card text-foreground px-3 py-2 text-sm focus:outline-none"
+          >
+            <option value="tables">Tables — one number per match</option>
+            <option value="seats">Seats — numbered chairs, two per table</option>
+          </select>
+          {pinnedCount > 0 && tournamentInfo.numbering_mode !== savedInfo.numbering_mode && (
+            <p className="text-xs text-amber-500 mt-1">
+              {pinnedCount} player{pinnedCount === 1 ? " has" : "s have"} a static
+              assignment — the number keeps its value but is reinterpreted under the
+              new mode. Review assignments after saving.
+            </p>
+          )}
+        </div>
+```
+
+- [ ] **Step 4: Type-check + commit**
+
+Run: `cd /Users/timestes/projects/rtt-seats && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -v "forge-anon-leak\|playDecksAuthorize" | grep "error TS"`
+Expected: no new errors.
+
+```bash
+cd /Users/timestes/projects/rtt-seats
+git add components/ui/TournamentSettings.tsx
+git commit -m "feat(tournament): numbering-mode setting (tables vs seats) with pin warning"
+```
+
+---
+
+### Task 10: Apply migration + full verification (coordinator)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Apply migration 078** to the linked Supabase project via the Supabase MCP `apply_migration` tool (name `static_seats`, content = the file from Task 1). Confirm with `list_migrations`.
+
+- [ ] **Step 2: Gates**
+
+Run: `cd /Users/timestes/projects/rtt-seats && npx vitest run && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -v "forge-anon-leak\|playDecksAuthorize" | grep "error TS"`
+Expected: suite green; no new type errors.
+
+- [ ] **Step 3: Live walkthrough** (dev server in the worktree, Playwright; see `verify` skill for auth):
+  1. Create a tournament with ≥6 participants; pin one player to table 3 via the players-tab edit pencil; verify the `T3` badge.
+  2. Start the tournament → rounds view: pinned player's match sits at table 3; other matches fill 1, 2, 4….
+  3. Regenerate pairings: pin still honored.
+  4. Print pairings + match slips: numbers agree with the rounds view.
+  5. Settings → switch to Seats: warning appears (1 player pinned). Save; rounds/print show per-chair numbers.
+  6. Pin two players to seats 9 and 10; regenerate until they're in different matches: seat-9 match at table 5, seat-10 player badged ⚠.
+  7. Swap a pinned player between matches via repair: table numbers follow the pin.
+
+- [ ] **Step 4: Push branch and open PR** against `main` (from the worktree; base `origin/main`).

--- a/docs/superpowers/specs/2026-07-15-static-seats-design.md
+++ b/docs/superpowers/specs/2026-07-15-static-seats-design.md
@@ -1,0 +1,223 @@
+# Static Seats & Seat-Numbering Mode — Design
+
+**Date:** 2026-07-15
+**Status:** Approved (brainstorm with host/owner)
+**Area:** Tournament tracker — pairing display, participants, print output
+
+## Problem
+
+Some players need a fixed physical location for the whole tournament
+(accessibility, equipment, proximity to an outlet). Today a match's "table
+number" is purely virtual — display index (`match_order`) plus
+`starting_table_number` — so there is no way to guarantee a player a
+location, and no way to express venues that number individual chairs
+("seats") rather than tables.
+
+Two features, one mechanism:
+
+1. **Numbering mode** — a tournament can number by *tables* (one number per
+   match, current behavior) or by *seats* (each player has their own chair
+   number; table *k* holds seats *2k−1* and *2k*).
+2. **Static pins** — the host can pin any participant to a specific table
+   (tables mode) or seat (seats mode). Every round, that player's match is
+   placed at their pinned location.
+
+### Decisions locked during brainstorm
+
+- Seats = **numbered chairs, two per table**, sequential (seats 1,2 = table 1;
+  seats 3,4 = table 2; …).
+- Numbering mode is a **per-tournament setting**, default `tables`; existing
+  tournaments unaffected.
+- Pins affect **where a match happens, never who plays whom**. The Swiss
+  pairing algorithm is untouched.
+- Two pinned players paired against each other: **lower number wins**,
+  deterministically; the other pin is visibly overridden for that round.
+
+## Architecture (Approach A — persisted table numbers)
+
+Pairing stays pure Swiss. A new **pure assignment function** runs after
+pairing and its result is persisted to a new `matches.table_number` column.
+Every consumer (rounds view, print pairings, match slips) reads the persisted
+number. One computation, one source of truth, no screen/print drift.
+
+```
+pairFirstRound / pairLaterRound   (unchanged)
+        │  matches in rank order (match_order 1..N)
+        ▼
+assignTables(matches, pins, { startingTableNumber, mode })   ← NEW, pure
+        │  matches + table_number (+ side swaps in seats mode)
+        ▼
+persist: matches.table_number     (createPairing / regenerate RPC / repair helper)
+        ▼
+display + print read match.table_number
+```
+
+## Schema (one migration)
+
+```sql
+alter table tournaments
+  add column numbering_mode text not null default 'tables'
+  check (numbering_mode in ('tables','seats'));
+
+alter table participants
+  add column assigned_seat integer
+  check (assigned_seat is null or assigned_seat >= 1);
+
+-- One pin value per tournament. Blocks "two players pinned to table 5".
+-- Seats mode couples who share a table use different values (9 and 10).
+create unique index participants_assigned_seat_unique
+  on participants (tournament_id, assigned_seat)
+  where assigned_seat is not null;
+
+alter table matches add column table_number integer;
+```
+
+- `participants.assigned_seat` is interpreted per mode: a **table number**
+  in tables mode, a **seat number** in seats mode. Null = no pin.
+- `matches.table_number` is null for all pre-existing rounds; display falls
+  back to today's index math, so legacy tournaments render unchanged.
+- The `regenerate_current_round_pairings` RPC gains `table_number` in its
+  `p_pairings` payload (same migration, `create or replace`).
+- RLS: existing host-only policies on all three tables already cover the new
+  columns; no policy changes.
+
+## Assignment algorithm — `lib/tournament/tableAssignment.ts`
+
+```ts
+interface AssignOptions { startingTableNumber: number; mode: 'tables' | 'seats'; }
+
+function assignTables<M extends { player1Id: string; player2Id: string; matchOrder: number }>(
+  matches: M[],                       // rank order (matchOrder asc)
+  pins: Map<string, number>,          // participantId -> assigned_seat (active players only)
+  opts: AssignOptions,
+): { matches: Array<M & { tableNumber: number }>; overriddenPins: string[] }
+```
+
+Definitions: in seats mode, seat *s* maps to table `ceil(s / 2)`; odd seat =
+player-1 chair, even seat = player-2 chair. In tables mode a pin is already a
+table number and has no side semantics. `startingTableNumber` does not shift
+the seat↔table formula (table *k* is always seats *2k−1, 2k*); it only sets
+where unpinned fill begins.
+
+1. **Claims.** For each match in rank order, collect its players' pins.
+   - Two pins in one match: the **lower value wins** and sets the claim; the
+     other player's pin is overridden (recorded in `overriddenPins`). If both
+     pins resolve to the *same table* in seats mode (seats 9 and 10 — the
+     happy case), both are honored: no override.
+   - One pin: claim = that pin's table.
+   - No pins: no claim.
+2. **Claim conflicts.** If two different matches claim the same table (only
+   possible in seats mode: seats 9 and 10 pinned to players in different
+   matches), sort claimants by (pin value asc, matchOrder asc); the first
+   keeps the table, the rest drop to the unpinned pool with their pins
+   overridden.
+3. **Fill.** Unclaimed matches take the lowest free table numbers
+   ≥ `startingTableNumber` in rank order, skipping claimed tables. Pinned
+   tables may be sparse or below `startingTableNumber` (pin = table 3 with
+   starting table 5 is honored at 3; pin = table 50 with 10 matches is
+   honored at 50).
+4. **Chair sides (seats mode only).** Within a claimed match, a player pinned
+   to an even seat is placed in the `player2` slot, odd seat in `player1`, so
+   they occupy their literal chair. The swap happens **before** persistence,
+   when the match has no scores, so it is safe. `matchOrder` is never
+   changed — rank order and physical location are independent fields.
+5. **Byes / drops.** A pinned player receiving a bye, or dropped out, claims
+   nothing that round. Pins of dropped players stay stored (dormant) and
+   resume if the player is restored.
+
+**Overridden pins are derivable, not stored**: any view can compare a
+player's `assigned_seat` to their match's actual table/seat and badge the
+mismatch. `overriddenPins` in the return value exists for tests and for
+potential toast messaging at generation time.
+
+## Write paths (3)
+
+1. **`createPairing`** ([utils/tournament/pairingUtilsV2.ts](../../utils/tournament/pairingUtilsV2.ts)) —
+   after `pairFirstRound`/`pairLaterRound`, load pins + mode + starting table
+   (already loads state via `stateAdapter`; extend it), run `assignTables`,
+   include `table_number` in `persistMatches`, and persist any seats-mode
+   side swaps in the same insert.
+2. **Regenerate** (`regenerateCurrentRoundPairingsAction` in
+   [app/tracker/tournaments/repair-actions.ts](../../app/tracker/tournaments/repair-actions.ts)) —
+   same computation server-side; passes `table_number` through the updated
+   RPC.
+3. **Repairs** (pairing-swap modal, swap-player-with-bye) — after any swap, a
+   shared helper `reassignRoundTables(client, tournamentId, round)` reloads
+   the round's matches (rank order), re-runs `assignTables`, and updates
+   `table_number` (and player slots for seats-mode sides). Repairs are
+   already gated to "no results entered this round," so re-placement is
+   physically safe.
+
+Pins edited mid-tournament apply at the **next** pairing generation,
+regenerate, or repair — never retroactively to an already-placed round.
+
+## UI
+
+- **Edit Participant modal**
+  ([components/ui/EditParticipantModal.tsx](../../components/ui/EditParticipantModal.tsx)) —
+  optional numeric field below the name, labeled per mode ("Static table #" /
+  "Static seat #"), clearable. Unique-index violation surfaces as
+  "Seat 9 is already assigned to ⟨name⟩."
+- **Players tab**
+  ([components/ui/ParticipantTable.tsx](../../components/ui/ParticipantTable.tsx)) —
+  compact badge on pinned rows (`T5` tables mode, `S9` seats mode), desktop
+  and mobile layouts.
+- **Tournament settings**
+  ([components/ui/TournamentSettings.tsx](../../components/ui/TournamentSettings.tsx)) —
+  "Numbering" toggle: Tables (default) / Seats, with one help sentence.
+  When any participant has a pin, switching shows an inline warning that pin
+  values will be reinterpreted under the new mode (edge case 11).
+- **Rounds view**
+  ([components/ui/TournamentRounds.tsx](../../components/ui/TournamentRounds.tsx)) —
+  table number displays `match.table_number ?? index + starting_table_number`
+  (legacy fallback). Rows sort by `table_number` (nulls → `match_order`
+  fallback) so the host reads the room in physical order. Seats mode shows
+  each player's seat (`2t−1` / `2t`). A pinned player whose actual placement
+  differs from their pin gets a subtle "pin overridden" badge.
+- **Print pairings** ([utils/printUtils.ts](../../utils/printUtils.ts), the
+  compact multi-column layout from PR #208) — table badge shows the persisted
+  `table_number`. Seats mode: replace the single leading badge with per-name
+  seat numbers (`9 Alice  vs  10 Bob`). Print handlers pass matches with
+  their persisted numbers instead of relying on array index.
+- **Match slips** — header "Table N" reads the persisted number; seats mode
+  shows "Seats 9 & 10", and each player row is annotated with their seat.
+
+## Edge cases
+
+| # | Case | Behavior |
+|---|------|----------|
+| 1 | Two pinned players paired together, different tables | Lower pin value hosts; other pin overridden + badged |
+| 2 | Two pinned players paired together, same table (seats 9+10) | Both honored, correct chairs, no override |
+| 3 | Same pin value on two players | Blocked by partial unique index; friendly UI error |
+| 4 | Seats 9 and 10 pinned, players land in different matches | Lower seat's match claims table 5; other match refilled + pin badged |
+| 5 | Pin beyond match count (table 50, 10 matches) | Honored; table numbers are sparse by design |
+| 6 | Pin below `starting_table_number` | Honored (explicit host intent) |
+| 7 | Pinned player gets the bye | No claim that round; pin resumes next round |
+| 8 | Pinned player drops out | Pin dormant; resumes if restored |
+| 9 | Legacy matches (`table_number` null) | Display falls back to index math — pixel-identical to today |
+| 10 | Pin edited mid-round | Current round untouched; applies at next generation/regenerate/repair |
+| 11 | Numbering mode switched while pins exist | Pin values are reinterpreted under the new mode (table 5 → seat 5). Settings toggle shows an inline warning listing how many players have pins ("3 players have static assignments — review them after switching"); no auto-conversion, no blocking |
+
+## Testing
+
+Unit tests for `assignTables` (pure, no IO — mirrors existing
+`lib/tournament/__tests__` style):
+
+- No pins → identity: tables `start..start+N−1` in rank order.
+- Single pin (tables + seats modes), sparse pin, pin below starting table.
+- Two pins one match: lower wins, override recorded; seats 9+10 happy case.
+- Cross-match same-table claim conflict (case 4).
+- Seats-mode chair sides: even-seat pin lands in player2 slot; odd in player1.
+- Pinned bye / dropped player claims nothing.
+- Determinism: same inputs → same outputs (no RNG in this function).
+
+Pairing algorithm tests are untouched — the algorithm doesn't change.
+Integration smoke: generate a round with pins in a dev tournament and verify
+rounds view, print pairings, and match slips agree on every number.
+
+## Out of scope (YAGNI)
+
+- Per-round pin overrides ("pin only for round 3").
+- Pin-aware opponent selection (pairing integrity stays pure Swiss).
+- Auto-assigning seats to all players.
+- Any change to bye mechanics or scoring.

--- a/docs/superpowers/specs/2026-07-15-static-seats-design.md
+++ b/docs/superpowers/specs/2026-07-15-static-seats-design.md
@@ -125,10 +125,20 @@ where unpinned fill begins.
    nothing that round. Pins of dropped players stay stored (dormant) and
    resume if the player is restored.
 
-**Overridden pins are derivable, not stored**: any view can compare a
-player's `assigned_seat` to their match's actual table/seat and badge the
-mismatch. `overriddenPins` in the return value exists for tests and for
-potential toast messaging at generation time.
+**Overridden pins are persisted, not derived**: `matches.player1_pin_overridden`
+/ `player2_pin_overridden` (migration 079) record the override decision at
+the moment `assignTables` runs, from its `overriddenPins` return value. Every
+write path (`createPairing`, regenerate, repair's `reassignRoundTables`) sets
+both flags on every match it writes — not only when a side swaps — so a
+round's flags always reflect the placement that produced it. The rounds view
+badges directly from these columns instead of comparing a match's
+`table_number` to the participant's *current* `assigned_seat`. Why: a pin
+comparison is only correct at generation time; if the host edits a pin after
+the round is placed, a live comparison drifts and produces a false "not
+honored" badge (or hides a real one) for the rest of the round — caught in
+adversarial review of the first implementation. Legacy rounds and rounds
+paired before migration 079 default both flags to `false`, so no badge shows
+— correct, since no override was ever computed for them.
 
 ## Write paths (3)
 
@@ -196,7 +206,7 @@ regenerate, or repair — never retroactively to an already-placed round.
 | 8 | Pinned player drops out | Pin dormant; resumes if restored |
 | 9 | Legacy matches (`table_number` null) | Display falls back to index math — pixel-identical to today |
 | 10 | Pin edited mid-round | Current round untouched; applies at next generation/regenerate/repair |
-| 11 | Numbering mode switched while pins exist | Pin values are reinterpreted under the new mode (table 5 → seat 5). Settings toggle shows an inline warning listing how many players have pins ("3 players have static assignments — review them after switching"); no auto-conversion, no blocking |
+| 11 | Numbering mode switched while pins exist | Only possible pre-start: the Numbering select locks once `tournaments.has_started` is true, so mode is fixed for the rest of the tournament. Before start, switching reinterprets pin values under the new mode (table 5 → seat 5); the settings toggle shows an inline warning listing how many players have pins ("3 players have static assignments — review them after switching"); no auto-conversion, no blocking |
 
 ## Testing
 

--- a/lib/tournament/__tests__/tableAssignment.test.ts
+++ b/lib/tournament/__tests__/tableAssignment.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { assignTables } from '../tableAssignment';
+import type { NumberingMode } from '../types';
+
+const m = (order: number, p1: string, p2: string) => ({
+  matchOrder: order, player1Id: p1, player2Id: p2,
+});
+const opts = (start = 1, mode: NumberingMode = 'tables') => ({
+  startingTableNumber: start, mode,
+});
+const tableOf = (r: ReturnType<typeof assignTables>, id: string) =>
+  r.matches.find(x => x.player1Id === id || x.player2Id === id)!.tableNumber;
+
+describe('assignTables — tables mode', () => {
+  it('no pins → identity fill from startingTableNumber in rank order', () => {
+    const r = assignTables([m(1, 'A', 'B'), m(2, 'C', 'D'), m(3, 'E', 'F')], new Map(), opts(5));
+    expect(r.matches.map(x => x.tableNumber)).toEqual([5, 6, 7]);
+    expect(r.overriddenPins).toEqual([]);
+  });
+
+  it('single pin places that match at the pinned table; fill skips it', () => {
+    const r = assignTables([m(1, 'A', 'B'), m(2, 'C', 'D'), m(3, 'E', 'F')],
+      new Map([['C', 2]]), opts(1));
+    expect(tableOf(r, 'C')).toBe(2);
+    expect(tableOf(r, 'A')).toBe(1);
+    expect(tableOf(r, 'E')).toBe(3);
+  });
+
+  it('sparse pin beyond match count is honored', () => {
+    const r = assignTables([m(1, 'A', 'B'), m(2, 'C', 'D')], new Map([['A', 50]]), opts(1));
+    expect(tableOf(r, 'A')).toBe(50);
+    expect(tableOf(r, 'C')).toBe(1);
+  });
+
+  it('pin below startingTableNumber is honored', () => {
+    const r = assignTables([m(1, 'A', 'B'), m(2, 'C', 'D')], new Map([['C', 3]]), opts(5));
+    expect(tableOf(r, 'C')).toBe(3);
+    expect(tableOf(r, 'A')).toBe(5);
+  });
+
+  it('two pinned players in one match: lower value wins, other overridden', () => {
+    const r = assignTables([m(1, 'A', 'B')], new Map([['A', 7], ['B', 4]]), opts(1));
+    expect(r.matches[0].tableNumber).toBe(4);
+    expect(r.overriddenPins).toEqual(['A']);
+  });
+});
+
+describe('assignTables — seats mode', () => {
+  it('even-seat pin maps to table ceil(s/2) and forces the player2 chair', () => {
+    // B pinned to seat 10 → table 5, even → player2 slot (input has B as player1).
+    const r = assignTables([m(1, 'B', 'A')], new Map([['B', 10]]), opts(1, 'seats'));
+    expect(r.matches[0].tableNumber).toBe(5);
+    expect(r.matches[0].player1Id).toBe('A');
+    expect(r.matches[0].player2Id).toBe('B');
+  });
+
+  it('odd-seat pin keeps/forces the player1 chair', () => {
+    const r = assignTables([m(1, 'A', 'B')], new Map([['A', 9]]), opts(1, 'seats'));
+    expect(r.matches[0].tableNumber).toBe(5);
+    expect(r.matches[0].player1Id).toBe('A');
+  });
+
+  it('seats 9+10 pinned and paired together: both honored, no override', () => {
+    const r = assignTables([m(1, 'X', 'Y')], new Map([['X', 10], ['Y', 9]]), opts(1, 'seats'));
+    expect(r.matches[0].tableNumber).toBe(5);
+    expect(r.matches[0].player1Id).toBe('Y'); // seat 9 = odd chair
+    expect(r.matches[0].player2Id).toBe('X');
+    expect(r.overriddenPins).toEqual([]);
+  });
+
+  it('cross-match same-table claims: lower seat wins, other bumped + overridden', () => {
+    // A pinned seat 9, C pinned seat 10 — both table 5, different matches.
+    const r = assignTables([m(1, 'A', 'B'), m(2, 'C', 'D')],
+      new Map([['A', 9], ['C', 10]]), opts(1, 'seats'));
+    expect(tableOf(r, 'A')).toBe(5);
+    expect(tableOf(r, 'C')).toBe(1); // bumped to normal fill
+    expect(r.overriddenPins).toEqual(['C']);
+  });
+});
+
+describe('assignTables — general', () => {
+  it('pin of a player not in any match (bye/dropped) claims nothing', () => {
+    const r = assignTables([m(1, 'A', 'B')], new Map([['Z', 1]]), opts(1));
+    expect(r.matches[0].tableNumber).toBe(1);
+  });
+
+  it('deterministic: identical inputs → identical outputs', () => {
+    const ms = [m(1, 'A', 'B'), m(2, 'C', 'D'), m(3, 'E', 'F')];
+    const pins = new Map([['E', 2], ['B', 7]]);
+    expect(assignTables(ms, pins, opts(1))).toEqual(assignTables(ms, pins, opts(1)));
+  });
+
+  it('returns matches in matchOrder order regardless of claims', () => {
+    const r = assignTables([m(1, 'A', 'B'), m(2, 'C', 'D')], new Map([['C', 1]]), opts(1));
+    expect(r.matches.map(x => x.matchOrder)).toEqual([1, 2]);
+  });
+
+  it('does not mutate its inputs', () => {
+    const ms = [m(1, 'B', 'A')];
+    const pins = new Map([['B', 10]]);
+    assignTables(ms, pins, opts(1, 'seats'));
+    expect(ms[0].player1Id).toBe('B'); // swap happened on a copy
+  });
+});

--- a/lib/tournament/tableAssignment.ts
+++ b/lib/tournament/tableAssignment.ts
@@ -1,0 +1,134 @@
+// lib/tournament/tableAssignment.ts
+//
+// Post-pairing table/seat assignment. Pure: no IO, no RNG. Decides WHERE each
+// match happens; never changes who plays whom.
+// Spec: docs/superpowers/specs/2026-07-15-static-seats-design.md
+//
+// Seat math (seats mode): table k holds seats 2k-1 (player1 chair) and 2k
+// (player2 chair). A pin is a table number in tables mode, a seat number in
+// seats mode.
+
+import type { NumberingMode } from "./types";
+
+export interface AssignOptions {
+  startingTableNumber: number;
+  mode: NumberingMode;
+}
+
+export interface AssignableMatch {
+  player1Id: string;
+  player2Id: string;
+  matchOrder: number;
+}
+
+export interface AssignResult<M extends AssignableMatch> {
+  /** In matchOrder order. player1Id/player2Id may be swapped vs input
+   * (seats-mode chair sides). */
+  matches: Array<M & { tableNumber: number }>;
+  /** Participants whose pin was not honored this round. */
+  overriddenPins: string[];
+}
+
+/** Table a pin points to: identity in tables mode, ceil(seat/2) in seats mode. */
+function pinTable(pin: number, mode: NumberingMode): number {
+  return mode === "seats" ? Math.ceil(pin / 2) : pin;
+}
+
+export function assignTables<M extends AssignableMatch>(
+  matches: M[],
+  pins: Map<string, number>,
+  opts: AssignOptions,
+): AssignResult<M> {
+  const { startingTableNumber, mode } = opts;
+  const overridden = new Set<string>();
+
+  // Rank order (matchOrder asc); input order isn't guaranteed.
+  const ranked = [...matches].sort((a, b) => a.matchOrder - b.matchOrder);
+
+  // Step 1: per-match claims. A match with two pins keeps the lower value
+  // (both, when they resolve to the same table — the seats 9+10 happy case).
+  interface Claim {
+    match: M;
+    table: number;
+    pinValue: number;
+    pinnedIds: string[];
+  }
+  const claims: Claim[] = [];
+  const unclaimed: M[] = [];
+  for (const match of ranked) {
+    const p1Pin = pins.get(match.player1Id);
+    const p2Pin = pins.get(match.player2Id);
+    if (p1Pin === undefined && p2Pin === undefined) {
+      unclaimed.push(match);
+      continue;
+    }
+    let pinValue: number;
+    let pinnedIds: string[];
+    if (p1Pin !== undefined && p2Pin !== undefined) {
+      if (pinTable(p1Pin, mode) === pinTable(p2Pin, mode)) {
+        pinValue = Math.min(p1Pin, p2Pin);
+        pinnedIds = [match.player1Id, match.player2Id];
+      } else if (p1Pin <= p2Pin) {
+        pinValue = p1Pin;
+        pinnedIds = [match.player1Id];
+        overridden.add(match.player2Id);
+      } else {
+        pinValue = p2Pin;
+        pinnedIds = [match.player2Id];
+        overridden.add(match.player1Id);
+      }
+    } else if (p1Pin !== undefined) {
+      pinValue = p1Pin;
+      pinnedIds = [match.player1Id];
+    } else {
+      pinValue = p2Pin as number;
+      pinnedIds = [match.player2Id];
+    }
+    claims.push({ match, table: pinTable(pinValue, mode), pinValue, pinnedIds });
+  }
+
+  // Step 2: resolve cross-match claims to the same table — (pin value asc,
+  // matchOrder asc); first claimant keeps it, the rest drop to fill.
+  claims.sort((a, b) => a.pinValue - b.pinValue || a.match.matchOrder - b.match.matchOrder);
+  const taken = new Set<number>();
+  const placed: Array<{ match: M; tableNumber: number; pinnedIds: string[] }> = [];
+  for (const c of claims) {
+    if (taken.has(c.table)) {
+      for (const id of c.pinnedIds) overridden.add(id);
+      unclaimed.push(c.match);
+      continue;
+    }
+    taken.add(c.table);
+    placed.push({ match: c.match, tableNumber: c.table, pinnedIds: c.pinnedIds });
+  }
+
+  // Step 3: fill — bumped + unpinned matches take the lowest free tables
+  // >= startingTableNumber in rank order, skipping claimed tables.
+  unclaimed.sort((a, b) => a.matchOrder - b.matchOrder);
+  let next = startingTableNumber;
+  for (const match of unclaimed) {
+    while (taken.has(next)) next++;
+    taken.add(next);
+    placed.push({ match, tableNumber: next, pinnedIds: [] });
+  }
+
+  // Step 4: seats-mode chair sides — an honored pin to an even seat sits in
+  // the player2 slot, odd in player1. Swaps a copy, never the input.
+  const out = placed.map(({ match, tableNumber, pinnedIds }) => {
+    let result: M = match;
+    if (mode === "seats") {
+      for (const id of pinnedIds) {
+        const pin = pins.get(id) as number;
+        const wantsPlayer1 = pin % 2 === 1;
+        const isPlayer1 = result.player1Id === id;
+        if (wantsPlayer1 !== isPlayer1) {
+          result = { ...result, player1Id: result.player2Id, player2Id: result.player1Id };
+        }
+      }
+    }
+    return { ...result, tableNumber };
+  });
+
+  out.sort((a, b) => a.matchOrder - b.matchOrder);
+  return { matches: out, overriddenPins: [...overridden] };
+}

--- a/lib/tournament/types.ts
+++ b/lib/tournament/types.ts
@@ -28,6 +28,8 @@ export interface Participant {
   droppedOut: boolean;
   /** Round at which the drop took effect (this round's result still counted). */
   dropAfterRound?: number;
+  /** Static table (tables mode) or seat (seats mode) pin. Undefined = none. */
+  assignedSeat?: number;
 }
 
 export interface MatchResult {
@@ -53,6 +55,10 @@ export interface Bye {
   round: number;
 }
 
+/** How a tournament numbers physical locations: one number per match
+ * ('tables') or one number per chair, two per table ('seats'). */
+export type NumberingMode = "tables" | "seats";
+
 export interface TournamentState {
   id: TournamentId;
   nRounds: number;
@@ -70,6 +76,11 @@ export interface TournamentState {
    * excluded. Optional for back-compat with hand-built test states — when
    * absent, all byes count (the pre-Option-C behavior). */
   startedRounds?: number[];
+  /** First table number used by unpinned fill. Optional for back-compat with
+   * hand-built test states; defaults to 1. */
+  startingTableNumber?: number;
+  /** Defaults to 'tables' when absent. */
+  numberingMode?: NumberingMode;
 }
 
 /** Per-participant aggregate computed from match history. */

--- a/supabase/migrations/078_static_seats.sql
+++ b/supabase/migrations/078_static_seats.sql
@@ -25,7 +25,7 @@ CREATE UNIQUE INDEX participants_assigned_seat_unique
 
 ALTER TABLE matches ADD COLUMN table_number integer;
 
--- Redefine the regenerate RPC (body from migration 036) with table_number
+-- Redefine the regenerate RPC (body from migration 038) with table_number
 -- added to the INSERT. ->> yields NULL when the key is absent, so old
 -- callers keep working.
 CREATE OR REPLACE FUNCTION regenerate_current_round_pairings(
@@ -116,6 +116,10 @@ BEGIN
       p_tournament_id, v_current_rnd, p_bye_id, 3, 0
     );
   END IF;
+
+  -- Recompute participant totals from the new match + bye state. Without this,
+  -- participants who lost or gained a bye in the re-pair keep stale totals.
+  PERFORM recompute_participant_totals(p_tournament_id);
 
   RETURN jsonb_build_object(
     'tournament_id', p_tournament_id,

--- a/supabase/migrations/078_static_seats.sql
+++ b/supabase/migrations/078_static_seats.sql
@@ -1,0 +1,131 @@
+-- Static seats & seat-numbering mode.
+-- Spec: docs/superpowers/specs/2026-07-15-static-seats-design.md
+--
+-- 1. tournaments.numbering_mode: 'tables' (default, current behavior) or
+--    'seats' (numbered chairs, two per table: table k = seats 2k-1, 2k).
+-- 2. participants.assigned_seat: optional static pin. Interpreted per mode
+--    (table number in tables mode, seat number in seats mode).
+-- 3. matches.table_number: the match's physical table, persisted at pairing
+--    time. NULL for legacy rounds (display falls back to index math).
+-- 4. regenerate_current_round_pairings: accepts table_number per pairing.
+
+ALTER TABLE tournaments
+  ADD COLUMN numbering_mode text NOT NULL DEFAULT 'tables'
+  CHECK (numbering_mode IN ('tables', 'seats'));
+
+ALTER TABLE participants
+  ADD COLUMN assigned_seat integer
+  CHECK (assigned_seat IS NULL OR assigned_seat >= 1);
+
+-- One pin value per tournament. Blocks two players pinned to the same
+-- table/seat. Seats-mode couples sharing a table use different values (9, 10).
+CREATE UNIQUE INDEX participants_assigned_seat_unique
+  ON participants (tournament_id, assigned_seat)
+  WHERE assigned_seat IS NOT NULL;
+
+ALTER TABLE matches ADD COLUMN table_number integer;
+
+-- Redefine the regenerate RPC (body from migration 036) with table_number
+-- added to the INSERT. ->> yields NULL when the key is absent, so old
+-- callers keep working.
+CREATE OR REPLACE FUNCTION regenerate_current_round_pairings(
+  p_tournament_id  UUID,
+  p_pairings       JSONB,
+  p_bye_id         UUID DEFAULT NULL,
+  p_unlock         BOOLEAN DEFAULT FALSE
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_host_id      UUID;
+  v_current_rnd  INT;
+  v_round_id     UUID;
+  v_is_completed BOOLEAN;
+  v_scored_count INT;
+  v_inserted     INT := 0;
+  v_pair         JSONB;
+BEGIN
+  SELECT host_id, current_round INTO v_host_id, v_current_rnd
+  FROM tournaments
+  WHERE id = p_tournament_id
+  FOR UPDATE;
+
+  IF v_host_id IS NULL THEN
+    RAISE EXCEPTION 'regenerate_current_round_pairings: tournament % not found', p_tournament_id;
+  END IF;
+
+  IF auth.uid() IS NULL OR auth.uid() <> v_host_id THEN
+    RAISE EXCEPTION 'regenerate_current_round_pairings: not the tournament host';
+  END IF;
+
+  SELECT id, is_completed INTO v_round_id, v_is_completed
+  FROM rounds
+  WHERE tournament_id = p_tournament_id
+    AND round_number = v_current_rnd;
+
+  -- Explicit NULL guard: a missing rounds row means the tournament state is
+  -- broken and re-pairing would proceed against an inconsistent context.
+  IF v_round_id IS NULL THEN
+    RAISE EXCEPTION 'regenerate_current_round_pairings: no rounds row for round % (tournament state inconsistent)', v_current_rnd;
+  END IF;
+
+  IF v_is_completed THEN
+    RAISE EXCEPTION 'regenerate_current_round_pairings: round % is already completed', v_current_rnd;
+  END IF;
+
+  SELECT COUNT(*) INTO v_scored_count
+  FROM matches
+  WHERE tournament_id = p_tournament_id
+    AND round = v_current_rnd
+    AND player1_score IS NOT NULL;
+
+  IF v_scored_count > 0 AND NOT p_unlock THEN
+    RAISE EXCEPTION 'regenerate_current_round_pairings: % match(es) already scored; pass p_unlock=true to override', v_scored_count;
+  END IF;
+
+  DELETE FROM matches
+   WHERE tournament_id = p_tournament_id
+     AND round = v_current_rnd;
+  DELETE FROM byes
+   WHERE tournament_id = p_tournament_id
+     AND round_number = v_current_rnd;
+
+  FOR v_pair IN SELECT * FROM jsonb_array_elements(p_pairings)
+  LOOP
+    INSERT INTO matches (
+      tournament_id, round, player1_id, player2_id,
+      player1_score, player2_score, match_order, table_number
+    ) VALUES (
+      p_tournament_id,
+      v_current_rnd,
+      (v_pair->>'player1_id')::UUID,
+      (v_pair->>'player2_id')::UUID,
+      NULL, NULL,
+      (v_pair->>'match_order')::INT,
+      (v_pair->>'table_number')::INT
+    );
+    v_inserted := v_inserted + 1;
+  END LOOP;
+
+  IF p_bye_id IS NOT NULL THEN
+    INSERT INTO byes (
+      tournament_id, round_number, participant_id,
+      match_points, differential
+    ) VALUES (
+      p_tournament_id, v_current_rnd, p_bye_id, 3, 0
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'tournament_id', p_tournament_id,
+    'round', v_current_rnd,
+    'matches_inserted', v_inserted,
+    'bye_id', p_bye_id
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION regenerate_current_round_pairings(UUID, JSONB, UUID, BOOLEAN) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION regenerate_current_round_pairings(UUID, JSONB, UUID, BOOLEAN) FROM anon;
+GRANT EXECUTE ON FUNCTION regenerate_current_round_pairings(UUID, JSONB, UUID, BOOLEAN) TO authenticated;

--- a/supabase/migrations/079_pin_override_flags.sql
+++ b/supabase/migrations/079_pin_override_flags.sql
@@ -1,0 +1,131 @@
+-- Persist pin-override facts at generation time.
+-- Spec: docs/superpowers/specs/2026-07-15-static-seats-design.md
+--
+-- Problem: the rounds view previously derived "pin overridden" by comparing
+-- a participant's LIVE assigned_seat to the match's persisted table_number.
+-- Editing a pin mid-round (after placement) then produces false "not
+-- honored" badges — or hides real ones — because the comparison re-runs
+-- against a pin value that has since changed. The override decision is only
+-- correct at the moment assignTables() ran; it must be stored, not derived.
+--
+-- 1. matches.player1_pin_overridden / player2_pin_overridden: booleans
+--    recorded at pairing time from assignTables()'s overriddenPins result.
+--    Default false so legacy rounds (and rounds paired before this column
+--    existed) show no badge — correct, since no pin was ever overridden by
+--    a computation that didn't track it.
+-- 2. regenerate_current_round_pairings: accepts the two flags per pairing.
+
+ALTER TABLE matches ADD COLUMN player1_pin_overridden boolean NOT NULL DEFAULT false;
+ALTER TABLE matches ADD COLUMN player2_pin_overridden boolean NOT NULL DEFAULT false;
+
+-- Redefine the regenerate RPC (body lineage: 038 -> 078 -> 079) with the two
+-- pin-overridden flags added to the INSERT. ->> yields NULL when a key is
+-- absent, COALESCE keeps that NULL false, so old callers keep working.
+CREATE OR REPLACE FUNCTION regenerate_current_round_pairings(
+  p_tournament_id  UUID,
+  p_pairings       JSONB,
+  p_bye_id         UUID DEFAULT NULL,
+  p_unlock         BOOLEAN DEFAULT FALSE
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_host_id      UUID;
+  v_current_rnd  INT;
+  v_round_id     UUID;
+  v_is_completed BOOLEAN;
+  v_scored_count INT;
+  v_inserted     INT := 0;
+  v_pair         JSONB;
+BEGIN
+  SELECT host_id, current_round INTO v_host_id, v_current_rnd
+  FROM tournaments
+  WHERE id = p_tournament_id
+  FOR UPDATE;
+
+  IF v_host_id IS NULL THEN
+    RAISE EXCEPTION 'regenerate_current_round_pairings: tournament % not found', p_tournament_id;
+  END IF;
+
+  IF auth.uid() IS NULL OR auth.uid() <> v_host_id THEN
+    RAISE EXCEPTION 'regenerate_current_round_pairings: not the tournament host';
+  END IF;
+
+  SELECT id, is_completed INTO v_round_id, v_is_completed
+  FROM rounds
+  WHERE tournament_id = p_tournament_id
+    AND round_number = v_current_rnd;
+
+  -- Explicit NULL guard: a missing rounds row means the tournament state is
+  -- broken and re-pairing would proceed against an inconsistent context.
+  IF v_round_id IS NULL THEN
+    RAISE EXCEPTION 'regenerate_current_round_pairings: no rounds row for round % (tournament state inconsistent)', v_current_rnd;
+  END IF;
+
+  IF v_is_completed THEN
+    RAISE EXCEPTION 'regenerate_current_round_pairings: round % is already completed', v_current_rnd;
+  END IF;
+
+  SELECT COUNT(*) INTO v_scored_count
+  FROM matches
+  WHERE tournament_id = p_tournament_id
+    AND round = v_current_rnd
+    AND player1_score IS NOT NULL;
+
+  IF v_scored_count > 0 AND NOT p_unlock THEN
+    RAISE EXCEPTION 'regenerate_current_round_pairings: % match(es) already scored; pass p_unlock=true to override', v_scored_count;
+  END IF;
+
+  DELETE FROM matches
+   WHERE tournament_id = p_tournament_id
+     AND round = v_current_rnd;
+  DELETE FROM byes
+   WHERE tournament_id = p_tournament_id
+     AND round_number = v_current_rnd;
+
+  FOR v_pair IN SELECT * FROM jsonb_array_elements(p_pairings)
+  LOOP
+    INSERT INTO matches (
+      tournament_id, round, player1_id, player2_id,
+      player1_score, player2_score, match_order, table_number,
+      player1_pin_overridden, player2_pin_overridden
+    ) VALUES (
+      p_tournament_id,
+      v_current_rnd,
+      (v_pair->>'player1_id')::UUID,
+      (v_pair->>'player2_id')::UUID,
+      NULL, NULL,
+      (v_pair->>'match_order')::INT,
+      (v_pair->>'table_number')::INT,
+      COALESCE((v_pair->>'player1_pin_overridden')::BOOLEAN, false),
+      COALESCE((v_pair->>'player2_pin_overridden')::BOOLEAN, false)
+    );
+    v_inserted := v_inserted + 1;
+  END LOOP;
+
+  IF p_bye_id IS NOT NULL THEN
+    INSERT INTO byes (
+      tournament_id, round_number, participant_id,
+      match_points, differential
+    ) VALUES (
+      p_tournament_id, v_current_rnd, p_bye_id, 3, 0
+    );
+  END IF;
+
+  -- Recompute participant totals from the new match + bye state. Without this,
+  -- participants who lost or gained a bye in the re-pair keep stale totals.
+  PERFORM recompute_participant_totals(p_tournament_id);
+
+  RETURN jsonb_build_object(
+    'tournament_id', p_tournament_id,
+    'round', v_current_rnd,
+    'matches_inserted', v_inserted,
+    'bye_id', p_bye_id
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION regenerate_current_round_pairings(UUID, JSONB, UUID, BOOLEAN) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION regenerate_current_round_pairings(UUID, JSONB, UUID, BOOLEAN) FROM anon;
+GRANT EXECUTE ON FUNCTION regenerate_current_round_pairings(UUID, JSONB, UUID, BOOLEAN) TO authenticated;

--- a/utils/printUtils.ts
+++ b/utils/printUtils.ts
@@ -168,7 +168,8 @@ export const printTournamentPairings = (
   byes: any[],
   roundNumber: number,
   startingTableNumber: number = 1,
-  tournamentName?: string | null
+  tournamentName?: string | null,
+  numberingMode: 'tables' | 'seats' = 'tables',
 ): void => {
   const heading = tournamentName || 'Tournament';
   const pageTitle = tournamentName
@@ -179,17 +180,31 @@ export const printTournamentPairings = (
   // CSS multi-columns (newspaper order) so a whole large-tournament round fits on a
   // single projected screen without scrolling and is easy to scan by table number.
   const pairingsHtml = (matches || [])
-    .map(
-      (match, index) => `
+    .map((match, index) => {
+      const table = match.table_number ?? index + startingTableNumber;
+      if (numberingMode === 'seats') {
+        // Per-chair numbers replace the single table badge.
+        return `
+        <li class="pair pair-seats">
+          <span class="names">
+            <span class="seat">${2 * table - 1}</span>
+            <span class="p">${escapeHtml(match.player1_id?.name)}</span>
+            <span class="vs">vs</span>
+            <span class="seat">${2 * table}</span>
+            <span class="p">${escapeHtml(match.player2_id?.name)}</span>
+          </span>
+        </li>`;
+      }
+      return `
         <li class="pair">
-          <span class="t">${index + startingTableNumber}</span>
+          <span class="t">${table}</span>
           <span class="names">
             <span class="p">${escapeHtml(match.player1_id?.name)}</span>
             <span class="vs">vs</span>
             <span class="p">${escapeHtml(match.player2_id?.name)}</span>
           </span>
-        </li>`
-    )
+        </li>`;
+    })
     .join('');
 
   // Byes render as a single compact strip below the pairings rather than a
@@ -260,6 +275,11 @@ export const printTournamentPairings = (
           .pair .names { display: flex; flex-wrap: wrap; align-items: baseline; gap: 2px 8px; }
           .pair .p { font-weight: 600; }
           .pair .vs { color: #9ca3af; font-size: 12px; font-weight: 500; }
+          .pair.pair-seats { grid-template-columns: 1fr; }
+          .pair .seat {
+            font-weight: 800; color: #555;
+            font-variant-numeric: tabular-nums; font-size: 13px;
+          }
 
           .byes {
             margin-top: 16px; padding-top: 10px; border-top: 1px solid #ddd;
@@ -313,23 +333,29 @@ export const printMatchSlips = (
   matches: any[],
   roundNumber: number,
   startingTableNumber: number = 1,
-  tournamentName?: string | null
+  tournamentName?: string | null,
+  numberingMode: 'tables' | 'seats' = 'tables',
 ): void => {
   const pageTitle = tournamentName
     ? `${tournamentName} - Round ${roundNumber} Match Slips`
     : `Round ${roundNumber} Match Slips`;
-  
+
   // Generate a match slip for each match
   const matchSlipsHtml = matches.map((match, index) => {
-    const tableNumber = index + startingTableNumber;
+    const tableNumber = match.table_number ?? index + startingTableNumber;
+    const locationLabel = numberingMode === 'seats'
+      ? `Seats ${2 * tableNumber - 1} &amp; ${2 * tableNumber}`
+      : `Table ${tableNumber}`;
+    const p1Seat = numberingMode === 'seats' ? `<span class="slip-seat">${2 * tableNumber - 1}</span> ` : '';
+    const p2Seat = numberingMode === 'seats' ? `<span class="slip-seat">${2 * tableNumber}</span> ` : '';
     const isLastSlip = index === matches.length - 1;
-    
+
     return `
       <div class="match-slip">
         <div class="match-header">
-          <strong>${tournamentName || 'Tournament'}</strong> - Round ${roundNumber} - Table ${tableNumber}
+          <strong>${escapeHtml(tournamentName || 'Tournament')}</strong> - Round ${roundNumber} - ${locationLabel}
         </div>
-        
+
         <table class="players-table">
           <thead>
             <tr class="header-row">
@@ -340,18 +366,18 @@ export const printMatchSlips = (
           </thead>
           <tbody>
             <tr class="player-row">
-              <td class="player-name">${match.player1_id.name}</td>
+              <td class="player-name">${p1Seat}${escapeHtml(match.player1_id?.name)}</td>
               <td class="score-cell"><div class="score-box"></div></td>
               <td class="signature-cell"><div class="signature-line"></div></td>
             </tr>
             <tr class="player-row">
-              <td class="player-name">${match.player2_id.name}</td>
+              <td class="player-name">${p2Seat}${escapeHtml(match.player2_id?.name)}</td>
               <td class="score-cell"><div class="score-box"></div></td>
               <td class="signature-cell"><div class="signature-line"></div></td>
             </tr>
           </tbody>
         </table>
-        
+
         <div class="instructions">Please fill in match score, have both players sign, and return to tournament organizer</div>
         ${!isLastSlip ? '<div class="cut-line"></div>' : ''}
       </div>
@@ -476,7 +502,9 @@ export const printMatchSlips = (
             text-align: left;
             vertical-align: middle;
           }
-          
+
+          .slip-seat { color: #888; font-weight: normal; }
+
           .score-cell {
             text-align: center;
             padding: 4px;

--- a/utils/printUtils.ts
+++ b/utils/printUtils.ts
@@ -388,7 +388,7 @@ export const printMatchSlips = (
   const printContent = `
     <html>
       <head>
-        <title>${pageTitle}</title>
+        <title>${escapeHtml(pageTitle)}</title>
         <style>
           @media print {
             @page {

--- a/utils/tournament/pairingUtilsV2.ts
+++ b/utils/tournament/pairingUtilsV2.ts
@@ -9,6 +9,7 @@
 import { createClient } from "../supabase/client";
 import { rngForRound } from "../../lib/tournament/rng";
 import { pairFirstRound, pairLaterRound } from "../../lib/tournament/pairing";
+import { assignTables } from "../../lib/tournament/tableAssignment";
 import { buildStateFromSupabase } from "./stateAdapter";
 
 type AnyClient = {
@@ -35,7 +36,13 @@ async function persistBye(
 async function persistMatches(
   client: AnyClient,
   tournamentId: string,
-  matches: Array<{ round: number; player1Id: string; player2Id: string; matchOrder: number }>,
+  matches: Array<{
+    round: number;
+    player1Id: string;
+    player2Id: string;
+    matchOrder: number;
+    tableNumber: number;
+  }>,
 ) {
   if (matches.length === 0) return;
   const rows = matches.map(m => ({
@@ -46,6 +53,7 @@ async function persistMatches(
     player1_score: null,
     player2_score: null,
     match_order: m.matchOrder,
+    table_number: m.tableNumber,
   }));
   await client.from("matches").insert(rows);
 }
@@ -86,7 +94,20 @@ export const createPairing = async (
     if (result.bye) {
       await persistBye(client, tournamentId, round, result.bye);
     }
-    await persistMatches(client, tournamentId, result.matches);
+
+    // Static seats: place each match at a physical table, honoring pins.
+    // Chair-side swaps (seats mode) happen here, before insert, while the
+    // match has no scores. Spec: 2026-07-15-static-seats-design.md
+    const pins = new Map<string, number>();
+    for (const p of state.participants) {
+      if (!p.droppedOut && p.assignedSeat != null) pins.set(p.id, p.assignedSeat);
+    }
+    const assigned = assignTables(result.matches, pins, {
+      startingTableNumber: state.startingTableNumber ?? 1,
+      mode: state.numberingMode ?? "tables",
+    });
+
+    await persistMatches(client, tournamentId, assigned.matches);
     await ensureRoundRow(client, tournamentId, round);
     return true;
   } catch (error) {

--- a/utils/tournament/pairingUtilsV2.ts
+++ b/utils/tournament/pairingUtilsV2.ts
@@ -42,6 +42,8 @@ async function persistMatches(
     player2Id: string;
     matchOrder: number;
     tableNumber: number;
+    player1PinOverridden: boolean;
+    player2PinOverridden: boolean;
   }>,
 ) {
   if (matches.length === 0) return;
@@ -54,6 +56,8 @@ async function persistMatches(
     player2_score: null,
     match_order: m.matchOrder,
     table_number: m.tableNumber,
+    player1_pin_overridden: m.player1PinOverridden,
+    player2_pin_overridden: m.player2PinOverridden,
   }));
   await client.from("matches").insert(rows);
 }
@@ -107,7 +111,16 @@ export const createPairing = async (
       mode: state.numberingMode ?? "tables",
     });
 
-    await persistMatches(client, tournamentId, assigned.matches);
+    // Persist the override decision now — it must not be re-derived later
+    // from a pin that may have changed since (spec: "Overridden pins" §).
+    const overridden = new Set(assigned.overriddenPins);
+    const matchesToPersist = assigned.matches.map(m => ({
+      ...m,
+      player1PinOverridden: overridden.has(m.player1Id),
+      player2PinOverridden: overridden.has(m.player2Id),
+    }));
+
+    await persistMatches(client, tournamentId, matchesToPersist);
     await ensureRoundRow(client, tournamentId, round);
     return true;
   } catch (error) {

--- a/utils/tournament/reassignTables.ts
+++ b/utils/tournament/reassignTables.ts
@@ -1,0 +1,72 @@
+// Recompute a round's table numbers after a manual repair (player swap,
+// bye swap, re-pair). Deterministic: same helper the pairing paths use.
+// Safe only pre-results — all repair flows are already gated to rounds
+// with no scores entered.
+
+import { assignTables } from "../../lib/tournament/tableAssignment";
+
+type AnyClient = {
+  from: (table: string) => any;
+};
+
+export async function reassignRoundTables(
+  client: AnyClient,
+  tournamentId: string,
+  round: number,
+): Promise<void> {
+  const [{ data: t }, { data: parts }, { data: ms }] = await Promise.all([
+    client
+      .from("tournaments")
+      .select("starting_table_number, numbering_mode")
+      .eq("id", tournamentId)
+      .single(),
+    client
+      .from("participants")
+      .select("id, assigned_seat")
+      .eq("tournament_id", tournamentId)
+      .not("assigned_seat", "is", null),
+    client
+      .from("matches")
+      .select(
+        "id, player1_id, player2_id, match_order, player1_match_points, player2_match_points, differential, differential2",
+      )
+      .eq("tournament_id", tournamentId)
+      .eq("round", round),
+  ]);
+  if (!t || !ms || ms.length === 0) return;
+
+  const pins = new Map<string, number>(
+    (parts || []).map((p: any) => [p.id as string, p.assigned_seat as number]),
+  );
+  const rows = (ms || []).map((m: any) => ({
+    id: m.id as string,
+    player1Id: m.player1_id as string,
+    player2Id: m.player2_id as string,
+    matchOrder: (m.match_order ?? 0) as number,
+  }));
+  const byId = new Map<string, any>((ms || []).map((m: any) => [m.id as string, m]));
+
+  const { matches: assigned } = assignTables(rows, pins, {
+    startingTableNumber: t.starting_table_number ?? 1,
+    mode: t.numbering_mode === "seats" ? "seats" : "tables",
+  });
+
+  for (const m of assigned) {
+    const orig = byId.get((m as any).id);
+    if (!orig) continue;
+    const swapped = orig.player1_id !== m.player1Id;
+    const patch: Record<string, unknown> = { table_number: m.tableNumber };
+    if (swapped) {
+      // Chair-side swap: mirror handleSwapPlayers' same-match flip — swap the
+      // per-side sibling columns along with the ids. Scores are null here
+      // (repairs are pre-results), so they don't need swapping.
+      patch.player1_id = m.player1Id;
+      patch.player2_id = m.player2Id;
+      patch.player1_match_points = orig.player2_match_points;
+      patch.player2_match_points = orig.player1_match_points;
+      patch.differential = orig.differential2;
+      patch.differential2 = orig.differential;
+    }
+    await client.from("matches").update(patch).eq("id", (m as any).id);
+  }
+}

--- a/utils/tournament/reassignTables.ts
+++ b/utils/tournament/reassignTables.ts
@@ -24,6 +24,7 @@ export async function reassignRoundTables(
       .from("participants")
       .select("id, assigned_seat")
       .eq("tournament_id", tournamentId)
+      .eq("dropped_out", false)
       .not("assigned_seat", "is", null),
     client
       .from("matches")
@@ -31,7 +32,8 @@ export async function reassignRoundTables(
         "id, player1_id, player2_id, match_order, player1_match_points, player2_match_points, differential, differential2",
       )
       .eq("tournament_id", tournamentId)
-      .eq("round", round),
+      .eq("round", round)
+      .order("match_order", { ascending: true }),
   ]);
   if (!t || !ms || ms.length === 0) return;
 
@@ -46,16 +48,25 @@ export async function reassignRoundTables(
   }));
   const byId = new Map<string, any>((ms || []).map((m: any) => [m.id as string, m]));
 
-  const { matches: assigned } = assignTables(rows, pins, {
+  const { matches: assigned, overriddenPins } = assignTables(rows, pins, {
     startingTableNumber: t.starting_table_number ?? 1,
     mode: t.numbering_mode === "seats" ? "seats" : "tables",
   });
+  const overridden = new Set(overriddenPins);
 
   for (const m of assigned) {
     const orig = byId.get((m as any).id);
     if (!orig) continue;
     const swapped = orig.player1_id !== m.player1Id;
-    const patch: Record<string, unknown> = { table_number: m.tableNumber };
+    // Pin-override flags are recomputed fresh here and always written — not
+    // just on a chair swap — because the override decision must reflect
+    // this reassignment, not linger from whatever was persisted before it
+    // (spec: "Overridden pins" §).
+    const patch: Record<string, unknown> = {
+      table_number: m.tableNumber,
+      player1_pin_overridden: overridden.has(m.player1Id),
+      player2_pin_overridden: overridden.has(m.player2Id),
+    };
     if (swapped) {
       // Chair-side swap: mirror handleSwapPlayers' same-match flip — swap the
       // per-side sibling columns along with the ids. Scores are null here

--- a/utils/tournament/stateAdapter.ts
+++ b/utils/tournament/stateAdapter.ts
@@ -50,7 +50,7 @@ export async function buildStateFromSupabase(
 ): Promise<TournamentState | null> {
   const { data: t } = await client
     .from("tournaments")
-    .select("id, n_rounds, current_round, max_score, has_started, has_ended")
+    .select("id, n_rounds, current_round, max_score, has_started, has_ended, starting_table_number, numbering_mode")
     .eq("id", tournamentId)
     .single();
   if (!t) return null;
@@ -58,13 +58,14 @@ export async function buildStateFromSupabase(
 
   const { data: parts } = await client
     .from("participants")
-    .select("id, name, joined_at, dropped_out")
+    .select("id, name, joined_at, dropped_out, assigned_seat")
     .eq("tournament_id", tournamentId);
   const participants: Participant[] = (parts || []).map((p: any) => ({
     id: p.id,
     name: p.name ?? "",
     joinedAt: p.joined_at ?? new Date(0).toISOString(),
     droppedOut: !!p.dropped_out,
+    assignedSeat: p.assigned_seat ?? undefined,
   }));
 
   const { data: matchRows } = await client
@@ -111,5 +112,7 @@ export async function buildStateFromSupabase(
     matches,
     byes,
     startedRounds,
+    startingTableNumber: t.starting_table_number ?? 1,
+    numberingMode: t.numbering_mode === "seats" ? "seats" : "tables",
   };
 }


### PR DESCRIPTION
## What

Hosts can now pin any participant to a **static table** (or chair) that every round's pairings respect, and tournaments can number by **tables** (default) or **seats** (numbered chairs — table k = seats 2k−1, 2k).

Spec: `docs/superpowers/specs/2026-07-15-static-seats-design.md` · Plan: `docs/superpowers/plans/2026-07-16-static-seats.md`

## How it works

- **Pairing is untouched** — who plays whom stays pure Swiss. A new pure function `assignTables()` (`lib/tournament/tableAssignment.ts`, 13 unit tests) runs after pairing and decides *where* each match happens; the result persists to a new `matches.table_number`.
- **Pins**: `participants.assigned_seat` (unique per tournament, edit-pencil UI on the Players tab, `T5`/`S9` roster badges). A pin is a table number in tables mode, a seat number in seats mode.
- **Conflicts are deterministic**: two pinned players paired together → lower number wins, the other gets a subtle ⚠ "pin overridden" badge that round. Cross-match seat claims to the same table → lower seat wins, other match refills. Seats 9+10 paired together → both honored, correct chairs.
- **All three write paths covered**: `createPairing`, regenerate (RPC updated in migration 078), and repair swaps (shared `reassignRoundTables` helper — pins follow players).
- **Display & print** read the persisted number; legacy rounds (null `table_number`) render exactly as before. Seats mode shows per-chair numbers in the rounds view, print pairings, and match slips.
- Settings gains a Tables/Seats toggle with a warning when pins exist (values reinterpret under the new mode).

## Edge cases (from the spec, all tested)

Pinned-vs-pinned pairing, duplicate pin values (DB unique index + friendly toast), sparse pins (table 50 with 10 matches), pins below the starting table, pinned byes/drops (dormant), mid-round pin edits (apply at next generation), legacy rounds, mode switching with pins.

## Verification

- `assignTables` unit suite (13 tests) + full vitest run green; `tsc --noEmit` clean.
- Migration **078 applied to the live DB** (columns, partial unique index, RPC verified present; new columns inherit table-level grants).
- Live E2E (Playwright, minted host session): 13/13 — pin via modal → T3 badge → duplicate rejected with friendly error → round 1 pairs Alice at table 3 with fill skipping to 1,2 → rounds view + print agree → seats-mode toggle warns, persists, and renders chair pairs (1·2/3·4/5·6) with per-player seat numbers and the overridden-pin badge.
- Direct live-RPC test as host: 6/6 — `table_number` inserted (sparse 7 honored), `recompute_participant_totals` runs (stale bye holder reset 3→0, new holder +3), anon rejected.

## Review

Per-task spec+quality reviews on every commit; final whole-branch review caught one Critical (078's RPC body would have reverted migration 038's `recompute_participant_totals` fix) — fixed in `69e30810` and re-verified both statically and live. Deferred minors (follow-up material, none blocking): extra `assignTables` test cases, `reassignRoundTables` error-surfacing/batching, pre-existing `printFinalStandings` escaping, settings warning copy plural.

🤖 Generated with [Claude Code](https://claude.com/claude-code)