### PR TITLE
Carry forward local-only commits: goldfish reveal-bottom fix + battle status text

### DIFF
--- a/app/goldfish/components/GoldfishCanvas.tsx
+++ b/app/goldfish/components/GoldfishCanvas.tsx
@@ -214,7 +214,8 @@ export default function GoldfishCanvas({ containerWidth, containerHeight, scale,
       // (Star) abilities fired from hand — flash the source card so the implicit
       // "reveal from hand" cost is visible (parity with multiplayer behavior).
       if (source && source.zone === 'hand') revealCardInHand(source.instanceId);
-      setPeekState({ cardIds: ids, title });
+      // Bottom/random reveals must not relocate cards to the top on dismiss.
+      setPeekState({ cardIds: ids, title, preserveOnDismiss: position !== 'top' });
     },
     [state.zones, revealCardInHand],
   );
@@ -402,7 +403,7 @@ export default function GoldfishCanvas({ containerWidth, containerHeight, scale,
   const [deckMenu, setDeckMenu] = useState<{ x: number; y: number } | null>(null);
   const [soulDeckMenu, setSoulDeckMenu] = useState<{ x: number; y: number } | null>(null);
   const [browseSoulDeck, setBrowseSoulDeck] = useState(false);
-  const [peekState, setPeekState] = useState<{ cardIds: string[]; title: string; sourceZone?: ZoneId } | null>(null);
+  const [peekState, setPeekState] = useState<{ cardIds: string[]; title: string; sourceZone?: ZoneId; preserveOnDismiss?: boolean } | null>(null);
   const [lookState, setLookState] = useState<{ cardIds: string[]; title: string; sourceZone?: ZoneId } | null>(null);
   const [deckDropPopup, setDeckDropPopup] = useState<{ cardInstanceId: string; x: number; y: number } | null>(null);
   const [soulDeckDropPopup, setSoulDeckDropPopup] = useState<{ cardInstanceId: string; batchIds?: string[]; x: number; y: number } | null>(null);
@@ -1360,7 +1361,9 @@ export default function GoldfishCanvas({ containerWidth, containerHeight, scale,
         : mode === 'bottom'
           ? `Bottom ${count} of Soul Deck`
           : `Random ${count} from Soul Deck`;
-      setPeekState({ cardIds: ids, title, sourceZone: 'soul-deck' });
+      // Dismissing a soul-deck reveal should leave the soul deck untouched, not
+      // relocate cards to the main deck's top.
+      setPeekState({ cardIds: ids, title, sourceZone: 'soul-deck', preserveOnDismiss: true });
     },
     [state.zones, pickSoulDeckIds],
   );
@@ -2824,7 +2827,7 @@ export default function GoldfishCanvas({ containerWidth, containerHeight, scale,
             if (deck.length === 0) { showGameToast('Deck is empty'); return; }
             const n = Math.min(count, deck.length);
             const ids = deck.slice(-n).map(c => c.instanceId);
-            setPeekState({ cardIds: ids, title: `Bottom ${n} of Deck` });
+            setPeekState({ cardIds: ids, title: `Bottom ${n} of Deck`, preserveOnDismiss: true });
           }}
           onDiscardBottom={(count) => {
             setDeckMenu(null);
@@ -2878,7 +2881,7 @@ export default function GoldfishCanvas({ containerWidth, containerHeight, scale,
             }
             const n = Math.min(count, deck.length);
             const ids = shuffled.slice(0, n).map(c => c.instanceId);
-            setPeekState({ cardIds: ids, title: `Random ${n} from Deck` });
+            setPeekState({ cardIds: ids, title: `Random ${n} from Deck`, preserveOnDismiss: true });
           }}
           onDiscardRandom={(count) => {
             setDeckMenu(null);
@@ -2986,6 +2989,7 @@ export default function GoldfishCanvas({ containerWidth, containerHeight, scale,
             didDragRef={modalDidDragRef}
             isDragActive={modalDrag.isDragging}
             sourceZone={peekState.sourceZone}
+            preserveOnDismiss={peekState.preserveOnDismiss}
           />
         )}
 

--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -5470,7 +5470,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
           statusText = 'No attacker in battle';
           break;
         case 'unknown':
-          statusText = 'Initiative unknown (face-down/variable stats)';
+          statusText = 'Initiative unknown (variable stats)';
           break;
         case 'initiative': {
           const reasonLabel = initiative.reason === 'mutual-destruction' ? 'mutual destruction' : initiative.reason;

--- a/app/shared/components/DeckPeekModal.tsx
+++ b/app/shared/components/DeckPeekModal.tsx
@@ -152,9 +152,17 @@ interface DeckPeekModalProps {
   isPrivateLook?: boolean;
   /** Zone to look up peeked cards in. Defaults to 'deck'. */
   sourceZone?: ZoneId;
+  /**
+   * When true, dismissing the modal (X / Escape / click-away) leaves the deck
+   * order untouched instead of returning the revealed cards to the top. Callers
+   * that reveal from the bottom or a random position pass this so a revealed
+   * bottom card isn't silently relocated to the top (and drawn next). The
+   * explicit footer buttons still reorder.
+   */
+  preserveOnDismiss?: boolean;
 }
 
-export function DeckPeekModal({ cardIds, title, onClose, onStartDrag, onStartMultiDrag, didDragRef, isDragActive, isPrivateLook, sourceZone = 'deck' }: DeckPeekModalProps) {
+export function DeckPeekModal({ cardIds, title, onClose, onStartDrag, onStartMultiDrag, didDragRef, isDragActive, isPrivateLook, sourceZone = 'deck', preserveOnDismiss = false }: DeckPeekModalProps) {
   const { dragHandleProps, modalStyle } = useDraggableModal();
   const { zones, actions } = useModalGame();
   const { moveCard, moveCardsBatch, moveCardToTopOfDeck, moveCardToBottomOfDeck, shuffleDeck, shuffleCardIntoDeck } = actions;
@@ -266,13 +274,22 @@ export function DeckPeekModal({ cardIds, title, onClose, onStartDrag, onStartMul
     onClose();
   };
 
+  // Dismissing without an explicit choice (X / Escape / click-away). For a
+  // bottom or random reveal, returning cards to the top would relocate the
+  // revealed bottom card and cause it to be drawn next — so those callers pass
+  // preserveOnDismiss to leave the deck untouched.
+  const handleDismiss = () => {
+    if (preserveOnDismiss) { onClose?.(); return; }
+    handleCloseAction('top');
+  };
+
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         if (selectedIds.size > 0) {
           setSelectedIds(new Set());
         } else {
-          handleCloseAction('top');
+          handleDismiss();
         }
       }
     };
@@ -294,7 +311,7 @@ export function DeckPeekModal({ cardIds, title, onClose, onStartDrag, onStartMul
     const handleMouseDown = (e: MouseEvent) => {
       if (isInside(e.target)) return;
       if (e.button === 0 && readyForClose && !didDragRef?.current && Date.now() - dragEndTimeRef.current > 300) {
-        handleCloseAction('top');
+        handleDismiss();
       }
     };
     const handleContextMenu = (e: MouseEvent) => {
@@ -461,7 +478,7 @@ export function DeckPeekModal({ cardIds, title, onClose, onStartDrag, onStartMul
         <DraggableTitleBar
           dragHandleProps={dragHandleProps}
           title={title}
-          onClose={onClose ? () => handleCloseAction('top') : undefined}
+          onClose={onClose ? handleDismiss : undefined}
         >
           {selectedIds.size > 0 && (
             <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>


### PR DESCRIPTION
Two commits that existed only on the local `main` checkout (never pushed / not on origin) — carried forward onto current `origin/main` via clean cherry-pick, authorship preserved.

- **`Update MultiplayerCanvas.tsx`** — battle status text: "Initiative unknown (face-down/variable stats)" → "Initiative unknown (variable stats)"
- **`fix(goldfish): reveal-bottom no longer relocates the card to top of deck`** — GoldfishCanvas + DeckPeekModal

Both cherry-picked without conflicts; touched files type-check clean.