### PR TITLE
feat(battle): remove the brigade soft-check advisory

### DIFF
--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -90,7 +90,6 @@ import {
   battleSideOf,
   sideTotals,
   computeInitiative,
-  brigadeMismatch as computeBrigadeMismatch,
   siteAttachedSoulIds,
   parseMeekStats,
   type BattleCardLike,
@@ -168,16 +167,6 @@ interface BattleCardEntry {
   like: BattleCardLike;
 }
 
-/** Mirrors battleMath.ts's private isEnhancementSegment / the server's
- *  enhSegment: exact 'GE'/'EE' segment on cardType, split on '/' and
- *  trimmed — there is no literal "Enhancement" type. */
-function isBattleEnhancementSegment(cardType: string): boolean {
-  return cardType
-    .split('/')
-    .map((s) => s.trim())
-    .some((s) => s === 'GE' || s === 'EE');
-}
-
 /**
  * Whether the Field of Battle band should be open. Phase-driven (spec §4): open
  * while the turn player is in the 'battle' phase, OR whenever battleState is
@@ -192,19 +181,6 @@ export function isBattleBandActive(
   battleState: string,
 ): boolean {
   return status === 'playing' && (currentPhase === 'battle' || battleState !== '');
-}
-
-/**
- * Whether a battle card should get the enhancement brigade soft-check. A dual
- * GE/Character card (e.g. Fire Foxes, "GE/Evil Character") can be played as its
- * CHARACTER side — a being in the band, not an enhancement on a character — so
- * the enhancement brigade rule doesn't apply. Exclude anything that is also a
- * character to avoid false "no matching brigade, discard it" flags. (Downside:
- * a dual card played AS an enhancement with a mismatched brigade won't be
- * flagged — acceptable for a soft advisory, since the mode isn't tracked.)
- */
-export function isBrigadeCheckableEnhancement(cardType: string): boolean {
-  return isBattleEnhancementSegment(cardType) && !isCharacterCard({ cardType });
 }
 
 /** Mirrors battleMath.ts's private isLostSoulLike / the server's
@@ -5327,32 +5303,6 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
     return entries;
   }, [battleActive, mpLayout, rawMain.cardWidth, gameState.myPlayer, gameState.opponentPlayer, myCards, opponentCards, forgeResolver]);
 
-  // Brigade soft-check (spec §6): every GE/EE-segment enhancement in the band
-  // whose brigade has no match among same-side characters. Order follows
-  // battleCardEntries (my cards, then opponent cards) so "show the first" is
-  // deterministic; the full list drives the red glow on every mismatched
-  // card, while only mismatchedBattleCards[0] gets the one interactive toast.
-  const mismatchedBattleCards = useMemo(() => {
-    if (battleCardEntries.length === 0) return [] as BattleCardEntry[];
-    const result: BattleCardEntry[] = [];
-    for (const entry of battleCardEntries) {
-      if (!isBrigadeCheckableEnhancement(entry.like.cardType)) continue;
-      const side = battleSideOf(entry.like);
-      const sameSideCharacters = battleCardEntries
-        .filter((e) => e !== entry && battleSideOf(e.like) === side && isCharacterCard({ cardType: e.like.cardType }))
-        .map((e) => e.like);
-      if (computeBrigadeMismatch(entry.like, sameSideCharacters)) {
-        result.push(entry);
-      }
-    }
-    return result;
-  }, [battleCardEntries]);
-
-  const mismatchedBattleCardIds = useMemo(
-    () => new Set(mismatchedBattleCards.map((e) => String(e.row.id))),
-    [mismatchedBattleCards],
-  );
-
   // Stakes Lost Soul rows (spec §5 header: Rescue attempt vs. Battle
   // challenge; spec §7/§8: Task 14's awaiting-soul picker eligibility).
   // Mirrors the server's battleStakesLobLostSouls exactly: T1/T2 use the
@@ -5657,7 +5607,6 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
   // player plays into their own RIGHT half (spec §3), so the cue always
   // renders on the viewer's own right half — never re-derive side
   // membership, reuse `battleSideOf` + `isCharacterCard` exactly like the
-  // same-side-character scan above (mismatchedBattleCards) and the
   // empty-side checks inside computeInitiative. Text-only memo (not the
   // Konva nodes themselves) — the actual Group is rendered as a plain
   // conditional near the band background (below card nodes in z-order),
@@ -6830,7 +6779,6 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
                     isSelected={isSelected(String(card.id))}
                     isDraggable={!isSpectator}
                     hoverProgress={hoveredInstanceId === String(card.id) ? hoverProgress : 0}
-                    brigadeMismatch={mismatchedBattleCardIds.has(String(card.id))}
                     nodeRef={registerCardNode}
                     onClick={handleCardClick}
                     onDragStart={handleCardDragStart}
@@ -8357,87 +8305,6 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
           })}
         </div>
       )}
-
-      {/* ================================================================
-          Brigade-mismatch toast (Battle Zone soft-check, spec §6, Task 12).
-          Every existing overlay (game toasts, emote overlay, request
-          banners) is pointerEvents:none and top/bottom-anchored — none can
-          host a button, so this gets its own band-edge-anchored container
-          with pointer events enabled. zIndex 600 sits between the drag
-          overlay (450) and GameToast (900). One toast at a time (the first
-          mismatched card, by battleCardEntries order); it disappears on its
-          own once that card leaves the band or the mismatch resolves, since
-          it's a pure function of live battle state — no local dismiss state
-          needed. Never rendered for spectators.
-          ================================================================ */}
-      {!isSpectator && battleActive && gameStatus === 'playing' && mpLayout?.zones.battle && mismatchedBattleCards.length > 0 && (() => {
-        const band = mpLayout.zones.battle;
-        const toastCard = mismatchedBattleCards[0];
-        // Band-edge-anchored: the band's bottom-right corner, clear of the
-        // header/banner (centered) and the totals chips (top corners). The
-        // 250-unit width is reserved in VIRTUAL space, so both corners go
-        // through virtualToScreen and the CSS width is their difference
-        // (the dragHoverZone pattern above) — a raw `width: 250` in screen
-        // px would exceed the reserved virtual span whenever scale < 1.
-        //
-        // BOTTOM-anchored (translateY(-100%)) with the bottom edge pinned
-        // just inside the band: the box grows UPWARD into the band as its
-        // text wraps, never downward — the resolution buttons / awaiting-
-        // soul pill (BattleResolutionUI) sit just BELOW the band's bottom
-        // edge (band bottom + 6), so a top-anchored box that wrapped taller
-        // at small scales used to spill down and cover them. Fonts/padding
-        // additionally scale with the canvas scale (floored at 0.75 → 9px
-        // minimum font, the legibility floor) so the box shrinks roughly
-        // with the band instead of swallowing it at small scales.
-        const toastVirtualWidth = 250;
-        const anchorY = band.y + band.height - 6;
-        const screenBottomLeft = virtualToScreen(band.x + band.width - toastVirtualWidth - 8, anchorY, scale, offsetX, offsetY);
-        const screenRight = virtualToScreen(band.x + band.width - 8, anchorY, scale, offsetX, offsetY);
-        const toastScale = Math.max(0.75, Math.min(1, scale));
-        return (
-          <div style={{ position: 'absolute', inset: 0, pointerEvents: 'none', zIndex: 600 }}>
-            <div
-              style={{
-                position: 'absolute',
-                left: screenBottomLeft.x,
-                top: screenBottomLeft.y,
-                transform: 'translateY(-100%)',
-                width: screenRight.x - screenBottomLeft.x,
-                pointerEvents: 'auto',
-                background: 'rgba(14, 10, 6, 0.95)',
-                border: '1px solid rgba(220, 38, 38, 0.5)',
-                borderRadius: 8,
-                padding: `${10 * toastScale}px ${12 * toastScale}px`,
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 8 * toastScale,
-                boxShadow: '0 8px 32px rgba(0,0,0,0.7)',
-              }}
-            >
-              <div style={{ fontSize: 12 * toastScale, color: '#e8bfbf', fontFamily: 'var(--font-cinzel), Georgia, serif', lineHeight: 1.4 }}>
-                No matching brigade in battle — REG says discard it
-              </div>
-              <button
-                onClick={() => moveCard(toastCard.row.id, 'discard')}
-                style={{
-                  alignSelf: 'flex-start',
-                  padding: `${6 * toastScale}px ${14 * toastScale}px`,
-                  background: '#5a2727',
-                  border: '1px solid #8a4242',
-                  borderRadius: 6,
-                  color: '#e8bfbf',
-                  fontSize: 12 * toastScale,
-                  fontFamily: 'var(--font-cinzel), Georgia, serif',
-                  letterSpacing: '0.05em',
-                  cursor: 'pointer',
-                }}
-              >
-                Discard
-              </button>
-            </div>
-          </div>
-        );
-      })()}
 
       {/* ================================================================
           Battle resolution buttons (spec §8, Task 13) — dispatch

--- a/app/play/components/__tests__/isHandCardFaceVisible.test.ts
+++ b/app/play/components/__tests__/isHandCardFaceVisible.test.ts
@@ -19,7 +19,6 @@ import {
   isFaceDownInPlayCardVisible,
   canViewerToggleMeek,
   isBattleBandActive,
-  isBrigadeCheckableEnhancement,
 } from '../MultiplayerCanvas';
 
 // Unit coverage for the hand-card visibility predicate that gates whether a
@@ -309,31 +308,5 @@ describe('isBattleBandActive', () => {
 
   it('closed while waiting (pre-game)', () => {
     expect(isBattleBandActive('waiting', 'battle', 'active')).toBe(false);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// isBrigadeCheckableEnhancement — only PURE enhancements get the brigade
-// soft-check. A dual GE/Character card (Fire Foxes) played as its character
-// side must NOT be flagged "no matching brigade, discard it".
-// ---------------------------------------------------------------------------
-
-describe('isBrigadeCheckableEnhancement', () => {
-  it('checks a pure Good/Evil Enhancement', () => {
-    expect(isBrigadeCheckableEnhancement('GE')).toBe(true);
-    expect(isBrigadeCheckableEnhancement('EE')).toBe(true);
-    expect(isBrigadeCheckableEnhancement('GE/EE')).toBe(true);
-  });
-
-  it('does NOT check a dual GE/Character card (Fire Foxes: "GE/Evil Character")', () => {
-    expect(isBrigadeCheckableEnhancement('GE/Evil Character')).toBe(false);
-    expect(isBrigadeCheckableEnhancement('EE/Evil Character')).toBe(false);
-    expect(isBrigadeCheckableEnhancement('GE/Hero')).toBe(false);
-  });
-
-  it('does NOT check a plain character or non-enhancement', () => {
-    expect(isBrigadeCheckableEnhancement('Hero')).toBe(false);
-    expect(isBrigadeCheckableEnhancement('Evil Character')).toBe(false);
-    expect(isBrigadeCheckableEnhancement('Dominant')).toBe(false);
   });
 });

--- a/app/play/lib/__tests__/battleMath.test.ts
+++ b/app/play/lib/__tests__/battleMath.test.ts
@@ -3,7 +3,6 @@ import {
   battleSideOf,
   sideTotals,
   computeInitiative,
-  brigadeMismatch,
   summarizeAutoReturn,
   siteAttachedSoulIds,
   parseMeekStats,
@@ -296,95 +295,6 @@ describe('computeInitiative — empty-side and unknown-stat states', () => {
     // Both sides populated with real characters -> falls through to the REG table,
     // not waiting-blocker/no-attacker.
     expect(computeInitiative(cards, '0', '')).toEqual({ kind: 'initiative', seat: '0', reason: 'losing' });
-  });
-});
-
-describe('brigadeMismatch', () => {
-  it('exact single-brigade match -> no mismatch', () => {
-    const enh = mkCard({ brigade: 'Good Gold' });
-    const chars = [mkCard({ brigade: 'Good Gold' })];
-    expect(brigadeMismatch(enh, chars)).toBe(false);
-  });
-
-  it('no matching brigade among same-side characters -> mismatch', () => {
-    const enh = mkCard({ brigade: 'Good Gold' });
-    const chars = [mkCard({ brigade: 'Evil Brown' })];
-    expect(brigadeMismatch(enh, chars)).toBe(true);
-  });
-
-  it('"Multi" on the enhancement matches anything', () => {
-    const enh = mkCard({ brigade: 'Multi' });
-    const chars = [mkCard({ brigade: 'Evil Brown' })];
-    expect(brigadeMismatch(enh, chars)).toBe(false);
-  });
-
-  it('"Good Multi" / "Evil Multi" on a character matches any enhancement brigade', () => {
-    const enh = mkCard({ brigade: 'Good Gold' });
-    const chars = [mkCard({ brigade: 'Evil Multi' })];
-    expect(brigadeMismatch(enh, chars)).toBe(false);
-  });
-
-  it('empty/neutral brigade on the enhancement matches anything', () => {
-    const enh = mkCard({ brigade: '' });
-    const chars = [mkCard({ brigade: 'Evil Brown' })];
-    expect(brigadeMismatch(enh, chars)).toBe(false);
-  });
-
-  it('"Good Gold/Evil Gold" splits on "/" and matches a character with just "Evil Gold"', () => {
-    const enh = mkCard({ brigade: 'Good Gold/Evil Gold' });
-    const chars = [mkCard({ brigade: 'Evil Gold' })];
-    expect(brigadeMismatch(enh, chars)).toBe(false);
-  });
-
-  it('no same-side characters present + a real enhancement brigade -> mismatch', () => {
-    const enh = mkCard({ brigade: 'Good Gold' });
-    expect(brigadeMismatch(enh, [])).toBe(true);
-  });
-
-  it('no same-side characters present + neutral enhancement brigade -> still no mismatch', () => {
-    const enh = mkCard({ brigade: '' });
-    expect(brigadeMismatch(enh, [])).toBe(false);
-  });
-
-  it('forge "Good Gold" enhancement matches an official plain "Gold" character', () => {
-    // Official card data writes plain "Gold" for both good and evil gold;
-    // forge brigades keep them distinct ("Good Gold"/"Evil Gold"). The
-    // soft-check must not flag a forge/official pair over that naming gap.
-    const enh = mkCard({ brigade: 'Good Gold' });
-    const chars = [mkCard({ brigade: 'Gold' })];
-    expect(brigadeMismatch(enh, chars)).toBe(false);
-  });
-
-  it('official plain "Gold" enhancement matches a forge "Evil Gold" character', () => {
-    const enh = mkCard({ brigade: 'Gold' });
-    const chars = [mkCard({ brigade: 'Evil Gold' })];
-    expect(brigadeMismatch(enh, chars)).toBe(false);
-  });
-
-  it('meek-notation character brigade "White (Clay)" matches a White enhancement', () => {
-    // Mary, Holy Virgin (GoC) stores "White (Clay)" (White normally, Clay when
-    // meek). The Child is Born (GoC) is "Silver/White" — its White matches her.
-    const enh = mkCard({ brigade: 'Silver/White' });
-    const chars = [mkCard({ brigade: 'White (Clay)' })];
-    expect(brigadeMismatch(enh, chars)).toBe(false);
-  });
-
-  it('meek-notation sub brigade also counts for matching', () => {
-    const enh = mkCard({ brigade: 'Clay' });
-    const chars = [mkCard({ brigade: 'White (Clay)' })];
-    expect(brigadeMismatch(enh, chars)).toBe(false);
-  });
-
-  it('multi-word brigade inside the parenthetical is not split on whitespace', () => {
-    const enh = mkCard({ brigade: 'Pale Green' });
-    const chars = [mkCard({ brigade: 'Green (Pale Green)' })];
-    expect(brigadeMismatch(enh, chars)).toBe(false);
-  });
-
-  it('meek-notation character still mismatches an unrelated enhancement brigade', () => {
-    const enh = mkCard({ brigade: 'Gold' });
-    const chars = [mkCard({ brigade: 'White (Clay)' })];
-    expect(brigadeMismatch(enh, chars)).toBe(true);
   });
 });
 

--- a/app/play/lib/battleMath.ts
+++ b/app/play/lib/battleMath.ts
@@ -212,53 +212,6 @@ export function computeInitiative(
   return { kind: 'initiative', seat, reason: a && b ? 'stalemate' : 'mutual-destruction' };
 }
 
-const BRIGADE_WILDCARDS = new Set(['Multi', 'Good Multi', 'Evil Multi']);
-
-function brigadeTokens(brigade: string): string[] {
-  // A brigade string can carry a parenthetical: the meek brigade on a
-  // character ("White (Clay)" — White normally, Clay when meek) or the
-  // character-side brigade on a dual GE/character card ("Green (Crimson)").
-  // Both the main and the parenthetical brigades count for matching, so pull
-  // the parens apart. Each part is a '/'-separated list; brigade names may
-  // themselves contain spaces ("Pale Green"), so we never split on whitespace.
-  const parenIdx = brigade.indexOf('(');
-  const parts =
-    parenIdx === -1
-      ? [brigade]
-      : [brigade.slice(0, parenIdx), brigade.slice(parenIdx + 1).replace(')', '')];
-  return parts
-    .flatMap((p) => p.split('/'))
-    .map((s) => s.trim())
-    // Forge brigades keep good/evil gold distinct ("Good Gold"/"Evil Gold");
-    // official card data writes plain "Gold" for both. Fold them together so
-    // a forge/official pair isn't flagged over the naming gap.
-    .map((s) => (s === 'Good Gold' || s === 'Evil Gold' ? 'Gold' : s))
-    .filter((s) => s.length > 0);
-}
-
-/**
- * REG "brigade soft-check": true when `enh` has no matching brigade among
- * `sameSideCharacters` and should be flagged. Tokens are split on '/' and
- * trimmed, case-preserving (exact string compare). A neutral/empty brigade
- * on the enhancement matches anything; 'Multi'/'Good Multi'/'Evil Multi' on
- * EITHER the enhancement or a character matches anything. With no matching
- * character present at all, a real (non-neutral, non-wildcard) enhancement
- * brigade is always a mismatch.
- */
-export function brigadeMismatch(enh: BattleCardLike, sameSideCharacters: BattleCardLike[]): boolean {
-  const enhTokens = brigadeTokens(enh.brigade);
-  if (enhTokens.length === 0) return false;
-  if (enhTokens.some((t) => BRIGADE_WILDCARDS.has(t))) return false;
-
-  for (const ch of sameSideCharacters) {
-    const chTokens = brigadeTokens(ch.brigade);
-    if (chTokens.some((t) => BRIGADE_WILDCARDS.has(t))) return false;
-    if (enhTokens.some((t) => chTokens.includes(t))) return false;
-  }
-
-  return true;
-}
-
 export interface AutoReturnSummary {
   toTerritory: number;
   toOrigin: number;

--- a/app/play/utils/__tests__/forgeResolver.test.ts
+++ b/app/play/utils/__tests__/forgeResolver.test.ts
@@ -67,10 +67,10 @@ describe("forge image seams", () => {
 });
 
 describe("resolveBattleRowFields", () => {
-  // Battle-zone math (totals/initiative/brigade soft-check) reads CardInstance
-  // rows whose text fields the leak spine blanked for forge cards. The viewer's
-  // granted resolver must re-hydrate name/brigade/stats or forge cards read as
-  // unknown stats and false brigade mismatches.
+  // Battle-zone math (totals/initiative) reads CardInstance rows whose text
+  // fields the leak spine blanked for forge cards. The viewer's granted
+  // resolver must re-hydrate name/brigade/stats or forge cards read as unknown
+  // stats.
   const blankRow = { cardImgFile: `forge:${ID}`, cardName: "", brigade: "", strength: "", toughness: "" };
 
   it("re-hydrates a granted forge row's name/brigade/stats", () => {

--- a/app/shared/components/GameCardNode.tsx
+++ b/app/shared/components/GameCardNode.tsx
@@ -67,10 +67,6 @@ export interface GameCardNodeProps {
   /** When true, plays a one-shot amber pulse glow: a brief fade-in + bloom,
    *  followed by a longer fade-out. Total duration ~1.8s. */
   lobArrivalGlow?: boolean;
-  /** When true (Battle Zone brigade soft-check), renders a continuous red
-   *  pulsing glow — "this enhancement has no matching-brigade character on
-   *  its side" (spec §6). Non-blocking warning, not a hard-block indicator. */
-  brigadeMismatch?: boolean;
   /** When true, suppress the per-card reveal countdown ring. Used when
    *  rendering the local viewer's own hand — the ring is meant for the
    *  receiving party (opponent), not the holder. */
@@ -107,7 +103,6 @@ export const GameCardNode = memo(function GameCardNode({
   isDraggable = true,
   hoverProgress,
   lobArrivalGlow,
-  brigadeMismatch,
   suppressRevealRing,
   nodeRef,
   onDragStart,
@@ -137,8 +132,6 @@ export const GameCardNode = memo(function GameCardNode({
 
   // Ref for the LOB arrival glow rect — used to run an imperative Konva Tween
   const arrivalGlowRef = useRef<Konva.Rect | null>(null);
-  // Ref for the brigade-mismatch glow rect — continuous pulse via yoyo tween.
-  const mismatchGlowRef = useRef<Konva.Rect | null>(null);
 
   useEffect(() => {
     const node = arrivalGlowRef.current;
@@ -184,38 +177,6 @@ export const GameCardNode = memo(function GameCardNode({
       node.opacity(0);
     }
   }, [lobArrivalGlow]);
-
-  // Brigade-mismatch glow — continuous pulse for as long as the mismatch
-  // holds (unlike the one-shot arrival bloom above). Reuses the same
-  // imperative-Tween idiom: a yoyo'd opacity tween looping indefinitely is
-  // cheap here because mismatches are rare (typically 0-1 cards at a time),
-  // unlike the LOB arrival glow which fires on every card that lands in a
-  // LOB and therefore avoids shadowBlur for perf. A handful of concurrent
-  // mismatch glows is an acceptable tradeoff for the "pulsing" requirement.
-  useEffect(() => {
-    const node = mismatchGlowRef.current;
-    if (!node) return;
-
-    if (brigadeMismatch) {
-      node.visible(true);
-      node.opacity(0.35);
-      const tween = new KonvaLib.Tween({
-        node,
-        duration: 0.9,
-        opacity: 0.85,
-        easing: KonvaLib.Easings.EaseInOut,
-        yoyo: true,
-        repeat: -1,
-      });
-      tween.play();
-      return () => {
-        tween.destroy();
-      };
-    } else {
-      node.visible(false);
-      node.opacity(0);
-    }
-  }, [brigadeMismatch]);
 
   const groupRefCb = useCallback((node: Konva.Group | null) => {
     nodeRef?.(card.instanceId, node);
@@ -292,27 +253,6 @@ export const GameCardNode = memo(function GameCardNode({
         stroke="#e8b86a"
         strokeWidth={1.5}
         cornerRadius={6}
-        visible={false}
-        opacity={0}
-        listening={false}
-        perfectDrawEnabled={false}
-      />
-
-      {/* Brigade-mismatch glow — red pulsing border (Battle Zone soft-check,
-          spec §6). opacity is animated imperatively in the effect above. */}
-      <Rect
-        ref={mismatchGlowRef as any}
-        x={-2}
-        y={-2}
-        width={cardWidth + 4}
-        height={cardHeight + 4}
-        fill="transparent"
-        stroke="#dc2626"
-        strokeWidth={2.5}
-        cornerRadius={6}
-        shadowColor="#dc2626"
-        shadowBlur={12}
-        shadowOpacity={0.7}
         visible={false}
         opacity={0}
         listening={false}


### PR DESCRIPTION
## Summary
- Removes the non-blocking "no matching brigade in battle — REG says discard it" toast advisory
- Removes the red pulsing mismatch glow on battle enhancements and the `brigadeMismatch` computation that drove both (battle zone spec §6)
- Keeps `battleCardEntries` / `battleSideOf`, which are still used by battle totals and initiative

## Why
The soft check produced noise during normal play without blocking anything, and brigade legality is better left to the players (the game is played manually — see spec).

## Testing
- `vitest run` on the touched test suites: 62 tests pass (`battleMath`, `forgeResolver`)
- Deleted the brigade-mismatch test cases along with the feature
- `tsc --noEmit` shows no errors in touched files (remaining errors are pre-existing in unrelated test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)