### PR TITLE
fix(multiplayer): game-over deck picker dead clicks + rematch-aware modal actions

### DIFF
--- a/app/play/components/GameOverOverlay.tsx
+++ b/app/play/components/GameOverOverlay.tsx
@@ -108,11 +108,16 @@ export default function GameOverOverlay({
 
   // Play Again from TurnIndicator — one-tap run-it-back with the last deck
   // (both normal and Forge). "Change deck" lives on the result modal / banner.
+  // If the opponent has already requested a rematch, "play again" means
+  // accept it — requesting on top of theirs is a server error.
   useEffect(() => {
-    if (playAgainTriggered && !rematchRequestedBy) {
+    if (!playAgainTriggered) return;
+    if (!rematchRequestedBy) {
       void handleOneTapRematch('request');
-      onPlayAgainHandled?.();
+    } else if (opponentRequested && !rematchResponse) {
+      void handleOneTapRematch('respond');
     }
+    onPlayAgainHandled?.();
   }, [playAgainTriggered, rematchRequestedBy, onPlayAgainHandled, isForge]);
 
   // Deck picker state
@@ -192,7 +197,10 @@ export default function GameOverOverlay({
   };
 
   // Show opponent's rematch request as a persistent banner
-  const showRematchBanner = opponentRequested && !rematchResponse;
+  // Hidden while the picker is open — the banner (z-800) would float above
+  // the body-portaled dialog (z-50) and steal clicks in its footprint. It
+  // returns if the picker is dismissed without a selection.
+  const showRematchBanner = opponentRequested && !rematchResponse && !pickerOpen;
   // Show waiting status
   const showWaitingStatus = iRequested && !rematchResponse;
   // Show rematch result
@@ -207,15 +215,18 @@ export default function GameOverOverlay({
           label={label}
           oppName={oppName}
           isLoupeVisible={isLoupeVisible}
+          // If the opponent already requested a rematch while this modal was
+          // up, "play again" / "change deck" must RESPOND to their request —
+          // firing a second request is a server error.
           onPlayAgain={() => {
             setModalDismissed(true);
-            void handleOneTapRematch('request');
+            void handleOneTapRematch(opponentRequested ? 'respond' : 'request');
           }}
           // Normal games can swap decks between rematches; Forge decks are
           // seat-locked, so the escape hatch is hidden there.
           onChangeDeck={isForge ? undefined : () => {
             setModalDismissed(true);
-            handleChangeDeck('request');
+            handleChangeDeck(opponentRequested ? 'respond' : 'request');
           }}
           onDismiss={() => setModalDismissed(true)}
         />
@@ -340,16 +351,17 @@ export default function GameOverOverlay({
         </div>
       )}
 
-      {/* Deck picker — renders above everything */}
+      {/* Deck picker. Rendered bare like every other DeckPickerModal site —
+          its Dialog portals to document.body (PR #219), so a positioned
+          wrapper here never contains it; a fixed inset-0 wrapper just sits
+          above the portaled dialog and swallows its clicks. */}
       {pickerOpen && (
-        <div style={{ position: 'fixed', inset: 0, right: isLoupeVisible ? 'clamp(280px, 20vw, 380px)' : '36px', zIndex: 950 }}>
-          <DeckPickerModal
-            open={pickerOpen}
-            onOpenChange={setPickerOpen}
-            onSelect={handleDeckSelected}
-            selectedDeckId={myPlayer?.deckId}
-          />
-        </div>
+        <DeckPickerModal
+          open={pickerOpen}
+          onOpenChange={setPickerOpen}
+          onSelect={handleDeckSelected}
+          selectedDeckId={myPlayer?.deckId}
+        />
       )}
 
       {/* Inline CSS animation */}

--- a/app/play/components/PregameScreen.tsx
+++ b/app/play/components/PregameScreen.tsx
@@ -56,10 +56,13 @@ function OpponentDisconnectBanner({ connectionStatus }: { connectionStatus: 'con
 export function OpponentJoinedToast({ name }: { name: string }) {
   return (
     <motion.div
-      initial={{ opacity: 0, y: -8 }}
-      animate={{ opacity: 1, y: 0 }}
+      // Horizontal centering lives in framer's x, not a Tailwind translate
+      // class — motion.div owns the inline transform and would clobber
+      // -translate-x-1/2, leaving the toast hanging right of center.
+      initial={{ opacity: 0, y: -8, x: '-50%' }}
+      animate={{ opacity: 1, y: 0, x: '-50%' }}
       transition={{ duration: 0.25 }}
-      className="absolute top-16 left-1/2 -translate-x-1/2 z-50 rounded-lg border border-amber-200/20 bg-black/85 backdrop-blur-sm px-4 py-2.5 pointer-events-none"
+      className="absolute top-16 left-1/2 z-50 rounded-lg border border-amber-200/20 bg-black/85 backdrop-blur-sm px-4 py-2.5 pointer-events-none"
     >
       <p className="font-cinzel text-sm text-amber-200/90 tracking-wide whitespace-nowrap">
         ⚔️ {name} joined — rolling for first player…


### PR DESCRIPTION
## Fixes two bugs in the WS-5 rematch surfaces (#228 follow-up)

Found by proper click-through e2e (real hit-tested clicks, no dispatchEvent shortcuts) — the gap called out in #228's "not click-through-verified" note.

### Bug 1 — nothing in the "Select a Deck" picker was clickable
`GameOverOverlay` wrapped `DeckPickerModal` in a `fixed inset-0 zIndex:950` div (pre-dates WS-5). Since **#219 portaled Dialog to `document.body`** (overlay `z-50`), the dialog teleports out of that wrapper — leaving a transparent full-screen div at z-950 sitting **above** the dialog, swallowing every click.

Evidence (`document.elementFromPoint` at a deck card's center, before fix):
```
0: <DIV> pos=fixed z=950 cls="" text=""   ← empty wrapper intercepts
```

**Fix:** render `DeckPickerModal` bare — matching every other render site in the codebase (GameLobby, PregameScreen, goldfish, both client.tsx pickers). Also hide the rematch banner (z-800) while the picker is open so it can't intercept over its footprint.

### Bug 2 — winner's modal actions fired an invalid second request
`GameOverModal`'s Play Again / Change deck were hard-wired to `'request'` mode. With the opponent's request already pending, they fired `request_rematch` → `SenderError: Rematch already requested` → silent dead flow. Both now **respond** when an opponent request is pending (modal + TurnIndicator trigger alike).

### Verification (live 2-player, dev module, real clicks)
- Hit-test after fix lands on the actual deck-card button.
- **Request path:** modal Change deck → picker → click deck → opponent sees banner. ✓
- **Respond path:** winner's modal Change deck → picker → click deck → accepted → fresh pregame roll, chat "rematch started", no console/page errors. ✓
- Typecheck: no new errors (7 pre-existing on main, all in unrelated forge test files).


### Also: center the opponent-joined toast
`OpponentJoinedToast` centered via Tailwind `-translate-x-1/2`, but framer-motion owns the inline transform while animating `y` and clobbers it — the toast hung right of center. The −50% x now lives in framer's `initial`/`animate`. Verified live: toast center == play-area center, off by 0.0px.

Client-only — no module or bindings change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
