### PR TITLE
feat(multiplayer): show a revealed reserve to spectators

### DIFF
--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -1101,17 +1101,18 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
   }, [opponentCards, opponentHandRevealed, opponentHandRevealSnapshotRaw, viewerKind, gameState.opponentPlayer?.shareHandWithSpectators]);
 
   // ---- Reserve privacy for spectators ----
-  // A player's reserve (its top-card face and the click-to-browse modal) stays
-  // hidden from spectators until that player shares their hand with spectators —
-  // the same consent flag that reveals the hand. When sharing is on, spectators
-  // may open the reserve read-only (no actions; see readOnly on ZoneBrowseModal).
-  // Player-side rules are unchanged: a player always sees their own reserve, and
-  // an opponent's reserve stays gated by reserveRevealed.
+  // A player's reserve (its top-card face and the click-to-browse modal) becomes
+  // visible to spectators when that player either reveals their reserve (the 👁
+  // toggle — a public game action, already shown to the opponent) or shares their
+  // hand with spectators. Spectators open the reserve read-only (no actions; see
+  // readOnly on ZoneBrowseModal). Player-side rules are unchanged: a player always
+  // sees their own reserve, and an opponent's reserve stays gated by reserveRevealed.
   const myShareHand = gameState.myPlayer?.shareHandWithSpectators ?? false;
   const oppShareHand = gameState.opponentPlayer?.shareHandWithSpectators ?? false;
-  const canViewMyReserve = !isSpectator || myShareHand;
+  const canViewMyReserve =
+    !isSpectator || myShareHand || (gameState.myPlayer?.reserveRevealed ?? false);
   const canViewOppReserve = isSpectator
-    ? oppShareHand
+    ? (oppShareHand || (gameState.opponentPlayer?.reserveRevealed ?? false))
     : (gameState.opponentPlayer?.reserveRevealed ?? false);
 
   // ---- Stage ref ----
@@ -7678,7 +7679,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
             const topCard = revealedReserveCard ?? cards[cards.length - 1];
             const topReserveCardRevealed = !!revealedReserveCard;
             const showFace = ((zoneKey === 'discard' || zoneKey === 'land-of-redemption' || zoneKey === 'banish') && topCard && !topCard.isFlipped)
-              || (zoneKey === 'reserve' && topCard && (isSpectator ? oppShareHand : (oppReserveRevealed || topReserveCardRevealed)));
+              || (zoneKey === 'reserve' && topCard && (oppReserveRevealed || topReserveCardRevealed || (isSpectator && oppShareHand)));
 
             return (
               <Group


### PR DESCRIPTION
## What

When a player reveals their reserve via the 👁 toggle (`reserveRevealed`), spectators can now see it — the reserve top-card face lights up and the read-only browse modal opens. Previously a revealed reserve was shown only to the **opponent**; spectators were gated on the *separate* `shareHandWithSpectators` consent flag and ignored `reserveRevealed` entirely.

## Why

Revealing your reserve is a public game action — the opponent already sees it, so anyone watching the table should too. This closes the reserve gap left after #160 ("show revealed cards to spectators"), which covered hand / in-play reveals but not the reserve toggle.

## How

Client-only render-gate change in `MultiplayerCanvas.tsx`. The `reserveRevealed` flag and the reserve card rows already reach spectators over the public `Player` / `CardInstance` subscriptions, so **no schema, reducer, or subscription changes** were needed.

Spectators now see a seat's reserve when that seat has `reserveRevealed` **OR** `shareHandWithSpectators` on:
- `canViewMyReserve` / `canViewOppReserve` (gate the click-to-browse modal + pile face) OR in each seat's `reserveRevealed`.
- The opponent-pile `showFace` now reads `oppReserveRevealed || topReserveCardRevealed || (isSpectator && oppShareHand)`, so spectators also see the per-card reveal **flash** (e.g. Herod's Temple) — matching what the opponent already sees.

Player-side behavior is unchanged: a player always sees their own reserve, and an opponent's reserve stays gated by `reserveRevealed`.

## Testing

- `tsc --noEmit`: **zero errors** in `MultiplayerCanvas.tsx` (the 7 repo-wide errors are pre-existing, all in `__tests__/` files, unrelated to this change).
- Logic traced end-to-end: the two derived booleans flow to the browse-modal open gate, the click handler, and the pile-face renderer; `ZoneBrowseModal` already renders `readOnly={isSpectator}`.
- ⚠️ **Not yet smoke-tested live.** Recommended manual QA: open a game, reveal a reserve via the 👁 toggle, and confirm a spectator sees the pile face + can open the read-only browse modal, for both seats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)