### PR TITLE
fix(ui): outside-click couldn't dismiss dialogs inside blurred panels (waiting-room deck picker)

### DIFF
--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useCallback } from "react";
+import { createPortal } from "react-dom";
 import { cn } from "@/lib/utils";
 
 /* ------------------------------------------------------------------ */
@@ -37,8 +38,14 @@ function Dialog({ open, onOpenChange, children }: DialogProps) {
   }, [open]);
 
   if (!open) return null;
+  if (typeof document === "undefined") return null;
 
-  return (
+  // Portal to <body>: an ancestor with transform/filter/backdrop-filter (e.g.
+  // the pregame panel's backdrop-blur) becomes the containing block for fixed
+  // descendants, which would confine the overlay to that ancestor's box —
+  // clicks outside it never reach the overlay, so outside-click dismissal
+  // silently breaks. Rendering from <body> keeps inset-0 viewport-sized.
+  return createPortal(
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
       onClick={handleClose}
@@ -46,7 +53,8 @@ function Dialog({ open, onOpenChange, children }: DialogProps) {
       aria-modal="true"
     >
       {children}
-    </div>
+    </div>,
+    document.body
   );
 }
 

--- a/components/ui/mobile-drawer.tsx
+++ b/components/ui/mobile-drawer.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useEffect } from "react";
+import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
 
 interface MobileDrawerProps {
@@ -20,7 +21,12 @@ export function MobileDrawer({ isOpen, onClose, children, title }: MobileDrawerP
     }
   }, [isOpen]);
 
-  return (
+  if (typeof document === "undefined") return null;
+
+  // Portal to <body> so an ancestor with transform/filter/backdrop-filter
+  // can't become the containing block for the fixed backdrop/sheet and
+  // confine them to its own box (breaking backdrop-tap dismissal).
+  return createPortal(
     <AnimatePresence>
       {isOpen && (
         <>
@@ -63,6 +69,7 @@ export function MobileDrawer({ isOpen, onClose, children, title }: MobileDrawerP
           </motion.div>
         </>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body
   );
 }


### PR DESCRIPTION
## Bug

In the pregame waiting room, the deck picker couldn't be dismissed by clicking outside it. The shared `Dialog` **does** close on overlay click — but the pregame panel's `backdrop-blur-sm` makes it the **containing block for `position: fixed` descendants**, so the dialog's `fixed inset-0` overlay was confined to the panel's box instead of the viewport. That's the dark rectangle hugging the modal in the report screenshot: clicks in the bright area around it never touched the overlay. (Escape already worked — its listener is on `document`.)

## Fix

Portal `Dialog` and `MobileDrawer` to `document.body` (the Radix pattern), so their fixed overlays are always viewport-sized no matter where they render. This fixes the class of bug — any dialog under a `transform`/`filter`/`backdrop-filter` ancestor — not just this screen.

- jayden theming unaffected: next-themes puts the theme class on `<html>`, still an ancestor of the portal target, so `[.jayden_&]` variants keep applying.
- Dialog CSS vars are theme-scoped in `globals.css` — unaffected.
- SSR-safe: both components bail before portaling when `document` is undefined (they only render open post-interaction anyway).

## Verification

- `tsc --noEmit` clean (only the known pre-existing test-file errors).
- Manual: waiting room → Change deck → click the area outside the panel → dialog closes; drawer backdrop tap on mobile; spot-check other dialogs (deck picker in practice/mid-game, forge picker) still open/close normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)