### PR TITLE
fix(nav): render desktop Play once, independent of array index

### DIFF
--- a/components/top-nav.tsx
+++ b/components/top-nav.tsx
@@ -204,7 +204,8 @@ const TopNav: React.FC = () => {
 
           {/* Desktop Navigation - Center */}
           <div className="hidden lg:flex lg:items-center lg:space-x-1 flex-1 justify-center">
-            {navLinks.slice(0, 1).map((link) => {
+            {/* Highlighted lead link (e.g. Nationals registration) — only when present */}
+            {navLinks.filter((link) => link.highlight).map((link) => {
               const Icon = link.icon;
               const isHighlight = link.highlight;
               return (
@@ -387,8 +388,8 @@ const TopNav: React.FC = () => {
               )}
             </div>
 
-            {/* Rest of nav links */}
-            {navLinks.slice(2).map((link) => {
+            {/* Rest of nav links (Play is rendered separately above, so exclude it) */}
+            {navLinks.filter((link) => !link.highlight && link.href !== "/play").map((link) => {
               if (link.authRequired && !user) return null;
               const Icon = link.icon;
               const isHighlight = link.highlight;


### PR DESCRIPTION
## Problem

After the merge earlier today that commented out the `/register` (Nationals) nav entry, the desktop header showed **two "Play" buttons** — and **"Deck Builder" silently disappeared** from the desktop nav.

Root cause: the desktop nav rendered `navLinks` in fixed index slices and *also* had a hardcoded Play link, so it only worked while the array order was exactly `[register, Play, …]`:

- `navLinks.slice(0, 1)` — meant to render the highlighted **register** lead link
- a hardcoded `<Link href="/play">Play</Link>` after the Admin dropdown
- `navLinks.slice(2)` — meant to render everything after Play

With `/register` commented out, `/play` shifted to index 0, so `slice(0, 1)` rendered Play **in addition to** the hardcoded Play → duplicate. And `slice(2)` now started at Spoilers, dropping **Deck Builder**.

## Fix

Select nav links by **role** instead of **array position**:

- lead link → `navLinks.filter((l) => l.highlight)` (the register button, only when present)
- trailing links → `navLinks.filter((l) => !l.highlight && l.href !== "/play")` (Deck Builder, Spoilers; Play stays the single hardcoded link)

This makes Play render exactly once, restores Deck Builder, and — importantly — **re-enabling the `/register` link next year won't reintroduce the duplicate**, since nothing depends on the index anymore.

Mobile was already correct (different slices, no hardcoded Play) and is **untouched**.

## Test plan

- [ ] Desktop nav shows a single "Play" and includes "Deck Builder"
- [ ] Uncomment the `/register` entry → highlighted Nationals link appears at the front, still one "Play"
- [ ] Mobile nav unchanged (one "Play", Deck Builder present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)