### PR TITLE
fix(battle): center floating board dialogs on the play mat, not the viewport

### DIFF
--- a/app/play/components/BattleResolutionUI.tsx
+++ b/app/play/components/BattleResolutionUI.tsx
@@ -127,10 +127,15 @@ function ResolutionButton({ label, tone, onClick }: { label: string; tone: Tone;
  * the picker. No opaque full-screen backdrop — the picker's own bounds are
  * kept small (max-height + scroll) specifically so it doesn't block the
  * chooser's view of the band behind it (spec §8).
+ *
+ * The picker centers on `centerX` — the band's horizontal midline in screen
+ * px, i.e. the middle of the play mat. Viewport centering sat visibly right
+ * of the board (the sidebar piles + chat column all live on the right).
  */
 function AwaitingSoulUI({
   topLeft,
   right,
+  centerX,
   mySeat,
   opponentSeat,
   attackerSeat,
@@ -148,6 +153,8 @@ function AwaitingSoulUI({
 }: {
   topLeft: { x: number; y: number };
   right: { x: number; y: number };
+  /** Horizontal midline of the battle band (= the play mat) in screen px. */
+  centerX: number;
   mySeat: string;
   opponentSeat: string;
   attackerSeat: string;
@@ -230,17 +237,18 @@ function AwaitingSoulUI({
   return (
     <div
       style={{
-        position: 'fixed',
+        position: 'absolute',
         inset: 0,
         zIndex: 900,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
         pointerEvents: 'none',
       }}
     >
       <div
         style={{
+          position: 'absolute',
+          left: centerX,
+          top: '50%',
+          transform: 'translate(-50%, -50%)',
           pointerEvents: 'auto',
           background: 'rgba(14, 10, 6, 0.97)',
           border: '1px solid rgba(107, 78, 39, 0.3)',
@@ -473,12 +481,16 @@ export default function BattleResolutionUI({
   const rowVirtualWidth = 300;
   const topLeft = virtualToScreen(band.x + 8, band.y + band.height - 8, scale, offsetX, offsetY);
   const right = virtualToScreen(band.x + 8 + rowVirtualWidth, band.y + band.height - 8, scale, offsetX, offsetY);
+  // Band horizontal midline = play-mat midline (the band spans the play area
+  // edge to edge) — the soul picker centers on this, not the viewport.
+  const bandCenterX = virtualToScreen(band.x + band.width / 2, band.y, scale, offsetX, offsetY).x;
 
   if (battleState === 'awaiting-soul') {
     return (
       <AwaitingSoulUI
         topLeft={topLeft}
         right={right}
+        centerX={bandCenterX}
         mySeat={mySeat}
         opponentSeat={opponentSeat}
         attackerSeat={attackerSeat}

--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -633,6 +633,11 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
     () => calculateMultiplayerLayout(virtualWidth, VIRTUAL_HEIGHT, normalizedFormat, viewerKind === 'spectator' ? 'spectator' : 'player', battleActive),
     [virtualWidth, normalizedFormat, viewerKind, battleActive],
   );
+  // Horizontal midline of the play mat (play area sans sidebar piles) in
+  // screen px — dialogs that float over the board center on this rather than
+  // the viewport/container midline, both of which sit visibly right of the
+  // board (sidebar piles + chat column all live on the right).
+  const playCenterScreenX = virtualToScreen(mpLayout.playAreaWidth / 2, 0, scale, offsetX, offsetY).x;
   // Band rect used for battle DROPS. While the band is still closed (a
   // divider-proxy drop that opens the battle) the current layout has no
   // battle rect yet, so normalize against the rect the band WILL have once
@@ -9357,15 +9362,16 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
             position: 'fixed',
             inset: 0,
             zIndex: 950,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
             background: 'rgba(0,0,0,0.4)',
           }}
           onClick={() => dismissPendingReserveMove(pendingReserveMove, false)}
         >
           <div
             style={{
+              position: 'absolute',
+              left: playCenterScreenX,
+              top: '50%',
+              transform: 'translate(-50%, -50%)',
               background: 'var(--gf-bg, #1a1510)',
               border: '1px solid var(--gf-border, #3a3428)',
               borderRadius: 10,
@@ -9536,6 +9542,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
 
       {countPrompt && (
         <CountPromptDialog
+          centerX={playCenterScreenX}
           req={{
             ...countPrompt,
             onConfirm: (count) => {

--- a/app/shared/components/CountPromptDialog.tsx
+++ b/app/shared/components/CountPromptDialog.tsx
@@ -5,9 +5,13 @@ import type { CountPromptRequest } from '../types/gameActions';
 
 interface CountPromptDialogProps {
   req: CountPromptRequest;
+  /** Screen-px X (relative to the positioned canvas container) to center on —
+   *  the play mat's midline. Defaults to the container's own midline, which
+   *  includes the sidebar piles and so sits right of the board. */
+  centerX?: number;
 }
 
-export function CountPromptDialog({ req }: CountPromptDialogProps) {
+export function CountPromptDialog({ req, centerX }: CountPromptDialogProps) {
   const [count, setCount] = useState(req.defaultCount);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -37,7 +41,7 @@ export function CountPromptDialog({ req }: CountPromptDialogProps) {
       style={{
         position: 'absolute',
         top: '50%',
-        left: '50%',
+        left: centerX ?? '50%',
         transform: 'translate(-50%, -50%)',
         zIndex: 900,
         pointerEvents: 'auto',


### PR DESCRIPTION
## Problem

The **"Choose a Lost Soul to rescue"** picker centered on the **viewport** (`position: fixed; inset: 0` + flex centering). But everything to the right of the play mat — the zone-pile sidebar and the preview/chat column — pushes the board's visual center well left of the viewport's, so the picker floated noticeably right of the field of battle.

## Fix

Anchor it to the **battle band's horizontal midline** (the band spans the play area edge to edge, so band center = play-mat center), computed with the same `virtualToScreen` idiom the resolution-button row already uses. Vertical centering unchanged.

## Same-class fixes (other dialogs that float over the board)

- **Turn-1 reserve-protection confirm** — was viewport-centered; now anchors to the play-mat midline (backdrop unchanged).
- **CountPromptDialog** (draw-N prompt) — was centered on the canvas container, which includes the sidebar piles, so it sat ~half a sidebar right of the board. Now takes an optional `centerX`; the multiplayer canvas passes the play-mat midline. Goldfish keeps the default (container midline) — untouched behavior.

## Considered and left alone

- **Concede / Leave / Game-over modals** — full-screen takeovers with backdrops that already deliberately offset for the loupe/chat column.
- **TargetCardOverlay banner** — top chrome aligned under the phase bar, not a board-floating dialog.
- **Waiting pill / resolution buttons / battle toasts** — already band-anchored.

## Verification

`tsc --noEmit`: only the 7 pre-existing errors also present on clean `origin/main` (test files unrelated to this change); none in the three touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)