### PR TITLE
fix(battle): don't brigade-flag a dual GE/Character card played as its character

### DIFF
--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -178,6 +178,19 @@ function isBattleEnhancementSegment(cardType: string): boolean {
     .some((s) => s === 'GE' || s === 'EE');
 }
 
+/**
+ * Whether a battle card should get the enhancement brigade soft-check. A dual
+ * GE/Character card (e.g. Fire Foxes, "GE/Evil Character") can be played as its
+ * CHARACTER side — a being in the band, not an enhancement on a character — so
+ * the enhancement brigade rule doesn't apply. Exclude anything that is also a
+ * character to avoid false "no matching brigade, discard it" flags. (Downside:
+ * a dual card played AS an enhancement with a mismatched brigade won't be
+ * flagged — acceptable for a soft advisory, since the mode isn't tracked.)
+ */
+export function isBrigadeCheckableEnhancement(cardType: string): boolean {
+  return isBattleEnhancementSegment(cardType) && !isCharacterCard({ cardType });
+}
+
 /** Mirrors battleMath.ts's private isLostSoulLike / the server's
  *  isLostSoulRow (battleStakesLobLostSouls): used client-side to count the
  *  stakes Lost Souls for the Rescue-attempt vs. Battle-challenge header. */
@@ -5298,7 +5311,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
     if (battleCardEntries.length === 0) return [] as BattleCardEntry[];
     const result: BattleCardEntry[] = [];
     for (const entry of battleCardEntries) {
-      if (!isBattleEnhancementSegment(entry.like.cardType)) continue;
+      if (!isBrigadeCheckableEnhancement(entry.like.cardType)) continue;
       const side = battleSideOf(entry.like);
       const sameSideCharacters = battleCardEntries
         .filter((e) => e !== entry && battleSideOf(e.like) === side && isCharacterCard({ cardType: e.like.cardType }))

--- a/app/play/components/__tests__/isHandCardFaceVisible.test.ts
+++ b/app/play/components/__tests__/isHandCardFaceVisible.test.ts
@@ -18,6 +18,7 @@ import {
   isHandCardFaceVisible,
   isFaceDownInPlayCardVisible,
   canViewerToggleMeek,
+  isBrigadeCheckableEnhancement,
 } from '../MultiplayerCanvas';
 
 // Unit coverage for the hand-card visibility predicate that gates whether a
@@ -279,5 +280,31 @@ describe('canViewerToggleMeek', () => {
 
   it('forbids a spectator (read-only)', () => {
     expect(canViewerToggleMeek('spectator')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isBrigadeCheckableEnhancement — only PURE enhancements get the brigade
+// soft-check. A dual GE/Character card (Fire Foxes) played as its character
+// side must NOT be flagged "no matching brigade, discard it".
+// ---------------------------------------------------------------------------
+
+describe('isBrigadeCheckableEnhancement', () => {
+  it('checks a pure Good/Evil Enhancement', () => {
+    expect(isBrigadeCheckableEnhancement('GE')).toBe(true);
+    expect(isBrigadeCheckableEnhancement('EE')).toBe(true);
+    expect(isBrigadeCheckableEnhancement('GE/EE')).toBe(true);
+  });
+
+  it('does NOT check a dual GE/Character card (Fire Foxes: "GE/Evil Character")', () => {
+    expect(isBrigadeCheckableEnhancement('GE/Evil Character')).toBe(false);
+    expect(isBrigadeCheckableEnhancement('EE/Evil Character')).toBe(false);
+    expect(isBrigadeCheckableEnhancement('GE/Hero')).toBe(false);
+  });
+
+  it('does NOT check a plain character or non-enhancement', () => {
+    expect(isBrigadeCheckableEnhancement('Hero')).toBe(false);
+    expect(isBrigadeCheckableEnhancement('Evil Character')).toBe(false);
+    expect(isBrigadeCheckableEnhancement('Dominant')).toBe(false);
   });
 });


### PR DESCRIPTION
## Bug
Playing **Fire Foxes** (`GE/Evil Character`) as its **Evil Character** side triggered the enhancement brigade soft-check — the "No matching brigade in battle — REG says discard it" popup — even though it's a character in the band, not an enhancement.

## Cause
The soft-check gates on `isBattleEnhancementSegment`, which returns true for any type containing a `GE`/`EE` segment. A dual GE/Character card matches that, so it got the *enhancement* brigade rule despite being played as a character.

## Fix
Add `isBrigadeCheckableEnhancement(cardType) = isBattleEnhancementSegment(cardType) && !isCharacterCard(...)` and gate the soft-check on it — instead of removing the popup, which still correctly flags genuine enhancement mismatches (the recent Mary / Child-is-Born fix).

Trade-off: a dual card played *as* an enhancement with a mismatched brigade won't be flagged. Acceptable for a soft advisory, since the engine doesn't track which mode a dual card was played in — and erring toward *not* nagging matches the intent.

## Testing
`isHandCardFaceVisible.test.ts` — 25 pass, incl. 3 new `isBrigadeCheckableEnhancement` cases: pure `GE`/`EE`/`GE/EE` are checked; `GE/Evil Character` (Fire Foxes), `EE/Evil Character`, `GE/Hero`, and plain characters/non-enhancements are not.

Not yet live-verified in a running game; the change is a pure predicate + one filter line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)