### PR TITLE
feat(WS-4): win detection + symmetric game-over screen

### DIFF
--- a/app/play/[code]/client.tsx
+++ b/app/play/[code]/client.tsx
@@ -1439,8 +1439,8 @@ function GameInner({ code, isConnected }: GameInnerProps) {
               isMyTurn={false}
               onSetPhase={() => {}}
               onEndTurn={() => {}}
-              myScore={gameState.myCards['land-of-redemption']?.length ?? 0}
-              opponentScore={gameState.opponentCards['land-of-redemption']?.length ?? 0}
+              myScore={gameState.soulsRescued.me}
+              opponentScore={gameState.soulsRescued.opponent}
               timerDisplay={gameTimer.formatted}
               timerPaused={isSearchModalOpen}
               timerVisible={gameTimer.isTimerVisible}
@@ -1495,8 +1495,8 @@ function GameInner({ code, isConnected }: GameInnerProps) {
               isMyTurn={false}
               onSetPhase={() => {}}
               onEndTurn={() => {}}
-              myScore={gameState.myCards['land-of-redemption']?.length ?? 0}
-              opponentScore={gameState.opponentCards['land-of-redemption']?.length ?? 0}
+              myScore={gameState.soulsRescued.me}
+              opponentScore={gameState.soulsRescued.opponent}
               timerDisplay={gameTimer.formatted}
               timerPaused={isSearchModalOpen}
               timerVisible={gameTimer.isTimerVisible}
@@ -1559,8 +1559,8 @@ function GameInner({ code, isConnected }: GameInnerProps) {
                 onPlayAgain={opponentDisconnected ? undefined : () => setPlayAgainTriggered(true)}
                 onBackToLobby={opponentDisconnected ? handleReturnToLobby : undefined}
                 rematchPending={rematchPending}
-                myScore={gameState.myCards['land-of-redemption']?.length ?? 0}
-                opponentScore={gameState.opponentCards['land-of-redemption']?.length ?? 0}
+                myScore={gameState.soulsRescued.me}
+                opponentScore={gameState.soulsRescued.opponent}
                 timerDisplay={gameTimer.formatted}
                 timerPaused={isSearchModalOpen}
                 timerVisible={gameTimer.isTimerVisible}
@@ -1742,8 +1742,8 @@ function GameInner({ code, isConnected }: GameInnerProps) {
               onPlayAgain={opponentDisconnected ? undefined : () => setPlayAgainTriggered(true)}
               onBackToLobby={opponentDisconnected ? handleReturnToLobby : undefined}
               rematchPending={rematchPending}
-              myScore={gameState.myCards['land-of-redemption']?.length ?? 0}
-              opponentScore={gameState.opponentCards['land-of-redemption']?.length ?? 0}
+              myScore={gameState.soulsRescued.me}
+              opponentScore={gameState.soulsRescued.opponent}
               timerDisplay={gameTimer.formatted}
               timerPaused={isSearchModalOpen}
               timerVisible={gameTimer.isTimerVisible}
@@ -1791,8 +1791,8 @@ function GameInner({ code, isConnected }: GameInnerProps) {
             hasPendingPriority={gameState.zoneSearchRequests.some(
               (r: any) => r.zone === 'action-priority' && r.status === 'pending' && r.requesterId === gameState.myPlayer?.id
             )}
-            myScore={gameState.myCards['land-of-redemption']?.length ?? 0}
-            opponentScore={gameState.opponentCards['land-of-redemption']?.length ?? 0}
+            myScore={gameState.soulsRescued.me}
+            opponentScore={gameState.soulsRescued.opponent}
             disconnectTimeoutFired={gameState.disconnectTimeoutFired}
             onClaimVictory={gameState.claimTimeoutVictory}
             timerDisplay={gameTimer.formatted}

--- a/app/play/components/GameOverOverlay.tsx
+++ b/app/play/components/GameOverOverlay.tsx
@@ -31,26 +31,36 @@ interface GameOverOverlayProps {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function deriveEndReason(gameActions: any[], myPlayer: any): { label: string; winnerName: string } {
+function deriveEndReason(
+  gameActions: any[],
+  myPlayer: any,
+): { label: string; winnerName: string; outcome: 'won' | 'lost' | 'ended' } {
   for (let i = gameActions.length - 1; i >= 0; i--) {
     const action = gameActions[i];
     const actionType: string = (action.actionType ?? '').toUpperCase();
 
+    if (actionType === 'WIN') {
+      const winnerId = action.playerId ?? action.actorId;
+      const iWon = myPlayer?.id !== undefined && winnerId === myPlayer.id;
+      return iWon
+        ? { label: 'You won', winnerName: myPlayer?.displayName ?? 'You', outcome: 'won' }
+        : { label: 'You lost', winnerName: '', outcome: 'lost' };
+    }
+
     if (actionType === 'RESIGN') {
       const actorId = action.playerId ?? action.actorId;
-      const myId = myPlayer?.id;
-      if (myId !== undefined && actorId !== undefined && actorId === myId) {
-        return { label: 'You resigned', winnerName: '' };
-      }
-      return { label: 'Opponent resigned', winnerName: myPlayer?.displayName ?? 'You' };
+      const iResigned = myPlayer?.id !== undefined && actorId === myPlayer.id;
+      return iResigned
+        ? { label: 'You resigned', winnerName: '', outcome: 'lost' }
+        : { label: 'Opponent resigned', winnerName: myPlayer?.displayName ?? 'You', outcome: 'won' };
     }
 
     if (actionType === 'TIMEOUT') {
-      return { label: 'Opponent disconnected', winnerName: myPlayer?.displayName ?? 'You' };
+      return { label: 'Opponent disconnected', winnerName: myPlayer?.displayName ?? 'You', outcome: 'won' };
     }
   }
 
-  return { label: 'Game ended', winnerName: '' };
+  return { label: 'Game ended', winnerName: '', outcome: 'ended' };
 }
 
 // ---------------------------------------------------------------------------
@@ -69,14 +79,13 @@ export default function GameOverOverlay({
   myDeckId,
 }: GameOverOverlayProps) {
   const { isLoupeVisible } = useCardPreview();
-  const { label, winnerName } = deriveEndReason(gameActions, myPlayer);
+  const { label, outcome } = deriveEndReason(gameActions, myPlayer);
   const oppName: string = opponentPlayer?.displayName ?? 'Opponent';
   const mySeat = myPlayer?.seat?.toString() ?? '0';
 
-  // Determine if the game ended because of opponent action (resign/disconnect)
-  const isOpponentResigned = label === 'Opponent resigned';
-  const isOpponentDisconnected = label === 'Opponent disconnected';
-  const isOpponentLeft = isOpponentResigned || isOpponentDisconnected;
+  // Both players get a persistent result screen — winner and loser alike.
+  const didWin = outcome === 'won';
+  const showResultModal = didWin || outcome === 'lost';
 
   // Rematch state from game (derived before effects that use it)
   const rematchRequestedBy = game?.rematchRequestedBy ?? '';
@@ -89,12 +98,13 @@ export default function GameOverOverlay({
   // Modal dismissed state
   const [modalDismissed, setModalDismissed] = useState(false);
 
-  // Auto-dismiss toast after 4 seconds (only when not showing modal)
+  // Auto-dismiss toast after 4 seconds — only the generic "Game ended"
+  // fallback uses a toast; wins and losses use the persistent modal.
   useEffect(() => {
-    if (isOpponentLeft) return;
+    if (outcome !== 'ended') return;
     const timer = setTimeout(() => setToastVisible(false), 4000);
     return () => clearTimeout(timer);
-  }, [isOpponentLeft]);
+  }, [outcome]);
 
   // Open deck picker when Play Again is triggered from TurnIndicator. Forge
   // games skip the picker entirely — the same authorized deck is reused.
@@ -168,12 +178,12 @@ export default function GameOverOverlay({
 
   return (
     <>
-      {/* Opponent left/resigned — blocking modal */}
-      {isOpponentLeft && !modalDismissed && (
-        <OpponentLeftModal
-          isOpponentResigned={isOpponentResigned}
-          oppName={oppName}
+      {/* Persistent result modal — both winner and loser get one */}
+      {showResultModal && !modalDismissed && (
+        <GameOverModal
+          didWin={didWin}
           label={label}
+          oppName={oppName}
           isLoupeVisible={isLoupeVisible}
           onPlayAgain={() => {
             setModalDismissed(true);
@@ -188,8 +198,8 @@ export default function GameOverOverlay({
         />
       )}
 
-      {/* Temporary toast — auto-dismisses (for self-resign / generic end) */}
-      {!isOpponentLeft && toastVisible && (() => {
+      {/* Temporary toast — auto-dismisses (generic/unknown end only) */}
+      {outcome === 'ended' && toastVisible && (() => {
         const isWin = label === 'Opponent resigned' || label === 'Opponent disconnected';
         const isLoss = label === 'You resigned';
         const accent = isWin
@@ -308,21 +318,22 @@ export default function GameOverOverlay({
 // ---------------------------------------------------------------------------
 
 /**
- * Blocking modal shown when the opponent resigns/disconnects. Dismiss is the
+ * Persistent blocking result modal shown to BOTH players when the game ends —
+ * a win or a loss (rescue win, resign, or disconnect). Dismiss is the
  * affirmative default (Enter); Escape also dismisses. Highest priority so it
  * wins the keyboard over any lingering banner.
  */
-function OpponentLeftModal({
-  isOpponentResigned,
-  oppName,
+function GameOverModal({
+  didWin,
   label,
+  oppName,
   isLoupeVisible,
   onPlayAgain,
   onDismiss,
 }: {
-  isOpponentResigned: boolean;
-  oppName: string;
+  didWin: boolean;
   label: string;
+  oppName: string;
   isLoupeVisible: boolean;
   onPlayAgain: () => void;
   onDismiss: () => void;
@@ -337,6 +348,24 @@ function OpponentLeftModal({
 
   const playAgainFocused = focusedIndex === 0;
   const dismissFocused = focusedIndex === 1;
+
+  const eyebrow = didWin ? 'Victory' : 'Defeat';
+  const title = didWin
+    ? (label === 'Opponent resigned'
+        ? `${oppName} Conceded`
+        : label === 'Opponent disconnected'
+          ? `${oppName} Left`
+          : 'You Won')
+    : (label === 'You resigned' ? 'You Resigned' : 'You Lost');
+  const subtitle = didWin
+    ? (label === 'Opponent resigned'
+        ? 'Your opponent has surrendered the game.'
+        : label === 'Opponent disconnected'
+          ? 'Your opponent has left the game.'
+          : 'You rescued enough Lost Souls to win.')
+    : (label === 'You resigned'
+        ? 'You surrendered the game.'
+        : 'Your opponent rescued enough Lost Souls to win.');
 
   return (
     <div
@@ -354,7 +383,7 @@ function OpponentLeftModal({
     >
       <div style={{
         background: 'rgba(14, 10, 6, 0.97)',
-        border: `1px solid ${isOpponentResigned ? 'rgba(196, 149, 90, 0.4)' : 'rgba(107, 78, 39, 0.3)'}`,
+        border: `1px solid ${didWin ? 'rgba(196, 149, 90, 0.4)' : 'rgba(107, 78, 39, 0.3)'}`,
         borderRadius: 10,
         padding: '32px 36px',
         textAlign: 'center',
@@ -367,8 +396,8 @@ function OpponentLeftModal({
           fontSize: 10,
           letterSpacing: '0.18em',
           textTransform: 'uppercase',
-          color: isOpponentResigned ? 'rgba(196, 149, 90, 0.7)' : 'rgba(196, 149, 90, 0.5)',
-        }}>{isOpponentResigned ? 'Victory' : 'Game Over'}</p>
+          color: didWin ? 'rgba(196, 149, 90, 0.7)' : 'rgba(196, 149, 90, 0.5)',
+        }}>{eyebrow}</p>
         <h2 style={{
           fontFamily: 'var(--font-cinzel), Georgia, serif',
           fontSize: 18,
@@ -376,13 +405,13 @@ function OpponentLeftModal({
           color: '#e8d5a3',
           marginTop: 8,
           textShadow: '0 1px 4px rgba(0,0,0,0.5)',
-        }}>{isOpponentResigned ? `${oppName} Conceded` : label}</h2>
+        }}>{title}</h2>
         <p style={{
           marginTop: 8,
           fontFamily: 'Georgia, serif',
           fontSize: 13,
           color: 'rgba(196, 149, 90, 0.5)',
-        }}>{isOpponentResigned ? 'Your opponent has surrendered the game.' : 'The game has ended.'}</p>
+        }}>{subtitle}</p>
 
         <div style={{ marginTop: 24, display: 'flex', gap: 12 }}>
           <button

--- a/app/play/hooks/useGameState.ts
+++ b/app/play/hooks/useGameState.ts
@@ -370,8 +370,10 @@ export function useGameState(gameId: bigint, forgeResolver?: ForgeResolverMap | 
 
   // Souls rescued — count cards in "land-of-redemption" zone per player
   const soulsRescued = useMemo(() => {
-    const myLor = myCards['land-of-redemption'] ?? [];
-    const oppLor = opponentCards['land-of-redemption'] ?? [];
+    const isLS = (c: any) =>
+      c.cardType === 'LS' || c.cardType === 'TOKEN_LS' || (c.cardName ?? '').toLowerCase().includes('lost soul');
+    const myLor = (myCards['land-of-redemption'] ?? []).filter(isLS);
+    const oppLor = (opponentCards['land-of-redemption'] ?? []).filter(isLS);
     return { me: myLor.length, opponent: oppLor.length };
   }, [myCards, opponentCards]);
 
@@ -1206,8 +1208,10 @@ export function useSpectatorGameState(gameId: bigint | null, forgeResolver?: For
   );
 
   const soulsRescued = useMemo(() => {
-    const myLor = myCards['land-of-redemption'] ?? [];
-    const oppLor = opponentCards['land-of-redemption'] ?? [];
+    const isLS = (c: any) =>
+      c.cardType === 'LS' || c.cardType === 'TOKEN_LS' || (c.cardName ?? '').toLowerCase().includes('lost soul');
+    const myLor = (myCards['land-of-redemption'] ?? []).filter(isLS);
+    const oppLor = (opponentCards['land-of-redemption'] ?? []).filter(isLS);
     return { me: myLor.length, opponent: oppLor.length };
   }, [myCards, opponentCards]);
 

--- a/docs/superpowers/plans/2026-07-20-ws4-win-detection.md
+++ b/docs/superpowers/plans/2026-07-20-ws4-win-detection.md
@@ -1,0 +1,272 @@
+# WS-4 Win Detection & Game-Over End States — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Auto-detect a rescue win (5 souls T1/Paragon, 7 T2) on the server and give both players a persistent VICTORY/DEFEAT screen. Per `docs/superpowers/specs/2026-07-20-ws4-win-detection-design.md`.
+
+**Architecture:** Logic-only SpacetimeDB change (new `checkAndApplyWin` helper at three soul→LoR choke points; `WIN` is a value of the existing `GameAction.actionType` string — no schema change, no bindings regen). Client teaches `deriveEndReason` about `WIN` and makes the game-over modal symmetric.
+
+**Tech Stack:** SpacetimeDB TS module, Next.js/React client. Verify with `tsc --noEmit` + live 2-player Playwright.
+
+## Global Constraints
+
+- Threshold: `normalizeFormat(game.format) === 'T2' ? 7 : 5` (5 for T1 **and** Paragon).
+- Rescued soul = `isLostSoulRow(c) && c.zone === 'land-of-redemption' && c.ownerId === player.id`.
+- `WIN` action logged via existing `logAction(ctx, gameId, playerId, actionType, payload, turnNumber, phase)`.
+- `checkAndApplyWin` re-reads the Game row and only fires while `status === 'playing'` (idempotent; callers may hold a stale snapshot).
+- No schema change → **no `spacetime generate`**; the module still needs an incremental **publish** (no `--clear`) for the new logic to run.
+- Keep the amber dialog styling (design-system migration is WS-6).
+- Stage only named files; never `git add -A`.
+
+---
+
+### Task 1: Server — `checkAndApplyWin` helper + three call sites
+
+**Files:**
+- Modify: `spacetimedb/src/index.ts`
+
+- [ ] **Step 1: Define the helper** (immediately after `isLostSoulRow`, which ends at L2737)
+
+```typescript
+// Rescue-win detection. A player wins by rescuing their Nth Lost Soul into
+// land-of-redemption (5 for T1/Paragon, 7 for T2). Called after any movement
+// of a soul into LoR. Idempotent: fires only while the game is still playing,
+// and re-reads the Game row because callers may hold a stale snapshot.
+function checkAndApplyWin(ctx: any, gameId: bigint) {
+  const game = ctx.db.Game.id.find(gameId);
+  if (!game || game.status !== 'playing') return;
+  const goal = normalizeFormat(game.format) === 'T2' ? 7 : 5;
+  const rows = [...ctx.db.CardInstance.card_instance_game_id.filter(gameId)];
+  for (const player of ctx.db.Player.player_game_id.filter(gameId)) {
+    let count = 0;
+    for (const c of rows) {
+      if (c.ownerId === player.id && c.zone === 'land-of-redemption' && isLostSoulRow(c)) count++;
+    }
+    if (count >= goal) {
+      ctx.db.Game.id.update({ ...game, status: 'finished' });
+      logAction(
+        ctx, gameId, player.id, 'WIN',
+        JSON.stringify({ winnerName: player.displayName, soulCount: count, format: normalizeFormat(game.format) }),
+        game.turnNumber, game.currentPhase,
+      );
+      return;
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Call site A — `moveLostSoulToLor`** (covers all three rescue reducers). Insert as the last statement before the function's closing `}` (after the `triggeredRefill` block at ~L5243):
+
+```typescript
+  if (triggeredRefill) {
+    refillSoulDeck(ctx, gameId);
+  }
+
+  checkAndApplyWin(ctx, gameId);
+}
+```
+
+- [ ] **Step 3: Call site B — `move_card`** (drag into LoR). After the `triggeredRefill` block at the end of the reducer (~L3396), before the reducer's closing `}`:
+
+```typescript
+    if (triggeredRefill) {
+      refillSoulDeck(ctx, game.id);
+    }
+
+    if (toZone === 'land-of-redemption') {
+      checkAndApplyWin(ctx, gameId);
+    }
+  }
+);
+```
+
+- [ ] **Step 4: Call site C — `move_cards_batch`** (batch drag into LoR). Inside the per-card write loop, right after the `ctx.db.CardInstance.id.update({...})` that ends at ~L3861:
+
+```typescript
+      ctx.db.CardInstance.id.update({
+        ...card,
+        zone: cardFinalZone,
+        // …unchanged…
+      });
+      if (cardFinalZone === 'land-of-redemption') {
+        checkAndApplyWin(ctx, gameId);
+      }
+    }
+```
+
+`checkAndApplyWin` is idempotent, so calling it per LoR-bound card in the loop is safe (later iterations no-op once finished).
+
+- [ ] **Step 5: Type-check the module**
+
+Run: `cd /Users/timestes/projects/rtt-ws4-win-detection/spacetimedb && npx tsc --noEmit`
+Expected: clean (or only pre-existing errors unrelated to these edits).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/timestes/projects/rtt-ws4-win-detection
+git add spacetimedb/src/index.ts
+git commit -m "feat(mp-server): auto-finish on rescue win (5/7 souls) + WIN action
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+*(Module is NOT published yet — that is the gated deploy step, Task 4.)*
+
+---
+
+### Task 2: Client — `deriveEndReason` learns `WIN` + symmetric game-over modal
+
+**Files:**
+- Modify: `app/play/components/GameOverOverlay.tsx`
+
+- [ ] **Step 1: Extend `deriveEndReason`** (L34-54) to add `outcome` and a `WIN` branch:
+
+```typescript
+function deriveEndReason(gameActions: any[], myPlayer: any):
+  { label: string; winnerName: string; outcome: 'won' | 'lost' | 'ended' } {
+  for (let i = gameActions.length - 1; i >= 0; i--) {
+    const action = gameActions[i];
+    const actionType: string = (action.actionType ?? '').toUpperCase();
+
+    if (actionType === 'WIN') {
+      const winnerId = action.playerId ?? action.actorId;
+      const iWon = myPlayer?.id !== undefined && winnerId === myPlayer.id;
+      return iWon
+        ? { label: 'You won', winnerName: myPlayer?.displayName ?? 'You', outcome: 'won' }
+        : { label: 'You lost', winnerName: '', outcome: 'lost' };
+    }
+    if (actionType === 'RESIGN') {
+      const actorId = action.playerId ?? action.actorId;
+      const iResigned = myPlayer?.id !== undefined && actorId === myPlayer.id;
+      return iResigned
+        ? { label: 'You resigned', winnerName: '', outcome: 'lost' }
+        : { label: 'Opponent resigned', winnerName: myPlayer?.displayName ?? 'You', outcome: 'won' };
+    }
+    if (actionType === 'TIMEOUT') {
+      return { label: 'Opponent disconnected', winnerName: myPlayer?.displayName ?? 'You', outcome: 'won' };
+    }
+  }
+  return { label: 'Game ended', winnerName: '', outcome: 'ended' };
+}
+```
+
+- [ ] **Step 2: Drive the modal off `outcome`.** In the component, replace the `isOpponentLeft`-only gating so the persistent blocking modal shows for every real result. Compute:
+
+```typescript
+  const { label, winnerName, outcome } = deriveEndReason(gameActions, myPlayer);
+  const oppName: string = opponentPlayer?.displayName ?? 'Opponent';
+  const mySeat = myPlayer?.seat?.toString() ?? '0';
+  const didWin = outcome === 'won';
+  const didLose = outcome === 'lost';
+  const showResultModal = didWin || didLose; // both sides get a persistent screen
+  const isOpponentDisconnected = label === 'Opponent disconnected';
+```
+
+- [ ] **Step 3: Render a symmetric `GameOverModal`.** Replace the `{isOpponentLeft && !modalDismissed && (<OpponentLeftModal .../>) }` block with:
+
+```tsx
+      {showResultModal && !modalDismissed && (
+        <GameOverModal
+          didWin={didWin}
+          label={label}
+          oppName={oppName}
+          canRematch={!isOpponentDisconnected}
+          isLoupeVisible={isLoupeVisible}
+          onPlayAgain={() => {
+            setModalDismissed(true);
+            if (isForge) { void handleForgeRematch('request'); }
+            else { setPickerMode('request'); setPickerOpen(true); }
+          }}
+          onDismiss={() => setModalDismissed(true)}
+        />
+      )}
+```
+
+And gate the fallback toast to the unknown case only: change `{!isOpponentLeft && toastVisible && (…)}` to `{outcome === 'ended' && toastVisible && (…)}`, and the auto-dismiss effect guard from `if (isOpponentLeft) return;` to `if (outcome !== 'ended') return;`.
+
+- [ ] **Step 4: Generalize `OpponentLeftModal` → `GameOverModal`.** Rename it and re-key its copy on `didWin` (keep the amber styling and the keyboard-nav hook):
+  - Eyebrow: `didWin ? 'Victory' : 'Defeat'`.
+  - Title: `didWin ? (label === 'Opponent resigned' ? \`${oppName} Conceded\` : 'You Won') : 'You Lost'`.
+  - Subtitle: win → "Your opponent has surrendered." / "You rescued enough souls." ; loss → "Your opponent rescued enough souls." / "You resigned." (pick by `label`).
+  - Actions: when `canRematch`, show **Play Again** + **Dismiss** (as today); when `!canRematch` (opponent disconnected), show **Back to Lobby** wired to `onDismiss` semantics is not enough — keep the existing behavior where disconnect routes through `onDismiss`/lobby. For this WS, opponent-disconnect keeps the current Play-Again-hidden behavior in `TurnIndicator`; the modal shows **Dismiss** only.
+
+- [ ] **Step 5: Type-check**
+
+Run: `cd /Users/timestes/projects/rtt-ws4-win-detection && npx tsc --noEmit 2>&1 | grep GameOverOverlay || echo "clean"`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/timestes/projects/rtt-ws4-win-detection
+git add app/play/components/GameOverOverlay.tsx
+git commit -m "feat(mp-client): symmetric VICTORY/DEFEAT game-over modal + WIN reason
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Client — soul score filtered to Lost Souls
+
+**Files:**
+- Modify: `app/play/hooks/useGameState.ts` (both `soulsRescued` computations, L372 + L1208)
+- Modify: `app/play/[code]/client.tsx` (5 score prop pairs)
+
+- [ ] **Step 1: Filter `soulsRescued` in `useGameState`.** In each of the two `soulsRescued` `useMemo`s, filter the LoR arrays before counting. Add a local predicate and apply it:
+
+```typescript
+    const isLS = (c: any) =>
+      c.cardType === 'LS' || c.cardType === 'TOKEN_LS' || (c.cardName ?? '').toLowerCase().includes('lost soul');
+    const myLor = (myCards['land-of-redemption'] ?? []).filter(isLS);
+    const oppLor = (opponentCards['land-of-redemption'] ?? []).filter(isLS);
+```
+
+(Replace the existing `const myLor = myCards['land-of-redemption'] ?? [];` / `oppLor` lines in both memos; the rest of each memo that reads `myLor.length` / `oppLor.length` is unchanged.)
+
+- [ ] **Step 2: Route the displayed score through the filtered value.** In `client.tsx`, replace all five pairs:
+
+```
+myScore={gameState.myCards['land-of-redemption']?.length ?? 0}
+opponentScore={gameState.opponentCards['land-of-redemption']?.length ?? 0}
+```
+with
+```
+myScore={gameState.soulsRescued.me}
+opponentScore={gameState.soulsRescued.opponent}
+```
+
+(Two `replace_all` edits — the pairs are byte-identical across all five call sites.)
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd /Users/timestes/projects/rtt-ws4-win-detection && npx tsc --noEmit 2>&1 | grep -E "useGameState|client\.tsx" || echo "clean"`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/timestes/projects/rtt-ws4-win-detection
+git add app/play/hooks/useGameState.ts "app/play/[code]/client.tsx"
+git commit -m "fix(mp-client): count only Lost Souls toward the rescued-souls score
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Deploy dev module + live verification  — **GATED on user confirmation**
+
+- [ ] **Step 1: Confirm with the user** before publishing (module publish affects live dev game state).
+- [ ] **Step 2: Publish** the dev module via the `spacetimedb-deploy` skill (incremental publish, **no** `--clear`, **no** `generate` — no schema change). Watch for the known post-publish index panic (`reference_stdb_clear_republish_index_panic`); if it appears, escalate before forcing a `--clear`.
+- [ ] **Step 3: Live verify** with the `verify` skill (2-player): rescue the 5th soul in a T1 game → both players get VICTORY / DEFEAT; resign shows the loser a persistent DEFEAT modal; the soul score matches.
+- [ ] **Step 4: Prod** — separate, pair the module publish with a Vercel deploy; do only after dev verification and user go-ahead.
+
+---
+
+## Self-review
+
+- **Spec coverage:** #18 win detection → Task 1; symmetric end-state (#19) → Task 2; score filter → Task 3; deploy → Task 4. All spec sections mapped.
+- **Placeholders:** none — real code throughout.
+- **Type consistency:** `checkAndApplyWin(ctx, gameId)`, `deriveEndReason` returns `{label, winnerName, outcome}`, `GameOverModal` prop names (`didWin`, `canRematch`) consistent across Tasks; `gameState.soulsRescued.{me,opponent}` matches the hook's exposed shape (`useGameState.ts:68,960`).

--- a/docs/superpowers/specs/2026-07-20-ws4-win-detection-design.md
+++ b/docs/superpowers/specs/2026-07-20-ws4-win-detection-design.md
@@ -1,0 +1,141 @@
+# WS-4 — Win Detection & Game-Over End States
+
+**Status:** Design approved in substance (fork answered: auto-end at 5/7 rescued souls, no deck-out). Ready for plan.
+**Source:** Workstream 4 of the multiplayer UX audit (PR #221). Covers audit items #18 (no game-rule win detection) and #19 (loser left on a live-looking board).
+**Branch:** `feat/ws4-win-detection`.
+
+## Goal
+
+Detect a real Redemption win on the server and give **both** players a persistent victory/defeat screen — closing the product gap where a rescued-5th-soul win produced no payoff and the loser was stranded on a playable-looking board.
+
+## The two problems, one shared fix
+
+- **#18 Win detection:** the module never finishes a game on a rules win; `deriveEndReason` only knows `RESIGN`/`TIMEOUT`. We add server auto-detection + a `WIN` game action.
+- **#19 Loser end-state:** the winner gets a persistent blocking modal; the loser gets only a 4-second toast, then a live-looking board. We make the game-over modal **symmetric** so the loser gets an equally persistent screen.
+
+Both are solved by: server finishes the game + logs `WIN`; the client's winner-only modal becomes a two-sided VICTORY/DEFEAT modal.
+
+## Rules
+
+- Win threshold: **5** rescued Lost Souls for T1 and Paragon, **7** for T2. From existing `normalizeFormat(game.format)` (`'T1' | 'T2' | 'Paragon'`).
+- Deck-out is **not** a win condition (per product owner) — out of scope.
+- A rescued soul = a `CardInstance` with `isLostSoulRow(c) === true`, `zone === 'land-of-redemption'`, owned by the player (rescue transfers `ownerId` to the rescuer/receiver).
+- Surrendering your own soul moves it to the **opponent's** LoR and counts toward **their** total — rules-correct, and handled naturally by checking both players.
+
+## Server design (`spacetimedb/src/index.ts`) — logic-only, no schema change
+
+No new table, no new reducer, no `WIN` column. `WIN` is a value of the existing `GameAction.actionType` string; `status:'finished'` uses the existing pattern. **Therefore no bindings regen — just an incremental module publish (no `--clear`).**
+
+**New shared helper** (place near `logAction`/`isLostSoulRow`):
+
+```typescript
+// Rescue-win detection. A player wins by rescuing their Nth Lost Soul into
+// land-of-redemption (5 for T1/Paragon, 7 for T2). Called after any movement
+// of a soul into LoR. Idempotent: only fires while the game is still playing,
+// and re-reads the Game row (callers may hold a stale snapshot).
+function checkAndApplyWin(ctx: any, gameId: bigint) {
+  const game = ctx.db.Game.id.find(gameId);
+  if (!game || game.status !== 'playing') return;
+  const goal = normalizeFormat(game.format) === 'T2' ? 7 : 5;
+  const rows = [...ctx.db.CardInstance.card_instance_game_id.filter(gameId)];
+  for (const player of ctx.db.Player.player_game_id.filter(gameId)) {
+    let count = 0;
+    for (const c of rows) {
+      if (c.ownerId === player.id && c.zone === 'land-of-redemption' && isLostSoulRow(c)) count++;
+    }
+    if (count >= goal) {
+      ctx.db.Game.id.update({ ...game, status: 'finished' });
+      logAction(
+        ctx, gameId, player.id, 'WIN',
+        JSON.stringify({ winnerName: player.displayName, soulCount: count, format: normalizeFormat(game.format) }),
+        game.turnNumber, game.currentPhase,
+      );
+      return;
+    }
+  }
+}
+```
+
+**Call sites** (three, covering both kinds of path):
+
+1. End of `moveLostSoulToLor` (~L5244) — covers all three rescue reducers (`rescue_lost_soul`, `surrender_lost_soul`, `surrender_soul`). `surrender_soul` continues after the primitive (battle auto-return + phase→discard); those spread the re-read Game row so `status:'finished'` is preserved, and the trailing `SET_PHASE` action is non-terminal so `deriveEndReason` still returns the `WIN`.
+2. `move_card` (~after L3283 write), guarded `if (toZone === 'land-of-redemption')` — covers dragging a soul into LoR.
+3. `move_cards_batch` (~after the L3848 loop), guarded by a `anyToLor` flag set when `cardFinalZone === 'land-of-redemption'` — covers batch drags.
+
+Mirrors the `resign_game` pattern (`ctx.db.Game.id.update({ ...game, status: 'finished' })` + `logAction(..., 'WIN', ...)`), using the existing `logAction(ctx, gameId, playerId, actionType, payload, turnNumber, phase)` helper and the canonical `isLostSoulRow` predicate (`index.ts:2735`).
+
+## Client design
+
+### 1. `deriveEndReason` learns `WIN` (`GameOverOverlay.tsx:34-54`)
+
+Add an `outcome` to the return and a `WIN` branch. The scan already walks `gameActions` newest-first; `WIN` joins `RESIGN`/`TIMEOUT` as terminal:
+
+```typescript
+function deriveEndReason(gameActions: any[], myPlayer: any):
+  { label: string; winnerName: string; outcome: 'won' | 'lost' | 'ended' } {
+  for (let i = gameActions.length - 1; i >= 0; i--) {
+    const action = gameActions[i];
+    const actionType: string = (action.actionType ?? '').toUpperCase();
+
+    if (actionType === 'WIN') {
+      const winnerId = action.playerId ?? action.actorId;
+      const iWon = myPlayer?.id !== undefined && winnerId === myPlayer.id;
+      return iWon
+        ? { label: 'You won', winnerName: myPlayer?.displayName ?? 'You', outcome: 'won' }
+        : { label: 'You lost', winnerName: '', outcome: 'lost' };
+    }
+    if (actionType === 'RESIGN') {
+      const actorId = action.playerId ?? action.actorId;
+      const iResigned = myPlayer?.id !== undefined && actorId === myPlayer.id;
+      return iResigned
+        ? { label: 'You resigned', winnerName: '', outcome: 'lost' }
+        : { label: 'Opponent resigned', winnerName: myPlayer?.displayName ?? 'You', outcome: 'won' };
+    }
+    if (actionType === 'TIMEOUT') {
+      return { label: 'Opponent disconnected', winnerName: myPlayer?.displayName ?? 'You', outcome: 'won' };
+    }
+  }
+  return { label: 'Game ended', winnerName: '', outcome: 'ended' };
+}
+```
+
+`client.tsx:1535` destructures `{ label, winnerName }` — still valid (extra field ignored).
+
+### 2. Symmetric GameOverModal (`GameOverOverlay.tsx`)
+
+Generalize the winner-only `OpponentLeftModal` into a persistent modal keyed on `outcome`:
+
+- `outcome === 'won'` → "VICTORY" (existing look), message per reason (soul win vs concede vs disconnect).
+- `outcome === 'lost'` → "DEFEAT", message ("Your opponent rescued enough souls." / "You resigned.").
+- Show the blocking modal for **both** `won` and `lost` (this replaces the loser's toast-only path — the fix for #19). `ended` (unknown) keeps the existing 4s toast fallback.
+- Keep the existing Play-Again vs Back-to-Lobby logic: rematch is offered whenever the opponent is still present (soul win/loss and resign); opponent-disconnect keeps Back-to-Lobby only.
+- Persistent standing signal after dismiss is unchanged: `TurnIndicator` already shows the finished state (Play Again + scores) in the top bar.
+
+Styling stays the current amber/inline system — migrating these bespoke dialogs to the design system is **WS-6**, deliberately not here.
+
+### 3. Soul score filtered to Lost Souls
+
+`client.tsx:1562-1563` (and the playing-state score props) count `land-of-redemption`.length, which includes any card dragged there. Filter to `isLostSoulRow` so the on-screen score can't read "5" without a real win. Reuse or add a small client-side Lost-Soul predicate; if `useGameState`'s `soulsRescued` (`useGameState.ts:371`) is the shared source, fix it there so player + spectator views agree.
+
+## Out of scope (deferred)
+
+- Deck-out detection (not a win condition).
+- Manual "claim victory" (auto-detection covers the only win condition).
+- Migrating game-over dialogs to the design system → **WS-6**.
+- Spectator-view game-over polish (spectators still see `status:'finished'`; dedicated victory framing for spectators is a follow-up).
+
+## Deploy & risk
+
+- **Only irreversible step:** publishing the updated **dev** SpacetimeDB module (incremental, no `--clear`, no bindings regen). Everything else is worktree-local. Implement fully, then publish via the `spacetimedb-deploy` skill and verify live before touching prod. Prod publish must pair with a Vercel deploy (per prior module-deploy convention).
+- Re-reading the Game row inside `checkAndApplyWin` avoids the stale-snapshot hazard flagged in `surrender_soul`.
+
+## Verification
+
+Driven with the `verify` skill (mint `sb-` cookies, 2-player Playwright; host `baboonytim@gmail.com`, joiner `landofredemption@gmail.com`).
+
+Success criteria:
+- Rescue the Nth Lost Soul (5 in a T1 game) → the game ends automatically; the **rescuer** sees VICTORY and the **opponent** sees DEFEAT, both persistent (no live-looking board).
+- Surrendering your own soul to the opponent's LoR can trigger the **opponent's** win.
+- Resign still works and now shows the loser a persistent DEFEAT modal (not a 4s toast).
+- The on-screen soul score matches the rescued-Lost-Soul count.
+- `tsc --noEmit` clean for changed client files; module type-checks/publishes.

--- a/spacetimedb/src/index.ts
+++ b/spacetimedb/src/index.ts
@@ -2736,6 +2736,33 @@ function isLostSoulRow(c: any): boolean {
   return c.cardType === 'LS' || c.cardType === 'TOKEN_LS' || c.cardName.toLowerCase().includes('lost soul');
 }
 
+// Rescue-win detection. A player wins by rescuing their Nth Lost Soul into
+// land-of-redemption (5 for T1/Paragon, 7 for T2). Called after any movement
+// of a soul into LoR (the moveLostSoulToLor primitive + the move_card /
+// move_cards_batch drag paths). Idempotent: fires only while the game is still
+// playing, and re-reads the Game row because callers may hold a stale snapshot.
+function checkAndApplyWin(ctx: any, gameId: bigint) {
+  const game = ctx.db.Game.id.find(gameId);
+  if (!game || game.status !== 'playing') return;
+  const goal = normalizeFormat(game.format) === 'T2' ? 7 : 5;
+  const rows = [...ctx.db.CardInstance.card_instance_game_id.filter(gameId)];
+  for (const player of ctx.db.Player.player_game_id.filter(gameId)) {
+    let count = 0;
+    for (const c of rows) {
+      if (c.ownerId === player.id && c.zone === 'land-of-redemption' && isLostSoulRow(c)) count++;
+    }
+    if (count >= goal) {
+      ctx.db.Game.id.update({ ...game, status: 'finished' });
+      logAction(
+        ctx, gameId, player.id, 'WIN',
+        JSON.stringify({ winnerName: player.displayName, soulCount: count, format: normalizeFormat(game.format) }),
+        game.turnNumber, game.currentPhase,
+      );
+      return;
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Helper: battleStakesLobLostSouls
 // The Lost Souls "at stake" for the battle currently in progress: the
@@ -3394,6 +3421,11 @@ export const move_card = spacetimedb.reducer(
     if (triggeredRefill) {
       refillSoulDeck(ctx, game.id);
     }
+
+    // Rescue win: a soul dragged into land-of-redemption may complete the goal.
+    if (toZone === 'land-of-redemption') {
+      checkAndApplyWin(ctx, gameId);
+    }
   }
 );
 
@@ -3859,6 +3891,11 @@ export const move_cards_batch = spacetimedb.reducer(
         ...leavePlayFieldOverrides(card, card.zone, cardFinalZone),
         ...battleEntryUpdates,
       });
+      // Rescue win: a soul batch-dragged into land-of-redemption may complete
+      // the goal. Idempotent, so a per-card call in the loop is safe.
+      if (cardFinalZone === 'land-of-redemption') {
+        checkAndApplyWin(ctx, gameId);
+      }
     }
 
     // Accessory cascade post-pass: for each mover that actually changed zone,
@@ -5241,6 +5278,9 @@ function moveLostSoulToLor(
   if (triggeredRefill) {
     refillSoulDeck(ctx, gameId);
   }
+
+  // Rescue win: this soul just landed in someone's land-of-redemption.
+  checkAndApplyWin(ctx, gameId);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Workstream 4 of the multiplayer UX audit (#221). Closes two audit items with one idea: the server finishes the game on a real win, and **both** players get a persistent VICTORY/DEFEAT screen.

Spec: `docs/superpowers/specs/2026-07-20-ws4-win-detection-design.md` · Plan: `docs/superpowers/plans/2026-07-20-ws4-win-detection.md`

## What changed

**Server** (`spacetimedb/src/index.ts`) — logic-only, no schema change
- New `checkAndApplyWin`: after any Lost Soul lands in `land-of-redemption` (via the `moveLostSoulToLor` primitive **or** the `move_card` / `move_cards_batch` drag paths), count that owner's Lost Souls there; at **5** (T1/Paragon) or **7** (T2) set the game `finished` and log a `WIN` action naming the winner. Deck-out is intentionally **not** a win condition.

**Client**
- `deriveEndReason` learns the `WIN` action and returns an `outcome` (won/lost/ended).
- The winner-only `OpponentLeftModal` becomes a symmetric **`GameOverModal`** shown persistently to *both* players — so the loser gets a real **DEFEAT** screen instead of a 4-second toast on a live-looking board (audit #19).
- Soul score counts only actual Lost Souls in `land-of-redemption`.

## Verification
- **Live 2-player game** (Playwright, real accounts, against the published dev module): resign → **HOST sees DEFEAT / "You Resigned"**, **opponent sees VICTORY / "Baboony Conceded"** — both persistent, board dimmed. This exercises the exact `GameOverModal` path a soul-win uses.
- Dev module **published** (`redemption-multiplayer-dev`): empty migration plan (confirms no schema change), healthy logs, bindings regenerated with **zero diff**.
- All changed files `tsc --noEmit` clean.
- The 5/7-soul auto-win itself is logic-reviewed + published; a quick manual soul-rescue smoke on the preview is worth a look before/after merge.

## Deploy note
Dev module is already published. **Prod is untouched** — merging needs the prod module published (`redemption-multiplayer`) paired with the Vercel deploy, since the `WIN` behavior lives in the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)