### PR TITLE
feat(play): batch notes on multi-selected cards ("Negated" a whole swath)

### DIFF
--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -1303,7 +1303,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
   const [resurrectReq, setResurrectReq] = useState<{ sourceInstanceId: string; abilityIndex: number } | null>(null);
   const [multiCardContextMenu, setMultiCardContextMenu] = useState<{ x: number; y: number } | null>(null);
   const [notePopover, setNotePopover] = useState<{
-    cardId: string;
+    cardIds: string[];
     x: number;
     y: number;
     initialValue: string;
@@ -8419,7 +8419,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
           }
           onEditNote={(card) => {
             setNotePopover({
-              cardId: card.instanceId,
+              cardIds: [card.instanceId],
               x: contextMenu.x,
               y: contextMenu.y,
               initialValue: card.notes ?? '',
@@ -8478,18 +8478,33 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
             actions={{ ...multiplayerActions, ...(sharedSoulActions ?? {}) }}
             onClose={() => setMultiCardContextMenu(null)}
             onClearSelection={() => { clearSelection(); setMultiCardContextMenu(null); }}
+            onEditNotes={(cardIds) => {
+              setNotePopover({
+                cardIds,
+                x: multiCardContextMenu.x,
+                y: multiCardContextMenu.y,
+                initialValue: '',
+              });
+            }}
             zones={allZonesForContextMenu as any}
           />
         );
       })()}
 
