### PR TITLE
feat(forge): switch-deck dialog in playtest games + waiting-room deck change

### DIFF
--- a/app/forge/play/games/ForgeDeckPicker.tsx
+++ b/app/forge/play/games/ForgeDeckPicker.tsx
@@ -7,6 +7,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogBody } from "@/
 import { MobileDrawer } from "@/components/ui/mobile-drawer";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { cn } from "@/lib/utils";
+import { listForgeDecks, listSharedForgeDecks } from "@/app/forge/lib/forgeDecks";
 import type { ForgeDeckSummary, SharedForgeDeckSummary } from "@/app/forge/lib/deckTypes";
 
 // The picker only needs these fields; both summary shapes structurally satisfy
@@ -80,6 +81,81 @@ export function ForgeDeckPicker({ decks, sharedDecks, selectedDeckId, onSelect }
         </MobileDrawer>
       )}
     </>
+  );
+}
+
+// Standalone dialog variant for in-game deck switching (gear menu / pregame).
+// Unlike ForgeDeckPicker it owns no trigger button and fetches the deck lists
+// itself on first open, so game surfaces don't need the lists threaded in.
+export function ForgeDeckPickerModal({
+  open,
+  onOpenChange,
+  onSelect,
+  selectedDeckId,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (deckId: string) => void;
+  selectedDeckId?: string | null;
+}) {
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+  const [decks, setDecks] = useState<ForgeDeckSummary[] | null>(null);
+  const [sharedDecks, setSharedDecks] = useState<SharedForgeDeckSummary[]>([]);
+  const [loadError, setLoadError] = useState(false);
+
+  // Fetch once on first open; a failed fetch retries on the next open.
+  useEffect(() => {
+    if (!open || decks !== null) return;
+    let cancelled = false;
+    setLoadError(false);
+    Promise.all([listForgeDecks(), listSharedForgeDecks()])
+      .then(([mine, shared]) => {
+        if (cancelled) return;
+        setDecks(mine);
+        setSharedDecks(shared);
+      })
+      .catch(() => {
+        if (!cancelled) setLoadError(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, decks]);
+
+  const body =
+    decks === null ? (
+      <p className="px-2 py-6 text-center text-sm text-muted-foreground">
+        {loadError ? "Could not load your Forge decks — close and try again." : "Loading decks…"}
+      </p>
+    ) : (
+      <PickerBody
+        decks={decks}
+        sharedDecks={sharedDecks}
+        selectedDeckId={selectedDeckId ?? null}
+        onPick={(id) => {
+          onSelect(id);
+          onOpenChange(false);
+        }}
+      />
+    );
+
+  if (isDesktop) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent size="md" className="max-h-[85vh] flex flex-col">
+          <DialogHeader>
+            <DialogTitle>Choose a deck</DialogTitle>
+          </DialogHeader>
+          <DialogBody className="flex-1 overflow-hidden flex flex-col gap-3 p-4">{body}</DialogBody>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <MobileDrawer isOpen={open} onClose={() => onOpenChange(false)} title="Choose a deck">
+      <div className="flex h-full flex-col gap-3 overflow-hidden px-4 pb-4">{body}</div>
+    </MobileDrawer>
   );
 }
 

--- a/app/play/[code]/client.tsx
+++ b/app/play/[code]/client.tsx
@@ -32,6 +32,7 @@ import { DebugOverlay } from '../components/DebugOverlay';
 import { useMultiplayerImagePreloader } from '@/app/play/hooks/useMultiplayerImagePreloader';
 import { buildPrioritizedImageUrls, buildCriticalImageUrls } from '@/app/play/lib/multiplayerImageUrls';
 import { DeckPickerModal } from '../components/DeckPickerModal';
+import { ForgeDeckPickerModal } from '@/app/forge/play/games/ForgeDeckPicker';
 import { getRandomLoadingMessage } from '@/app/shared/constants/loadingMessages';
 import { ArrowLeft } from 'lucide-react';
 import { loadDeckForGame } from '../actions';
@@ -73,6 +74,58 @@ interface GameParams {
 // ---------------------------------------------------------------------------
 interface GameClientProps {
   code: string;
+}
+
+// ---------------------------------------------------------------------------
+// ForgeSwapErrorDialog — shown when a forge switch-deck load fails (deck no
+// longer shared, network). Styled to match the amber confirm dialogs below.
+// ---------------------------------------------------------------------------
+function ForgeSwapErrorDialog({ error, onClose }: { error: string | null; onClose: () => void }) {
+  if (!error) return null;
+  return (
+    <div style={{
+      position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.7)',
+      display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
+    }}>
+      <div style={{
+        background: 'rgba(14, 10, 6, 0.97)',
+        border: '1px solid rgba(107, 78, 39, 0.3)',
+        borderRadius: 8,
+        padding: '20px 28px',
+        maxWidth: 340,
+        width: '100%',
+        textAlign: 'center',
+        boxShadow: '0 8px 48px rgba(0,0,0,0.6), 0 0 0 1px rgba(196, 149, 90, 0.08)',
+      }}>
+        <p style={{
+          fontFamily: 'Georgia, serif',
+          color: '#e8d5a3',
+          fontSize: 13,
+          lineHeight: 1.5,
+        }}>
+          {error}
+        </p>
+        <button
+          onClick={onClose}
+          style={{
+            marginTop: 18,
+            padding: '7px 18px',
+            background: 'rgba(196, 149, 90, 0.15)',
+            border: '1px solid rgba(196, 149, 90, 0.45)',
+            borderRadius: 4,
+            color: '#e8d5a3',
+            cursor: 'pointer',
+            fontSize: 12,
+            fontFamily: 'Georgia, serif',
+            fontWeight: 600,
+            transition: 'all 0.15s ease',
+          }}
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -155,6 +208,11 @@ function GameInner({ code, isConnected }: GameInnerProps) {
   // pendingDeckData rather than dealing a fresh hand.
   const [showPracticeDeckPicker, setShowPracticeDeckPicker] = useState(false);
   const [practiceDeckConfirm, setPracticeDeckConfirm] = useState<{ deckId: string; deckName: string; deckData: string; paragon: string; format: string } | null>(null);
+
+  // Forge switch-deck failure (deck no longer shared, network) — the picker has
+  // already closed by the time the server action resolves, so surface it in a
+  // dedicated dialog rather than failing silently.
+  const [forgeSwapError, setForgeSwapError] = useState<string | null>(null);
 
   // Image preload gate — keeps the board obscured until the tier-1 (visible)
   // card images have loaded, so slow-wifi users aren't dropped into a board
@@ -325,6 +383,40 @@ function GameInner({ code, isConnected }: GameInnerProps) {
       .catch(() => { if (!cancelled) setForgeResolver(new Map()); });
     return () => { cancelled = true; };
   }, [isForge, forgeResolver]);
+
+  // Forge switch-deck selection handlers. Both go through loadForgeDeckForGame
+  // so the deckData that reaches a reducer is always the sanitized server-action
+  // output (leak spine) — never client-assembled. The already-fetched
+  // forgeResolver covers any deck the viewer can load (it's grant-scoped, not
+  // per-deck), so no resolver refresh is needed after a swap.
+  const handleForgeReloadSelect = useCallback(async (deckId: string) => {
+    setShowReloadDeckPicker(false);
+    try {
+      const r = await loadForgeDeckForGame(deckId);
+      if (r.ok === false) { setForgeSwapError(r.error); return; }
+      setReloadDeckConfirm({ deckId: r.deck.id, deckName: r.deck.name, deckData: JSON.stringify(r.deckData), paragon: r.deck.paragon });
+    } catch {
+      setForgeSwapError('Failed to load deck.');
+    }
+  }, []);
+
+  const handleForgePracticeSelect = useCallback(async (deckId: string) => {
+    setShowPracticeDeckPicker(false);
+    if (!gameParams || deckId === gameParams.deckId) return;
+    try {
+      const r = await loadForgeDeckForGame(deckId);
+      if (r.ok === false) { setForgeSwapError(r.error); return; }
+      setPracticeDeckConfirm({
+        deckId: r.deck.id,
+        deckName: r.deck.name,
+        deckData: JSON.stringify(r.deckData),
+        paragon: r.deck.paragon,
+        format: r.deck.format || gameParams.format || 'Type 1',
+      });
+    } catch {
+      setForgeSwapError('Failed to load deck.');
+    }
+  }, [gameParams]);
 
   // ---- Image preload — hoisted from MultiplayerCanvas so the cache survives
   // the canvas remounts that happen at every lifecycle transition.
@@ -1128,32 +1220,42 @@ function GameInner({ code, isConnected }: GameInnerProps) {
             <WaitingRoomGoldfish
               deck={goldfishDeck}
               username={gameParams?.displayName}
-              onLoadDeck={isForge ? undefined : () => setShowPracticeDeckPicker(true)}
+              onLoadDeck={() => setShowPracticeDeckPicker(true)}
             />
           </div>
 
           {/* Practice deck picker — opens from the gear menu in practice mode */}
-          <DeckPickerModal
-            open={showPracticeDeckPicker}
-            onOpenChange={setShowPracticeDeckPicker}
-            onSelect={async (deck) => {
-              setShowPracticeDeckPicker(false);
-              if (!gameParams || deck.id === gameParams.deckId) return;
-              try {
-                const result = await loadDeckForGame(deck.id);
-                setPracticeDeckConfirm({
-                  deckId: deck.id,
-                  deckName: deck.name,
-                  deckData: JSON.stringify(result.deckData),
-                  paragon: deck.paragon || '',
-                  format: deck.format || gameParams.format || 'Type 1',
-                });
-              } catch (err) {
-                console.error('Failed to load deck for practice swap:', err);
-              }
-            }}
-            selectedDeckId={gameParams?.deckId}
-          />
+          {isForge ? (
+            <ForgeDeckPickerModal
+              open={showPracticeDeckPicker}
+              onOpenChange={setShowPracticeDeckPicker}
+              onSelect={handleForgePracticeSelect}
+              selectedDeckId={gameParams?.deckId}
+            />
+          ) : (
+            <DeckPickerModal
+              open={showPracticeDeckPicker}
+              onOpenChange={setShowPracticeDeckPicker}
+              onSelect={async (deck) => {
+                setShowPracticeDeckPicker(false);
+                if (!gameParams || deck.id === gameParams.deckId) return;
+                try {
+                  const result = await loadDeckForGame(deck.id);
+                  setPracticeDeckConfirm({
+                    deckId: deck.id,
+                    deckName: deck.name,
+                    deckData: JSON.stringify(result.deckData),
+                    paragon: deck.paragon || '',
+                    format: deck.format || gameParams.format || 'Type 1',
+                  });
+                } catch (err) {
+                  console.error('Failed to load deck for practice swap:', err);
+                }
+              }}
+              selectedDeckId={gameParams?.deckId}
+            />
+          )}
+          <ForgeSwapErrorDialog error={forgeSwapError} onClose={() => setForgeSwapError(null)} />
 
           {practiceDeckConfirm && (
             <div style={{
@@ -1204,7 +1306,7 @@ function GameInner({ code, isConnected }: GameInnerProps) {
                       setPracticeDeckConfirm(null);
                       // Tell SpacetimeDB about the new deck so it gets used when
                       // the actual game starts.
-                      gameState.pregameChangeDeck(next.deckId, next.deckData);
+                      gameState.pregameChangeDeck(next.deckId, next.deckData, next.paragon);
                       // Update local state so practice rebuilds with new deck.
                       // Persist to sessionStorage so a refresh keeps the swap.
                       setGameParams((prev) => {
@@ -1266,6 +1368,25 @@ function GameInner({ code, isConnected }: GameInnerProps) {
         } : undefined}
         canReady={canReady}
         isForge={isForge}
+        onDeckChanged={(next) => {
+          // Mirror the practice-swap bookkeeping: keep gameParams/sessionStorage
+          // and the local deckData (which feeds practice goldfish + image
+          // preload) in sync with what the server now has in pendingDeckData.
+          setGameParams((prev) => {
+            if (!prev) return prev;
+            const updated = {
+              ...prev,
+              deckId: next.deckId,
+              deckName: next.deckName,
+              paragon: next.paragon,
+            };
+            try {
+              sessionStorage.setItem(`${SESSION_KEY_PREFIX}${code}`, JSON.stringify(updated));
+            } catch {}
+            return updated;
+          });
+          setDeckData(next.deckData);
+        }}
       />
     );
   }
@@ -1330,7 +1451,7 @@ function GameInner({ code, isConnected }: GameInnerProps) {
           </div>
           <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
             {gameId !== null && (
-              <MultiplayerCanvas gameId={gameId} onLoadDeck={isForge ? undefined : () => setShowReloadDeckPicker(true)} undoStack={undoStack} onSearchModalChange={setIsSearchModalOpen} isTimerVisible={gameTimer.isTimerVisible} onToggleTimer={gameTimer.toggleTimerVisibility} getImage={getImage} chatScale={chatScale} setChatScale={setChatScale} resetChatScale={resetChatScale} minChatScale={CHAT_MIN_SCALE} maxChatScale={CHAT_MAX_SCALE} chatStep={CHAT_STEP} forgeResolver={forgeResolver} />
+              <MultiplayerCanvas gameId={gameId} onLoadDeck={() => setShowReloadDeckPicker(true)} undoStack={undoStack} onSearchModalChange={setIsSearchModalOpen} isTimerVisible={gameTimer.isTimerVisible} onToggleTimer={gameTimer.toggleTimerVisibility} getImage={getImage} chatScale={chatScale} setChatScale={setChatScale} resetChatScale={resetChatScale} minChatScale={CHAT_MIN_SCALE} maxChatScale={CHAT_MAX_SCALE} chatStep={CHAT_STEP} forgeResolver={forgeResolver} />
             )}
             <PregameCeremonyOverlay gameState={gameState} />
             {/* Suppress the load gate during the pregame ceremony — its 30s
@@ -1386,7 +1507,7 @@ function GameInner({ code, isConnected }: GameInnerProps) {
           </div>
           <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
             {gameId !== null && (
-              <MultiplayerCanvas gameId={gameId} onLoadDeck={isForge ? undefined : () => setShowReloadDeckPicker(true)} undoStack={undoStack} onSearchModalChange={setIsSearchModalOpen} isTimerVisible={gameTimer.isTimerVisible} onToggleTimer={gameTimer.toggleTimerVisibility} getImage={getImage} chatScale={chatScale} setChatScale={setChatScale} resetChatScale={resetChatScale} minChatScale={CHAT_MIN_SCALE} maxChatScale={CHAT_MAX_SCALE} chatStep={CHAT_STEP} forgeResolver={forgeResolver} />
+              <MultiplayerCanvas gameId={gameId} onLoadDeck={() => setShowReloadDeckPicker(true)} undoStack={undoStack} onSearchModalChange={setIsSearchModalOpen} isTimerVisible={gameTimer.isTimerVisible} onToggleTimer={gameTimer.toggleTimerVisibility} getImage={getImage} chatScale={chatScale} setChatScale={setChatScale} resetChatScale={resetChatScale} minChatScale={CHAT_MIN_SCALE} maxChatScale={CHAT_MAX_SCALE} chatStep={CHAT_STEP} forgeResolver={forgeResolver} />
             )}
             <ImageLoadingGate open={!imagesGateOpen} progress={imageLoadProgress} />
             <GameToastContainer />
@@ -1449,7 +1570,7 @@ function GameInner({ code, isConnected }: GameInnerProps) {
               />
             </div>
             <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
-              <MultiplayerCanvas gameId={gameId} onLoadDeck={isForge ? undefined : () => setShowReloadDeckPicker(true)} undoStack={undoStack} onSearchModalChange={setIsSearchModalOpen} isTimerVisible={gameTimer.isTimerVisible} onToggleTimer={gameTimer.toggleTimerVisibility} getImage={getImage} chatScale={chatScale} setChatScale={setChatScale} resetChatScale={resetChatScale} minChatScale={CHAT_MIN_SCALE} maxChatScale={CHAT_MAX_SCALE} chatStep={CHAT_STEP} forgeResolver={forgeResolver} />
+              <MultiplayerCanvas gameId={gameId} onLoadDeck={() => setShowReloadDeckPicker(true)} undoStack={undoStack} onSearchModalChange={setIsSearchModalOpen} isTimerVisible={gameTimer.isTimerVisible} onToggleTimer={gameTimer.toggleTimerVisibility} getImage={getImage} chatScale={chatScale} setChatScale={setChatScale} resetChatScale={resetChatScale} minChatScale={CHAT_MIN_SCALE} maxChatScale={CHAT_MAX_SCALE} chatStep={CHAT_STEP} forgeResolver={forgeResolver} />
               {/* Bottom toolbar — stays active for draw/shuffle, end turn disabled */}
               <GameToolbar
                 actions={{
@@ -1515,15 +1636,24 @@ function GameInner({ code, isConnected }: GameInnerProps) {
           <ParagonDrawer paragons={paragonEntries} />
 
           {/* Deck reload picker (available after game ends for rematch/practice) */}
-          <DeckPickerModal
-            open={showReloadDeckPicker}
-            onOpenChange={(open) => setShowReloadDeckPicker(open)}
-            onSelect={async (deck) => {
-              const result = await loadDeckForGame(deck.id);
-              setShowReloadDeckPicker(false);
-              setReloadDeckConfirm({ deckId: deck.id, deckName: deck.name, deckData: JSON.stringify(result.deckData), paragon: deck.paragon || '' });
-            }}
-          />
+          {isForge ? (
+            <ForgeDeckPickerModal
+              open={showReloadDeckPicker}
+              onOpenChange={setShowReloadDeckPicker}
+              onSelect={handleForgeReloadSelect}
+            />
+          ) : (
+            <DeckPickerModal
+              open={showReloadDeckPicker}
+              onOpenChange={(open) => setShowReloadDeckPicker(open)}
+              onSelect={async (deck) => {
+                const result = await loadDeckForGame(deck.id);
+                setShowReloadDeckPicker(false);
+                setReloadDeckConfirm({ deckId: deck.id, deckName: deck.name, deckData: JSON.stringify(result.deckData), paragon: deck.paragon || '' });
+              }}
+            />
+          )}
+          <ForgeSwapErrorDialog error={forgeSwapError} onClose={() => setForgeSwapError(null)} />
 
           {/* Deck reload confirmation dialog */}
           {reloadDeckConfirm && (
@@ -1675,7 +1805,7 @@ function GameInner({ code, isConnected }: GameInnerProps) {
         </div>
         <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
           {gameId !== null && (
-            <MultiplayerCanvas gameId={gameId} onLoadDeck={isForge ? undefined : () => setShowReloadDeckPicker(true)} undoStack={undoStack} onSearchModalChange={setIsSearchModalOpen} isTimerVisible={gameTimer.isTimerVisible} onToggleTimer={gameTimer.toggleTimerVisibility} getImage={getImage} chatScale={chatScale} setChatScale={setChatScale} resetChatScale={resetChatScale} minChatScale={CHAT_MIN_SCALE} maxChatScale={CHAT_MAX_SCALE} chatStep={CHAT_STEP} forgeResolver={forgeResolver} />
+            <MultiplayerCanvas gameId={gameId} onLoadDeck={() => setShowReloadDeckPicker(true)} undoStack={undoStack} onSearchModalChange={setIsSearchModalOpen} isTimerVisible={gameTimer.isTimerVisible} onToggleTimer={gameTimer.toggleTimerVisibility} getImage={getImage} chatScale={chatScale} setChatScale={setChatScale} resetChatScale={resetChatScale} minChatScale={CHAT_MIN_SCALE} maxChatScale={CHAT_MAX_SCALE} chatStep={CHAT_STEP} forgeResolver={forgeResolver} />
           )}
           <ImageLoadingGate open={!imagesGateOpen} progress={imageLoadProgress} />
           {/* Quick action toolbar — floating above hand area */}
@@ -1754,15 +1884,24 @@ function GameInner({ code, isConnected }: GameInnerProps) {
       <ParagonDrawer paragons={paragonEntries} />
 
       {/* Deck reload picker */}
-      <DeckPickerModal
-        open={showReloadDeckPicker}
-        onOpenChange={(open) => setShowReloadDeckPicker(open)}
-        onSelect={async (deck) => {
-          const result = await loadDeckForGame(deck.id);
-          setShowReloadDeckPicker(false);
-          setReloadDeckConfirm({ deckId: deck.id, deckName: deck.name, deckData: JSON.stringify(result.deckData), paragon: deck.paragon || '' });
-        }}
-      />
+      {isForge ? (
+        <ForgeDeckPickerModal
+          open={showReloadDeckPicker}
+          onOpenChange={setShowReloadDeckPicker}
+          onSelect={handleForgeReloadSelect}
+        />
+      ) : (
+        <DeckPickerModal
+          open={showReloadDeckPicker}
+          onOpenChange={(open) => setShowReloadDeckPicker(open)}
+          onSelect={async (deck) => {
+            const result = await loadDeckForGame(deck.id);
+            setShowReloadDeckPicker(false);
+            setReloadDeckConfirm({ deckId: deck.id, deckName: deck.name, deckData: JSON.stringify(result.deckData), paragon: deck.paragon || '' });
+          }}
+        />
+      )}
+      <ForgeSwapErrorDialog error={forgeSwapError} onClose={() => setForgeSwapError(null)} />
 
       {/* Deck reload confirmation dialog */}
       {reloadDeckConfirm && (

--- a/app/play/components/PregameScreen.tsx
+++ b/app/play/components/PregameScreen.tsx
@@ -5,8 +5,10 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 import TopNav from '@/components/top-nav';
 import { DeckPickerModal } from './DeckPickerModal';
+import { ForgeDeckPickerModal } from '@/app/forge/play/games/ForgeDeckPicker';
 import type { DeckOption } from './DeckPickerCard';
 import { loadDeckForGame } from '../actions';
+import { loadForgeDeckForGame } from '@/app/forge/lib/playDecks';
 import type { GameState } from '../hooks/useGameState';
 import { DebugOverlay } from './DebugOverlay';
 
@@ -67,10 +69,12 @@ interface PregameScreenProps {
   // server-anchored choose-first countdown can't start while a slow-wifi
   // player is still downloading card images.
   canReady: boolean;
-  // True for Forge playtest games — the deck was authorized at join time and
-  // the server hard-rejects mid-pregame deck changes, so the "Change deck"
-  // control is hidden.
+  // True for Forge playtest games — "Change deck" opens the Forge deck picker
+  // and swaps go through loadForgeDeckForGame (sanitized deckData + paragon).
   isForge?: boolean;
+  // Called after a successful pregame deck swap so the owner can keep local
+  // deck state (gameParams, sessionStorage, practice goldfish deck) in sync.
+  onDeckChanged?: (next: { deckId: string; deckName: string; deckData: string; paragon: string }) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -91,6 +95,7 @@ export default function PregameScreen({
   onTogglePublic,
   canReady,
   isForge,
+  onDeckChanged,
 }: PregameScreenProps) {
   const { game, myPlayer, opponentPlayer } = gameState;
 
@@ -169,6 +174,7 @@ export default function PregameScreen({
             showDice={phase === 'rolling' || phase === 'choosing' || phase === 'revealing'}
             canReady={canReady}
             isForge={isForge}
+            onDeckChanged={onDeckChanged}
           />
 
           {/* Action area — contextual */}
@@ -297,6 +303,7 @@ function PlayerCards({
   showDice,
   canReady,
   isForge,
+  onDeckChanged,
 }: {
   isWaiting: boolean;
   phase: string;
@@ -314,18 +321,48 @@ function PlayerCards({
   showDice: boolean;
   canReady: boolean;
   isForge?: boolean;
+  onDeckChanged?: (next: { deckId: string; deckName: string; deckData: string; paragon: string }) => void;
 }) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [isChangingDeck, setIsChangingDeck] = useState(false);
+  const [changeError, setChangeError] = useState<string | null>(null);
 
   const handleDeckSelected = async (deck: DeckOption) => {
     setPickerOpen(false);
     setIsChangingDeck(true);
+    setChangeError(null);
     try {
       const result = await loadDeckForGame(deck.id);
-      gameState.pregameChangeDeck(deck.id, JSON.stringify(result.deckData));
+      const deckData = JSON.stringify(result.deckData);
+      const paragon = deck.paragon || '';
+      gameState.pregameChangeDeck(deck.id, deckData, paragon);
+      onDeckChanged?.({ deckId: deck.id, deckName: deck.name, deckData, paragon });
     } catch (e) {
       console.error('Failed to change deck:', e);
+      setChangeError('Failed to load deck.');
+    } finally {
+      setIsChangingDeck(false);
+    }
+  };
+
+  // Forge swap — deckData/paragon must come from loadForgeDeckForGame (the
+  // sanitized server action), never assembled client-side.
+  const handleForgeDeckSelected = async (deckId: string) => {
+    setPickerOpen(false);
+    setIsChangingDeck(true);
+    setChangeError(null);
+    try {
+      const r = await loadForgeDeckForGame(deckId);
+      if (r.ok === false) {
+        setChangeError(r.error);
+        return;
+      }
+      const deckData = JSON.stringify(r.deckData);
+      gameState.pregameChangeDeck(r.deck.id, deckData, r.deck.paragon);
+      onDeckChanged?.({ deckId: r.deck.id, deckName: r.deck.name, deckData, paragon: r.deck.paragon });
+    } catch (e) {
+      console.error('Failed to change deck:', e);
+      setChangeError('Failed to load deck.');
     } finally {
       setIsChangingDeck(false);
     }
@@ -354,7 +391,19 @@ function PlayerCards({
         <div className="rounded-lg border border-[#c4955a]/30 bg-black/40 p-3 text-left">
           <p className="text-xs font-cinzel text-[#c4955a] truncate">{myDisplayName}</p>
           {isWaiting && (
-            <p className="text-[10px] text-[#c4955a]/50 mt-1 font-cinzel tracking-wide">Ready</p>
+            <div className="mt-1 flex flex-col items-start gap-0.5">
+              <p className="text-[10px] text-[#c4955a]/50 font-cinzel tracking-wide">Ready</p>
+              <button
+                onClick={() => setPickerOpen(true)}
+                disabled={isChangingDeck}
+                className="text-[10px] text-amber-200/40 hover:text-amber-200/70 transition-colors disabled:opacity-50"
+              >
+                {isChangingDeck ? 'Loading...' : 'Change deck'}
+              </button>
+              {changeError && (
+                <p className="text-[10px] text-red-400/80">{changeError}</p>
+              )}
+            </div>
           )}
           {isDeckSelect && (
             <p className="text-[10px] text-amber-200/40 mt-0.5 truncate">
@@ -378,7 +427,7 @@ function PlayerCards({
           {/* Ready button in deck_select */}
           {isDeckSelect && (
             <div className="mt-2 flex flex-col gap-1.5">
-              {!myReady && !isForge && (
+              {!myReady && (
                 <button
                   onClick={() => setPickerOpen(true)}
                   disabled={isChangingDeck}
@@ -386,6 +435,9 @@ function PlayerCards({
                 >
                   {isChangingDeck ? 'Loading...' : 'Change deck'}
                 </button>
+              )}
+              {changeError && (
+                <p className="text-[10px] text-red-400/80">{changeError}</p>
               )}
               <Button
                 variant={myReady ? 'outline' : 'default'}
@@ -449,12 +501,21 @@ function PlayerCards({
         </div>
       </div>
 
-      <DeckPickerModal
-        open={pickerOpen}
-        onOpenChange={setPickerOpen}
-        onSelect={handleDeckSelected}
-        selectedDeckId={myPlayer?.deckId}
-      />
+      {isForge ? (
+        <ForgeDeckPickerModal
+          open={pickerOpen}
+          onOpenChange={setPickerOpen}
+          onSelect={handleForgeDeckSelected}
+          selectedDeckId={myPlayer?.deckId}
+        />
+      ) : (
+        <DeckPickerModal
+          open={pickerOpen}
+          onOpenChange={setPickerOpen}
+          onSelect={handleDeckSelected}
+          selectedDeckId={myPlayer?.deckId}
+        />
+      )}
     </>
   );
 }

--- a/app/play/hooks/useGameState.ts
+++ b/app/play/hooks/useGameState.ts
@@ -142,7 +142,7 @@ export interface GameState {
   pregameChooseFirst: (chosenSeat: bigint) => void;
   pregameAcknowledgeFirst: () => void;
   pregameSkipToReveal: (chosenSeat: bigint) => void;
-  pregameChangeDeck: (deckId: string, deckData: string) => void;
+  pregameChangeDeck: (deckId: string, deckData: string, paragon: string) => void;
   // Rematch actions
   requestRematch: (deckId: string, deckData: string, paragon: string, format: string) => void;
   respondRematch: (accepted: boolean, deckId: string, deckData: string, paragon: string, format: string) => void;
@@ -793,8 +793,8 @@ export function useGameState(gameId: bigint, forgeResolver?: ForgeResolverMap | 
     conn?.reducers.pregameSkipToReveal({ gameId, chosenSeat });
   }, [conn, gameId]);
 
-  const pregameChangeDeck = useCallback((deckId: string, deckData: string) => {
-    conn?.reducers.pregameChangeDeck({ gameId, deckId, deckData });
+  const pregameChangeDeck = useCallback((deckId: string, deckData: string, paragon: string) => {
+    conn?.reducers.pregameChangeDeck({ gameId, deckId, deckData, paragon });
   }, [conn, gameId]);
 
   const requestRematch = useCallback((deckId: string, deckData: string, paragon: string, format: string) => {
@@ -1327,7 +1327,7 @@ export function useSpectatorGameState(gameId: bigint | null, forgeResolver?: For
     pregameChooseFirst: noopBigint,
     pregameAcknowledgeFirst: noop,
     pregameSkipToReveal: noopBigint,
-    pregameChangeDeck: useCallback((_deckId: string, _deckData: string) => {}, []),
+    pregameChangeDeck: useCallback((_deckId: string, _deckData: string, _paragon: string) => {}, []),
     requestRematch: useCallback((_deckId: string, _deckData: string, _paragon: string, _format: string) => {}, []),
     respondRematch: useCallback((_accepted: boolean, _deckId: string, _deckData: string, _paragon: string, _format: string) => {}, []),
     revealCards: useCallback((_cardIds: string, _context?: string) => {}, []),

--- a/docs/superpowers/specs/2026-07-19-forge-switch-deck-design.md
+++ b/docs/superpowers/specs/2026-07-19-forge-switch-deck-design.md
@@ -1,0 +1,93 @@
+# Forge switch-deck (gear menu + pregame) — design
+
+**Date:** 2026-07-19
+**Status:** approved
+
+## Problem
+
+Forge playtest games have no way to switch decks once you're in a game. The gear
+menu's "Load Deck" entry is withheld (`onLoadDeck={isForge ? undefined : ...}`
+in `app/play/[code]/client.tsx`), the pregame "Change deck" button is hidden for
+forge, and the SpacetimeDB reducers hard-reject forge games
+(`reload_deck` / `pregame_change_deck`: "disabled in playtest games").
+
+These were scoping guards from the original forge-multiplayer build, not a
+leak-spine necessity: forge games already accept client-supplied `deckData` at
+create/join, sourced from the sanitized `loadForgeDeckForGame` server action
+(forge cards leave as `forge:<uuid>` stubs, paragon sanitized).
+
+Additionally, the plain waiting room (host alone, opponent not yet joined) has
+no deck-change control even in normal games — only the practice-mode gear menu
+offers one, even though the `pregame_change_deck` reducer already accepts swaps
+in `waiting` status.
+
+## Scope (user-approved)
+
+1. **Mid-game gear menu** in forge games → forge switch-deck dialog → confirm →
+   `reload_deck`.
+2. **Practice-mode gear menu** (waiting room goldfish) in forge games → forge
+   switch-deck dialog → confirm → `pregame_change_deck`.
+3. **Pregame deck-select "Change deck" button** shown for forge too, opening the
+   forge picker.
+4. **Plain waiting room**: add a "Change deck" control for BOTH normal and forge
+   games (normal → `DeckPickerModal`, forge → forge picker).
+
+## Server changes (`spacetimedb/src/index.ts`)
+
+- `reload_deck`: remove the `isForgeGame` guard. Everything else is shared with
+  the normal path (`insertCardsShuffleDraw`, Player.deckId/paragon update).
+- `pregame_change_deck`: remove the `isForgeGame` guard AND add a
+  `paragon: t.string()` param written to the Player row. This also fixes a
+  pre-existing gap where a pregame swap left `Player.paragon` stale in normal
+  games (only `reload_deck` updated it).
+- Republish module + regen TypeScript bindings (spacetimedb-deploy skill).
+
+## Client changes
+
+### New `ForgeDeckPickerModal`
+
+In `app/forge/play/games/ForgeDeckPicker.tsx`, export a standalone modal
+(`open` / `onOpenChange` / `onSelect(deckId)`) reusing the existing
+`PickerBody` (search + "Your decks" / "Shared by others"). The modal fetches
+`listForgeDecks()` + `listSharedForgeDecks()` (both `"use server"` actions) on
+first open — no prop threading into the game client.
+
+### `app/play/[code]/client.tsx`
+
+- Mid-game gear (4 `MultiplayerCanvas` call sites): forge passes an
+  `onLoadDeck` that opens the forge picker. On select:
+  `loadForgeDeckForGame(id)` → on `ok:false` show the error → on success feed
+  the existing amber "Clear all cards and load a new deck?" confirm →
+  `gameState.reloadDeck(id, JSON.stringify(deckData), deck.paragon)`.
+- Practice-mode gear (`WaitingRoomGoldfish`): forge branch feeds the existing
+  `practiceDeckConfirm` flow (updates sessionStorage/gameParams so refresh
+  keeps the swap), calling `pregameChangeDeck(id, deckData, paragon)`.
+- `useGameState.pregameChangeDeck` gains the `paragon` arg; normal-game callers
+  pass `deck.paragon || ''`.
+
+### `app/play/components/PregameScreen.tsx`
+
+- Deck-select phase: show "Change deck" for forge too; forge opens
+  `ForgeDeckPickerModal`, normal keeps `DeckPickerModal`. Forge select path
+  goes through `loadForgeDeckForGame`.
+- Waiting state (`isWaiting`): render the same small "Change deck" text button
+  in the player card for both normal and forge.
+
+### No resolver refresh needed
+
+`getForgePlayResolver` returns ALL cards granted to the member (not per-deck),
+so the already-fetched in-game `forgeResolver` covers any deck they can load.
+
+## Known limitation (pre-existing, kept for parity)
+
+Swapping to a deck of a different format while waiting does not update the Game
+row's `format`, so the lobby listing still shows the original format. Normal
+games behave this way today; unchanged here.
+
+## Verification
+
+- `tsc --noEmit` type gate.
+- Manual/e2e: forge game → gear → switch deck mid-game re-deals the new deck;
+  waiting-room swap persists across refresh; normal-game waiting room gains the
+  "Change deck" button; pregame swap to a paragon deck updates the
+  ParagonDrawer (paragon fix).

--- a/lib/spacetimedb/module_bindings/pregame_change_deck_reducer.ts
+++ b/lib/spacetimedb/module_bindings/pregame_change_deck_reducer.ts
@@ -14,4 +14,5 @@ export default {
   gameId: __t.u64(),
   deckId: __t.string(),
   deckData: __t.string(),
+  paragon: __t.string(),
 };

--- a/spacetimedb/src/index.ts
+++ b/spacetimedb/src/index.ts
@@ -1267,11 +1267,11 @@ export const pregame_change_deck = spacetimedb.reducer(
     gameId: t.u64(),
     deckId: t.string(),
     deckData: t.string(),
+    paragon: t.string(),
   },
-  (ctx, { gameId, deckId, deckData }) => {
+  (ctx, { gameId, deckId, deckData, paragon }) => {
     const game = ctx.db.Game.id.find(gameId);
     if (!game) throw new SenderError('Game not found');
-    if (isForgeGame(ctx, gameId)) throw new SenderError('Deck change is disabled in playtest games');
     // Allow swap while waiting for opponent (status='waiting') OR during the
     // pregame deck-select phase. Both states are pre-shuffle, so swapping
     // pendingDeckData is safe.
@@ -1294,7 +1294,7 @@ export const pregame_change_deck = spacetimedb.reducer(
       throw new SenderError('Invalid deck data');
     }
 
-    ctx.db.Player.id.update({ ...player, deckId, pendingDeckData: deckData });
+    ctx.db.Player.id.update({ ...player, deckId, paragon, pendingDeckData: deckData });
 
     logAction(ctx, gameId, player.id, 'PREGAME_DECK_CHANGE',
       JSON.stringify({ seat: player.seat.toString(), newDeckId: deckId }),
@@ -6246,7 +6246,6 @@ export const reload_deck = spacetimedb.reducer(
   (ctx, { gameId, deckId, deckData, paragon }) => {
     const game = ctx.db.Game.id.find(gameId);
     if (!game) throw new SenderError('Game not found');
-    if (isForgeGame(ctx, gameId)) throw new SenderError('Deck reload is disabled in playtest games');
     if (game.status !== 'playing' && game.status !== 'finished') throw new SenderError('Game is not in progress');
 
     const player = findPlayerBySender(ctx, gameId);


### PR DESCRIPTION
## What

Forge playtest games get the gear-icon → switch-deck dialog, everywhere normal games have it — plus one addition for everyone: a **Change deck** control in the plain waiting room (host waiting for an opponent), which previously existed only via practice mode.

### Surfaces
- **Mid-game gear menu** (forge): opens the Forge deck picker → amber confirm → `reload_deck` re-deals the new deck.
- **Practice-mode gear menu** (forge): same picker feeding the existing pregame-swap confirm (`pregame_change_deck`), with sessionStorage bookkeeping so a refresh keeps the swap.
- **Pregame deck-select**: the Change deck button now shows for forge too.
- **Plain waiting room** (normal **and** forge): new Change deck text button in the player card — the reducer already accepted swaps in `waiting` status.

### Server
- Removed the forge scoping guards on `reload_deck` / `pregame_change_deck`. Not a leak-spine relaxation: forge deckData already reaches reducers client-supplied at create/join, and every new path sources it from the sanitized `loadForgeDeckForGame` server action (forge cards leave as stubs, paragon sanitized).
- `pregame_change_deck` gains a `paragon` param written to the Player row — fixes a pre-existing gap where pregame swaps left `Player.paragon` stale (wrong ParagonDrawer) in normal games too.

### Client
- New `ForgeDeckPickerModal` in `ForgeDeckPicker.tsx` — standalone dialog reusing the lobby `PickerBody` (Your decks / Shared by others, client-side search); self-fetches via `listForgeDecks` / `listSharedForgeDecks` on first open.
- `onDeckChanged` callback bubbles pregame swaps up from `PregameScreen` so gameParams / sessionStorage / practice goldfish deck stay in sync.
- Forge load failures (deck no longer shared) surface in an amber dialog instead of failing silently.
- No resolver refresh needed after swaps — `getForgePlayResolver` is grant-scoped, not per-deck.

## Deploy coupling ⚠️

**Dev module is published** (incremental, `redemption-multiplayer-dev`) and bindings are regenerated. **Production module must be republished together with the Vercel deploy of this PR** — `pregame_change_deck`'s signature changed, so old client + new module (or vice versa) breaks pregame deck changes.

## Verification
- `tsc --noEmit`: no new errors (7 pre-existing test-file errors on main, unchanged).
- Known limitation kept for parity: swapping to a different-format deck while waiting doesn't update the Game row's format (normal games behave this way today).

Spec: `docs/superpowers/specs/2026-07-19-forge-switch-deck-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)