### PR TITLE
feat(deckcheck): temporary rule flagging Roots 2 cards as not yet legal

### DIFF
--- a/utils/deckcheck/__tests__/rules-t2.test.ts
+++ b/utils/deckcheck/__tests__/rules-t2.test.ts
@@ -1792,4 +1792,18 @@ describe("validateT2Rules", () => {
     );
     expect(quantityErrors).toHaveLength(1);
   });
+
+  // TEMPORARY: remove alongside checkRoots2NotYetLegal once Roots 2 is legal.
+  it("flags Roots 2 cards as not yet tournament legal", () => {
+    const roots2Card = makeCard({ name: "Timothy", set: "RR2" });
+    const mainDeck = makeValidMainDeck(100, [roots2Card]);
+    const cardGroups = [makeGroup("Timothy", [roots2Card])];
+
+    const issues = validateT2Rules(mainDeck, [], cardGroups);
+    expect(
+      issues.some(
+        (i) => i.rule === "roots2-not-yet-legal" && i.type === "error"
+      )
+    ).toBe(true);
+  });
 });

--- a/utils/deckcheck/__tests__/rules.test.ts
+++ b/utils/deckcheck/__tests__/rules.test.ts
@@ -25,6 +25,7 @@ import {
   checkVanillaLimit,
   checkSitesCitiesLimit,
   checkBannedCards,
+  checkRoots2NotYetLegal,
   checkSpecialCards,
   validateT1Rules,
 } from "../rules";
@@ -1611,6 +1612,45 @@ describe("Rule: checkBannedCards (t1-banned-card)", () => {
       makeCard({ name: "Aaron", set: "Priests" }),
     ];
     expect(checkBannedCards(cards, [])).toHaveLength(0);
+  });
+});
+
+// TEMPORARY: remove alongside checkRoots2NotYetLegal once Roots 2 is legal.
+describe("Rule: checkRoots2NotYetLegal (roots2-not-yet-legal)", () => {
+  it("flags a Roots 2 card in the main deck by set code", () => {
+    const card = makeCard({ name: "A New Creation [RR2]", set: "RR2" });
+    const issues = checkRoots2NotYetLegal([card], []);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].rule).toBe("roots2-not-yet-legal");
+    expect(issues[0].type).toBe("error");
+    expect(issues[0].message).toContain("A New Creation [RR2]");
+    expect(issues[0].message).toContain("not yet tournament legal");
+  });
+
+  it("flags a Roots 2 card by official set name", () => {
+    const card = makeCard({ name: "Timothy", set: "Roots 2" });
+    expect(checkRoots2NotYetLegal([card], [])).toHaveLength(1);
+  });
+
+  it("flags a Roots 2 card in the reserve", () => {
+    const card = makeCard({ name: "Seth", set: "RR2", isReserve: true });
+    expect(checkRoots2NotYetLegal([], [card])).toHaveLength(1);
+  });
+
+  it("does NOT flag original Roots cards", () => {
+    const card = makeCard({ name: "David (Roots)", set: "Roots" });
+    expect(checkRoots2NotYetLegal([card], [])).toHaveLength(0);
+  });
+
+  it("skips cards with quantity 0", () => {
+    const card = makeCard({ name: "Seth", set: "RR2", quantity: 0 });
+    expect(checkRoots2NotYetLegal([card], [])).toHaveLength(0);
+  });
+
+  it("is surfaced by validateT1Rules", () => {
+    const mainDeck = [makeCard({ name: "Timothy", set: "RR2" })];
+    const issues = validateT1Rules(mainDeck, [], []);
+    expect(issues.some((i) => i.rule === "roots2-not-yet-legal")).toBe(true);
   });
 });
 

--- a/utils/deckcheck/rules.ts
+++ b/utils/deckcheck/rules.ts
@@ -928,6 +928,41 @@ export function checkBannedCards(
   return issues;
 }
 
