### PR TITLE
feat(deckcheck): make Roots 2 cards tournament legal

### DIFF
--- a/utils/deckcheck/__tests__/rules-t2.test.ts
+++ b/utils/deckcheck/__tests__/rules-t2.test.ts
@@ -1792,18 +1792,4 @@ describe("validateT2Rules", () => {
     );
     expect(quantityErrors).toHaveLength(1);
   });
-
-  // TEMPORARY: remove alongside checkRoots2NotYetLegal once Roots 2 is legal.
-  it("flags Roots 2 cards as not yet tournament legal", () => {
-    const roots2Card = makeCard({ name: "Timothy", set: "RR2" });
-    const mainDeck = makeValidMainDeck(100, [roots2Card]);
-    const cardGroups = [makeGroup("Timothy", [roots2Card])];
-
-    const issues = validateT2Rules(mainDeck, [], cardGroups);
-    expect(
-      issues.some(
-        (i) => i.rule === "roots2-not-yet-legal" && i.type === "error"
-      )
-    ).toBe(true);
-  });
 });

--- a/utils/deckcheck/__tests__/rules.test.ts
+++ b/utils/deckcheck/__tests__/rules.test.ts
@@ -25,7 +25,6 @@ import {
   checkVanillaLimit,
   checkSitesCitiesLimit,
   checkBannedCards,
-  checkRoots2NotYetLegal,
   checkSpecialCards,
   validateT1Rules,
 } from "../rules";
@@ -1612,45 +1611,6 @@ describe("Rule: checkBannedCards (t1-banned-card)", () => {
       makeCard({ name: "Aaron", set: "Priests" }),
     ];
     expect(checkBannedCards(cards, [])).toHaveLength(0);
-  });
-});
-
-// TEMPORARY: remove alongside checkRoots2NotYetLegal once Roots 2 is legal.
-describe("Rule: checkRoots2NotYetLegal (roots2-not-yet-legal)", () => {
-  it("flags a Roots 2 card in the main deck by set code", () => {
-    const card = makeCard({ name: "A New Creation [RR2]", set: "RR2" });
-    const issues = checkRoots2NotYetLegal([card], []);
-    expect(issues).toHaveLength(1);
-    expect(issues[0].rule).toBe("roots2-not-yet-legal");
-    expect(issues[0].type).toBe("error");
-    expect(issues[0].message).toContain("A New Creation [RR2]");
-    expect(issues[0].message).toContain("not yet tournament legal");
-  });
-
-  it("flags a Roots 2 card by official set name", () => {
-    const card = makeCard({ name: "Timothy", set: "Roots 2" });
-    expect(checkRoots2NotYetLegal([card], [])).toHaveLength(1);
-  });
-
-  it("flags a Roots 2 card in the reserve", () => {
-    const card = makeCard({ name: "Seth", set: "RR2", isReserve: true });
-    expect(checkRoots2NotYetLegal([], [card])).toHaveLength(1);
-  });
-
-  it("does NOT flag original Roots cards", () => {
-    const card = makeCard({ name: "David (Roots)", set: "Roots" });
-    expect(checkRoots2NotYetLegal([card], [])).toHaveLength(0);
-  });
-
-  it("skips cards with quantity 0", () => {
-    const card = makeCard({ name: "Seth", set: "RR2", quantity: 0 });
-    expect(checkRoots2NotYetLegal([card], [])).toHaveLength(0);
-  });
-
-  it("is surfaced by validateT1Rules", () => {
-    const mainDeck = [makeCard({ name: "Timothy", set: "RR2" })];
-    const issues = validateT1Rules(mainDeck, [], []);
-    expect(issues.some((i) => i.rule === "roots2-not-yet-legal")).toBe(true);
   });
 });
 

--- a/utils/deckcheck/rules.ts
+++ b/utils/deckcheck/rules.ts
@@ -928,41 +928,6 @@ export function checkBannedCards(
   return issues;
 }
 
