### PR TITLE
fix(card-search): eliminate horizontal scroll jitter on mobile results

### DIFF
--- a/app/decklist/card-search/client.tsx
+++ b/app/decklist/card-search/client.tsx
@@ -1720,7 +1720,7 @@ export default function CardSearchClient({
       {/* Left panel: Card search */}
       {showSearch && (
         <div className="flex-1 flex flex-col overflow-hidden min-w-0">
-        <div className="bg-background text-foreground transition-colors duration-200 flex-1 flex flex-col overflow-auto md:overflow-hidden">
+        <div className="bg-background text-foreground transition-colors duration-200 flex-1 flex flex-col overflow-y-auto overflow-x-hidden md:overflow-hidden">
           <div className="p-1.5 md:p-2 flex flex-col items-center md:sticky md:top-0 z-40 bg-background text-foreground border-b border-border shadow-sm">
         <div className="relative w-full px-1 md:px-2 flex flex-col items-center justify-center gap-1.5 md:gap-2">
           <div className="w-full flex flex-col gap-1.5 md:gap-2 text-center">
@@ -2218,7 +2218,7 @@ export default function CardSearchClient({
         )}
       </div>
       {/* Collapse/Expand Filter Grid Button — mobile only (on desktop it's in the search header) */}
-      <div className={`flex-shrink-0 ${!filterGridCollapsed ? 'sticky top-0 z-30' : ''} flex md:hidden flex-row items-center justify-between px-3 py-1.5 bg-background border-b border-border`}>
+      <div className={`flex-shrink-0 ${!filterGridCollapsed ? 'sticky top-0 z-30' : ''} flex md:hidden flex-row flex-wrap items-center justify-between gap-y-1.5 px-3 py-1.5 bg-background border-b border-border`}>
         <div className="flex items-center gap-1.5">
           <label htmlFor="card-sort-mobile" className="text-xs text-muted-foreground font-medium">Sort:</label>
           <select


### PR DESCRIPTION
## Problem

On the mobile search tab, scrolling the results felt "slippery" — it drifted side-to-side during vertical scroll, worse on smaller displays.

Root cause: the mobile results scroll container used `overflow-auto` (both axes), so touch momentum drifted horizontally even when content fit. On ≤~340px screens the mobile Sort/CSV/Filters toolbar is also ~21px too wide, turning that spill into real horizontal scroll.

## Change

- Make the results container **vertical-only**: `overflow-auto` → `overflow-y-auto overflow-x-hidden` (desktop keeps `md:overflow-hidden`).
- Let the mobile toolbar **wrap** (`flex-wrap gap-y-1.5`) so on very narrow screens the Filters control moves to a second line instead of forcing horizontal scroll (never clipped).

## Verification

Measured against the live site at **320 / 360 / 390px**: horizontal overflow is 0, vertical scroll still works, and the Filters control is fully visible at every width. No change at ≥360px (toolbar fits on one line, no overflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)