### PR TITLE
chore(nav): hide Nationals 2026 registration button

### DIFF
--- a/components/top-nav.tsx
+++ b/components/top-nav.tsx
@@ -17,7 +17,8 @@ import { createClient } from "../utils/supabase/client";
 import { getUserSafe } from "../utils/supabase/getUserSafe";
 import { signOutAction } from "../app/actions";
 import { useIsAdmin } from "../hooks/useIsAdmin";
-import { NATIONALS_CONFIG } from "../app/config/nationals";
+// Hidden until Nationals 2026 registration reopens next year — see commented nav link below.
+// import { NATIONALS_CONFIG } from "../app/config/nationals";
 
 // @supabase/ssr's createBrowserClient is already a singleton in the browser,
 // but binding the result to a module-level const keeps the JS reference stable
@@ -127,7 +128,8 @@ const TopNav: React.FC = () => {
   type NavLink = { href: string; label: string; icon: IconType; highlight?: boolean; authRequired?: boolean; isNew?: boolean };
 
   const navLinks: NavLink[] = [
-    { href: "/register", label: NATIONALS_CONFIG.adminOnly ? `${NATIONALS_CONFIG.displayName} (Admin Only)` : `${NATIONALS_CONFIG.displayName}`, icon: HiUserAdd, highlight: true },
+    // Hidden until Nationals 2026 registration reopens next year — re-enable this link and the NATIONALS_CONFIG import above.
+    // { href: "/register", label: NATIONALS_CONFIG.adminOnly ? `${NATIONALS_CONFIG.displayName} (Admin Only)` : `${NATIONALS_CONFIG.displayName}`, icon: HiUserAdd, highlight: true },
     { href: "/play", label: "Play", icon: GiCrossedSwords },
     { href: "/decklist/card-search?new=true", label: "Deck Builder", icon: TbSearch },
     { href: "/spoilers", label: "Spoilers", icon: HiSparkles },


### PR DESCRIPTION
## What

Hides the **Nationals 2026** registration button from the top nav (desktop + mobile) by commenting out its entry in `navLinks`, along with the now-unused `NATIONALS_CONFIG` import.

## Why

Nationals 2026 registration is closed; the button should be hidden until it reopens next year.

## Re-enabling next year

Uncomment two spots in [components/top-nav.tsx](components/top-nav.tsx):
1. The `NATIONALS_CONFIG` import near the top.
2. The `/register` entry in the `navLinks` array.

Both are left in place, commented, with a note pointing to each other — no config or logic was changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)