-// ---------------------------------------------------------------------------
-// TEMPORARY: Roots 2 legality gate
-// ---------------------------------------------------------------------------
-
-// Roots 2 set markers: set code "RR2" (carddata column 2) and the official
-// set name, matched case-insensitively against ResolvedCard.set.
-const ROOTS_2_SETS = new Set(["rr2", "roots 2"]);
-
-/**
- * Rule: roots2-not-yet-legal — Roots 2 cards are not yet tournament legal.
- *
- * TEMPORARY: remove this function, its call in each validate*Rules entry
- * point, and its tests once Roots 2 becomes tournament legal.
- */
-export function checkRoots2NotYetLegal(
-  mainDeckCards: ResolvedCard[],
-  reserveCards: ResolvedCard[]
-): DeckCheckIssue[] {
-  const issues: DeckCheckIssue[] = [];
-
-  for (const card of [...mainDeckCards, ...reserveCards]) {
-    if (card.quantity === 0) continue;
-    if (ROOTS_2_SETS.has(card.set.toLowerCase())) {
-      issues.push({
-        type: "error",
-        rule: "roots2-not-yet-legal",
-        message: `"${card.name}" is from Roots 2, which is not yet tournament legal.`,
-        cards: [card.name],
-      });
-    }
-  }
-
-  return issues;
-}
-
 /**
  * Helper: check if a card matches one of the special exception cards.
  */
@@ -1098,9 +1063,6 @@ export function validateT1Rules(
   // Banned cards
   issues.push(...checkBannedCards(mainDeckCards, reserveCards));
 
-  // TEMPORARY: Roots 2 not yet tournament legal
-  issues.push(...checkRoots2NotYetLegal(mainDeckCards, reserveCards));
-
   // Special card exceptions
   issues.push(...checkSpecialCards(mainDeckCards, reserveCards, cardGroups));
 
@@ -1182,9 +1144,6 @@ export function validateParagonRules(
 
   // Banned cards
   issues.push(...checkBannedCards(mainDeckCards, reserveCards));
-
-  // TEMPORARY: Roots 2 not yet tournament legal
-  issues.push(...checkRoots2NotYetLegal(mainDeckCards, reserveCards));
 
   // Special card exceptions
   issues.push(...checkSpecialCards(mainDeckCards, reserveCards, cardGroups));
@@ -1669,9 +1628,6 @@ export function validateT2Rules(
   issues.push(...checkSitesCitiesLimit(mainDeckCards, reserveCards));
   issues.push(...checkBannedCards(mainDeckCards, reserveCards));
   issues.push(...checkSpecialCards(mainDeckCards, reserveCards, cardGroups));
-
-  // TEMPORARY: Roots 2 not yet tournament legal
-  issues.push(...checkRoots2NotYetLegal(mainDeckCards, reserveCards));
 
   // Character alias checks (dual-alignment characters with different names)
   issues.push(


### PR DESCRIPTION
## What

Removes the temporary **Roots 2 legality gate** so Roots 2 cards no longer show as illegal in the deck checker.

Previously, `checkRoots2NotYetLegal` flagged any card whose set was `RR2` / `Roots 2` with:

> "…" is from Roots 2, which is not yet tournament legal.

That gate was always documented as removable once Roots 2 became tournament legal.

## Changes

- Delete the `checkRoots2NotYetLegal` rule function and the `ROOTS_2_SETS` marker set in `utils/deckcheck/rules.ts`.
- Remove its three call sites — `validateT1Rules`, `validateParagonRules`, and `validateT2Rules` — so the change applies to every format.
- Remove the associated unit tests in `rules.test.ts` and `rules-t2.test.ts`.

Roots 2 cards are now subject to the same deck-building rules as any other legal set. Net: **98 deletions, no additions.**

## Verification

- `vitest run utils/deckcheck` → **316 tests pass**.
- `tsc --noEmit` → no new errors in deckcheck (the only failures are pre-existing, in unrelated forge/supabase test files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)