-      {notePopover && (
+      {!isSpectator && notePopover && (
         <CardNotePopover
           x={notePopover.x}
           y={notePopover.y}
           initialValue={notePopover.initialValue}
           onSave={(text) => {
-            gameState.setNote(BigInt(notePopover.cardId), text);
+            // Empty text from the multi-card path is a click-away cancel, not a
+            // bulk clear — "Clear All Notes" is the explicit affordance for that.
+            // Single-card keeps the clear-by-emptying flow.
+            if (text !== '' || notePopover.cardIds.length === 1) {
+              for (const id of notePopover.cardIds) {
+                gameState.setNote(BigInt(id), text);
+              }
+            }
             setNotePopover(null);
           }}
           onCancel={() => setNotePopover(null)}

--- a/app/shared/components/MultiCardContextMenu.tsx
+++ b/app/shared/components/MultiCardContextMenu.tsx
@@ -28,11 +28,13 @@ interface MultiCardContextMenuProps {
   onClose: () => void;
   onClearSelection: () => void;
   onExchange?: (cardIds: string[]) => void;
+  /** Opens a note editor applying the entered text to every selected card */
+  onEditNotes?: (cardIds: string[]) => void;
   /** Live zone state for resolving selected card data */
   zones?: Record<ZoneId, GameCard[]>;
 }
 
-export function MultiCardContextMenu({ selectedIds, x, y, actions, onClose, onClearSelection, onExchange, zones }: MultiCardContextMenuProps) {
+export function MultiCardContextMenu({ selectedIds, x, y, actions, onClose, onClearSelection, onExchange, onEditNotes, zones }: MultiCardContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const [pos, setPos] = useState<{ left: number; top: number; ready: boolean }>({ left: x, top: y, ready: false });
 
@@ -250,6 +252,44 @@ export function MultiCardContextMenu({ selectedIds, x, y, actions, onClose, onCl
         >
           Flip All Face-Up
         </button>
+      )}
+
+      {onEditNotes && (
+        <>
+          <div style={separatorStyle} />
+          <div style={labelStyle}>Note</div>
+          <button
+            style={itemStyle}
+            onClick={() => doAction(() => {
+              for (const id of selectedIds) actions.setNote(id, 'Negated');
+            })}
+            {...hoverHandlers}
+          >
+            Mark All &ldquo;Negated&rdquo;
+          </button>
+          {/* Captures ids at click time — the popover outlives the menu and any
+              selection clearing (same pattern as Exchange with Deck). */}
+          <button
+            style={itemStyle}
+            onClick={() => { onClose(); onEditNotes(selectedIds); }}
+            {...hoverHandlers}
+          >
+            Add Note to All...
+          </button>
+          {selectedCards.some(c => c.notes) && (
+            <button
+              style={itemStyle}
+              onClick={() => doAction(() => {
+                for (const card of selectedCards) {
+                  if (card.notes) actions.setNote(card.instanceId, '');
+                }
+              })}
+              {...hoverHandlers}
+            >
+              Clear All Notes
+            </button>
+          )}
+        </>
       )}
 
       <div style={separatorStyle} />

--- a/docs/superpowers/specs/2026-07-16-multi-card-notes-design.md
+++ b/docs/superpowers/specs/2026-07-16-multi-card-notes-design.md
@@ -1,0 +1,84 @@
+# Multi-Card Notes (Batch "Negated") — Design
+
+**Date:** 2026-07-16
+**Status:** Approved (adversarial subagent review, 2 rounds)
+
+## Problem
+
+In multiplayer, a player often needs to mark a wide swath of cards at once — e.g.
+"Negated" across most of a battle line-up. Today notes are single-card only: the
+marquee drag-select exists, the multi-card context menu exists, and per-card notes
+exist, but they aren't connected.
+
+## What already exists (unchanged)
+
+- Marquee drag-select (`useSelectionState`, wired in `MultiplayerCanvas`). One
+  marquee selects a single owner's cards (majority-owner rule), so noting both
+  sides takes two passes. Opponent-owned swaths work: `set_note` has no
+  ownership gate, and the multi menu opens for any selected card.
+- `MultiCardContextMenu` (shared with goldfish) with per-card client-side loops
+  for Meek All / Flip All.
+- `set_note` reducer (40-char max, trims, overwrites), `CardInstance.notes`,
+  note pill on `GameCardNode`, `CardNotePopover` editor, "Negated" preset in the
+  single-card menu.
+
+## Changes
+
+### 1. `app/shared/components/MultiCardContextMenu.tsx`
+
+New optional prop `onEditNotes?: (cardIds: string[]) => void`. A **Note**
+section between the meek/flip toggles and "Move to...", rendered only when the
+prop is provided (mirrors how `onEditNote` gates the single-card note section):
+
+- **Mark All "Negated"** — loops `actions.setNote(id, 'Negated')` via `doAction`.
+- **Add Note to All...** — `onClick={() => { onClose(); onEditNotes(selectedIds); }}`
+  (the `onExchange` pattern, NOT `doAction`): ids are captured at click time so
+  the popover survives menu close / selection clearing.
+- **Clear All Notes** — only rendered when ≥1 selected card has a non-empty note
+  (resolved from `zones`); loops `actions.setNote(id, '')` via `doAction`.
+
+Goldfish does not pass `onEditNotes`, so no note items appear there (goldfish's
+single-card menu has no note section either — avoids un-clearable notes).
+The `allTokens` early-return branch intentionally keeps its focused menu
+(Rescue / Remove); mixed token+card selections hit the main branch and work.
+
+### 2. `app/play/components/MultiplayerCanvas.tsx`
+
+- `notePopover` state generalized from `{ cardId, x, y, initialValue }` to
+  `{ cardIds: string[], x, y, initialValue }`. Single-card path passes a
+  one-element list seeded with the card's current note; multi path seeds `''`.
+- `onSave` loops `gameState.setNote(BigInt(id), text)` over `cardIds`, with one
+  guard: **empty text + multiple cards = cancel, not bulk clear.**
+  `CardNotePopover` saves on click-away, so without the guard an abandoned
+  multi-note dialog would silently wipe existing notes on every selected card.
+  The single-card path keeps the existing clear-by-emptying flow.
+- Wire `onEditNotes` on the multi-menu render (opens popover at menu x/y).
+- Hygiene: wrap the popover render in `!isSpectator` (its only setters were
+  already spectator-gated; server rejects non-players regardless).
+
+### 3. `spacetimedb/src/index.ts` — fix hidden-identity log leak
+
+`set_note` currently logs `cardName`/`cardImgFile` unconditionally, so noting a
+face-down or in-hand card announces its identity in the game log — and batch
+noting would turn that into a one-click sweep of the opponent's face-down cards.
+Fix: omit `cardName`/`cardImgFile` from the SET_NOTE payload when
+`card.isFlipped || card.zone === 'hand'`, mirroring the existing guards in
+`flip_card`/`meek_card`. `ChatPanel` already falls back to the generic
+"set a note on a card" line when `cardName` is absent — no client change.
+
+Requires a module publish + bindings regen (reducer signature unchanged, so no
+binding diff expected — publish is for server behavior).
+
+## Semantics
+
+- Applying a note **overwrites** each card's existing note (single-card parity).
+- No undo participation (consistent with Meek All).
+- N cards → N SET_NOTE log lines (consistent with Meek All).
+- `flip_card` wiping notes on face-down flip is unchanged, deliberate behavior.
+
+## Out of scope
+
+- Batch `set_notes_batch` reducer (client loop matches the menu's existing
+  pattern; revisit only if log volume becomes a problem).
+- Note items in the token-only menu branch.
+- Goldfish note UI.

--- a/spacetimedb/src/index.ts
+++ b/spacetimedb/src/index.ts
@@ -6533,18 +6533,23 @@ export const set_note = spacetimedb.reducer(
     const previousNote = card.notes;
     ctx.db.CardInstance.id.update({ ...card, notes: trimmed });
 
+    // The note pill is public, but a face-down or in-hand card's identity is
+    // not — omit it from the log (mirrors flip_card/meek_card).
+    const notePayload: Record<string, string> = {
+      cardInstanceId: cardInstanceId.toString(),
+      note: trimmed,
+      previousNote,
+    };
+    if (!card.isFlipped && card.zone !== 'hand') {
+      notePayload.cardName = card.cardName;
+      notePayload.cardImgFile = card.cardImgFile;
+    }
     logAction(
       ctx,
       gameId,
       player.id,
       'SET_NOTE',
-      JSON.stringify({
-        cardInstanceId: cardInstanceId.toString(),
-        cardName: card.cardName,
-        cardImgFile: card.cardImgFile,
-        note: trimmed,
-        previousNote,
-      }),
+      JSON.stringify(notePayload),
       game.turnNumber,
       game.currentPhase,
     );


### PR DESCRIPTION
## What

In multiplayer, marquee-select a group of cards, right-click → new **Note** section in the multi-card menu:

- **Mark All "Negated"** — one click applies the `Negated` note to every selected card
- **Add Note to All...** — opens the existing note popover; the text (≤40 chars) is applied to every selected card
- **Clear All Notes** — shown only when at least one selected card has a note

Works on opponent-owned selections too (one marquee = one owner, so noting both sides is two passes). Notes overwrite, matching single-card behavior. Goldfish is unaffected — the section is gated on the new optional `onEditNotes` prop, which only multiplayer wires (goldfish has no note UI, so batch-applied notes would have been un-clearable there).

## Fix folded in: SET_NOTE log identity leak

`set_note` logged `cardName`/`cardImgFile` unconditionally, so noting a face-down or in-hand card announced its identity in the game log — and batch noting would have turned that into a one-click sweep of an opponent's face-down cards. The payload now omits identity for face-down/in-hand cards (mirrors `flip_card`/`meek_card`); ChatPanel already falls back to its generic "set a note on a card" line.

## Details

- `notePopover` state generalized to `cardIds: string[]`; single-card path passes a one-element list. An empty save from the multi path is treated as click-away **cancel**, not a bulk clear (the popover saves on click-away; "Clear All Notes" is the explicit affordance).
- Per-card client-side `setNote` loop, same pattern as Meek All / Flip All in this menu. No undo participation (consistent with those).
- Popover render wrapped in `!isSpectator` (hygiene; setters were already gated).
- Design spec: `docs/superpowers/specs/2026-07-16-multi-card-notes-design.md` (adversarial subagent review, 2 rounds — caught the log leak, the goldfish trap, and the empty-save wipe).

## Deploy

- ✅ Dev module published (`redemption-multiplayer-dev`); bindings regenerated with **no diff** (reducer signature unchanged)
- ⚠️ On merge: publish `redemption-multiplayer` (prod) alongside the Vercel deploy

## Verification

- `npx tsc --noEmit` — no errors in touched files (7 pre-existing errors in untouched test files)
- Dev module publish + bindings regen clean
- Not yet manually exercised in-browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)