### PR TITLE
fix(play): LoR soul abilities in browse modal + Harvest token to opponent's LoB

### DIFF
--- a/app/goldfish/components/GoldfishCanvas.tsx
+++ b/app/goldfish/components/GoldfishCanvas.tsx
@@ -2954,6 +2954,15 @@ export default function GoldfishCanvas({ containerWidth, containerHeight, scale,
             onStartMultiDrag={modalStartMultiDrag}
             didDragRef={modalDidDragRef}
             isDragActive={modalDrag.isDragging}
+            onRequestCardMenu={(card, clientX, clientY) => {
+              const container = stageRef.current?.container().getBoundingClientRect();
+              setBrowseZone(null);
+              setContextMenu({
+                card,
+                x: clientX - (container?.left ?? 0),
+                y: clientY - (container?.top ?? 0),
+              });
+            }}
           />
         )}
 

--- a/app/goldfish/state/gameReducer.ts
+++ b/app/goldfish/state/gameReducer.ts
@@ -121,6 +121,13 @@ function spawnTokenInState(
   // thematically belong in LoB).
   const targetZone: ZoneId = ability.defaultZone ?? 'territory';
 
+  // Whose zone the token lands in. `spawnForOpponent` (Harvest-style souls that
+  // "create a token in an opponent's Land of Bondage") places it in the
+  // opponent's copy of the zone, owned by the opponent side.
+  const tokenOwnerId = ability.spawnForOpponent
+    ? (source.ownerId === 'player1' ? 'player2' : 'player1')
+    : source.ownerId;
+
   // Stagger each token relative to the source's position IF the source is
   // already in territory. Otherwise use a reasonable default near the
   // center-ish area so tokens appear together and visible.
@@ -148,7 +155,7 @@ function spawnTokenInState(
   const occupied: Array<{ x: number; y: number }> =
     targetZone === 'territory'
       ? state.zones[targetZone]
-          .filter(c => c.ownerId === source.ownerId)
+          .filter(c => c.ownerId === tokenOwnerId)
           .map(c => ({ x: Number(c.posX), y: Number(c.posY) }))
           .filter(p => Number.isFinite(p.x) && Number.isFinite(p.y))
       : [];
@@ -173,7 +180,7 @@ function spawnTokenInState(
     isFlipped: false,
     isToken: true,
     zone: targetZone,
-    ownerId: source.ownerId,
+    ownerId: tokenOwnerId,
     notes: '',
     posX: targetZone === 'territory' ? slots[i].x : undefined,
     posY: targetZone === 'territory' ? slots[i].y : undefined,

--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -9082,6 +9082,10 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
             didDragRef={modalDidDragRef}
             isDragActive={modalDrag.isDragging}
             readOnly={isSpectator}
+            onRequestCardMenu={(card, clientX, clientY) => {
+              setBrowseMyZone(null);
+              setContextMenu({ card, x: clientX, y: clientY });
+            }}
           />
         )}
 

--- a/app/shared/components/ZoneBrowseModal.tsx
+++ b/app/shared/components/ZoneBrowseModal.tsx
@@ -10,6 +10,7 @@ import { getCardImageUrl } from '@/app/shared/utils/cardImageUrl';
 import { useDraggableModal } from '@/app/shared/hooks/useDraggableModal';
 import { DraggableTitleBar } from './DraggableTitleBar';
 import { compareCardsDefault } from '@/lib/cards/defaultSort';
+import { hasUsableAbilityInZone } from '@/lib/cards/cardAbilities';
 
 const MOVE_ZONES: { id: ZoneId; label: string }[] = [
   { id: 'hand', label: 'Hand' },
@@ -145,9 +146,15 @@ interface ZoneBrowseModalProps {
   didDragRef?: React.MutableRefObject<boolean>;
   isDragActive?: boolean;
   readOnly?: boolean;
+  /** When provided, right-clicking a card that has a right-click ability usable
+   *  from its current zone (e.g. a Lost Soul "Harvest" in the Land of
+   *  Redemption) defers to the canvas's full card menu — which surfaces the
+   *  ability — instead of this modal's move-only popup. Receives viewport
+   *  coordinates. */
+  onRequestCardMenu?: (card: GameCard, clientX: number, clientY: number) => void;
 }
 
-export function ZoneBrowseModal({ zoneId, onClose, onStartDrag, onStartMultiDrag, didDragRef, isDragActive, readOnly }: ZoneBrowseModalProps) {
+export function ZoneBrowseModal({ zoneId, onClose, onStartDrag, onStartMultiDrag, didDragRef, isDragActive, readOnly, onRequestCardMenu }: ZoneBrowseModalProps) {
   const { dragHandleProps, modalStyle } = useDraggableModal();
   const { zones, actions } = useModalGame();
   const { moveCard, moveCardsBatch, moveCardToTopOfDeck, moveCardToBottomOfDeck, shuffleCardIntoDeck, shuffleDeck } = actions;
@@ -254,6 +261,15 @@ export function ZoneBrowseModal({ zoneId, onClose, onStartDrag, onStartMultiDrag
     e.preventDefault();
     if (readOnly) return;
     onCardMouseLeave();
+    // A card with a right-click ability usable from this zone (e.g. a Lost Soul
+    // "Harvest" in the Land of Redemption) defers to the canvas's full card
+    // menu so the ability is reachable. Multi-selections keep the batch-move
+    // popup below.
+    const isMultiSelected = selectedIds.has(card.instanceId) && selectedIds.size > 1;
+    if (onRequestCardMenu && !isMultiSelected && hasUsableAbilityInZone(card)) {
+      onRequestCardMenu(card, e.clientX, e.clientY);
+      return;
+    }
     setContextCard({ card, x: e.clientX, y: e.clientY });
     // Re-set the loupe preview so it keeps showing the right-clicked card
     setPreviewCard({ cardName: card.cardName, cardImgFile: card.cardImgFile, isMeek: card.isMeek });

--- a/lib/cards/__tests__/cardAbilities.test.ts
+++ b/lib/cards/__tests__/cardAbilities.test.ts
@@ -16,6 +16,7 @@ import {
   isCharacterCard,
   isHeroCard,
   getEffectiveAbilities,
+  hasUsableAbilityInZone,
 } from '../cardAbilities';
 import {
   IMITATE_SOUL_IMAGES as serverImitateImages,
@@ -333,6 +334,43 @@ describe('simplifyLostSoulName', () => {
 
   it('strips "Lost Soul " prefix when neither quoted nor parenthetical exists', () => {
     expect(simplifyLostSoulName('Lost Soul Romans 3:23')).toBe('Romans 3:23');
+  });
+});
+
+describe('hasUsableAbilityInZone', () => {
+  it('true for Lost Soul "Harvest" resting in the Land of Redemption', () => {
+    // spawn_token has no explicit sourceZones → DEFAULT (which includes LoR).
+    expect(hasUsableAbilityInZone({
+      cardName: 'Lost Soul "Harvest" [John 4:35]',
+      zone: 'land-of-redemption',
+    })).toBe(true);
+  });
+
+  it('false for the same soul in a pile zone abilities cannot fire from (reserve)', () => {
+    expect(hasUsableAbilityInZone({
+      cardName: 'Lost Soul "Harvest" [John 4:35]',
+      zone: 'reserve',
+    })).toBe(false);
+  });
+
+  it('false for a card with no registered ability', () => {
+    expect(hasUsableAbilityInZone({
+      cardName: 'Lost Soul Romans 3:23',
+      zone: 'land-of-redemption',
+    })).toBe(false);
+  });
+
+  it('respects explicit sourceZones (Virgin Birth is usable from hand, not reserve)', () => {
+    expect(hasUsableAbilityInZone({ cardName: 'Virgin Birth', zone: 'hand' })).toBe(true);
+    expect(hasUsableAbilityInZone({ cardName: 'Virgin Birth', zone: 'reserve' })).toBe(false);
+  });
+
+  it('sees inherited abilities from an imitated soul (Imitate → Lawless in LoR)', () => {
+    expect(hasUsableAbilityInZone({
+      cardName: 'Lost Soul "Imitate" [III John 1:11]',
+      imitatingName: 'Lost Soul "Lawless" [Hebrews 12:8]',
+      zone: 'land-of-redemption',
+    })).toBe(true);
   });
 });
 

--- a/lib/cards/cardAbilities.ts
+++ b/lib/cards/cardAbilities.ts
@@ -25,7 +25,10 @@ export type CardAbility = AbilityBase & (
   // spawning `tokenName` (count-based: 0→first, 1→second, …). Everyone else
   // gets the normal `tokenName`. The cycle index is derived from how many of
   // those tokens the player already has in play, so no extra state is stored.
-  | { type: 'spawn_token'; tokenName: string; count?: number; defaultZone?: ZoneId; cyclingTokenNames?: string[]; cyclingAllowedUsers?: string[] }
+  // `spawnForOpponent` places the token(s) in the OPPONENT's copy of
+  // `defaultZone` (owned by the opponent) instead of the caster's — e.g. Lost
+  // Soul "Harvest" creates its token in an opponent's Land of Bondage.
+  | { type: 'spawn_token'; tokenName: string; count?: number; defaultZone?: ZoneId; spawnForOpponent?: boolean; cyclingTokenNames?: string[]; cyclingAllowedUsers?: string[] }
   | { type: 'shuffle_and_draw'; shuffleCount: number; drawCount: number }
   | { type: 'all_players_shuffle_and_draw'; shuffleCount: number; drawCount: number }
   | { type: 'reveal_own_deck'; position: 'top' | 'bottom' | 'random'; count: number }
@@ -77,8 +80,8 @@ export const CARD_ABILITIES: Record<string, CardAbility[]> = {
   'The Heavenly Host (GoC)':                             [{ type: 'spawn_token', tokenName: 'Heavenly Host Token', cyclingTokenNames: ['Heavenly Host Token (Blue)', 'Heavenly Host Token (Purple)', 'Heavenly Host Token (Silver)'], cyclingAllowedUsers: ['jaychambers'] }],
   'Kingdom of the Divine':                               [{ type: 'spawn_token', tokenName: 'Daniel Soul Token' }],
   'Kingdom of the Divine [T2C AB]':                      [{ type: 'spawn_token', tokenName: 'Daniel Soul Token' }],
-  'Lost Soul "Harvest" [John 4:35]':                     [{ type: 'spawn_token', tokenName: 'Harvest Soul Token' }],
-  'Lost Soul "Harvest" [John 4:35] [2023 - 2nd Place]':  [{ type: 'spawn_token', tokenName: 'Harvest Soul Token' }],
+  'Lost Soul "Harvest" [John 4:35]':                     [{ type: 'spawn_token', tokenName: 'Harvest Soul Token', defaultZone: 'land-of-bondage', spawnForOpponent: true }],
+  'Lost Soul "Harvest" [John 4:35] [2023 - 2nd Place]':  [{ type: 'spawn_token', tokenName: 'Harvest Soul Token', defaultZone: 'land-of-bondage', spawnForOpponent: true }],
   'Lost Soul "Imitate" [III John 1:11]':                 [{ type: 'imitate_lost_soul' }],
   'Lost Soul "Imitate" [III John 1:11]  [AB - RoJ]':     [{ type: 'imitate_lost_soul' }],
   'Lost Soul "The First" [Luke 13:30]':                  [{ type: 'draw_and_topdeck_self' }],

--- a/lib/cards/cardAbilities.ts
+++ b/lib/cards/cardAbilities.ts
@@ -450,6 +450,24 @@ export function getEffectiveAbilities(card: { cardName: string; imitatingName?: 
   return [...base, ...imitated];
 }
 
+/**
+ * True when `card` has at least one right-click ability activatable from the
+ * zone it currently occupies. Mirrors the per-ability zone gate in
+ * CardContextMenu, but collapsed to "any usable ability". Used by the pile
+ * browse modal to decide whether to surface the full card menu (with ability
+ * options) instead of the move-only popup — e.g. a rescued Lost Soul "Harvest"
+ * sitting in the Land of Redemption.
+ */
+export function hasUsableAbilityInZone(card: {
+  cardName: string;
+  imitatingName?: string;
+  zone: ZoneId;
+}): boolean {
+  return getEffectiveAbilities(card).some((a) =>
+    (a.sourceZones ?? DEFAULT_ABILITY_SOURCE_ZONES).includes(card.zone),
+  );
+}
+
 export function abilityLabel(a: CardAbility): string {
   switch (a.type) {
     case 'spawn_token': {

--- a/spacetimedb/src/cardAbilities.ts
+++ b/spacetimedb/src/cardAbilities.ts
@@ -29,7 +29,10 @@ export type CardAbility = AbilityBase & (
   // the spawn cycles through cyclingTokenNames instead of spawning `tokenName`.
   // Cycle index is derived from how many of those tokens the player already has
   // in play, so no extra state is stored. Everyone else gets `tokenName`.
-  | { type: 'spawn_token'; tokenName: string; count?: number; defaultZone?: ZoneId; cyclingTokenNames?: string[]; cyclingAllowedUsers?: string[] }
+  // `spawnForOpponent` places the token(s) in the OPPONENT's copy of
+  // `defaultZone` (owned by the opponent) instead of the caster's — e.g. Lost
+  // Soul "Harvest" creates its token in an opponent's Land of Bondage.
+  | { type: 'spawn_token'; tokenName: string; count?: number; defaultZone?: ZoneId; spawnForOpponent?: boolean; cyclingTokenNames?: string[]; cyclingAllowedUsers?: string[] }
   | { type: 'shuffle_and_draw'; shuffleCount: number; drawCount: number }
   | { type: 'all_players_shuffle_and_draw'; shuffleCount: number; drawCount: number }
   | { type: 'reveal_own_deck'; position: 'top' | 'bottom' | 'random'; count: number }
@@ -74,8 +77,8 @@ export const CARD_ABILITIES: Record<string, CardAbility[]> = {
   'The Heavenly Host (GoC)':                             [{ type: 'spawn_token', tokenName: 'Heavenly Host Token', cyclingTokenNames: ['Heavenly Host Token (Blue)', 'Heavenly Host Token (Purple)', 'Heavenly Host Token (Silver)'], cyclingAllowedUsers: ['jaychambers'] }],
   'Kingdom of the Divine':                               [{ type: 'spawn_token', tokenName: 'Daniel Soul Token' }],
   'Kingdom of the Divine [T2C AB]':                      [{ type: 'spawn_token', tokenName: 'Daniel Soul Token' }],
-  'Lost Soul "Harvest" [John 4:35]':                     [{ type: 'spawn_token', tokenName: 'Harvest Soul Token' }],
-  'Lost Soul "Harvest" [John 4:35] [2023 - 2nd Place]':  [{ type: 'spawn_token', tokenName: 'Harvest Soul Token' }],
+  'Lost Soul "Harvest" [John 4:35]':                     [{ type: 'spawn_token', tokenName: 'Harvest Soul Token', defaultZone: 'land-of-bondage', spawnForOpponent: true }],
+  'Lost Soul "Harvest" [John 4:35] [2023 - 2nd Place]':  [{ type: 'spawn_token', tokenName: 'Harvest Soul Token', defaultZone: 'land-of-bondage', spawnForOpponent: true }],
   'Lost Soul "Imitate" [III John 1:11]':                 [{ type: 'imitate_lost_soul' }],
   'Lost Soul "Imitate" [III John 1:11]  [AB - RoJ]':     [{ type: 'imitate_lost_soul' }],
   'Lost Soul "The First" [Luke 13:30]':                  [{ type: 'draw_and_topdeck_self' }],

--- a/spacetimedb/src/index.ts
+++ b/spacetimedb/src/index.ts
@@ -3977,13 +3977,25 @@ function spawnTokenImpl(
   // visible main play area. Registry can override via ability.defaultZone.
   const targetZone = ability.defaultZone ?? 'territory';
 
-  // Compute starting zoneIndex based on existing cards for (targetZone, ownerId).
+  // Whose zone the token lands in. `spawnForOpponent` (Harvest-style souls that
+  // "create a token in an opponent's Land of Bondage") places it in the
+  // opponent's copy of the zone, owned by the opponent. Falls back to the
+  // caster if no opponent row exists.
+  let tokenOwnerId = source.ownerId;
+  if (ability.spawnForOpponent) {
+    const opponent = [...ctx.db.Player.player_game_id.filter(gameId)].find(
+      (p: any) => p.id !== source.ownerId,
+    );
+    if (opponent) tokenOwnerId = opponent.id;
+  }
+
+  // Compute starting zoneIndex based on existing cards for (targetZone, tokenOwnerId).
   // In the same pass, collect occupied territory positions so spawned tokens
   // can cascade past them instead of stacking invisibly on a previous batch.
   let maxIdx = -1n;
   const occupied: Array<{ x: number; y: number }> = [];
   for (const c of ctx.db.CardInstance.card_instance_game_id.filter(gameId)) {
-    if (c.ownerId === source.ownerId && c.zone === targetZone) {
+    if (c.ownerId === tokenOwnerId && c.zone === targetZone) {
       if (c.zoneIndex > maxIdx) maxIdx = c.zoneIndex;
       const x = c.posX ? Number(c.posX) : NaN;
       const y = c.posY ? Number(c.posY) : NaN;
@@ -4018,8 +4030,8 @@ function spawnTokenImpl(
     ctx.db.CardInstance.insert({
       id: 0n,
       gameId,
-      ownerId: source.ownerId,
-      originalOwnerId: source.ownerId,
+      ownerId: tokenOwnerId,
+      originalOwnerId: tokenOwnerId,
       zone: targetZone,
       zoneIndex: maxIdx,
       posX,


### PR DESCRIPTION
Two related Land-of-Redemption fixes.

## 1. Souls' right-click abilities reachable from the LoR browse modal
Right-clicking a soul in the Land of Redemption pile-browse only offered "Move to…", so a rescued Lost Soul "Harvest" (and other souls with a right-click ability) couldn't fire it from there. When a browsed card has an ability usable from its current zone, the modal now defers to the canvas's full `CardContextMenu` — reusing all existing ability dispatch. Adds a pure `hasUsableAbilityInZone` helper (+ unit tests).

## 2. Harvest token spawns in the opponent's Land of Bondage
Per the card text ("create a Lost Soul token in an opponent's Land of Bondage"), the Harvest LS token now spawns in the opponent's LoB (opponent-owned) instead of the caster's Territory. Adds a `spawnForOpponent` flag to `spawn_token`; both the SpacetimeDB reducer and the goldfish reducer honor it.

## Verification
- Unit tests (`hasUsableAbilityInZone`) + CARD_ABILITIES parity test green
- Type-checks clean (app + module)
- Goldfish E2E: browse right-click shows "Create Harvest Soul Token"; firing it puts the token in Land of Bondage (Territory stays 0), 0 console errors

## Deploy status
- ✅ SpacetimeDB modules **already republished** to maincloud (dev `redemption-multiplayer-dev` + prod `redemption-multiplayer`) from an origin/main base — incremental, empty migration plan, no data loss. Done while no games were active (0 playing, 0 connected).
- Merging this makes origin/main match the deployed module (a redeploy from origin/main before this would revert change #2's server half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)