### PR TITLE
fix(battle): close the battle band when the game ends (e.g. concede)

### DIFF
--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -178,6 +178,22 @@ function isBattleEnhancementSegment(cardType: string): boolean {
     .some((s) => s === 'GE' || s === 'EE');
 }
 
+/**
+ * Whether the Field of Battle band should be open. Phase-driven (spec §4): open
+ * while the turn player is in the 'battle' phase, OR whenever battleState is
+ * non-empty (covers a battle still resolving a soul surrender, or drift between
+ * the two signals). Gated on a live game: a finished game (e.g. a concede
+ * mid-battle, which only flips status to 'finished' without clearing the phase
+ * or battleState) — or a waiting one — never shows the band.
+ */
+export function isBattleBandActive(
+  status: string,
+  currentPhase: string,
+  battleState: string,
+): boolean {
+  return status === 'playing' && (currentPhase === 'battle' || battleState !== '');
+}
+
 /** Mirrors battleMath.ts's private isLostSoulLike / the server's
  *  isLostSoulRow (battleStakesLobLostSouls): used client-side to count the
  *  stakes Lost Souls for the Rescue-attempt vs. Battle-challenge header. */
@@ -607,9 +623,15 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
   // Phase-driven (spec §4): the band is visible whenever the turn player has
   // set_phase('battle'), OR whenever battleState is non-empty (defensive OR —
   // covers e.g. a battle still resolving a soul surrender after the phase bar
-  // has moved on, or any state drift between the two signals).
-  const rawBattleActive =
-    gameState.game?.currentPhase === 'battle' || (gameState.game?.battleState ?? '') !== '';
+  // has moved on, or any state drift between the two signals). Gated on a live
+  // game so a concede mid-battle (status -> 'finished' without clearing the
+  // phase/battleState) closes the band instead of leaving it open. See
+  // isBattleBandActive.
+  const rawBattleActive = isBattleBandActive(
+    gameState.game?.status ?? '',
+    gameState.game?.currentPhase ?? '',
+    gameState.game?.battleState ?? '',
+  );
   const rawBattleActiveRef = useRef(rawBattleActive);
   rawBattleActiveRef.current = rawBattleActive;
   const [battleActive, setBattleActive] = useState(rawBattleActive);

--- a/app/play/components/__tests__/isHandCardFaceVisible.test.ts
+++ b/app/play/components/__tests__/isHandCardFaceVisible.test.ts
@@ -18,6 +18,7 @@ import {
   isHandCardFaceVisible,
   isFaceDownInPlayCardVisible,
   canViewerToggleMeek,
+  isBattleBandActive,
 } from '../MultiplayerCanvas';
 
 // Unit coverage for the hand-card visibility predicate that gates whether a
@@ -279,5 +280,33 @@ describe('canViewerToggleMeek', () => {
 
   it('forbids a spectator (read-only)', () => {
     expect(canViewerToggleMeek('spectator')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isBattleBandActive — the Field of Battle band only opens during a live game.
+// A concede mid-battle flips status to 'finished' without clearing the phase or
+// battleState, so the status gate is what closes the band.
+// ---------------------------------------------------------------------------
+
+describe('isBattleBandActive', () => {
+  it('open while playing and in the battle phase', () => {
+    expect(isBattleBandActive('playing', 'battle', '')).toBe(true);
+  });
+
+  it('open while playing and a battle is resolving (battleState set, phase moved on)', () => {
+    expect(isBattleBandActive('playing', 'main', 'awaiting-soul')).toBe(true);
+  });
+
+  it('closed while playing with no battle', () => {
+    expect(isBattleBandActive('playing', 'main', '')).toBe(false);
+  });
+
+  it('closed once finished even if phase/battleState were never cleared (concede mid-battle)', () => {
+    expect(isBattleBandActive('finished', 'battle', 'active')).toBe(false);
+  });
+
+  it('closed while waiting (pre-game)', () => {
+    expect(isBattleBandActive('waiting', 'battle', 'active')).toBe(false);
   });
 });


### PR DESCRIPTION
## Request
When someone concedes mid-battle, close the Field of Battle band if it's open.

## Cause
The Concede button → `resignGame` → the `resign_game` reducer, which **only** sets `status: 'finished'` — it never clears `currentPhase` or `battleState`. The band's visibility (`rawBattleActive`) keyed solely on `currentPhase === 'battle' || battleState !== ''`, so the band stayed open behind the game-over overlay after a concede.

## Fix
Gate band visibility on a live game with a new pure predicate `isBattleBandActive(status, currentPhase, battleState)` — the band opens only while `status === 'playing'`. This closes it on concede **and every other game-over path** (disconnect timeout, win conditions), with no SpacetimeDB republish.

Client-only by design: the server-side battle rows stay put, but they're inert on a finished game and never render once the band is closed. If you'd rather the cards actually return to each player's territory on concede (a cleaner final board), that's a follow-up server change in `resign_game` (call `runBattleAutoReturn`) — happy to do it, but it needs a module republish.

## Testing
`isHandCardFaceVisible.test.ts` — 27 pass, incl. 5 new `isBattleBandActive` cases (open in battle phase; open while a soul surrender resolves; closed with no battle; **closed once finished even if phase/battleState were never cleared** — the concede case; closed while waiting).

Not yet live-verified in a running game; the change is a pure predicate + one call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)