### PR TITLE
feat(pregame): remove the useless roll-ceremony skip button

### DIFF
--- a/app/play/components/PregameScreen.tsx
+++ b/app/play/components/PregameScreen.tsx
@@ -300,7 +300,6 @@ function PlayerCards({
   myPlayer,
   gameState,
   showDice,
-  skipped,
   isForge,
   onDeckChanged,
 }: {
@@ -316,7 +315,6 @@ function PlayerCards({
   myPlayer: any;
   gameState: GameState;
   showDice: boolean;
-  skipped?: boolean;
   isForge?: boolean;
   onDeckChanged?: (next: { deckId: string; deckName: string; deckData: string; paragon: string }) => void;
 }) {
@@ -367,21 +365,12 @@ function PlayerCards({
 
   // Die animation state — track whether dice have been revealed for this session
   const [diceRevealed, setDiceRevealed] = useState(false);
-  const [diceSkipped, setDiceSkipped] = useState(false);
   useEffect(() => {
     if (!showDice) return;
     // Start tumbling after a brief pause
     const timer = setTimeout(() => setDiceRevealed(true), 600);
     return () => clearTimeout(timer);
   }, [showDice]);
-
-  // Click-to-skip — land the dice on the known result immediately.
-  useEffect(() => {
-    if (skipped) {
-      setDiceSkipped(true);
-      setDiceRevealed(true);
-    }
-  }, [skipped]);
 
   return (
     <>
@@ -415,7 +404,6 @@ function PlayerCards({
                 accentColor="#c4955a"
                 isWinner={iWonRoll}
                 revealed={diceRevealed}
-                skipAnimation={diceSkipped}
               />
             </div>
           )}
@@ -444,7 +432,6 @@ function PlayerCards({
                     accentColor="#4a7ab5"
                     isWinner={!iWonRoll}
                     revealed={diceRevealed}
-                    skipAnimation={diceSkipped}
                   />
                 </div>
               )}
@@ -481,29 +468,23 @@ export function InlineDie({
   accentColor,
   isWinner,
   revealed,
-  skipAnimation,
 }: {
   finalValue: number;
   accentColor: string;
   isWinner: boolean;
   revealed: boolean;
-  skipAnimation?: boolean;
 }) {
   // Only reveal the "Winner" label after the die has actually landed,
   // otherwise the result is spoiled before the tumble animation finishes.
   const [landed, setLanded] = useState(false);
   useEffect(() => {
-    if (skipAnimation) {
-      setLanded(true);
-      return;
-    }
     if (!revealed) {
       setLanded(false);
       return;
     }
     const timer = setTimeout(() => setLanded(true), RITUAL_TUMBLE_MS);
     return () => clearTimeout(timer);
-  }, [revealed, skipAnimation]);
+  }, [revealed]);
 
   return (
     <div className="flex flex-col items-center gap-1">
@@ -513,7 +494,6 @@ export function InlineDie({
         size={56}
         isWinner={isWinner}
         revealed={revealed}
-        skipAnimation={skipAnimation}
       />
       {isWinner && landed && (
         <motion.span
@@ -653,10 +633,6 @@ function WaitingActions({
 
 export function PregameCeremonyOverlay({ gameState }: { gameState: GameState }) {
   const { game, myPlayer, opponentPlayer } = gameState;
-  // The roll result is server-authoritative (rollResult0/1, rollWinner) — the
-  // tumble is pure client theater, so skipping just races the local view to
-  // the known outcome and fires the pending auto-acks early (WS-3 §4).
-  const [skipped, setSkipped] = useState(false);
   if (!game || !myPlayer) return null;
 
   const phase = game.pregamePhase;
@@ -682,7 +658,6 @@ export function PregameCeremonyOverlay({ gameState }: { gameState: GameState }) 
           myPlayer={myPlayer}
           gameState={gameState}
           showDice={true}
-          skipped={skipped}
         />
 
         {/* Action area */}
@@ -694,7 +669,6 @@ export function PregameCeremonyOverlay({ gameState }: { gameState: GameState }) 
               iWonRoll={iWonRoll}
               opponentName={opponentName}
               myPlayer={myPlayer}
-              skipped={skipped}
             />
           ) : phase === 'revealing' ? (
             <RevealArea
@@ -702,20 +676,9 @@ export function PregameCeremonyOverlay({ gameState }: { gameState: GameState }) 
               myPlayer={myPlayer}
               opponentName={opponentName}
               iWonRoll={iWonRoll}
-              skipped={skipped}
             />
           ) : null}
         </div>
-
-        {/* Skip — reveals the outcome instantly; choosing stays a real click */}
-        {!skipped && (phase === 'rolling' || phase === 'revealing') && (
-          <button
-            onClick={() => setSkipped(true)}
-            className="mt-4 text-[11px] text-amber-200/40 hover:text-amber-200/70 font-cinzel tracking-widest uppercase transition-colors"
-          >
-            Skip ▸
-          </button>
-        )}
       </div>
     </div>
   );
@@ -823,14 +786,12 @@ function RollAndChooseArea({
   iWonRoll,
   opponentName,
   myPlayer,
-  skipped,
 }: {
   gameState: GameState;
   phase: string;
   iWonRoll: boolean;
   opponentName: string;
   myPlayer: any;
-  skipped?: boolean;
 }) {
   const { game } = gameState;
   const hasChosenRef = useRef(false);
@@ -852,14 +813,10 @@ function RollAndChooseArea({
   // Show results = dice have landed (we track this via a brief delay)
   const [showResults, setShowResults] = useState(false);
   useEffect(() => {
-    if (skipped) {
-      setShowResults(true);
-      return;
-    }
     // Show results after tumble animation completes
     const timer = setTimeout(() => setShowResults(true), RITUAL_TUMBLE_MS + 700);
     return () => clearTimeout(timer);
-  }, [skipped]);
+  }, []);
 
   // Auto-acknowledge roll for the loser (after tumble + display time).
   // Depend on the *stable* reducer callback (useCallback in useGameState), not
@@ -870,15 +827,11 @@ function RollAndChooseArea({
   useEffect(() => {
     if (iWonRoll || myRollAcked) return;
     if (phase !== 'rolling') return;
-    if (skipped) {
-      acknowledgeRoll();
-      return;
-    }
     const timer = setTimeout(() => {
       acknowledgeRoll();
     }, RITUAL_TUMBLE_MS + ROLLING_RESULT_DISPLAY_MS);
     return () => clearTimeout(timer);
-  }, [iWonRoll, myRollAcked, phase, acknowledgeRoll, skipped]);
+  }, [iWonRoll, myRollAcked, phase, acknowledgeRoll]);
 
   // Countdown timer — synced to server deadline
   useEffect(() => {
@@ -974,13 +927,11 @@ function RevealArea({
   myPlayer,
   opponentName,
   iWonRoll,
-  skipped,
 }: {
   gameState: GameState;
   myPlayer: any;
   opponentName: string;
   iWonRoll: boolean;
-  skipped?: boolean;
 }) {
   const { game } = gameState;
   if (!game || !myPlayer) return null;
@@ -1011,15 +962,11 @@ function RevealArea({
   const acknowledgeFirst = gameState.pregameAcknowledgeFirst;
   useEffect(() => {
     if (alreadyAcked) return;
-    if (skipped) {
-      acknowledgeFirst();
-      return;
-    }
     const timer = setTimeout(() => {
       acknowledgeFirst();
     }, REVEAL_AUTO_ACK_MS);
     return () => clearTimeout(timer);
-  }, [alreadyAcked, acknowledgeFirst, skipped]);
+  }, [alreadyAcked, acknowledgeFirst]);
 
   return (
     <motion.div
@@ -1148,31 +1095,20 @@ function RitualDie({
   size,
   isWinner,
   revealed,
-  skipAnimation,
 }: {
   finalValue: number;
   accentColor: string;
   size: number;
   isWinner: boolean;
   revealed: boolean;
-  skipAnimation?: boolean;
 }) {
   const [displayValue, setDisplayValue] = useState<number | '?'>('?');
   const [isTumbling, setIsTumbling] = useState(false);
   const [showSparks, setShowSparks] = useState(false);
 
-  // Skip: immediately land on final value
   useEffect(() => {
-    if (skipAnimation && displayValue !== finalValue) {
-      setIsTumbling(false);
-      setDisplayValue(finalValue);
-      setShowSparks(true);
-    }
-  }, [skipAnimation, finalValue, displayValue]);
-
-  useEffect(() => {
-    if (!revealed || skipAnimation) {
-      if (!skipAnimation) setDisplayValue('?');
+    if (!revealed) {
+      setDisplayValue('?');
       return;
     }
 
@@ -1191,7 +1127,7 @@ function RitualDie({
     }, RITUAL_TUMBLE_MS / RITUAL_TUMBLE_FRAMES);
 
     return () => clearInterval(interval);
-  }, [revealed, finalValue, skipAnimation]);
+  }, [revealed, finalValue]);
 
   return (
     <div style={{ position: 'relative', width: size, height: size, margin: '0 auto' }}>


### PR DESCRIPTION
## What

Removes the **`Skip ▸`** button from the pregame "who goes first" d20 ceremony and all of its plumbing (`skipped` / `skipAnimation` / `diceSkipped` props and state threaded through `PlayerCards`, `InlineDie`, `RitualDie`, `RollAndChooseArea`, `RevealArea`, and `PregameCeremonyOverlay`).

## Why

The button couldn't do its job:

- **The result is server-authoritative.** `rollResult0/1` + `rollWinner` arrive in the *same* Game-row update that flips the phase to `rolling` and starts the tumble. The animation is pure client theater over an already-known outcome.
- **A ~1.2s animation can't be manually skipped.** The tumble is 600ms pause + 1200ms tumble (result shown ~1.9s). The `Skip ▸` control was a dim 40%-opacity, 11px link — a player can't notice, read, and tap it (one-handed, on a phone) before the animation it's meant to skip has already finished. It's a race the human loses by construction.
- **It can't touch the actual wait.** The real friction is the **loser** sitting on *"Waiting for them to choose who goes first…"* for up to 30s while the winner decides — and that's a genuine two-party decision no client button can shortcut. The skip button isn't even rendered during the winner's `choosing` phase.

A decision panel of three independent reviewers landed 2–1 on removal (the dissent favored a persisted "don't show again" preference — noted as a possible follow-up below).

## Scope / safety

- Single file, **+7 / −71**. Normal reveal path is preserved (tumble on `revealed` → land on `finalValue` → "Winner" label → timer-based auto-acks).
- The separate `pregameSkipToReveal` "roll + choose in one step" reducer flow is **untouched**.
- `tsc --noEmit`: no new errors in `app/play/` (only pre-existing test-file errors remain).

## Follow-ups (out of scope)

- The up-to-30s **loser wait** is the real UX debt — a calmer waiting state or a shorter winner-decision timeout is where the next effort belongs.
- If a "skip ceremonies" escape hatch is still wanted, the right shape is a **remembered preference** (persist once → auto-fast-forward future rolls), not a per-game manual click against a 1.2s window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)