### PR TITLE
feat(WS-1): Forge lobby & deck-choice parity

### DIFF
--- a/app/forge/play/games/ForgeGameLobby.tsx
+++ b/app/forge/play/games/ForgeGameLobby.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { Loader2 } from "lucide-react";
 import { useTable } from "spacetimedb/react";
+import { Button } from "@/components/ui/button";
 import { tables } from "@/lib/spacetimedb/module_bindings";
 import { useSpacetimeConnection } from "@/app/play/hooks/useSpacetimeConnection";
 import { SpacetimeProvider } from "@/app/play/lib/spacetimedb-provider";
@@ -16,6 +19,7 @@ function LobbyInner({ decks, sharedDecks, displayName, userId, initialJoinCode }
   const [selectedDeckId, setSelectedDeckId] = useState<string | null>(decks[0]?.id ?? sharedDecks[0]?.id ?? null);
   const [joinCode, setJoinCode] = useState(initialJoinCode ?? "");
   const [error, setError] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
   // Selection resolves across both your decks and shared decks; stash() only
   // needs id/name/format, which both summary shapes carry.
   const selected =
@@ -53,6 +57,7 @@ function LobbyInner({ decks, sharedDecks, displayName, userId, initialJoinCode }
   function handleCreate() {
     const code = Math.random().toString(36).slice(2, 6).toUpperCase();
     if (!stash(code, "create")) return;
+    setIsCreating(true);
     router.push(`/play/${code}`);
   }
 
@@ -80,7 +85,16 @@ function LobbyInner({ decks, sharedDecks, displayName, userId, initialJoinCode }
       <section className="space-y-2">
         <h2 className="text-sm font-medium">Deck</h2>
         {decks.length === 0 && sharedDecks.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No Forge decks yet — build one first.</p>
+          <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+            No Forge decks yet.{" "}
+            <Link
+              href="/forge/play/decks/new"
+              className="font-medium text-primary underline underline-offset-2 hover:text-primary/80"
+            >
+              Build one
+            </Link>{" "}
+            to start playtesting.
+          </div>
         ) : (
           <ForgeDeckPicker
             decks={decks}
@@ -91,10 +105,20 @@ function LobbyInner({ decks, sharedDecks, displayName, userId, initialJoinCode }
         )}
       </section>
       <section className="grid gap-3 sm:grid-cols-2">
-        <button onClick={handleCreate} disabled={!selected} className="rounded-lg border p-4 text-left hover:bg-muted/50 disabled:opacity-50 [.jayden_&]:bg-card/80 [.jayden_&]:backdrop-blur-sm [.jayden_&]:border-primary/20">
+        <div className="flex flex-col gap-2 rounded-lg border p-4 [.jayden_&]:bg-card/80 [.jayden_&]:backdrop-blur-sm [.jayden_&]:border-primary/20">
           <div className="font-medium">Host a game</div>
           <div className="text-sm text-muted-foreground">Get a code to share with another playtester.</div>
-        </button>
+          <Button onClick={handleCreate} disabled={!selected || isCreating} className="mt-1 w-full">
+            {isCreating ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Loading deck…
+              </>
+            ) : (
+              "Create game"
+            )}
+          </Button>
+        </div>
         <div className="rounded-lg border p-4 [.jayden_&]:bg-card/80 [.jayden_&]:backdrop-blur-sm [.jayden_&]:border-primary/20">
           <div className="font-medium">Join by code</div>
           <div className="mt-2 flex gap-2">
@@ -105,7 +129,14 @@ function LobbyInner({ decks, sharedDecks, displayName, userId, initialJoinCode }
               placeholder="CODE"
               className="w-24 rounded-md border bg-background p-2 text-sm uppercase tracking-widest"
             />
-            <button onClick={() => handleJoin(joinCode)} disabled={!selected || joinCode.trim().length !== 4} className="rounded-md border px-3 text-sm hover:bg-muted/50 disabled:opacity-50">Join</button>
+            <Button
+              variant="outline"
+              onClick={() => handleJoin(joinCode)}
+              disabled={!selected || joinCode.trim().length !== 4}
+              className="h-10 shrink-0 px-4"
+            >
+              Join
+            </Button>
           </div>
         </div>
       </section>
@@ -114,14 +145,16 @@ function LobbyInner({ decks, sharedDecks, displayName, userId, initialJoinCode }
         {openGames.length === 0 ? (
           <p className="text-sm text-muted-foreground">Nobody is waiting right now.</p>
         ) : (
-          <ul className="divide-y rounded-lg border [.jayden_&]:bg-card/80 [.jayden_&]:backdrop-blur-sm [.jayden_&]:border-primary/20">
+          <ul className="max-w-md divide-y rounded-lg border [.jayden_&]:bg-card/80 [.jayden_&]:backdrop-blur-sm [.jayden_&]:border-primary/20">
             {openGames.map((g) => (
               <li key={String(g.id)} className="flex items-center justify-between gap-2 p-3">
                 <div>
                   <div className="text-sm font-medium">{g.createdByName || "Playtester"}</div>
                   <div className="text-xs text-muted-foreground">{g.format} · code {g.code}</div>
                 </div>
-                <button onClick={() => handleJoin(g.code)} disabled={!selected} className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted/50 disabled:opacity-50">Join</button>
+                <Button variant="outline" size="sm" onClick={() => handleJoin(g.code)} disabled={!selected}>
+                  Join
+                </Button>
               </li>
             ))}
           </ul>

--- a/app/play/[code]/client.tsx
+++ b/app/play/[code]/client.tsx
@@ -1278,7 +1278,7 @@ function GameInner({ code, isConnected }: GameInnerProps) {
                   fontSize: 13,
                   lineHeight: 1.5,
                 }}>
-                  Swap your game deck to <strong>{practiceDeckConfirm.deckName}</strong>?
+                  Change your game deck to <strong>{practiceDeckConfirm.deckName}</strong>?
                   <br />
                   <span style={{ fontSize: 11, color: 'rgba(196, 149, 90, 0.7)' }}>
                     Your practice game will reset and your opponent will see the new deck once they join.
@@ -1339,7 +1339,7 @@ function GameInner({ code, isConnected }: GameInnerProps) {
                       fontWeight: 600,
                     }}
                   >
-                    Swap Deck
+                    Change deck
                   </button>
                 </div>
               </div>

--- a/app/play/components/GameLobby.tsx
+++ b/app/play/components/GameLobby.tsx
@@ -6,7 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
-import { Loader2, Pencil, ArrowLeftRight } from 'lucide-react';
+import { Loader2, Pencil, ArrowLeftRight, Eye } from 'lucide-react';
 import { getCardImageUrl } from '@/lib/card-images';
 import { getCardImageUrl as getBlobCardImageUrl } from '@/app/shared/utils/cardImageUrl';
 import { useSpacetimeConnection } from '../hooks/useSpacetimeConnection';
@@ -316,6 +316,9 @@ export function GameLobby({ decks, userId, displayName: initialDisplayName, hasU
                       {selectedDeck.card_count} cards
                     </span>
                   )}
+                  {selectedDeck.id === decks[0]?.id && selectedDeck.last_played_at && (
+                    <span className="text-xs text-muted-foreground/80">· Last played</span>
+                  )}
                 </div>
               </div>
               <div className="flex items-center gap-2 shrink-0">
@@ -334,7 +337,7 @@ export function GameLobby({ decks, userId, displayName: initialDisplayName, hasU
                   onClick={() => setPickerOpen(true)}
                 >
                   <ArrowLeftRight className="h-4 w-4" />
-                  Swap
+                  Change deck
                 </Button>
               </div>
             </div>
@@ -521,12 +524,15 @@ export function GameLobby({ decks, userId, displayName: initialDisplayName, hasU
                   variant="outline"
                   onClick={() => handleJoinGame()}
                   disabled={isJoining || isCreating || gameCode.length !== 4 || (!isSpectate && !selectedDeck)}
-                  className="shrink-0 h-12 w-20"
+                  className="shrink-0 h-12 w-24"
                 >
                   {isJoining ? (
                     <Loader2 className="h-4 w-4 animate-spin" />
                   ) : isSpectate ? (
-                    'Watch'
+                    <>
+                      <Eye className="mr-1.5 h-4 w-4" />
+                      Watch
+                    </>
                   ) : (
                     'Join'
                   )}
@@ -553,6 +559,11 @@ export function GameLobby({ decks, userId, displayName: initialDisplayName, hasU
                   />
                 </button>
               </div>
+              {isSpectate && (
+                <p className="text-xs text-muted-foreground text-center">
+                  Spectating — you&apos;ll watch this game, not play.
+                </p>
+              )}
             </div>
           </div>
 

--- a/docs/superpowers/plans/2026-07-20-ws1-forge-lobby-parity.md
+++ b/docs/superpowers/plans/2026-07-20-ws1-forge-lobby-parity.md
@@ -1,0 +1,273 @@
+# WS-1 Forge Lobby & Deck-Choice Parity — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the Forge lobby to parity with the normal `/play` lobby and unify deck-choice copy, per `docs/superpowers/specs/2026-07-20-ws1-forge-lobby-parity-design.md`.
+
+**Architecture:** Surgical, inline edits to three existing files. Port shadcn `Button`/loading patterns that already exist in `GameLobby.tsx`. No shared-component extraction, no lobby merge (that is WS-6).
+
+**Tech Stack:** Next.js 15 / React 19 / TypeScript, shadcn `Button`/`Badge`, lucide-react icons, Tailwind. Verification is type-check + manual visual (no unit tests exist for these surfaces).
+
+## Global Constraints
+
+- Deck-change verb is **"Change deck"** everywhere a control changes the deck. First-time-selection surfaces (`Choose a deck…` placeholder, `Choose a deck` dialog titles) stay.
+- Spectate stays **off by default**; item only improves the ON-state's legibility — no routing/logic change.
+- Design system: restrained; reserve primary green for CTAs/hover; no flashy color (`[[feedback_reserve_green_accent]]`, `[[feedback_no_focus_rings]]`).
+- Type gate is `npx tsc --noEmit` — do **not** run a full `next build` (dev server may share `.next`).
+- Stage only the files named in each task; never `git add -A`.
+
+---
+
+### Task 1: Forge lobby — real Host CTA, loading feedback, empty-state link, tighter rows
+
+**Files:**
+- Modify: `app/forge/play/games/ForgeGameLobby.tsx`
+
+Covers spec items #1 (real CTA), #2 (loading feedback), #3 (builder link), #4 (tighter open-games rows).
+
+- [ ] **Step 1: Add imports**
+
+At the top import block, add:
+
+```tsx
+import Link from "next/link";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+```
+
+- [ ] **Step 2: Add `isCreating` state + wire `handleCreate`**
+
+Add next to the other `useState`s in `LobbyInner`:
+
+```tsx
+const [isCreating, setIsCreating] = useState(false);
+```
+
+Change `handleCreate` to set it before navigating (navigation unmounts the lobby, so no reset needed):
+
+```tsx
+function handleCreate() {
+  const code = Math.random().toString(36).slice(2, 6).toUpperCase();
+  if (!stash(code, "create")) return;
+  setIsCreating(true);
+  router.push(`/play/${code}`);
+}
+```
+
+- [ ] **Step 3: Empty state → builder link**
+
+Replace the empty-state paragraph (currently `<p ...>No Forge decks yet — build one first.</p>`) with:
+
+```tsx
+<div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+  No Forge decks yet.{" "}
+  <Link
+    href="/forge/play/decks/new"
+    className="font-medium text-primary underline underline-offset-2 hover:text-primary/80"
+  >
+    Build one
+  </Link>{" "}
+  to start playtesting.
+</div>
+```
+
+- [ ] **Step 4: Host card → real Button CTA with feedback**
+
+Replace the `<button onClick={handleCreate} ...>Host a game ...</button>` card (the first grid child) with a card whose action is a real primary `Button`, keeping symmetry with the Join card:
+
+```tsx
+<div className="flex flex-col gap-2 rounded-lg border p-4 [.jayden_&]:bg-card/80 [.jayden_&]:backdrop-blur-sm [.jayden_&]:border-primary/20">
+  <div className="font-medium">Host a game</div>
+  <div className="text-sm text-muted-foreground">Get a code to share with another playtester.</div>
+  <Button
+    onClick={handleCreate}
+    disabled={!selected || isCreating}
+    className="mt-1 w-full"
+  >
+    {isCreating ? (
+      <>
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        Loading deck…
+      </>
+    ) : (
+      "Create game"
+    )}
+  </Button>
+</div>
+```
+
+- [ ] **Step 5: Join-by-code button → shadcn Button (parity)**
+
+In the "Join by code" card, swap the bare `<button ...>Join</button>` for:
+
+```tsx
+<Button
+  variant="outline"
+  onClick={() => handleJoin(joinCode)}
+  disabled={!selected || joinCode.trim().length !== 4}
+  className="h-10 shrink-0 px-4"
+>
+  Join
+</Button>
+```
+
+- [ ] **Step 6: Tighten the open-games rows**
+
+On the open-games `<ul>` (`className="divide-y rounded-lg border ..."`), add a width cap so the clickable row isn't a full-bleed banner:
+
+```tsx
+<ul className="max-w-md divide-y rounded-lg border [.jayden_&]:bg-card/80 [.jayden_&]:backdrop-blur-sm [.jayden_&]:border-primary/20">
+```
+
+Also swap each row's `<button ...>Join</button>` for a shadcn `Button`:
+
+```tsx
+<Button
+  variant="outline"
+  size="sm"
+  onClick={() => handleJoin(g.code)}
+  disabled={!selected}
+>
+  Join
+</Button>
+```
+
+- [ ] **Step 7: Type-check**
+
+Run: `cd /Users/timestes/projects/rtt-ws1-forge-lobby && npx tsc --noEmit`
+Expected: no new errors in `ForgeGameLobby.tsx`.
+
+- [ ] **Step 8: Visual check**
+
+Load `/forge/play/games`. Confirm: "Create game" is a green button; clicking shows "Loading deck…" + spinner + disabled; with 0 decks the empty state links to `/forge/play/decks/new`; the open-games list (seed one with a second account) is compact, not full-width.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /Users/timestes/projects/rtt-ws1-forge-lobby
+git add app/forge/play/games/ForgeGameLobby.tsx
+git commit -m "feat(forge-lobby): real Host CTA + loading, builder link, tighter rows
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Normal lobby — "Change deck" verb, "Last played" hint, obvious spectate ON-state
+
+**Files:**
+- Modify: `app/play/components/GameLobby.tsx`
+
+Covers spec items #5 (verb), #6 (last-played hint), #7 (spectate on-state).
+
+- [ ] **Step 1: Add the `Eye` icon import**
+
+Extend the existing lucide import:
+
+```tsx
+import { Loader2, Pencil, ArrowLeftRight, Eye } from 'lucide-react';
+```
+
+- [ ] **Step 2: Verb — "Swap" → "Change deck"**
+
+In the deck-change `Button` (the one with `<ArrowLeftRight .../>`), change the label text `Swap` to `Change deck`. Keep the icon.
+
+- [ ] **Step 3: "Last played" hint**
+
+In the deck-info badge row (the `flex items-center gap-2 mt-0.5` div holding the format `Badge` and `{card_count} cards`), append after the card-count span:
+
+```tsx
+{selectedDeck.id === decks[0]?.id && selectedDeck.last_played_at && (
+  <span className="text-xs text-muted-foreground/80">· Last played</span>
+)}
+```
+
+- [ ] **Step 4: Spectate — Eye icon on the Watch button**
+
+In the join `Button`'s content, replace the `isSpectate ? 'Watch' : 'Join'` branch so Watch carries an icon, and widen the fixed button so it fits:
+
+```tsx
+{isJoining ? (
+  <Loader2 className="h-4 w-4 animate-spin" />
+) : isSpectate ? (
+  <>
+    <Eye className="mr-1.5 h-4 w-4" />
+    Watch
+  </>
+) : (
+  'Join'
+)}
+```
+
+Change that button's `className` width from `w-20` to `w-24` (`className="shrink-0 h-12 w-24"`).
+
+- [ ] **Step 5: Spectate — explanatory caption when ON**
+
+Immediately after the spectate-toggle row's closing `</div>` (still inside the join column), add:
+
+```tsx
+{isSpectate && (
+  <p className="text-xs text-muted-foreground text-center">
+    Spectating — you&apos;ll watch this game, not play.
+  </p>
+)}
+```
+
+- [ ] **Step 6: Type-check**
+
+Run: `cd /Users/timestes/projects/rtt-ws1-forge-lobby && npx tsc --noEmit`
+Expected: no new errors in `GameLobby.tsx`.
+
+- [ ] **Step 7: Visual check**
+
+Load `/play`. Confirm: the deck control reads "Change deck"; the auto-selected deck shows "· Last played" that disappears after changing decks; toggling Spectate on shows the Eye+Watch button and the caption.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/timestes/projects/rtt-ws1-forge-lobby
+git add app/play/components/GameLobby.tsx
+git commit -m "feat(play-lobby): Change-deck verb, last-played hint, clearer spectate state
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: In-game practice-swap confirm — copy consolidation
+
+**Files:**
+- Modify: `app/play/[code]/client.tsx` (two strings, ~L1281 and ~L1342)
+
+Covers spec item #8. Copy-only; internal identifiers stay.
+
+- [ ] **Step 1: Body copy**
+
+Change `Swap your game deck to <strong>{practiceDeckConfirm.deckName}</strong>?` to `Change your game deck to <strong>{practiceDeckConfirm.deckName}</strong>?`
+
+- [ ] **Step 2: Button label**
+
+Change the confirm button label `Swap Deck` to `Change deck`.
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd /Users/timestes/projects/rtt-ws1-forge-lobby && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/timestes/projects/rtt-ws1-forge-lobby
+git add "app/play/[code]/client.tsx"
+git commit -m "feat(play): unify deck-change verb to 'Change deck' in practice-swap confirm
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-review
+
+- **Spec coverage:** items #1-#8 each map to a task step above (Task 1 → #1-#4; Task 2 → #5-#7; Task 3 → #8). No gaps.
+- **Placeholders:** none — every step shows the exact JSX/copy.
+- **Type consistency:** uses existing symbols only (`Button`, `Badge`, `Loader2`, `Eye`, `Link`, `DeckOption.last_played_at`, `handleCreate`, `isCreating`).

--- a/docs/superpowers/specs/2026-07-20-ws1-forge-lobby-parity-design.md
+++ b/docs/superpowers/specs/2026-07-20-ws1-forge-lobby-parity-design.md
@@ -1,0 +1,70 @@
+# WS-1 — Forge Lobby & Deck-Choice Parity
+
+**Status:** Design approved (Approach A: surgical parity). Ready for implementation plan.
+**Source:** First of six workstreams decomposed from the multiplayer UX audit (PR #221, `docs/multiplayer-flows-ux-audit.md`).
+**Branch:** `feat/ws1-forge-lobby-parity`.
+
+## Goal
+
+Bring the Forge playtest lobby up to the polish of the normal `/play` lobby, and remove a cluster of small deck-choice inconsistencies across both. Every change traces to an audit finding. This is **parity work** — port patterns that already exist in `GameLobby.tsx`; do not invent new UI vocabulary and do not merge the two lobby files (that unification is WS-6).
+
+## Approach
+
+**Surgical parity (Approach A).** Fix each item inline, matching each file's existing style. No shared-component extraction, no lobby merge, no restyle beyond what each item requires. Rejected alternatives: extracting shared lobby primitives (does WS-6's job early, collides later), and copy-only (doesn't deliver "make it a real button").
+
+## Scope — the eight changes
+
+### `app/forge/play/games/ForgeGameLobby.tsx`
+
+1. **"Host a game" → real primary CTA.**
+   Today it's a bordered `<div>`-button ([L94-97](app/forge/play/games/ForgeGameLobby.tsx#L94)) that doesn't read as a button. Replace with the shadcn `Button` primary CTA (green, `size="lg"`, full-width `h-12`), with "Get a code to share with another playtester." as a caption beneath — mirroring the normal lobby's Create Game ([GameLobby.tsx:455-469](app/play/components/GameLobby.tsx#L455)).
+
+2. **Host loading feedback.**
+   Add an `isCreating` state. On click, the button shows a `Loader2` spinner + "Loading deck…" and disables, matching normal ([GameLobby.tsx:461-468](app/play/components/GameLobby.tsx#L461)). `handleCreate` sets it before `router.push`. (No cleanup needed — navigation unmounts the lobby.)
+
+3. **Empty state → builder link.**
+   "No Forge decks yet — build one first." ([L82-83](app/forge/play/games/ForgeGameLobby.tsx#L82)) becomes an actionable link/button to **`/forge/play/decks/new`** (the Forge Deckbuilder route, confirmed in `ForgeNav.tsx`). Style after the normal lobby's "Build one" link ([GameLobby.tsx:344-349](app/play/components/GameLobby.tsx#L344)). Host/Join stay disabled while `!selected` (already the case).
+
+4. **Tighten the too-wide open-games join rows.**
+   The `<li>` rows ([L118-127](app/forge/play/games/ForgeGameLobby.tsx#L118)) span the full `max-w-3xl` with the Join button flung to the far edge, leaving a large dead gap — the "banner … way too wide." Constrain the open-games list to a compact width (e.g. cap the `<ul>` at ~`max-w-md`) so each clickable row is a tidy card, not a full-bleed banner. Content-left / Join-right stays, but the horizontal gap collapses. Visual-only; no behavior change.
+
+### `app/play/components/GameLobby.tsx`
+
+5. **Deck-change verb: "Swap" → "Change deck".**
+   [L337](app/play/components/GameLobby.tsx#L337). Keep the `ArrowLeftRight` icon.
+
+6. **Explain the pre-selected deck.**
+   The lobby silently auto-selects the last-played deck (`decks[0]`, [L37](app/play/components/GameLobby.tsx#L37)). Add a muted **"Last played"** chip beside the format badge in the deck-info row ([L308-319](app/play/components/GameLobby.tsx#L308)). Guard: show only when the selected deck is the initial auto-pick **and** carries a real timestamp — `selectedDeck.id === decks[0]?.id && selectedDeck.last_played_at` (field exists on `DeckOption`, `DeckPickerCard.tsx:17`). It disappears once the user deliberately changes decks, so it never mislabels a manual choice.
+
+7. **Make the spectate ON-state obvious.**
+   Spectate already defaults OFF ([L87](app/play/components/GameLobby.tsx#L87)) and stays off — verified as the correct default. The real footgun is that turning it on silently relabels Join→Watch. When `isSpectate` is true ([L519-555](app/play/components/GameLobby.tsx#L519)): give the "Watch" button a distinct treatment (an `Eye` icon + clearer styling) and add a small caption under the join input — "Spectating — you'll watch, not play." Restrained per the design system (no flashy color). **Logic unchanged** — only the on-state's legibility.
+
+### `app/play/[code]/client.tsx` — verb consolidation (copy-only)
+
+8. **In-game practice-swap confirm copy.**
+   "Swap your game deck to …" ([L1281](app/play/[code]/client.tsx#L1281)) → "Change your game deck to …"; "Swap Deck" button ([L1342](app/play/[code]/client.tsx#L1342)) → "Change deck". Internal identifiers (`ForgeSwapErrorDialog`, `forgeSwapError`, handler names) are **not** user-facing — leave them. Pregame already reads "Change deck." Deck-picker **dialog titles** stay "Choose a deck" (that's *choosing*, not *changing*); only trigger/action buttons unify.
+
+## Out of scope (deferred, on purpose)
+
+- Merging `GameLobby` and `ForgeGameLobby` into one component → **WS-6**.
+- Restyling the Forge deck-selector bar itself / adding Forge card-art preview → lower-priority polish.
+- Any change to spectate routing, the `Spectator` table, or self-spectate ("watch your own game") → **WS-2**.
+- Gating debug artifacts → explicitly kept per user.
+
+## Verb inventory (for completeness)
+
+Surfaces that will read "Change deck" after this WS: normal lobby button (#5), in-game practice confirm (#8), pregame (already correct, `PregameScreen.tsx:401`). Empty-state placeholder `Choose a deck…` and dialog titles `Choose a deck` (`ForgeDeckPicker.tsx`) intentionally remain — they describe first-time selection, not changing.
+
+## File-overlap / sequencing note
+
+Item #8 edits `client.tsx`, which WS-2 and WS-3 also touch — but these are two isolated string lines. As long as WS-1 lands first, there is no real collision. Items #1-4 (`ForgeGameLobby.tsx`) and #5-7 (`GameLobby.tsx`) are disjoint from all other workstreams.
+
+## Verification
+
+Manual, driven with the `verify` skill (mint `sb-` cookies, standalone Playwright) — host = `baboonytim@gmail.com`, joiner = `landofredemption@gmail.com`, both have Forge + normal decks.
+
+Success criteria:
+- **Forge lobby:** "Host a game" renders as a green primary button; clicking it shows "Loading deck…" + spinner + disabled before navigation; with zero Forge decks the empty state links to `/forge/play/decks/new`; the open-games rows are compact, not full-bleed.
+- **Normal lobby:** the deck-change control reads "Change deck"; the auto-selected last-played deck shows a "Last played" chip that vanishes after a manual change; toggling Spectate on makes it unmistakable that Join became Watch, with the explanatory caption.
+- **In-game:** the practice-swap confirm reads "Change …/Change deck".
+- `npm run build` (or `tsc --noEmit`) passes; no unused imports left by the CTA/`Eye`/`Loader2` additions.


### PR DESCRIPTION
First of six workstreams decomposed from the multiplayer UX audit (#221). **Surgical parity** — port patterns that already exist in the normal `/play` lobby; no lobby merge (that's WS-6).

Spec: `docs/superpowers/specs/2026-07-20-ws1-forge-lobby-parity-design.md` · Plan: `docs/superpowers/plans/2026-07-20-ws1-forge-lobby-parity.md`

## What changed (8 items, all from the audit)

**Forge lobby** (`ForgeGameLobby.tsx`)
- **"Host a game" is a real button now** — a shadcn primary CTA ("Create game"), not a bordered `<div>`.
- **Click feedback** — flips to "Loading deck…" + spinner + disabled on create (parity with `/play`).
- **Empty state links to the Deckbuilder** (`/forge/play/decks/new`) instead of a dead-end "build one first."
- **Tighter open-games rows** — the too-wide, full-bleed join banner is capped (`max-w-md`) into a compact row.

**Normal lobby** (`GameLobby.tsx`)
- **Deck-change verb unified to "Change deck"** (was "Swap").
- **Pre-selected deck is explained** — a subtle "· Last played" hint on the auto-picked deck that disappears once you change decks.
- **Spectate ON-state is obvious** — the Watch button gains an Eye icon and a "you'll watch this game, not play" caption, killing the silent Join→Watch swap. (Default stays **off** — verified as correct.)

**In-game** (`client.tsx`)
- Practice-swap confirm copy → "Change deck" (verb consolidation, copy-only).

## Verification
- ✅ `tsc --noEmit` clean for all three changed files (repo's pre-existing `__tests__` type errors are unrelated).
- ⏳ Visual QA pending — please eyeball the Vercel preview (or I can drive it in Playwright with the `verify` skill before merge).

## Deferred (on purpose)
Merging the two lobby components → **WS-6**. Self-spectate / "watch your own game in a 2nd tab" → **WS-2**. Debug artifacts kept per your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)