+// ---------------------------------------------------------------------------
+// TEMPORARY: Roots 2 legality gate
+// ---------------------------------------------------------------------------
+
+// Roots 2 set markers: set code "RR2" (carddata column 2) and the official
+// set name, matched case-insensitively against ResolvedCard.set.
+const ROOTS_2_SETS = new Set(["rr2", "roots 2"]);
+
+/**
+ * Rule: roots2-not-yet-legal — Roots 2 cards are not yet tournament legal.
+ *
+ * TEMPORARY: remove this function, its call in each validate*Rules entry
+ * point, and its tests once Roots 2 becomes tournament legal.
+ */
+export function checkRoots2NotYetLegal(
+  mainDeckCards: ResolvedCard[],
+  reserveCards: ResolvedCard[]
+): DeckCheckIssue[] {
+  const issues: DeckCheckIssue[] = [];
+
+  for (const card of [...mainDeckCards, ...reserveCards]) {
+    if (card.quantity === 0) continue;
+    if (ROOTS_2_SETS.has(card.set.toLowerCase())) {
+      issues.push({
+        type: "error",
+        rule: "roots2-not-yet-legal",
+        message: `"${card.name}" is from Roots 2, which is not yet tournament legal.`,
+        cards: [card.name],
+      });
+    }
+  }
+
+  return issues;
+}
+
 /**
  * Helper: check if a card matches one of the special exception cards.
  */
@@ -1063,6 +1098,9 @@ export function validateT1Rules(
   // Banned cards
   issues.push(...checkBannedCards(mainDeckCards, reserveCards));
 
+  // TEMPORARY: Roots 2 not yet tournament legal
+  issues.push(...checkRoots2NotYetLegal(mainDeckCards, reserveCards));
+
   // Special card exceptions
   issues.push(...checkSpecialCards(mainDeckCards, reserveCards, cardGroups));
 
@@ -1144,6 +1182,9 @@ export function validateParagonRules(
 
   // Banned cards
   issues.push(...checkBannedCards(mainDeckCards, reserveCards));
+
+  // TEMPORARY: Roots 2 not yet tournament legal
+  issues.push(...checkRoots2NotYetLegal(mainDeckCards, reserveCards));
 
   // Special card exceptions
   issues.push(...checkSpecialCards(mainDeckCards, reserveCards, cardGroups));
@@ -1628,6 +1669,9 @@ export function validateT2Rules(
   issues.push(...checkSitesCitiesLimit(mainDeckCards, reserveCards));
   issues.push(...checkBannedCards(mainDeckCards, reserveCards));
   issues.push(...checkSpecialCards(mainDeckCards, reserveCards, cardGroups));
+
+  // TEMPORARY: Roots 2 not yet tournament legal
+  issues.push(...checkRoots2NotYetLegal(mainDeckCards, reserveCards));
 
   // Character alias checks (dual-alignment characters with different names)
   issues.push(


### PR DESCRIPTION
## Summary

Temporary legality gate: any decklist containing a Roots 2 card is now flagged illegal, per the set not yet being tournament legal.

- New rule `roots2-not-yet-legal` in `utils/deckcheck/rules.ts` — errors on any main-deck or reserve card whose set is `RR2` (or `Roots 2`), case-insensitive, skipping quantity-0 rows (same conventions as `checkBannedCards`).
- Wired into **all three** format validators: Type 1, Type 2, and Paragon.
- Surfaces everywhere deckcheck runs: deck save (`app/decklist/actions.ts`), the deck builder legality checklist, and `/api/deckcheck`.

## Removal

Clearly marked `TEMPORARY` at the definition, all three call sites, and both test blocks. When Roots 2 becomes legal, delete `checkRoots2NotYetLegal`, its three `issues.push(...)` lines, and the tests — nothing else references it.

## Tests

7 new tests (flags by set code + official name, main + reserve, ignores original Roots, skips quantity 0, surfaced via `validateT1Rules` and `validateT2Rules`). Full deckcheck suite: **323/323 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)