### PR TITLE
feat: YTG Shopify set importer (draft-first, productSet)

### DIFF
--- a/app/admin/import-set/page.tsx
+++ b/app/admin/import-set/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -76,6 +76,10 @@ export default function AdminImportSetPage() {
   const [error, setError] = useState("");
   const [loadingSets, setLoadingSets] = useState(false);
   const [loadingPlans, setLoadingPlans] = useState(false);
+  // Guards against a stale `GET ?set=A` response landing after the admin has
+  // already switched to set B — without this, A's plans could get applied
+  // while setCode reads B, and a subsequent POST would write the wrong set.
+  const fetchSeq = useRef(0);
 
   useEffect(() => {
     if (!adminLoading && !isAdmin) {
@@ -102,6 +106,7 @@ export default function AdminImportSetPage() {
   }, [isAdmin]);
 
   const handleSetChange = async (code: string) => {
+    const seq = ++fetchSeq.current;
     setSetCode(code);
     setResults(null);
     setSummary(null);
@@ -115,6 +120,7 @@ export default function AdminImportSetPage() {
     try {
       const res = await fetch(`/api/admin/import-set?set=${encodeURIComponent(code)}`);
       const data = await res.json();
+      if (seq !== fetchSeq.current) return; // a newer set was picked while this request was in flight
       if (!res.ok) throw new Error(data.error || "Failed to load plans");
       const newPlans = data.plans as CardPlan[];
       setPlans(newPlans);
@@ -124,9 +130,10 @@ export default function AdminImportSetPage() {
       }
       setRows(nextRows);
     } catch (err) {
+      if (seq !== fetchSeq.current) return;
       setError(err instanceof Error ? err.message : "Failed to load plans");
     } finally {
-      setLoadingPlans(false);
+      if (seq === fetchSeq.current) setLoadingPlans(false);
     }
   };
 
@@ -270,7 +277,7 @@ export default function AdminImportSetPage() {
               id="set-picker"
               value={setCode}
               onChange={(e) => handleSetChange(e.target.value)}
-              disabled={loadingSets}
+              disabled={loadingSets || loadingPlans || running}
               className="mt-1 flex h-10 w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
             >
               <option value="">{loadingSets ? "Loading sets…" : "Select a set…"}</option>

--- a/app/admin/import-set/page.tsx
+++ b/app/admin/import-set/page.tsx
@@ -187,6 +187,21 @@ export default function AdminImportSetPage() {
     });
   };
 
+  const setIncludeForAll = (include: boolean) => {
+    setRows((prev) => {
+      const next = { ...prev };
+      for (const p of plans) {
+        const row = next[p.cardKey];
+        if (!row) continue;
+        // Include-all leaves skip-existing rows out (same rule as the initial defaults);
+        // they can still be opted in per-row.
+        if (include && p.plannedAction === "skip-existing") continue;
+        next[p.cardKey] = { ...row, include };
+      }
+      return next;
+    });
+  };
+
   const includedCount = plans.filter((p) => rows[p.cardKey]?.include).length;
   const blankPriceCount = plans.filter((p) => rows[p.cardKey]?.include && !rows[p.cardKey].price.trim()).length;
   const finalBlankCount = plans.filter(
@@ -321,6 +336,12 @@ export default function AdminImportSetPage() {
                 </Button>
                 <Button variant="outline" onClick={setAllPrices} disabled={!defaultPrice.trim()}>
                   Set ALL prices to {defaultPrice.trim() || "X"}
+                </Button>
+                <Button variant="outline" onClick={() => setIncludeForAll(true)}>
+                  Include all
+                </Button>
+                <Button variant="outline" onClick={() => setIncludeForAll(false)}>
+                  Include none
                 </Button>
                 <div className="text-sm text-muted-foreground ml-auto">
                   {includedCount} included · {blankPriceCount} with blank price

--- a/app/admin/import-set/page.tsx
+++ b/app/admin/import-set/page.tsx
@@ -1,0 +1,473 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import TopNav from "@/components/top-nav";
+import { useIsAdmin } from "@/hooks/useIsAdmin";
+
+// Mirrors lib/shopify/importSet.ts. Inlined (not imported) because that
+// module pulls server-only deps (Supabase admin client, Shopify token) into
+// the client bundle.
+interface CardPlan {
+  cardKey: string;
+  cardName: string;
+  title: string;
+  handle: string;
+  sku: string;
+  tags: string[];
+  imageUrl: string | null;
+  plannedAction: "create" | "update" | "skip-existing";
+  warnings: string[];
+}
+
+interface ImportResultRow {
+  cardKey: string;
+  action: "created" | "updated" | "skipped" | "error";
+  productId: string | null;
+  error: string | null;
+  mock: boolean;
+}
+
+interface ImportSummary {
+  created: number;
+  updated: number;
+  skipped: number;
+  errors: number;
+  reconciled: boolean;
+  mock: boolean;
+}
+
+type RowState = { include: boolean; price: string; titleOverride: string };
+
+const PRICE_INPUT_RE = /^\d*\.?\d{0,2}$/;
+
+function actionBadgeClass(action: CardPlan["plannedAction"] | ImportResultRow["action"]) {
+  switch (action) {
+    case "update":
+    case "updated":
+      return "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300";
+    case "skip-existing":
+    case "skipped":
+      return "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300";
+    case "error":
+      return "bg-destructive/10 text-destructive";
+    default:
+      return "bg-muted text-foreground";
+  }
+}
+
+export default function AdminImportSetPage() {
+  const router = useRouter();
+  const { isAdmin, loading: adminLoading } = useIsAdmin();
+
+  const [sets, setSets] = useState<{ code: string; name: string; count: number }[]>([]);
+  const [setCode, setSetCode] = useState("");
+  const [plans, setPlans] = useState<CardPlan[]>([]);
+  const [rows, setRows] = useState<Record<string, RowState>>({});
+  const [active, setActive] = useState(false);
+  const [defaultPrice, setDefaultPrice] = useState("");
+  const [running, setRunning] = useState(false);
+  const [results, setResults] = useState<ImportResultRow[] | null>(null);
+  const [summary, setSummary] = useState<ImportSummary | null>(null);
+  const [dryRunMsg, setDryRunMsg] = useState("");
+  const [error, setError] = useState("");
+  const [loadingSets, setLoadingSets] = useState(false);
+  const [loadingPlans, setLoadingPlans] = useState(false);
+
+  useEffect(() => {
+    if (!adminLoading && !isAdmin) {
+      router.replace("/");
+    }
+  }, [adminLoading, isAdmin, router]);
+
+  useEffect(() => {
+    if (!isAdmin) return;
+    const loadSets = async () => {
+      setLoadingSets(true);
+      try {
+        const res = await fetch("/api/admin/import-set");
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || "Failed to load sets");
+        setSets(data.sets);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load sets");
+      } finally {
+        setLoadingSets(false);
+      }
+    };
+    loadSets();
+  }, [isAdmin]);
+
+  const handleSetChange = async (code: string) => {
+    setSetCode(code);
+    setResults(null);
+    setSummary(null);
+    setDryRunMsg("");
+    setError("");
+    setPlans([]);
+    setRows({});
+    if (!code) return;
+
+    setLoadingPlans(true);
+    try {
+      const res = await fetch(`/api/admin/import-set?set=${encodeURIComponent(code)}`);
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to load plans");
+      const newPlans = data.plans as CardPlan[];
+      setPlans(newPlans);
+      const nextRows: Record<string, RowState> = {};
+      for (const p of newPlans) {
+        nextRows[p.cardKey] = { include: p.plannedAction === "create", price: "", titleOverride: "" };
+      }
+      setRows(nextRows);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load plans");
+    } finally {
+      setLoadingPlans(false);
+    }
+  };
+
+  const updateRow = (cardKey: string, patch: Partial<RowState>) => {
+    setRows((prev) => ({ ...prev, [cardKey]: { ...prev[cardKey], ...patch } }));
+  };
+
+  const handlePriceChange = (cardKey: string, value: string) => {
+    if (!PRICE_INPUT_RE.test(value)) return;
+    updateRow(cardKey, { price: value });
+  };
+
+  const handleDefaultPriceChange = (value: string) => {
+    if (!PRICE_INPUT_RE.test(value)) return;
+    setDefaultPrice(value);
+  };
+
+  const applyToBlankRows = () => {
+    if (!defaultPrice.trim()) return;
+    setRows((prev) => {
+      const next = { ...prev };
+      for (const p of plans) {
+        const row = next[p.cardKey];
+        if (row?.include && !row.price.trim()) {
+          next[p.cardKey] = { ...row, price: defaultPrice };
+        }
+      }
+      return next;
+    });
+  };
+
+  const setAllPrices = () => {
+    if (!defaultPrice.trim()) return;
+    setRows((prev) => {
+      const next = { ...prev };
+      for (const p of plans) {
+        const row = next[p.cardKey];
+        if (row?.include) {
+          next[p.cardKey] = { ...row, price: defaultPrice };
+        }
+      }
+      return next;
+    });
+  };
+
+  const includedCount = plans.filter((p) => rows[p.cardKey]?.include).length;
+  const blankPriceCount = plans.filter((p) => rows[p.cardKey]?.include && !rows[p.cardKey].price.trim()).length;
+  const finalBlankCount = plans.filter(
+    (p) => rows[p.cardKey]?.include && !rows[p.cardKey].price.trim() && !defaultPrice.trim(),
+  ).length;
+
+  const buildCardsPayload = () =>
+    plans.map((p) => ({
+      cardKey: p.cardKey,
+      price: rows[p.cardKey].price.trim() || (defaultPrice.trim() || null),
+      include: rows[p.cardKey].include,
+      titleOverride: rows[p.cardKey].titleOverride.trim() || undefined,
+    }));
+
+  const handleDryRun = async () => {
+    setRunning(true);
+    setError("");
+    setDryRunMsg("");
+    setResults(null);
+    setSummary(null);
+    try {
+      const res = await fetch("/api/admin/import-set", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          setCode,
+          status: active ? "ACTIVE" : "DRAFT",
+          dryRun: true,
+          cards: buildCardsPayload(),
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Dry run failed");
+      setPlans(data.plans);
+      setDryRunMsg(`Dry run OK — ${includedCount} cards planned, no writes`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Dry run failed");
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const handleImport = async () => {
+    const statusLabel = active ? "ACTIVE" : "DRAFT";
+    const confirmed = window.confirm(
+      `Import ${includedCount} cards as ${statusLabel}?\n${finalBlankCount} card(s) will have a blank price.`,
+    );
+    if (!confirmed) return;
+
+    setRunning(true);
+    setError("");
+    setDryRunMsg("");
+    setResults(null);
+    setSummary(null);
+    try {
+      const res = await fetch("/api/admin/import-set", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          setCode,
+          status: statusLabel,
+          cards: buildCardsPayload(),
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Import failed");
+      setResults(data.results);
+      setSummary(data.summary);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Import failed");
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  if (adminLoading || !isAdmin) return null;
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <TopNav />
+
+      <div className="flex-1 w-full overflow-auto px-5">
+        <div className="max-w-7xl mx-auto py-8">
+          <h1 className="text-3xl font-bold mb-2">Import Set to Shopify</h1>
+          <p className="text-muted-foreground mb-6">
+            Preview card products for a set, adjust prices, then publish to the store.
+          </p>
+
+          {error && (
+            <div className="mb-4 px-4 py-2 rounded-md bg-destructive/10 text-destructive text-sm">{error}</div>
+          )}
+
+          <div className="mb-6 max-w-md">
+            <Label htmlFor="set-picker">Set</Label>
+            <select
+              id="set-picker"
+              value={setCode}
+              onChange={(e) => handleSetChange(e.target.value)}
+              disabled={loadingSets}
+              className="mt-1 flex h-10 w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <option value="">{loadingSets ? "Loading sets…" : "Select a set…"}</option>
+              {sets.map((s) => (
+                <option key={s.code} value={s.code}>
+                  {s.name} ({s.code}) — {s.count} cards
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {loadingPlans && <p className="text-muted-foreground mb-6">Loading cards…</p>}
+
+          {plans.length > 0 && (
+            <>
+              <div className="bg-card border rounded-lg p-4 mb-6 flex flex-wrap items-end gap-4">
+                <div>
+                  <Label htmlFor="default-price">Default price</Label>
+                  <Input
+                    id="default-price"
+                    inputMode="decimal"
+                    value={defaultPrice}
+                    onChange={(e) => handleDefaultPriceChange(e.target.value)}
+                    placeholder="0.00"
+                    className="mt-1 w-28"
+                  />
+                </div>
+                <Button variant="outline" onClick={applyToBlankRows} disabled={!defaultPrice.trim()}>
+                  Apply to blank rows
+                </Button>
+                <Button variant="outline" onClick={setAllPrices} disabled={!defaultPrice.trim()}>
+                  Set ALL prices to {defaultPrice.trim() || "X"}
+                </Button>
+                <div className="text-sm text-muted-foreground ml-auto">
+                  {includedCount} included · {blankPriceCount} with blank price
+                </div>
+              </div>
+
+              <div className="flex items-center gap-2 mb-6">
+                <input
+                  id="active-toggle"
+                  type="checkbox"
+                  checked={active}
+                  onChange={(e) => setActive(e.target.checked)}
+                  className="w-4 h-4"
+                />
+                <Label htmlFor="active-toggle">Publish as ACTIVE immediately (default: DRAFT)</Label>
+              </div>
+
+              <div className="bg-card border rounded-lg overflow-hidden mb-6">
+                <div className="overflow-x-auto">
+                  <table className="w-full">
+                    <thead className="bg-muted">
+                      <tr>
+                        <th className="px-4 py-3 text-left text-sm font-semibold"></th>
+                        <th className="px-4 py-3 text-left text-sm font-semibold">Image</th>
+                        <th className="px-4 py-3 text-left text-sm font-semibold">Card</th>
+                        <th className="px-4 py-3 text-left text-sm font-semibold">Title</th>
+                        <th className="px-4 py-3 text-left text-sm font-semibold">Tags</th>
+                        <th className="px-4 py-3 text-left text-sm font-semibold">Action</th>
+                        <th className="px-4 py-3 text-left text-sm font-semibold">Warnings</th>
+                        <th className="px-4 py-3 text-left text-sm font-semibold">Price</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y">
+                      {plans.map((plan) => {
+                        const row = rows[plan.cardKey];
+                        if (!row) return null;
+                        return (
+                          <tr key={plan.cardKey} className="hover:bg-muted/50">
+                            <td className="px-4 py-3">
+                              <input
+                                type="checkbox"
+                                checked={row.include}
+                                onChange={(e) => updateRow(plan.cardKey, { include: e.target.checked })}
+                                className="w-4 h-4"
+                              />
+                            </td>
+                            <td className="px-4 py-3">
+                              {plan.imageUrl ? (
+                                <img
+                                  src={plan.imageUrl}
+                                  alt={plan.cardName}
+                                  className="h-14 w-10 object-contain"
+                                  loading="lazy"
+                                />
+                              ) : (
+                                <div className="h-14 w-10 bg-muted flex items-center justify-center text-center text-[10px] leading-tight text-amber-600 dark:text-amber-400">
+                                  no image
+                                </div>
+                              )}
+                            </td>
+                            <td className="px-4 py-3 text-sm">{plan.cardName}</td>
+                            <td className="px-4 py-3">
+                              <div className="text-sm text-muted-foreground mb-1">{plan.title}</div>
+                              <Input
+                                value={row.titleOverride}
+                                onChange={(e) => updateRow(plan.cardKey, { titleOverride: e.target.value })}
+                                placeholder={plan.title}
+                                className="h-8 text-xs"
+                              />
+                            </td>
+                            <td className="px-4 py-3 text-xs text-muted-foreground">{plan.tags.join(", ")}</td>
+                            <td className="px-4 py-3">
+                              <span
+                                className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${actionBadgeClass(plan.plannedAction)}`}
+                              >
+                                {plan.plannedAction}
+                              </span>
+                              {plan.plannedAction === "skip-existing" && (
+                                <div className="mt-1 text-[10px] text-amber-600 dark:text-amber-400">
+                                  exists in store
+                                </div>
+                              )}
+                            </td>
+                            <td className="px-4 py-3 text-xs text-amber-600 dark:text-amber-400">
+                              {plan.warnings.join(", ")}
+                            </td>
+                            <td className="px-4 py-3">
+                              <Input
+                                inputMode="decimal"
+                                value={row.price}
+                                onChange={(e) => handlePriceChange(plan.cardKey, e.target.value)}
+                                placeholder="0.00"
+                                className="h-8 w-20 text-xs"
+                              />
+                              {!row.price.trim() && (
+                                <div className="mt-0.5 text-[10px] text-amber-600 dark:text-amber-400">blank</div>
+                              )}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-4 mb-8">
+                <Button variant="outline" onClick={handleDryRun} disabled={running}>
+                  Dry run
+                </Button>
+                <Button onClick={handleImport} disabled={running || includedCount === 0}>
+                  Import {includedCount} cards
+                </Button>
+                {running && <span className="text-sm text-muted-foreground">Working, please wait…</span>}
+                {dryRunMsg && <span className="text-sm text-muted-foreground">{dryRunMsg}</span>}
+              </div>
+            </>
+          )}
+
+          {results && summary && (
+            <div className="bg-card border rounded-lg overflow-hidden mb-8">
+              {summary.mock && (
+                <div className="px-4 py-2 bg-violet-100 text-violet-800 dark:bg-violet-950 dark:text-violet-300 text-sm">
+                  MOCK MODE — no real Shopify writes
+                </div>
+              )}
+              <div className="px-4 py-3 border-b text-sm">
+                created {summary.created} · updated {summary.updated} · skipped {summary.skipped} · errors{" "}
+                {summary.errors}
+                {summary.reconciled && (
+                  <span className="ml-2 text-muted-foreground">Price pipeline reconciled</span>
+                )}
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead className="bg-muted">
+                    <tr>
+                      <th className="px-4 py-2 text-left text-sm font-semibold">Card key</th>
+                      <th className="px-4 py-2 text-left text-sm font-semibold">Action</th>
+                      <th className="px-4 py-2 text-left text-sm font-semibold">Product ID</th>
+                      <th className="px-4 py-2 text-left text-sm font-semibold">Error</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y">
+                    {results.map((r) => (
+                      <tr key={r.cardKey} className="hover:bg-muted/50">
+                        <td className="px-4 py-2 text-sm">{r.cardKey}</td>
+                        <td className="px-4 py-2">
+                          <span
+                            className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${actionBadgeClass(r.action)}`}
+                          >
+                            {r.action}
+                          </span>
+                        </td>
+                        <td className="px-4 py-2 text-sm text-muted-foreground">{r.productId ?? "—"}</td>
+                        <td className="px-4 py-2 text-sm text-destructive">{r.error ?? ""}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/import-set/page.tsx
+++ b/app/admin/import-set/page.tsx
@@ -44,6 +44,14 @@ type RowState = { include: boolean; price: string; titleOverride: string };
 
 const PRICE_INPUT_RE = /^\d*\.?\d{0,2}$/;
 
+// The input allows in-progress values like ".5" or "5." that the server's
+// stricter regex rejects — normalize those to "0.50" / "5.00" before POST.
+function normalizePriceEntry(value: string): string {
+  if (!value || (!value.startsWith(".") && !value.endsWith("."))) return value;
+  const n = Number(value);
+  return Number.isNaN(n) ? value : n.toFixed(2);
+}
+
 function actionBadgeClass(action: CardPlan["plannedAction"] | ImportResultRow["action"]) {
   switch (action) {
     case "update":
@@ -186,12 +194,15 @@ export default function AdminImportSetPage() {
   ).length;
 
   const buildCardsPayload = () =>
-    plans.map((p) => ({
-      cardKey: p.cardKey,
-      price: rows[p.cardKey].price.trim() || (defaultPrice.trim() || null),
-      include: rows[p.cardKey].include,
-      titleOverride: rows[p.cardKey].titleOverride.trim() || undefined,
-    }));
+    plans.map((p) => {
+      const rawPrice = rows[p.cardKey].price.trim() || defaultPrice.trim() || null;
+      return {
+        cardKey: p.cardKey,
+        price: rawPrice !== null ? normalizePriceEntry(rawPrice) : null,
+        include: rows[p.cardKey].include,
+        titleOverride: rows[p.cardKey].titleOverride.trim() || undefined,
+      };
+    });
 
   const handleDryRun = async () => {
     setRunning(true);

--- a/app/api/admin/import-set/route.ts
+++ b/app/api/admin/import-set/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { isRegistrationAdmin } from '@/utils/adminUtils';
 import { planSetImport, executeImport, listImportableSets, type ImportRequest } from '@/lib/shopify/importSet';
 
+// A ~350-card set import plus the post-import reconcile (sync + matching +
+// price computation) can approach this budget. Imports are ledger-safe if
+// the function is killed mid-reconcile — the nightly cron job completes
+// reconciliation on its own schedule.
 export const maxDuration = 300;
 
 export async function GET(request: NextRequest) {

--- a/app/api/admin/import-set/route.ts
+++ b/app/api/admin/import-set/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { isRegistrationAdmin } from '@/utils/adminUtils';
+import { planSetImport, executeImport, listImportableSets, type ImportRequest } from '@/lib/shopify/importSet';
+
+export const maxDuration = 300;
+
+export async function GET(request: NextRequest) {
+  if (!(await isRegistrationAdmin())) {
+    return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+  }
+  try {
+    const setCode = request.nextUrl.searchParams.get('set');
+    if (!setCode) return NextResponse.json({ sets: listImportableSets() });
+    const plans = await planSetImport(setCode);
+    if (plans.length === 0) return NextResponse.json({ error: `Unknown set: ${setCode}` }, { status: 400 });
+    return NextResponse.json({ setCode, plans });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  if (!(await isRegistrationAdmin())) {
+    return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+  }
+  try {
+    const body = await request.json();
+    const { setCode, status, dryRun, cards } = body as ImportRequest & { dryRun?: boolean };
+    if (!setCode || (status !== 'DRAFT' && status !== 'ACTIVE') || !Array.isArray(cards)) {
+      return NextResponse.json({ error: 'setCode, status (DRAFT|ACTIVE) and cards[] are required' }, { status: 400 });
+    }
+    if (dryRun) return NextResponse.json({ plans: await planSetImport(setCode) });
+    const { results, summary } = await executeImport({ setCode, status, cards });
+    return NextResponse.json({ results, summary });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/docs/superpowers/plans/2026-07-25-ytg-shopify-set-import.md
+++ b/docs/superpowers/plans/2026-07-25-ytg-shopify-set-import.md
@@ -1,0 +1,853 @@
+# YTG Shopify Set Import — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Admin picks a Redemption set, previews one Shopify product per card (image + editable price), and imports them into YTG's live store as DRAFT (or ACTIVE) via GraphQL `productSet`, with an idempotency ledger and reconcile into the existing pricing pipeline.
+
+**Architecture:** A pure builder (`productFromCard`) maps `CardData` → `ProductSetInput`; a thin GraphQL write client (`admin-write`) owns throttling and a mock mode; an orchestrator (`importSet`) plans and executes per-card upserts against a new `shopify_card_imports` ledger; an admin-gated API route exposes preview/execute; a client admin page renders the preview table. Spec: `docs/superpowers/specs/2026-07-25-ytg-shopify-set-import-design.md`.
+
+**Tech Stack:** Next.js 15 App Router route handlers, TypeScript, Supabase (service-role via `getSupabaseAdmin()`), Shopify GraphQL Admin API 2026-07, Vitest.
+
+## Global Constraints
+
+- **Worktree isolation (repo rule):** all work happens in a dedicated worktree `../rtt-ytg-import` on branch `feat/ytg-set-import` created from `origin/main`. Use **absolute paths** everywhere. Never run `git checkout/reset/stash` in the main checkout; never `git add -A` — always add specific files.
+- **Env vars:** `SHOPFIY_CLIENT_ID` (typo is intentional — matches the real Shopify app config), `SHOPIFY_CLIENT_SECRET`, `NEXT_PUBLIC_SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `NEXT_PUBLIC_BLOB_BASE_URL`. New: `SHOPIFY_WRITE_MOCK` — when `'1'`, `productSetUpsert` returns fabricated IDs and makes no network call.
+- **Write API version:** `2026-07` (GraphQL). Do NOT touch the read path in `lib/pricing/shopify.ts` (REST, pinned `2024-01`) other than importing its exported `getShopifyAccessToken`.
+- **Constants:** `vendor: "Your Turn Games"`, `productType: "Single"`, default `status: DRAFT`.
+- **Card key format:** `` `${card.name}|${card.set}|${card.imgFile}` `` (must match `lib/pricing/matching.ts:45`).
+- **Tags:** built as `string[]`, **sorted alphabetically** (YTG convention observed in dump).
+- **Single-variant pattern (Shopify requirement, verified):** `productOptions: [{ name: "Title", values: [{ name: "Default Title" }] }]` + `variants: [{ optionValues: [{ optionName: "Title", name: "Default Title" }], price, sku }]`. Exact capitalization `"Title"` / `"Default Title"` is mandatory.
+- **File input field is `contentType: "IMAGE"`** (NOT `mediaContentType` — that's the output-side name).
+- **Update semantics (verified):** omitting the `variants`/`productOptions`/`files` KEYS entirely leaves existing data unchanged; an empty array is destructive. On re-runs where media was already attached, OMIT `files`.
+- **Tests:** Vitest, files named `*.test.ts` beside source, run with `npm test` (one-shot) — no jsdom needed (node env).
+- **UI rules (user feedback memories):** no `focus:ring-*` classes on form controls; no green/primary color on text at rest; plain headings.
+- **Admin gating:** the new API route MUST check `isRegistrationAdmin()` from `@/utils/adminUtils` (existing pricing routes don't gate — that's a known gap we are not copying for a live-store write path).
+- **Commit messages:** end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+---
+
+### Task 0: Worktree setup
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Create the worktree**
+
+```bash
+cd /Users/timestes/projects/redemption-tournament-tracker
+git fetch origin
+git worktree add ../rtt-ytg-import -b feat/ytg-set-import origin/main
+```
+
+- [ ] **Step 2: Copy the (untracked) spec + this plan into the worktree so they ship with the PR**
+
+```bash
+mkdir -p /Users/timestes/projects/rtt-ytg-import/docs/superpowers/specs /Users/timestes/projects/rtt-ytg-import/docs/superpowers/plans
+cp /Users/timestes/projects/redemption-tournament-tracker/docs/superpowers/specs/2026-07-25-ytg-shopify-set-import-design.md /Users/timestes/projects/rtt-ytg-import/docs/superpowers/specs/
+cp /Users/timestes/projects/redemption-tournament-tracker/docs/superpowers/plans/2026-07-25-ytg-shopify-set-import.md /Users/timestes/projects/rtt-ytg-import/docs/superpowers/plans/
+```
+
+- [ ] **Step 3: Install deps in the worktree**
+
+```bash
+cd /Users/timestes/projects/rtt-ytg-import && npm install
+```
+
+- [ ] **Step 4: Commit the docs**
+
+```bash
+cd /Users/timestes/projects/rtt-ytg-import
+git add docs/superpowers/specs/2026-07-25-ytg-shopify-set-import-design.md docs/superpowers/plans/2026-07-25-ytg-shopify-set-import.md
+git commit -m "docs: YTG Shopify set import spec + plan
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 1: Ledger migration (`shopify_card_imports`)
+
+**Files:**
+- Create: `supabase/migrations/080_create_shopify_card_imports.sql`
+
+**Interfaces:**
+- Produces: table `shopify_card_imports` with columns `card_key text PK`, `set_code text`, `shopify_product_id text`, `shopify_variant_id text`, `handle text`, `status text` (`created|updated|skipped|error`), `media_attached boolean`, `error text`, `created_at`, `updated_at`. Task 4 reads/writes it via the service-role client (RLS blocks anon/authenticated entirely).
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- 080_create_shopify_card_imports.sql
+-- Ledger for the YTG Shopify set importer (docs/superpowers/specs/2026-07-25-ytg-shopify-set-import-design.md §7).
+-- One row per card ever imported; keyed by the canonical card_key `${name}|${set}|${imgFile}`.
+-- Accessed exclusively via the service-role client — no anon/authenticated policies on purpose.
+
+CREATE TABLE public.shopify_card_imports (
+  card_key           TEXT PRIMARY KEY,
+  set_code           TEXT NOT NULL,
+  shopify_product_id TEXT,
+  shopify_variant_id TEXT,
+  handle             TEXT,
+  status             TEXT NOT NULL CHECK (status IN ('created', 'updated', 'skipped', 'error')),
+  media_attached     BOOLEAN NOT NULL DEFAULT false,
+  error              TEXT,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_shopify_card_imports_set_code ON public.shopify_card_imports (set_code);
+
+ALTER TABLE public.shopify_card_imports ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON public.shopify_card_imports FROM anon, authenticated;
+```
+
+- [ ] **Step 2: Sanity-check the SQL parses (no local supabase needed — just eyeball + optional `psql` dry parse is unavailable; rely on review). Confirm filename doesn't collide:**
+
+Run: `ls /Users/timestes/projects/rtt-ytg-import/supabase/migrations/ | grep '^080'`
+Expected: only the new file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/timestes/projects/rtt-ytg-import
+git add supabase/migrations/080_create_shopify_card_imports.sql
+git commit -m "feat(import-set): shopify_card_imports ledger migration
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+**Note:** applying to prod happens in Task 7 (via Supabase MCP), not here.
+
+---
+
+### Task 2: Pure builder `productFromCard` + unit tests
+
+**Files:**
+- Create: `lib/shopify/productFromCard.ts`
+- Test: `lib/shopify/productFromCard.test.ts`
+
+**Interfaces:**
+- Consumes: `CardData` from `@/lib/cards/generated/cardData`; `normalizeBrigadeField` from `@/app/decklist/card-search/utils` (signature: `normalizeBrigadeField(brigade: string, alignment: string, cardName?: string): string[]` — returns canonical brigade names, THROWS on unknown tokens); `sanitizeImgFile`, `getCardImageUrl` from `@/app/shared/utils/cardImageUrl`.
+- Produces (used by Tasks 4–5):
+
+```ts
+export interface ShopifyProductSetInput {
+  title: string;
+  handle: string;
+  productType: string;
+  vendor: string;
+  tags: string[];
+  status: 'DRAFT' | 'ACTIVE';
+  productOptions?: { name: string; values: { name: string }[] }[];
+  variants?: { optionValues: { optionName: string; name: string }[]; price: string; sku: string }[];
+  files?: { originalSource: string; contentType: 'IMAGE'; alt: string }[];
+  metafields?: { namespace: string; key: string; value: string; type: string }[];
+}
+
+export interface ProductBuildOptions {
+  price: string | null;        // normalized "1.50"; null => "0.00" + warning "no-price"
+  imageUrl: string | null;     // null => no files + warning "no-image"
+  status: 'DRAFT' | 'ACTIVE';
+  titleOverride?: string;      // admin-entered title replaces the computed one verbatim
+  includeMedia?: boolean;      // default true; false => omit files even if imageUrl set (update re-runs)
+}
+
+export interface BuiltProduct {
+  cardKey: string;
+  input: ShopifyProductSetInput;
+  warnings: string[];          // 'no-price' | 'no-image' | 'no-set-alias' | `brigade-unmapped:<value>` | `type-unmapped:<value>`
+}
+
+export function baseCardName(name: string): string;       // strips ONE trailing " (...)" or " [...]" group
+export function slugifyTitle(title: string): string;      // YTG-style handle slug
+export function cardSku(card: CardData): string;          // `${set}-${sanitizeImgFile(imgFile)}` with whitespace removed
+export function productFromCard(card: CardData, ytgAbbrev: string | null, opts: ProductBuildOptions): BuiltProduct;
+```
+
+**Mapping rules (all live here, unit-tested against real dump rows):**
+- `title` = `titleOverride` ?? `` `${baseCardName(card.name)} (${ytgAbbrev ?? card.set})` ``; if `ytgAbbrev` is null add warning `no-set-alias`.
+- `handle` = `slugifyTitle(title)`: lowercase → strip `['’‘"“”]` → replace runs of `[^a-z0-9]` with `-` → trim leading/trailing `-`. (We do NOT replicate YTG's legacy `risenlegacy` collapse bug.)
+- `tags` (alphabetically sorted, deduped):
+  - **type**: split `card.type` on `/` (trim each — dump has `"Fortress / Evil Character"`), map via `TYPE_TAGS`: `Hero→Hero, GE→Good Enhancement, EE→Evil Enhancement, Evil Character→Evil Character, Artifact→Artifact, Lost Soul→Lost Soul, Dominant→Dominant, Fortress→Fortress, Site→Site, City→City, Covenant→Covenant, Curse→Curse, Hero Token→Hero, Evil Character Token→Evil Character, Lost Soul Token→Lost Soul`. Unknown part → warning `type-unmapped:<part>`, part skipped. If mapped parts span both alignments (any of {Hero, GE} AND any of {Evil Character, EE}) also add `Dual Alignment`.
+  - **colors**: `normalizeBrigadeField(card.brigade, card.alignment, card.name)` in try/catch (skip entirely when `card.brigade` is empty). Map canonical → YTG tag: `Good Gold→Gold`, everything else identity (`Evil Gold` stays `Evil Gold`, `Pale Green` stays, etc.). On throw: warning `brigade-unmapped:<card.brigade>`, no color tags.
+  - **set**: `card.officialSet` as-is.
+  - **rarity**: only when normalized rarity ∈ {`Legacy Rare`, `Ultra Rare`} (normalize `Ultra-Rare` → `Ultra Rare`).
+  - **grouping**: `card.legality === 'Rotation'` → `Rotation Cards`; `card.officialSet.startsWith('Promo')` → `Promos`.
+- `variants`/`productOptions`: ALWAYS included (exact Default Title pattern from Global Constraints), `price` = opts.price ?? `"0.00"` (warning `no-price` when null), `sku` = `cardSku(card)`.
+- `files`: included only when `opts.imageUrl` is non-null AND `opts.includeMedia !== false`: `[{ originalSource: opts.imageUrl, contentType: 'IMAGE', alt: baseCardName(card.name) }]`. When `imageUrl` is null → warning `no-image`.
+- `metafields`: always `[{ namespace: 'custom', key: 'rtt_card_key', value: cardKey, type: 'single_line_text_field' }]`.
+- `cardKey` = `` `${card.name}|${card.set}|${card.imgFile}` ``.
+
+- [ ] **Step 1: Extract REAL fixtures.** Pull exact card JSON from generated card data and the matching real YTG product from the dump, to paste into the test:
+
+```bash
+cd /Users/timestes/projects/rtt-ytg-import
+jq -c '.[] | select(.name == "\"I AM\" Has Sent Me (PoC)" or .name == "Abusive Soldiers (GoC)" or .name == "A Roman Soldier'\''s Faith (Ap)")' lib/cards/generated/cardData.json
+jq -c '.[] | select(.title == "\"I AM\" Has Sent Me (PoC)" or .title == "Abusive Soldiers (GoC)" or .title == "A Roman Soldier'\''s Faith (Ap)")' scripts/output/ytg_products.json
+```
+
+Use the printed card objects verbatim as test fixtures, and the printed products' `title`/`handle`/`tags` as expected values. Known expected values from the dump (verify against your extraction, trust the extraction if they differ):
+- `"I AM" Has Sent Me (PoC)` → handle `i-am-has-sent-me-poc`, tags `Good Enhancement, Green, Prophecies of Christ, Rotation Cards, Teal`
+- `A Roman Soldier's Faith (Ap)` → handle `a-roman-soldiers-faith-ap`, tags `Apostles, Good Enhancement, Red` (NO `Rotation Cards` — legality isn't Rotation)
+
+- [ ] **Step 2: Write the failing test** (`lib/shopify/productFromCard.test.ts`). Structure (fill fixtures from Step 1):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import type { CardData } from '@/lib/cards/generated/cardData';
+import { productFromCard, baseCardName, slugifyTitle, cardSku } from './productFromCard';
+
+// Fixtures: EXACT rows from lib/cards/generated/cardData.json (Step 1 extraction)
+const I_AM_HAS_SENT_ME: CardData = /* paste */;
+const ABUSIVE_SOLDIERS: CardData = /* paste */;
+const ROMAN_SOLDIERS_FAITH: CardData = /* paste */;
+
+describe('baseCardName', () => {
+  it('strips a trailing set parenthetical', () => {
+    expect(baseCardName('Abusive Soldiers (GoC)')).toBe('Abusive Soldiers');
+  });
+  it('strips a trailing bracket qualifier', () => {
+    expect(baseCardName('7 Years of Famine [RR2]')).toBe('7 Years of Famine');
+  });
+  it('keeps internal quotes/parentheticals', () => {
+    expect(baseCardName('"I AM" Has Sent Me (PoC)')).toBe('"I AM" Has Sent Me');
+  });
+  it('returns names with no qualifier unchanged', () => {
+    expect(baseCardName('Son of God')).toBe('Son of God');
+  });
+});
+
+describe('slugifyTitle', () => {
+  it('matches YTG handle for quoted title', () => {
+    expect(slugifyTitle('"I AM" Has Sent Me (PoC)')).toBe('i-am-has-sent-me-poc');
+  });
+  it('collapses apostrophes without a hyphen', () => {
+    expect(slugifyTitle("A Roman Soldier's Faith (Ap)")).toBe('a-roman-soldiers-faith-ap');
+  });
+  it('handles commas and multiple parentheticals', () => {
+    expect(slugifyTitle('Abaddon, the Destroyer (AB) (RoJ)')).toBe('abaddon-the-destroyer-ab-roj');
+  });
+});
+
+describe('productFromCard', () => {
+  const opts = { price: '0.75', imageUrl: 'https://blob.example/card-images/x.jpg', status: 'DRAFT' as const };
+
+  it('reproduces the real YTG product shape for "I AM" Has Sent Me (PoC)', () => {
+    const built = productFromCard(I_AM_HAS_SENT_ME, 'PoC', opts);
+    expect(built.input.title).toBe('"I AM" Has Sent Me (PoC)');
+    expect(built.input.handle).toBe('i-am-has-sent-me-poc');
+    expect(built.input.tags).toEqual(['Good Enhancement', 'Green', 'Prophecies of Christ', 'Rotation Cards', 'Teal']);
+    expect(built.input.productType).toBe('Single');
+    expect(built.input.vendor).toBe('Your Turn Games');
+    expect(built.input.status).toBe('DRAFT');
+    expect(built.input.productOptions).toEqual([{ name: 'Title', values: [{ name: 'Default Title' }] }]);
+    expect(built.input.variants).toEqual([{ optionValues: [{ optionName: 'Title', name: 'Default Title' }], price: '0.75', sku: cardSku(I_AM_HAS_SENT_ME) }]);
+    expect(built.input.files).toEqual([{ originalSource: opts.imageUrl, contentType: 'IMAGE', alt: '"I AM" Has Sent Me' }]);
+    expect(built.warnings).toEqual([]);
+  });
+
+  it('maps bare Gold brigade on an evil card to Evil Gold tag', () => {
+    const built = productFromCard(ABUSIVE_SOLDIERS, 'GoC', opts);
+    expect(built.input.tags).toContain('Evil Gold');
+    expect(built.input.tags).not.toContain('Gold');
+    expect(built.input.tags).toContain('Evil Character');
+    expect(built.input.tags).toContain('Gospel of Christ');
+  });
+
+  it('omits Rotation Cards for non-rotation cards', () => {
+    const built = productFromCard(ROMAN_SOLDIERS_FAITH, 'Ap', opts);
+    expect(built.input.tags).toEqual(['Apostles', 'Good Enhancement', 'Red']);
+  });
+
+  it('handles missing price / image / alias with warnings, never throws', () => {
+    const built = productFromCard(I_AM_HAS_SENT_ME, null, { price: null, imageUrl: null, status: 'DRAFT' });
+    expect(built.input.variants![0].price).toBe('0.00');
+    expect(built.input.files).toBeUndefined();
+    expect(built.input.title).toBe('"I AM" Has Sent Me (PoC)'); // falls back to card.set
+    expect(built.warnings).toEqual(expect.arrayContaining(['no-price', 'no-image', 'no-set-alias']));
+  });
+
+  it('omits files when includeMedia is false (update re-run)', () => {
+    const built = productFromCard(I_AM_HAS_SENT_ME, 'PoC', { ...opts, includeMedia: false });
+    expect(built.input.files).toBeUndefined();
+  });
+
+  it('uses titleOverride verbatim and slugs the handle from it', () => {
+    const built = productFromCard(I_AM_HAS_SENT_ME, 'PoC', { ...opts, titleOverride: '"I AM" Has Sent Me (Legacy Rare)' });
+    expect(built.input.title).toBe('"I AM" Has Sent Me (Legacy Rare)');
+    expect(built.input.handle).toBe('i-am-has-sent-me-legacy-rare');
+  });
+
+  it('always attaches the rtt_card_key metafield', () => {
+    const built = productFromCard(I_AM_HAS_SENT_ME, 'PoC', opts);
+    expect(built.input.metafields).toEqual([{ namespace: 'custom', key: 'rtt_card_key', value: built.cardKey, type: 'single_line_text_field' }]);
+  });
+
+  it('adds Dual Alignment for cross-alignment compound types', () => {
+    const dual: CardData = { ...I_AM_HAS_SENT_ME, type: 'GE/EE' };
+    const built = productFromCard(dual, 'PoC', opts);
+    expect(built.input.tags).toEqual(expect.arrayContaining(['Good Enhancement', 'Evil Enhancement', 'Dual Alignment']));
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd /Users/timestes/projects/rtt-ytg-import && npx vitest run lib/shopify/productFromCard.test.ts`
+Expected: FAIL — cannot resolve `./productFromCard`.
+
+- [ ] **Step 4: Implement `lib/shopify/productFromCard.ts`** per the Interfaces/mapping rules above. Full skeleton:
+
+```ts
+import type { CardData } from '@/lib/cards/generated/cardData';
+import { normalizeBrigadeField } from '@/app/decklist/card-search/utils';
+import { sanitizeImgFile } from '@/app/shared/utils/cardImageUrl';
+
+// ... interfaces from the Interfaces block, verbatim ...
+
+const TYPE_TAGS: Record<string, string> = {
+  'Hero': 'Hero', 'GE': 'Good Enhancement', 'EE': 'Evil Enhancement',
+  'Evil Character': 'Evil Character', 'Artifact': 'Artifact', 'Lost Soul': 'Lost Soul',
+  'Dominant': 'Dominant', 'Fortress': 'Fortress', 'Site': 'Site', 'City': 'City',
+  'Covenant': 'Covenant', 'Curse': 'Curse',
+  'Hero Token': 'Hero', 'Evil Character Token': 'Evil Character', 'Lost Soul Token': 'Lost Soul',
+};
+const GOOD_TYPE_PARTS = new Set(['Hero', 'GE']);
+const EVIL_TYPE_PARTS = new Set(['Evil Character', 'EE']);
+// Canonical brigade name -> YTG tag name (identity unless listed)
+const BRIGADE_TAGS: Record<string, string> = { 'Good Gold': 'Gold' };
+
+export function baseCardName(name: string): string {
+  return name.replace(/\s*[([][^)\]]*[)\]]\s*$/, '').trim();
+}
+
+export function slugifyTitle(title: string): string {
+  return title.toLowerCase().replace(/['‘’"“”]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+export function cardSku(card: CardData): string {
+  return `${card.set}-${sanitizeImgFile(card.imgFile)}`.replace(/\s+/g, '');
+}
+
+export function productFromCard(card: CardData, ytgAbbrev: string | null, opts: ProductBuildOptions): BuiltProduct {
+  const warnings: string[] = [];
+  const cardKey = `${card.name}|${card.set}|${card.imgFile}`;
+  if (!ytgAbbrev) warnings.push('no-set-alias');
+  const title = opts.titleOverride ?? `${baseCardName(card.name)} (${ytgAbbrev ?? card.set})`;
+  // tags: type parts + Dual Alignment + brigade colors + officialSet + rarity + grouping,
+  // deduped via Set, sorted with .sort()
+  // ... per mapping rules ...
+  if (opts.price === null) warnings.push('no-price');
+  // variants/productOptions always present; files conditional; metafields always
+  // ...
+  return { cardKey, input, warnings };
+}
+```
+
+- [ ] **Step 5: Run tests until green**
+
+Run: `cd /Users/timestes/projects/rtt-ytg-import && npx vitest run lib/shopify/productFromCard.test.ts`
+Expected: PASS (all). If a tag expectation mismatches the real dump product, trust the dump — adjust the mapping table, not the fixture.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/timestes/projects/rtt-ytg-import
+git add lib/shopify/productFromCard.ts lib/shopify/productFromCard.test.ts
+git commit -m "feat(import-set): pure card->ProductSetInput builder with dump-grounded tests
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: GraphQL write client `admin-write` + tests
+
+**Files:**
+- Create: `lib/shopify/admin-write.ts`
+- Test: `lib/shopify/admin-write.test.ts`
+
+**Interfaces:**
+- Consumes: `getShopifyAccessToken()` from `@/lib/pricing/shopify` (NOT used inside this module's functions — token is passed in); `ShopifyProductSetInput` from `./productFromCard`.
+- Produces (used by Task 4):
+
+```ts
+export interface ProductSetOutcome {
+  productId: string | null;
+  variantId: string | null;
+  handle: string | null;
+  userErrors: { field: string[] | null; message: string; code: string | null }[];
+  mock: boolean;
+}
+export async function shopifyGraphQL<T>(token: string, query: string, variables: Record<string, unknown>, fetchImpl?: typeof fetch): Promise<T>;
+export async function productSetUpsert(token: string, input: ShopifyProductSetInput, identifier?: { id: string }, fetchImpl?: typeof fetch): Promise<ProductSetOutcome>;
+```
+
+**Behavior:**
+- Endpoint `https://your-turn-games.myshopify.com/admin/api/2026-07/graphql.json`, headers `Content-Type: application/json` + `X-Shopify-Access-Token`.
+- Retry loop (max 5 attempts): HTTP 429 → wait `Retry-After` seconds (default 2); GraphQL `errors[].extensions.code === 'THROTTLED'` → wait `max(1000, (requestedQueryCost - currentlyAvailable) / restoreRate * 1000)` (fallback 2000ms) and retry. Other `errors` → throw. Non-ok HTTP → throw with body text.
+- Pacing: after a successful call, if `extensions.cost.throttleStatus.currentlyAvailable < 100`, sleep `((100 - currentlyAvailable) / restoreRate) * 1000` ms before returning.
+- Mock mode: `process.env.SHOPIFY_WRITE_MOCK === '1'` → `productSetUpsert` returns `{ productId: 'gid://shopify/Product/mock-<slug>', variantId: 'gid://shopify/ProductVariant/mock-<slug>', handle: input.handle, userErrors: [], mock: true }` where `<slug>` = `input.handle`. No fetch.
+- Mutation (exact):
+
+```graphql
+mutation productSetUpsert($input: ProductSetInput!, $identifier: ProductSetIdentifiers) {
+  productSet(synchronous: true, identifier: $identifier, input: $input) {
+    product { id handle variants(first: 1) { nodes { id } } }
+    userErrors { field message code }
+  }
+}
+```
+
+- `productSetUpsert` returns `userErrors` verbatim when present (caller decides error handling); `productId`/`variantId`/`handle` come from `data.productSet.product` (null-safe).
+
+- [ ] **Step 1: Write the failing test** (`lib/shopify/admin-write.test.ts`) with a stub `fetchImpl`:
+
+```ts
+import { describe, it, expect, afterEach } from 'vitest';
+import { shopifyGraphQL, productSetUpsert } from './admin-write';
+import type { ShopifyProductSetInput } from './productFromCard';
+
+const INPUT: ShopifyProductSetInput = {
+  title: 'Test Card (XX)', handle: 'test-card-xx', productType: 'Single',
+  vendor: 'Your Turn Games', tags: ['Hero'], status: 'DRAFT',
+  productOptions: [{ name: 'Title', values: [{ name: 'Default Title' }] }],
+  variants: [{ optionValues: [{ optionName: 'Title', name: 'Default Title' }], price: '1.00', sku: 'XX-test' }],
+};
+
+function jsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}) {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json', ...headers } });
+}
+
+afterEach(() => { delete process.env.SHOPIFY_WRITE_MOCK; });
+
+describe('shopifyGraphQL', () => {
+  it('POSTs query+variables with the access token header and returns data', async () => {
+    let captured: { url: string; init: RequestInit } | null = null;
+    const fetchImpl = (async (url: any, init: any) => {
+      captured = { url: String(url), init };
+      return jsonResponse({ data: { ok: true }, extensions: { cost: { throttleStatus: { maximumAvailable: 1000, currentlyAvailable: 990, restoreRate: 50 } } } });
+    }) as typeof fetch;
+    const data = await shopifyGraphQL<{ ok: boolean }>('tok', 'query { x }', {}, fetchImpl);
+    expect(data).toEqual({ ok: true });
+    expect(captured!.url).toBe('https://your-turn-games.myshopify.com/admin/api/2026-07/graphql.json');
+    expect((captured!.init.headers as Record<string, string>)['X-Shopify-Access-Token']).toBe('tok');
+  });
+
+  it('retries on THROTTLED then succeeds', async () => {
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls++;
+      if (calls === 1) return jsonResponse({ errors: [{ message: 'Throttled', extensions: { code: 'THROTTLED' } }], extensions: { cost: { requestedQueryCost: 12, throttleStatus: { maximumAvailable: 1000, currentlyAvailable: 5, restoreRate: 50 } } } });
+      return jsonResponse({ data: { ok: 1 } });
+    }) as typeof fetch;
+    const data = await shopifyGraphQL<{ ok: number }>('tok', 'q', {}, fetchImpl);
+    expect(data).toEqual({ ok: 1 });
+    expect(calls).toBe(2);
+  }, 15000);
+
+  it('retries on HTTP 429 honoring Retry-After', async () => {
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls++;
+      if (calls === 1) return jsonResponse({}, 429, { 'Retry-After': '0.01' });
+      return jsonResponse({ data: { ok: 1 } });
+    }) as typeof fetch;
+    await shopifyGraphQL('tok', 'q', {}, fetchImpl);
+    expect(calls).toBe(2);
+  });
+
+  it('throws on non-throttle GraphQL errors', async () => {
+    const fetchImpl = (async () => jsonResponse({ errors: [{ message: 'syntax error' }] })) as typeof fetch;
+    await expect(shopifyGraphQL('tok', 'q', {}, fetchImpl)).rejects.toThrow(/syntax error/);
+  });
+});
+
+describe('productSetUpsert', () => {
+  it('parses product + variant ids and userErrors', async () => {
+    const fetchImpl = (async () => jsonResponse({
+      data: { productSet: { product: { id: 'gid://shopify/Product/1', handle: 'test-card-xx', variants: { nodes: [{ id: 'gid://shopify/ProductVariant/2' }] } }, userErrors: [] } },
+    })) as typeof fetch;
+    const out = await productSetUpsert('tok', INPUT, undefined, fetchImpl);
+    expect(out).toEqual({ productId: 'gid://shopify/Product/1', variantId: 'gid://shopify/ProductVariant/2', handle: 'test-card-xx', userErrors: [], mock: false });
+  });
+
+  it('returns userErrors without throwing', async () => {
+    const fetchImpl = (async () => jsonResponse({
+      data: { productSet: { product: null, userErrors: [{ field: ['input', 'title'], message: 'bad', code: 'INVALID' }] } },
+    })) as typeof fetch;
+    const out = await productSetUpsert('tok', INPUT, undefined, fetchImpl);
+    expect(out.productId).toBeNull();
+    expect(out.userErrors[0].code).toBe('INVALID');
+  });
+
+  it('mock mode fabricates ids and never calls fetch', async () => {
+    process.env.SHOPIFY_WRITE_MOCK = '1';
+    const fetchImpl = (async () => { throw new Error('should not fetch'); }) as typeof fetch;
+    const out = await productSetUpsert('tok', INPUT, undefined, fetchImpl);
+    expect(out.mock).toBe(true);
+    expect(out.productId).toBe('gid://shopify/Product/mock-test-card-xx');
+    expect(out.handle).toBe('test-card-xx');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/timestes/projects/rtt-ytg-import && npx vitest run lib/shopify/admin-write.test.ts`
+Expected: FAIL — cannot resolve `./admin-write`.
+
+- [ ] **Step 3: Implement `lib/shopify/admin-write.ts`** per Behavior above (single retry loop; `const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));`; identifier passed straight through as GraphQL variable, `{ input, identifier }`).
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd /Users/timestes/projects/rtt-ytg-import && npx vitest run lib/shopify/admin-write.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/timestes/projects/rtt-ytg-import
+git add lib/shopify/admin-write.ts lib/shopify/admin-write.test.ts
+git commit -m "feat(import-set): productSet GraphQL client with throttling + mock mode
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Orchestrator `importSet` + sync helper + tests
+
+**Files:**
+- Create: `lib/shopify/importSet.ts`
+- Create: `lib/pricing/syncShopifyProducts.ts`
+- Modify: `lib/pricing/matching.ts` (ONE word: make `loadSetAliases` exported — `async function loadSetAliases` → `export async function loadSetAliases`. Touch nothing else.)
+- Test: `lib/shopify/importSet.test.ts`
+
+**Interfaces:**
+- Consumes: `productFromCard`, `cardSku`, `slugifyTitle`, `baseCardName`, types from `./productFromCard`; `productSetUpsert`, `ProductSetOutcome` from `./admin-write`; `getShopifyAccessToken` from `@/lib/pricing/shopify`; `getSupabaseAdmin` from `@/lib/pricing/supabase-admin`; `loadSetAliases`, `runMatchingPipeline`, `computeCheapestPrices` from `@/lib/pricing/matching`; `CARDS` from `@/lib/cards/generated/cardData`; `getCardImageUrl` from `@/app/shared/utils/cardImageUrl`.
+- Produces (used by Task 5):
+
+```ts
+export interface CardPlan {
+  cardKey: string;
+  cardName: string;
+  title: string;
+  handle: string;
+  sku: string;
+  tags: string[];
+  imageUrl: string | null;      // '' from getCardImageUrl is normalized to null
+  plannedAction: 'create' | 'update' | 'skip-existing';
+  warnings: string[];
+}
+export interface LedgerRow {
+  card_key: string; set_code: string; shopify_product_id: string | null;
+  shopify_variant_id: string | null; handle: string | null; status: string;
+  media_attached: boolean; error: string | null;
+}
+export interface PlanContext {
+  aliasMap: Map<string, string>;
+  ledger: Map<string, LedgerRow>;
+  existingHandles: Set<string>;
+  existingTitles: Set<string>;
+}
+export function planCard(card: CardData, ctx: PlanContext): CardPlan;                    // pure
+export async function planSetImport(setCode: string): Promise<CardPlan[]>;               // loads ctx, maps planCard
+export function listImportableSets(): { code: string; name: string; count: number }[];   // distinct card.set, sorted by name
+
+export interface ImportCardSpec { cardKey: string; price: string | null; include: boolean; titleOverride?: string }
+export interface ImportRequest { setCode: string; status: 'DRAFT' | 'ACTIVE'; cards: ImportCardSpec[] }
+export interface ImportResultRow { cardKey: string; action: 'created' | 'updated' | 'skipped' | 'error'; productId: string | null; error: string | null; mock: boolean }
+export interface ImportSummary { created: number; updated: number; skipped: number; errors: number; reconciled: boolean; mock: boolean }
+export async function executeImport(req: ImportRequest): Promise<{ results: ImportResultRow[]; summary: ImportSummary }>;
+```
+
+**Behavior:**
+- `planCard`: build via `productFromCard(card, ctx.aliasMap.get(card.set) ?? null, { price: null, imageUrl, status: 'DRAFT' })` where `imageUrl = getCardImageUrl(card.imgFile) || null`. plannedAction: ledger hit with non-null `shopify_product_id` → `update`; else computed handle ∈ existingHandles OR computed title ∈ existingTitles → `skip-existing`; else `create`. Suppress `no-price` warning at plan time (prices come from the admin later); keep the others.
+- `planSetImport(setCode)`: cards = `CARDS.filter(c => c.set === setCode)`; ctx loads: `loadSetAliases()`, ledger rows `.from('shopify_card_imports').select('*').eq('set_code', setCode)`, and existing handles/titles from `shopify_products` (paginate: `.select('handle, title').range(from, from + 999)` until short page — mirror has ~5k rows).
+- `executeImport`:
+  1. Recompute the plan context once. For each spec with `include` (skip rest): find card by cardKey from `CARDS` (build a Map first); missing card → result `error` "unknown card_key".
+  2. Card's ledger row decides `identifier` (`{ id: row.shopify_product_id }` when present) and `includeMedia` (`!row?.media_attached`). Cards planned `skip-existing` WITHOUT a ledger row → result `skipped` and ledger upsert `status: 'skipped'`, no Shopify call.
+  3. Validate price: `/^\d+(\.\d{1,2})?$/` after trim; invalid non-null price → result `error`, no call. Normalize with `Number(p).toFixed(2)`; null stays null (builder emits `0.00` + warning).
+  4. Build with `productFromCard(card, alias, { price, imageUrl, status: req.status, titleOverride, includeMedia })`; call `productSetUpsert(token, built.input, identifier)`. Token: `await getShopifyAccessToken()` once up front — in mock mode (`SHOPIFY_WRITE_MOCK === '1'`) skip token fetch and pass `'mock'`.
+  5. `userErrors.length > 0` → action `error` (join messages). Else action `created` (no identifier) / `updated` (identifier). Upsert ledger row after EVERY card (onConflict `card_key`): status, ids, handle, `media_attached: previous || files were included`, error, `updated_at: new Date().toISOString()`.
+  6. Per-card try/catch: a throw records `error` result + ledger row and CONTINUES the batch.
+  7. Sequential loop (no concurrency — pacing lives in the client; ~2-4 cards/s is fine for ≤350-card sets).
+  8. Reconcile at the end ONLY if at least one `created`/`updated` AND not mock: `await syncShopifyProducts(); await runMatchingPipeline({ setCodes: [req.setCode] }); await computeCheapestPrices();` — wrap in try/catch, set `summary.reconciled` accordingly (a reconcile failure must not fail the import response).
+- `lib/pricing/syncShopifyProducts.ts`: extract of the sync body already duplicated in `app/api/admin/sync-shopify/route.ts:5-40` and the cron — `getShopifyAccessToken()` → `fetchAllShopifyProducts(token, 'Single')` → map to rows (same fields incl. `raw_json`, `last_synced_at`) → upsert `shopify_products` in batches of 500, `onConflict: 'id'`. Returns count synced. DO NOT modify the two existing call sites (surgical-changes rule).
+
+- [ ] **Step 1: Write the failing test** for the pure/deterministic parts (`lib/shopify/importSet.test.ts`):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { planCard, listImportableSets, type PlanContext, type LedgerRow } from './importSet';
+import { CARDS } from '@/lib/cards/generated/cardData';
+
+const rr2Card = CARDS.find(c => c.set === 'RR2')!; // any Roots 2 card
+
+function ctx(overrides: Partial<PlanContext> = {}): PlanContext {
+  return { aliasMap: new Map([['RR2', 'Roots 2']]), ledger: new Map(), existingHandles: new Set(), existingTitles: new Set(), ...overrides };
+}
+
+describe('planCard', () => {
+  it('plans create for an unknown card', () => {
+    const plan = planCard(rr2Card, ctx());
+    expect(plan.plannedAction).toBe('create');
+    expect(plan.cardKey).toBe(`${rr2Card.name}|${rr2Card.set}|${rr2Card.imgFile}`);
+    expect(plan.title.endsWith('(Roots 2)')).toBe(true);
+    expect(plan.warnings).not.toContain('no-price'); // suppressed at plan time
+  });
+
+  it('plans update when the ledger has a product id', () => {
+    const key = `${rr2Card.name}|${rr2Card.set}|${rr2Card.imgFile}`;
+    const row: LedgerRow = { card_key: key, set_code: 'RR2', shopify_product_id: 'gid://shopify/Product/9', shopify_variant_id: null, handle: 'x', status: 'created', media_attached: true, error: null };
+    const plan = planCard(rr2Card, ctx({ ledger: new Map([[key, row]]) }));
+    expect(plan.plannedAction).toBe('update');
+  });
+
+  it('plans skip-existing on handle collision with the store mirror', () => {
+    const first = planCard(rr2Card, ctx());
+    const plan = planCard(rr2Card, ctx({ existingHandles: new Set([first.handle]) }));
+    expect(plan.plannedAction).toBe('skip-existing');
+  });
+});
+
+describe('listImportableSets', () => {
+  it('includes RR2 with its official name and a plausible count', () => {
+    const sets = listImportableSets();
+    const rr2 = sets.find(s => s.code === 'RR2');
+    expect(rr2).toBeDefined();
+    expect(rr2!.name).toBe('Roots 2');
+    expect(rr2!.count).toBeGreaterThan(200);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/timestes/projects/rtt-ytg-import && npx vitest run lib/shopify/importSet.test.ts`
+Expected: FAIL — cannot resolve `./importSet`.
+
+- [ ] **Step 3: Make `loadSetAliases` exported in `lib/pricing/matching.ts`** (add the `export` keyword at its definition, ~line 52 — nothing else).
+
+- [ ] **Step 4: Implement `lib/pricing/syncShopifyProducts.ts` and `lib/shopify/importSet.ts`** per Behavior above.
+
+- [ ] **Step 5: Run the new test + the whole suite**
+
+Run: `cd /Users/timestes/projects/rtt-ytg-import && npx vitest run lib/shopify/ && npm test`
+Expected: new tests PASS; full suite has no NEW failures (note any pre-existing failures and leave them).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/timestes/projects/rtt-ytg-import
+git add lib/shopify/importSet.ts lib/shopify/importSet.test.ts lib/pricing/syncShopifyProducts.ts lib/pricing/matching.ts
+git commit -m "feat(import-set): set import orchestrator, ledger writes, reconcile hook
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: API route `app/api/admin/import-set/route.ts`
+
+**Files:**
+- Create: `app/api/admin/import-set/route.ts`
+
+**Interfaces:**
+- Consumes: `planSetImport`, `executeImport`, `listImportableSets`, `ImportRequest` from `@/lib/shopify/importSet`; `isRegistrationAdmin` from `@/utils/adminUtils`; `NextRequest`/`NextResponse` from `next/server`.
+- Produces (consumed by Task 6 UI):
+  - `GET /api/admin/import-set` → `200 { sets: { code, name, count }[] }`
+  - `GET /api/admin/import-set?set=RR2` → `200 { setCode: 'RR2', plans: CardPlan[] }`
+  - `POST` body `{ setCode: string; status: 'DRAFT'|'ACTIVE'; dryRun?: boolean; cards: { cardKey: string; price: string|null; include: boolean; titleOverride?: string }[] }`
+    - `dryRun: true` → `200 { plans: CardPlan[] }` (same as GET preview — no writes)
+    - else → `200 { results: ImportResultRow[], summary: ImportSummary }`
+  - Unauthed → `403 { error: 'Admin access required' }`. Bad input → `400 { error }`. Failure → `500 { error }`.
+
+- [ ] **Step 1: Implement the route** (no unit test — route is thin glue; verified via curl + UI):
+
+```ts
+import { NextRequest, NextResponse } from 'next/server';
+import { isRegistrationAdmin } from '@/utils/adminUtils';
+import { planSetImport, executeImport, listImportableSets, type ImportRequest } from '@/lib/shopify/importSet';
+
+export const maxDuration = 300;
+
+export async function GET(request: NextRequest) {
+  if (!(await isRegistrationAdmin())) {
+    return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+  }
+  try {
+    const setCode = request.nextUrl.searchParams.get('set');
+    if (!setCode) return NextResponse.json({ sets: listImportableSets() });
+    const plans = await planSetImport(setCode);
+    if (plans.length === 0) return NextResponse.json({ error: `Unknown set: ${setCode}` }, { status: 400 });
+    return NextResponse.json({ setCode, plans });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  if (!(await isRegistrationAdmin())) {
+    return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+  }
+  try {
+    const body = await request.json();
+    const { setCode, status, dryRun, cards } = body as ImportRequest & { dryRun?: boolean };
+    if (!setCode || (status !== 'DRAFT' && status !== 'ACTIVE') || !Array.isArray(cards)) {
+      return NextResponse.json({ error: 'setCode, status (DRAFT|ACTIVE) and cards[] are required' }, { status: 400 });
+    }
+    if (dryRun) return NextResponse.json({ plans: await planSetImport(setCode) });
+    const { results, summary } = await executeImport({ setCode, status, cards });
+    return NextResponse.json({ results, summary });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd /Users/timestes/projects/rtt-ytg-import && npx tsc --noEmit`
+Expected: no NEW errors (compare against `git stash`-free baseline by running once before Task 2 if unsure; repo compiles clean on main).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/timestes/projects/rtt-ytg-import
+git add app/api/admin/import-set/route.ts
+git commit -m "feat(import-set): admin-gated preview/execute API route
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Admin UI `app/admin/import-set/page.tsx`
+
+**Files:**
+- Create: `app/admin/import-set/page.tsx` (single `"use client"` file, follows `app/admin/registrations/page.tsx` conventions: `useIsAdmin()` gate, `components/ui` primitives, Tailwind tokens, hand-rolled layout)
+
+**Interfaces:**
+- Consumes: the Task 5 route (`fetch('/api/admin/import-set…')`); `useIsAdmin` from `@/hooks/useIsAdmin`; `Button`, `Input`, `Label` from `@/components/ui/*`; `TopNav` if the registrations page uses it (mirror its import).
+- Produces: page at `/admin/import-set`.
+
+**Required UI behavior (spec §5, §6b, §10):**
+1. **Gate:** `useIsAdmin()`; while loading show nothing; if not admin, `router.replace('/')`.
+2. **Set picker:** on mount `GET /api/admin/import-set` → `<select>` of `sets` as `Roots 2 (RR2) — 224 cards`; choosing one fetches `?set=CODE` and stores `plans` in state alongside per-row UI state: `{ include: plannedAction === 'create', price: '', titleOverride: '' }` (rows planned `update` default include=false too — re-runs are opt-in; `skip-existing` rows default include=false and show a "exists in store" badge).
+3. **Preview table** (wrap in `overflow-x-auto`): columns — include checkbox · thumbnail (`<img src={imageUrl} className="h-14 w-10 object-contain" loading="lazy">`, gray "no image" box + amber warning when null) · card name · computed title (small text; editable via a per-row title-override input shown when the row has warnings or on a per-row "edit" toggle — keep simple: always render a text input prefilled empty with placeholder = computed title) · tags (small, comma-joined) · planned action badge (`create` neutral, `update` blue, `skip-existing` amber) · warnings (amber text, comma-joined) · price `<Input inputMode="decimal">`.
+4. **Bulk price helpers** above the table: default-price input + "Apply to blank rows" button; "Set ALL prices to X" button (both operate on included rows only). Show count: "N included · M with blank price".
+5. **Draft/Active toggle:** a labeled checkbox "Publish as ACTIVE immediately (default: DRAFT)". Unchecked = DRAFT.
+6. **Buttons:** "Dry run" → POST with `dryRun: true`, re-renders plans (confirms server agrees) and shows a green-free confirmation line "Dry run OK — N cards planned, no writes". "Import N cards" → `window.confirm` summarizing (N cards, X blank prices, DRAFT/ACTIVE) then POST for real; disable while running with progress text.
+7. **Results panel:** table of `results` rows (cardKey → action badge / productId / error text), plus summary line "created X · updated Y · skipped Z · errors W" and, when `summary.mock`, a violet "MOCK MODE — no real Shopify writes" banner. When `summary.reconciled` show "Price pipeline reconciled".
+8. **Validation:** price inputs validate `/^\d*\.?\d{0,2}$/` on change (reject other keystrokes); blank allowed (flagged amber in the row).
+9. Styling: `bg-card border rounded-lg`, `bg-muted` header row, `divide-y` body, `text-muted-foreground` secondary text — copy the registrations page's table classes. NO `focus:ring` classes, NO green accents at rest.
+
+- [ ] **Step 1: Implement the page** per the behavior list. Keep it one file, ~350-450 lines. State shape:
+
+```ts
+type RowState = { include: boolean; price: string; titleOverride: string };
+const [sets, setSets] = useState<{ code: string; name: string; count: number }[]>([]);
+const [setCode, setSetCode] = useState('');
+const [plans, setPlans] = useState<CardPlan[]>([]);          // CardPlan type inlined locally (mirror lib/shopify/importSet.ts CardPlan)
+const [rows, setRows] = useState<Record<string, RowState>>({}); // keyed by cardKey
+const [active, setActive] = useState(false);
+const [defaultPrice, setDefaultPrice] = useState('');
+const [running, setRunning] = useState(false);
+const [results, setResults] = useState<ImportResultRow[] | null>(null);
+const [summary, setSummary] = useState<ImportSummary | null>(null);
+const [dryRunMsg, setDryRunMsg] = useState('');
+const [error, setError] = useState('');
+```
+
+POST body construction: `cards: plans.map(p => ({ cardKey: p.cardKey, price: rows[p.cardKey].price.trim() || (defaultPrice.trim() || null), include: rows[p.cardKey].include, titleOverride: rows[p.cardKey].titleOverride.trim() || undefined }))`.
+
+- [ ] **Step 2: Type-check + lint pass**
+
+Run: `cd /Users/timestes/projects/rtt-ytg-import && npx tsc --noEmit`
+Expected: clean (no new errors).
+
+- [ ] **Step 3: Smoke-run in dev with mock mode** (only if a dev server can be started cleanly; otherwise skip — Task 7 covers verification):
+
+```bash
+cd /Users/timestes/projects/rtt-ytg-import && SHOPIFY_WRITE_MOCK=1 npm run dev
+```
+
+Load `/admin/import-set` logged in as an admin, pick a small set, eyeball the table. (The `verify` skill documents minting admin sessions if needed.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/timestes/projects/rtt-ytg-import
+git add app/admin/import-set/page.tsx
+git commit -m "feat(import-set): admin preview/import UI with editable prices
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Verification, migration apply, PR
+
+**Files:** none new
+
+- [ ] **Step 1: Full test suite**
+
+Run: `cd /Users/timestes/projects/rtt-ytg-import && npm test`
+Expected: all new tests pass; zero NEW failures vs main.
+
+- [ ] **Step 2: Type gate**
+
+Run: `cd /Users/timestes/projects/rtt-ytg-import && npx tsc --noEmit`
+Expected: clean. (Skip full `next build` per standing user preference; if run anyway, use `NEXT_DIST_DIR=.next-build` to avoid clobbering a live dev server.)
+
+- [ ] **Step 3: Mock end-to-end sanity** — exercise `executeImport` directly against a tiny slice with `SHOPIFY_WRITE_MOCK=1` using a scratch script (NOT committed) that imports 2 cards of a small set with fake prices and prints results; confirm ledger rows land in Supabase (needs `SUPABASE_SERVICE_ROLE_KEY` in env — if unavailable, note it and rely on unit tests).
+
+- [ ] **Step 4: Apply migration 080 to prod via Supabase MCP** (`mcp__supabase__apply_migration`, name `080_create_shopify_card_imports`) — additive, empty table, zero-risk. If MCP unavailable, note in PR that migration needs applying.
+
+- [ ] **Step 5: Push + PR**
+
+```bash
+cd /Users/timestes/projects/rtt-ytg-import
+git push -u origin feat/ytg-set-import
+gh pr create --base main --title "feat: YTG Shopify set importer (draft-first, productSet)" --body "$(cat <<'EOF'
+## Summary
+- Admin page + API to create one Shopify product per card of a set in YTG's store (spec: docs/superpowers/specs/2026-07-25-ytg-shopify-set-import-design.md)
+- Pure `productFromCard` builder grounded in real YTG dump conventions (title/handle/tags), unit-tested
+- GraphQL `productSet` write client (API 2026-07) with cost-based throttling, THROTTLED/429 retry, and `SHOPIFY_WRITE_MOCK=1` mode
+- `shopify_card_imports` ledger (migration 080) for idempotent re-runs; reconciles into the existing pricing pipeline post-import
+- Draft-first with explicit ACTIVE toggle; per-card editable prices with bulk helpers; dry-run preview
+
+## Blocked on YTG
+- `write_products` scope on the custom app — until granted, real imports will 403; mock mode + dry-run fully work
+
+## Test plan
+- [x] `npm test` (builder + client + planner units, dump-grounded fixtures)
+- [x] `tsc --noEmit`
+- [ ] Live small-set draft import once scope is granted (spec §11.4)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: Clean up worktree** (AFTER PR is open; keep it if follow-ups are expected):
+
+```bash
+git -C /Users/timestes/projects/redemption-tournament-tracker worktree remove ../rtt-ytg-import
+```
+
+---
+
+## Self-review notes (spec → task coverage)
+
+- §5 architecture units → Tasks 2 (builder), 3 (admin-write), 4 (importSet + ledger use), 5 (route), 6 (page), 1 (migration). CSV adapter (§4 fallback, phase 5 "optional") — deliberately NOT included; spec marks it optional.
+- §6 field mapping + §6a images + §6b prices → Task 2 rules + Task 6 UI helpers.
+- §7 idempotency (ledger, identifier, handle pre-check, sku, metafield) → Tasks 2 (sku/metafield), 4 (ledger/identifier/pre-check via mirror).
+- §8 API details → Task 3 (endpoint/version/mutation/throttle), scope limitation handled via mock mode + PR note.
+- §9 reconcile → Task 4 step 8.
+- §10 safety → draft default (Tasks 2/5/6), dry-run (5/6), validation (4/6), per-card isolation (4), admin gate (5).
+- §11 testing → dump-grounded unit tests (2), dry-run (6), live trial deferred to post-scope-grant (PR note).
+- Handle pre-check uses the local `shopify_products` mirror, not a live Shopify query — documented tradeoff (mirror refreshes nightly + at each import's reconcile).

--- a/docs/superpowers/specs/2026-07-25-ytg-shopify-set-import-design.md
+++ b/docs/superpowers/specs/2026-07-25-ytg-shopify-set-import-design.md
@@ -1,0 +1,152 @@
+# YTG Shopify Set Import — Design
+
+- **Date:** 2026-07-25
+- **Status:** Draft (design / brainstorming output)
+- **Owner:** landofredemption
+- **Related code:** `lib/pricing/shopify.ts`, `app/api/admin/sync-shopify/route.ts`, `lib/cards/lookup.ts`, `supabase/migrations/011_create_price_tables.sql`
+
+## 1. Goal
+
+Let an admin select a Redemption set and create one Shopify product per card in that set inside YTG's live store (`your-turn-games.myshopify.com`), so YTG no longer hand-creates dozens–hundreds of single-card listings when a new set drops. We already hold the card data (names, type, brigade, rarity, set), the card images (public Vercel Blob URLs), and already talk to this exact store for pricing — this feature adds the first *write* path.
+
+Each imported product carries a **card image** and the **price YTG enters inline during import**, so a set can be created complete-in-one-pass ("one shot") rather than needing per-card cleanup in Shopify afterward.
+
+Success = an admin picks a set, sees a preview with each card's image and an editable price, runs it, and the set's cards appear in Shopify with image + price attached; afterward the existing price pipeline picks them up automatically. Products land as **draft** by default (YTG reviews then publishes), with an **Active** toggle for a true one-shot.
+
+## 2. Context (what already exists)
+
+- **Read integration:** `lib/pricing/shopify.ts` authenticates to `your-turn-games.myshopify.com` via a custom-app token (`getShopifyAccessToken()`, env `SHOPFIY_CLIENT_ID` [sic] + `SHOPIFY_CLIENT_SECRET`) and reads products (`fetchAllShopifyProducts`, filtered to `product_type='Single'`). It handles 429/`Retry-After`. Pinned to REST API version `2024-01`.
+- **Pricing pipeline (Shopify → app):** cron `app/api/cron/sync-prices` and manual `app/api/admin/sync-shopify` upsert products into Supabase `shopify_products`, then a matcher (`lib/pricing/matching.ts`) resolves each card → product into `card_price_mappings` / `card_prices`, which the deck builder reads.
+- **Card data:** generated `lib/cards/generated/cardData.json` via `lib/cards/lookup.ts` (`CARDS`, `findCard`, `CardData`). Fields: `name, set, imgFile, officialSet, type, brigade, strength, toughness, class, identifier, specialAbility, rarity, reference, alignment, legality`. Card key = `` `${name}|${set}|${imgFile}` ``.
+- **Set mapping:** Supabase `set_aliases` maps carddata set codes → YTG/Shopify set abbreviations.
+- **Real YTG "Single" shape (from `scripts/output/ytg_products.json`, 5,131 products):**
+  - `title`: `"He is Risen" (Legacy Rare)`, `"I AM" Has Sent Me (PoC)` — card name + a parenthetical (set abbrev, or a rarity/variant qualifier).
+  - `handle`: slug of title · `vendor`: `Your Turn Games` · `product_type`: `Single` · `status`: `active`.
+  - `tags` (comma-sep): card type + brigade/color + set name + rarity + grouping, e.g. `Good Enhancement, Gospel of Christ, Legacy Rare, Rotation Cards, White`.
+  - `variant`: single default variant, `price` string, **SKU empty, inventory not tracked**.
+  - `images`: none — YTG singles are text-only listings.
+
+## 3. Non-goals
+
+- Not importing stock levels. Inventory is not tracked on YTG singles, so we don't touch it. (Prices and images **are** in scope — see §6, §6a, §6b.)
+- Not touching the existing read/pricing path beyond consuming its reconcile step.
+- Not in scope: Forge custom sets. This targets official Redemption sets YTG sells as singles.
+- Not backfilling / de-duplicating YTG's existing 4,868 singles.
+- Not hosting/processing images ourselves — we reuse the existing public Blob URLs and hand Shopify the URL; Shopify fetches and stores its own copy.
+
+## 4. Approach
+
+**Chosen: in-app API importer, draft-first, via GraphQL `productSet`.**
+
+An admin page + API route builds a Shopify product per card and upserts it with the GraphQL Admin API's `productSet` mutation, as `DRAFT`, then reconciles into the pricing pipeline.
+
+Why `productSet` over REST or `productCreate`:
+- Shopify's **REST Admin API is legacy (as of 2024-10-01)**; its product endpoints are maintenance-mode with no new features. A new write path should be GraphQL.
+- Shopify explicitly recommends **`productSet`** for apps that "sync product data from an external source." It sets product fields + the single variant's price/SKU in **one call**, supports an **`identifier`** argument for idempotent upsert, and requires only `write_products`.
+- `productCreate` would need a second `productVariantsBulkUpdate` call to set the variant price — two round-trips per card for no benefit here.
+
+**Rejected alternatives:**
+- **REST `POST /products.json`** — matches existing code style but is on the deprecated path; avoid for new writes.
+- **CSV export + Shopify's native importer** — zero write-scope and zero live-store risk, but a manual step for YTG, no idempotency, no round-trip. Kept as a near-free fallback: the core builder emits a normalized product object, and a CSV serializer is a thin adapter over it.
+- **GraphQL bulk operations (`bulkOperationRunMutation` + JSONL)** — built for thousands of items; overkill for set-sized batches (~150–350 cards). Revisit only if we ever import the whole catalog at once.
+
+## 5. Architecture (small, testable units)
+
+- **`lib/shopify/productFromCard.ts`** — pure function `(CardData, setAlias, { price, imageUrl }) → ProductSetInput`. No I/O; price and image URL are passed in. This is where every mapping/naming decision lives, so it's unit-testable against real dump examples.
+- **`lib/shopify/admin-write.ts`** — GraphQL client + write calls: `shopifyGraphQL(query, variables)` (reuses `getShopifyAccessToken()`), `productSetUpsert(input, identifier?)`. Owns cost-based throttling and THROTTLED retry.
+- **`lib/shopify/importSet.ts`** — orchestrator: gather the set's cards from `cardData.json` → consult the import ledger → build inputs → upsert with concurrency/pacing → collect per-card results (`created | updated | skipped | error`) → write ledger rows.
+- **`app/api/admin/import-set/route.ts`** — admin-gated. `GET`/preview builds the per-card plan (planned action, built title/tags, resolved image URL, image-available flag). `POST { setCode, status, cards: [{ cardKey, price, include }] }` executes with the prices the admin entered. A `dryRun` flag returns the plan without writing.
+- **`app/admin/import-set/` page** — pick a set → preview table with an **image thumbnail**, built title/tags, an **editable price** per row, and planned action (create / already-exists / needs-attention) → **Draft/Active** toggle + bulk price helpers → **Dry-run** then **Execute** → results with per-card status and errors.
+- **Migration: `shopify_card_imports`** (new) — ledger keyed by `card_key`: `shopify_product_id`, `variant_id`, `handle`, `status`, `error`, `created_at`, `updated_at`. Makes re-runs safe and gives an audit trail.
+
+Data flow: `cardData` (+ `set_aliases`) → `productFromCard` → `importSet` → `productSet` (Shopify) → ledger → existing `sync-shopify` reconcile → `shopify_products` / matcher → deck-builder prices.
+
+## 6. Field mapping (grounded in the real dump)
+
+| Shopify field | Source / rule |
+|---|---|
+| `title` | `card.name` + ` (` + set abbrev from `set_aliases` + `)`. For the common case (importing one new set) every card gets that set's abbrev. Cards needing a rarity/variant qualifier (e.g. `(Legacy Rare)`) are flagged in preview for manual title override. |
+| `handle` | deterministic slug of the title (mirrors YTG's scheme). |
+| `productType` | `"Single"` (so the existing `product_type=Single` sync filter picks it up). |
+| `vendor` | `"Your Turn Games"`. |
+| `tags` | assembled: `card.type` + brigade→color name(s) + set name + `card.rarity` + rotation/grouping tag. Needs a brigade-code→color-name map (reuse/derive from the deck-builder brigade colors). |
+| `variant.price` | the price YTG enters per card in the preview (see §6b). No hard-coded placeholder in the mapping. |
+| `variant.sku` | canonical SKU we assign (e.g. `<setAbbrev>-<identifier>`), giving future idempotency YTG's own SKU-less singles lack. |
+| `status` | `DRAFT` by default; `ACTIVE` if the admin flips the per-import toggle. |
+| media (image) | one image per product from the card's public Blob URL (see §6a). |
+
+Tag construction and the parenthetical convention are the two spots with per-set nuance; both live in `productFromCard` and are validated against dump examples, so tuning is localized. `productFromCard` stays pure — the price and image URL are passed *into* it (from the preview edits and the image resolver), not fetched inside it.
+
+### 6a. Card images
+
+- **Source:** `getCardImageUrl(card.imgFile)` from `app/shared/utils/cardImageUrl.ts` → `${NEXT_PUBLIC_BLOB_BASE_URL}/card-images/<imgFile>.jpg`. This is already a **public** Vercel Blob URL (the deck builder serves card art from it), so Shopify can fetch it directly — no upload/staging pipeline.
+- **Mechanism:** attach in the same `productSet` call via the media/`files` field: `{ originalSource: <blobUrl>, mediaContentType: IMAGE, alt: <card name> }`. Shopify downloads and stores its own copy; media processing is **asynchronous** on Shopify's side (status goes `PROCESSING` → `READY`), so we don't block on it — the product is usable immediately and the image lands shortly after.
+- **Missing images:** some cards may resolve to no Blob asset (e.g. a `forge:` ref or an un-synced image). These are **flagged in the preview** ("no image") and the product is still created without media rather than blocking the batch.
+- **Idempotency:** the ledger records whether media was attached. On an update/re-run we omit the media field so Shopify doesn't append a duplicate image.
+
+### 6b. Per-card price entry ("one shot")
+
+- The preview table has an **editable price column**, one input per card, so YTG sets every price in this one screen instead of editing each product in Shopify afterward.
+- **Bulk helpers:** a "set all prices to $X" action and an "apply to blank only" variant, plus an optional set-level default so a whole common-rarity set can be filled in one action.
+- **Validation:** price is a non-negative decimal (2 places). Rows left blank fall back to the set-level default; any still-blank are flagged (not blocked) so the admin can decide.
+- The entered price becomes `variant.price` in the `productSet` input. Combined with images and the `ACTIVE` toggle, a set can be imported publish-ready in a single pass.
+
+## 7. Idempotency
+
+Primary mechanism is our own **ledger** (`shopify_card_imports`), fully under our control:
+
+1. For each card, look up `card_key` in the ledger.
+2. **Miss** → `productSet` create; record `shopify_product_id` + `variant_id`.
+3. **Hit** → `productSet(identifier: { id })` update (no duplicate).
+4. Before first-time create, also pre-check Shopify by deterministic `handle` to avoid colliding with a pre-existing YTG listing; if found, record it as `skipped` (needs-attention) rather than creating a second one.
+
+We additionally set a stable `sku` and (optionally) a `custom.rtt_card_key` metafield so products remain traceable to their card even outside the ledger.
+
+## 8. Shopify API details
+
+- **Auth:** reuse `getShopifyAccessToken()` + `X-Shopify-Access-Token` header. No new auth mechanism.
+- **Endpoint:** GraphQL Admin `POST /admin/api/<version>/graphql.json`.
+- **Version:** target a current stable version (2026-07 at time of writing) for the write path; `productSet` requires ≥ 2024-04. (Aside: the read path is still pinned to `2024-01`, now past its support window — worth bumping separately, but out of scope here.)
+- **Mutation:** `productSet(synchronous: true, identifier: …, input: ProductSetInput)`. `synchronous: true` is fine for single-variant products; switch to async + `productOperation` polling only if we hit timeouts on large sets.
+- **Media:** image attached in the same `productSet` input via the media/`files` field (`originalSource` = public Blob URL, `mediaContentType: IMAGE`). Shopify fetches and stores its own copy; processing is async (`PROCESSING` → `READY`) and does not block the mutation response.
+- **Scope:** `write_products` must be added to YTG's custom app (currently read-only). This scope also covers product media. `write_inventory` not needed (inventory untracked).
+- **Env:** `NEXT_PUBLIC_BLOB_BASE_URL` must be present in the environment running the import (used to build image URLs).
+- **Rate limits:** cost-based — 1,000-point bucket, 50 pts/s restore, ~10 pts/mutation ⇒ ~5 upserts/s sustained. Pace off `extensions.cost.throttleStatus`; back off on `THROTTLED`. A 300-card set ≈ ~60–70s.
+
+## 9. Round-trip / reconciliation
+
+After a successful import, trigger the existing `sync-shopify` → `shopify_products` → matcher pipeline (or a set-scoped variant of it) so newly-created cards flow into `card_price_mappings` / `card_prices` and start showing prices in the deck builder with no extra wiring. Ledger `card_key` = the matcher's join key, so mappings land cleanly.
+
+## 10. Safety & operations
+
+- **Draft by default** — nothing is shopper-visible until YTG publishes; `ACTIVE` is an explicit opt-in toggle for a one-shot import.
+- **Dry-run preview** — required first look; shows planned action, built payload, resolved image, and the entered price per card, no writes.
+- **Price validation** — non-negative decimal (2 places); blank falls back to the set-level default and is flagged. No accidental $0 unless the admin leaves it so.
+- **Per-card error isolation** — one bad card (bad price, missing image, API error) is reported and the batch continues.
+- **Idempotent re-runs** — ledger + `identifier` upsert; safe to re-run a partially-imported set.
+- **Admin-gated** — same admin auth as existing `app/api/admin/*` routes.
+- **Preview grounded in real data** — the builder's output is diffable against `scripts/output/ytg_products.json` examples before we ever write.
+
+## 11. Testing & verification
+
+1. **Unit:** `productFromCard` against real card→product pairs extracted from the YTG dump (given card X + a price + an image URL, produce YTG's actual title/tags/handle shape with the media + price fields set).
+2. **Dry-run** a real set; eyeball the preview table end to end — image thumbnails resolve, prices editable, planned actions correct.
+3. **Dev store** (optional but recommended): run a small set as drafts against a Shopify development store before touching production — confirm images process to `READY` and prices attach.
+4. **Live small-set trial:** import one small set as drafts → verify in Shopify admin that each product has the right image + entered price → reconcile → confirm prices appear in the deck builder.
+
+## 12. Dependencies / open questions
+
+- **`write_products` scope** on YTG's custom app (config change on YTG's side); also covers product media.
+- **Brigade→color-name map** for tags (source it from existing deck-builder brigade colors, or define once).
+- **Card image coverage** — a new set's images must be synced to Blob (`/api/sync-card-images`) before/at import; the preview flags any card with no resolvable image. Confirm timing so a fresh set's art is present when YTG imports.
+- **Title parenthetical per set** — default to set abbrev; confirm which sets need rarity/variant qualifiers (reverse-engineer from the dump; flag exceptions in preview).
+- **Rotation/grouping tags** — confirm which grouping tags (e.g. `Rotation Cards`) YTG wants on a new set.
+- **Default price** — optional set-level default used for blank rows; confirm whether YTG wants one (e.g. by common rarity) or prefers to fill every price explicitly.
+
+## 13. Phasing
+
+1. Ledger migration + `productFromCard` builder (price + image params) + unit tests (no network).
+2. `admin-write.ts` (`productSet` with media + throttling) + `importSet` orchestrator + dry-run/preview API.
+3. Admin UI: preview table with image thumbnails, editable prices + bulk helpers, Draft/Active toggle → execute → results.
+4. Reconcile hook + live small-set trial (verify image + price landed).
+5. Optional: CSV export adapter.

--- a/docs/ytg-shopify-write-access-guide.md
+++ b/docs/ytg-shopify-write-access-guide.md
@@ -1,0 +1,112 @@
+# Granting Write Access for the Set Importer — YTG Store Owner Guide
+
+A walk-through for adding the `write_products` permission to the existing
+RedemptionCCG.app integration on `your-turn-games.myshopify.com`. Written to be
+read together over a call. About 5–10 minutes.
+
+## What we're asking for, in plain terms
+
+The integration that already reads your singles prices needs one additional
+permission — **write products** — so it can create the new-set listings for you
+(one product per card, with image and price attached).
+
+Reassurances up front:
+
+- **Everything imports as a hidden Draft** by default. Nothing appears in the
+  store until you publish it (there's an "active" option, but it's off unless
+  you turn it on per import).
+- The permission covers **products only** (products, variants, collections).
+  It cannot touch orders, customers, payments, payouts, or store settings.
+- **Inventory is untouched** — the importer doesn't track or change stock.
+- **No new passwords or secrets to send.** The app keeps its existing
+  credentials; you're only widening what those credentials may do.
+- You can **revoke it at any time** (remove the permission or the app).
+
+Current state, verified via the API: the app has exactly one permission today —
+`read_products`. We're adding `write_products` (which includes read).
+
+## Before you start
+
+- Log in as the **store owner** account (staff accounts may lack access to the
+  app-development area).
+- The app to modify is the custom app used for the price sync — its API key
+  (Client ID) starts with `773…`. If more than one app is listed, check the
+  key's first characters against that.
+
+## Part 1 — Open the app's settings
+
+The app was set up with Shopify's newer app system, so its settings most likely
+live in Shopify's **Dev Dashboard** rather than the store admin itself.
+
+1. Go to **https://dev.shopify.com** and sign in with the same account you use
+   for the store. (Alternative route: Shopify admin → **Settings** → **Apps and
+   sales channels** → **Develop apps** → the button that sends you to the Dev
+   Dashboard.)
+2. Open **Apps** and click the price-sync app.
+
+> **If the app isn't listed in the Dev Dashboard**, it's an older-style custom
+> app managed inside the store admin — skip to "Fallback: older-style app"
+> below. Same result, shorter path.
+
+## Part 2 — Add the write-products permission
+
+In the Dev Dashboard, permissions ("access scopes") are part of the app's
+configuration and ship as a new **version** of the app:
+
+1. Open the app's **Versions** (or configuration) tab.
+2. Find the **Admin API access scopes** section.
+3. Add **`write_products`**. Depending on the screen, this is either a
+   checkbox under a *Products* heading or a search box — if it's a search box,
+   type `write_products` and select it. Leave `read_products` as is.
+4. Save / **Release** the new version. (Releasing an app version here is just
+   Shopify's way of saving a settings change — it doesn't touch your store
+   theme or anything shopper-facing.)
+
+## Part 3 — Approve the new permission on the store
+
+Shopify does not silently widen an installed app's permissions — the store has
+to approve the addition once:
+
+1. Go back to your **store admin** → **Settings** → **Apps and sales
+   channels**, and open the app's entry. If Shopify wants approval, you'll see
+   a banner or button describing the new permission — click **Update / Approve**.
+2. If no prompt appears there, return to the Dev Dashboard app page and look
+   for an **Installs** section — re-running **Install** for
+   `your-turn-games` presents the same approval screen (it re-authorizes;
+   it doesn't create a duplicate app).
+
+The approval screen should list *"Modify products"* (or `write_products`) as
+the only change. That's the expected ask — if it lists anything more
+(orders, customers, etc.), stop and tell me before approving.
+
+## Fallback — older-style app (only if Part 1 found it in the store admin)
+
+1. Shopify admin → **Settings** → **Apps and sales channels** → **Develop
+   apps** → click the app.
+2. **Configuration** tab → **Admin API integration** → **Edit**.
+3. Under **Products**, tick **write_products** (Read and write).
+4. **Save**. No reinstall or new token is needed; the change applies to the
+   existing credentials.
+
+## Part 4 — Tell me, and I'll confirm from my side
+
+Nothing to copy or send. Once you've approved, I run a 30-second check that
+asks Shopify what the app's credentials are now allowed to do — I'm looking
+for `write_products` to appear next to `read_products`. I'll confirm on the
+spot.
+
+## What happens next
+
+1. We pick **one cheap card** and import just it, as a Draft, while you watch.
+2. You open it in your admin: right title, right image, right price, hidden
+   from the storefront. Publish it or delete it — your call.
+3. When you're happy, we do a full set the same way: you review the Draft
+   products in bulk and publish when ready.
+
+## Undo / revocation
+
+- Remove the permission the same way it was added (edit scopes back to
+  read-only), or uninstall the app from **Settings → Apps and sales
+  channels** — either immediately cuts off write access.
+- Rotating the app's client secret (Dev Dashboard → app → Settings →
+  Credentials) also invalidates the integration's access entirely.

--- a/lib/pricing/matching.ts
+++ b/lib/pricing/matching.ts
@@ -49,7 +49,7 @@ export async function loadCardData(): Promise<CardRow[]> {
 /**
  * Load set aliases from Supabase.
  */
-async function loadSetAliases(): Promise<Map<string, string>> {
+export async function loadSetAliases(): Promise<Map<string, string>> {
   const supabase = getSupabaseAdmin();
   const { data, error } = await supabase.from('set_aliases').select('*');
   if (error) throw new Error(`Failed to load set_aliases: ${error.message}`);

--- a/lib/pricing/syncShopifyProducts.ts
+++ b/lib/pricing/syncShopifyProducts.ts
@@ -1,0 +1,48 @@
+/**
+ * Sync Shopify products into the `shopify_products` mirror table.
+ *
+ * Extracted from the sync body duplicated in app/api/admin/sync-shopify/route.ts
+ * and the cron job, so importSet's post-import reconcile step can reuse it
+ * without an HTTP round-trip. Those two call sites are left as-is.
+ */
+
+import { getSupabaseAdmin } from './supabase-admin';
+import { getShopifyAccessToken, fetchAllShopifyProducts } from './shopify';
+
+export async function syncShopifyProducts(): Promise<number> {
+  const token = await getShopifyAccessToken();
+  const products = await fetchAllShopifyProducts(token, 'Single');
+
+  const supabase = getSupabaseAdmin();
+  const rows = products.map(p => {
+    const price = Math.min(...p.variants.map(v => parseFloat(v.price)));
+    const inventory = p.variants.reduce((sum, v) => sum + (v.inventory_quantity || 0), 0);
+    return {
+      id: String(p.id),
+      title: p.title,
+      handle: p.handle,
+      tags: p.tags || null,
+      product_type: p.product_type,
+      price,
+      inventory_quantity: inventory,
+      raw_json: p,
+      last_synced_at: new Date().toISOString(),
+    };
+  });
+
+  let synced = 0;
+  const batchSize = 500;
+  for (let i = 0; i < rows.length; i += batchSize) {
+    const batch = rows.slice(i, i + batchSize);
+    const { error } = await supabase
+      .from('shopify_products')
+      .upsert(batch, { onConflict: 'id' });
+    if (error) {
+      console.error(`Sync batch error:`, error.message);
+    } else {
+      synced += batch.length;
+    }
+  }
+
+  return synced;
+}

--- a/lib/shopify/admin-write.test.ts
+++ b/lib/shopify/admin-write.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { shopifyGraphQL, productSetUpsert } from './admin-write';
+import type { ShopifyProductSetInput } from './productFromCard';
+
+const INPUT: ShopifyProductSetInput = {
+  title: 'Test Card (XX)', handle: 'test-card-xx', productType: 'Single',
+  vendor: 'Your Turn Games', tags: ['Hero'], status: 'DRAFT',
+  productOptions: [{ name: 'Title', values: [{ name: 'Default Title' }] }],
+  variants: [{ optionValues: [{ optionName: 'Title', name: 'Default Title' }], price: '1.00', sku: 'XX-test' }],
+};
+
+function jsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}) {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json', ...headers } });
+}
+
+afterEach(() => { delete process.env.SHOPIFY_WRITE_MOCK; });
+
+describe('shopifyGraphQL', () => {
+  it('POSTs query+variables with the access token header and returns data', async () => {
+    let captured: { url: string; init: RequestInit } | null = null;
+    const fetchImpl = (async (url: any, init: any) => {
+      captured = { url: String(url), init };
+      return jsonResponse({ data: { ok: true }, extensions: { cost: { throttleStatus: { maximumAvailable: 1000, currentlyAvailable: 990, restoreRate: 50 } } } });
+    }) as typeof fetch;
+    const data = await shopifyGraphQL<{ ok: boolean }>('tok', 'query { x }', {}, fetchImpl);
+    expect(data).toEqual({ ok: true });
+    expect(captured!.url).toBe('https://your-turn-games.myshopify.com/admin/api/2026-07/graphql.json');
+    expect((captured!.init.headers as Record<string, string>)['X-Shopify-Access-Token']).toBe('tok');
+  });
+
+  it('retries on THROTTLED then succeeds', async () => {
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls++;
+      if (calls === 1) return jsonResponse({ errors: [{ message: 'Throttled', extensions: { code: 'THROTTLED' } }], extensions: { cost: { requestedQueryCost: 12, throttleStatus: { maximumAvailable: 1000, currentlyAvailable: 5, restoreRate: 50 } } } });
+      return jsonResponse({ data: { ok: 1 } });
+    }) as typeof fetch;
+    const data = await shopifyGraphQL<{ ok: number }>('tok', 'q', {}, fetchImpl);
+    expect(data).toEqual({ ok: 1 });
+    expect(calls).toBe(2);
+  }, 15000);
+
+  it('retries on HTTP 429 honoring Retry-After', async () => {
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls++;
+      if (calls === 1) return jsonResponse({}, 429, { 'Retry-After': '0.01' });
+      return jsonResponse({ data: { ok: 1 } });
+    }) as typeof fetch;
+    await shopifyGraphQL('tok', 'q', {}, fetchImpl);
+    expect(calls).toBe(2);
+  });
+
+  it('throws on non-throttle GraphQL errors', async () => {
+    const fetchImpl = (async () => jsonResponse({ errors: [{ message: 'syntax error' }] })) as typeof fetch;
+    await expect(shopifyGraphQL('tok', 'q', {}, fetchImpl)).rejects.toThrow(/syntax error/);
+  });
+});
+
+describe('productSetUpsert', () => {
+  it('parses product + variant ids and userErrors', async () => {
+    const fetchImpl = (async () => jsonResponse({
+      data: { productSet: { product: { id: 'gid://shopify/Product/1', handle: 'test-card-xx', variants: { nodes: [{ id: 'gid://shopify/ProductVariant/2' }] } }, userErrors: [] } },
+    })) as typeof fetch;
+    const out = await productSetUpsert('tok', INPUT, undefined, fetchImpl);
+    expect(out).toEqual({ productId: 'gid://shopify/Product/1', variantId: 'gid://shopify/ProductVariant/2', handle: 'test-card-xx', userErrors: [], mock: false });
+  });
+
+  it('returns userErrors without throwing', async () => {
+    const fetchImpl = (async () => jsonResponse({
+      data: { productSet: { product: null, userErrors: [{ field: ['input', 'title'], message: 'bad', code: 'INVALID' }] } },
+    })) as typeof fetch;
+    const out = await productSetUpsert('tok', INPUT, undefined, fetchImpl);
+    expect(out.productId).toBeNull();
+    expect(out.userErrors[0].code).toBe('INVALID');
+  });
+
+  it('mock mode fabricates ids and never calls fetch', async () => {
+    process.env.SHOPIFY_WRITE_MOCK = '1';
+    const fetchImpl = (async () => { throw new Error('should not fetch'); }) as typeof fetch;
+    const out = await productSetUpsert('tok', INPUT, undefined, fetchImpl);
+    expect(out.mock).toBe(true);
+    expect(out.productId).toBe('gid://shopify/Product/mock-test-card-xx');
+    expect(out.handle).toBe('test-card-xx');
+  });
+});

--- a/lib/shopify/admin-write.ts
+++ b/lib/shopify/admin-write.ts
@@ -1,0 +1,138 @@
+import type { ShopifyProductSetInput } from './productFromCard';
+
+const ENDPOINT = 'https://your-turn-games.myshopify.com/admin/api/2026-07/graphql.json';
+const MAX_ATTEMPTS = 5;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export interface ProductSetOutcome {
+  productId: string | null;
+  variantId: string | null;
+  handle: string | null;
+  userErrors: { field: string[] | null; message: string; code: string | null }[];
+  mock: boolean;
+}
+
+interface ThrottleStatus {
+  maximumAvailable: number;
+  currentlyAvailable: number;
+  restoreRate: number;
+}
+
+interface GraphQLResponseBody {
+  data?: unknown;
+  errors?: { message: string; extensions?: { code?: string } }[];
+  extensions?: { cost?: { requestedQueryCost?: number; throttleStatus?: ThrottleStatus } };
+}
+
+export async function shopifyGraphQL<T>(
+  token: string,
+  query: string,
+  variables: Record<string, unknown>,
+  fetchImpl: typeof fetch = fetch,
+): Promise<T> {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const res = await fetchImpl(ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Shopify-Access-Token': token,
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+
+    if (res.status === 429) {
+      const retryAfter = Number(res.headers.get('Retry-After')) || 2;
+      await sleep(retryAfter * 1000);
+      continue;
+    }
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Shopify GraphQL request failed (${res.status}): ${text}`);
+    }
+
+    const body = (await res.json()) as GraphQLResponseBody;
+
+    if (body.errors && body.errors.length > 0) {
+      const throttled = body.errors.some((e) => e.extensions?.code === 'THROTTLED');
+      if (throttled) {
+        const cost = body.extensions?.cost;
+        const requestedQueryCost = cost?.requestedQueryCost;
+        const currentlyAvailable = cost?.throttleStatus?.currentlyAvailable;
+        const restoreRate = cost?.throttleStatus?.restoreRate;
+        let waitMs = 2000;
+        if (
+          typeof requestedQueryCost === 'number' &&
+          typeof currentlyAvailable === 'number' &&
+          typeof restoreRate === 'number' &&
+          restoreRate > 0
+        ) {
+          waitMs = Math.max(1000, ((requestedQueryCost - currentlyAvailable) / restoreRate) * 1000);
+        }
+        await sleep(waitMs);
+        continue;
+      }
+      throw new Error(body.errors.map((e) => e.message).join('; '));
+    }
+
+    const throttleStatus = body.extensions?.cost?.throttleStatus;
+    if (throttleStatus && throttleStatus.currentlyAvailable < 100 && throttleStatus.restoreRate > 0) {
+      const waitMs = ((100 - throttleStatus.currentlyAvailable) / throttleStatus.restoreRate) * 1000;
+      await sleep(waitMs);
+    }
+
+    return body.data as T;
+  }
+
+  throw new Error(`Shopify GraphQL request failed after ${MAX_ATTEMPTS} attempts (rate limited)`);
+}
+
+const PRODUCT_SET_MUTATION = `
+mutation productSetUpsert($input: ProductSetInput!, $identifier: ProductSetIdentifiers) {
+  productSet(synchronous: true, identifier: $identifier, input: $input) {
+    product { id handle variants(first: 1) { nodes { id } } }
+    userErrors { field message code }
+  }
+}
+`;
+
+interface ProductSetData {
+  productSet: {
+    product: { id: string; handle: string; variants: { nodes: { id: string }[] } } | null;
+    userErrors: { field: string[] | null; message: string; code: string | null }[];
+  };
+}
+
+export async function productSetUpsert(
+  token: string,
+  input: ShopifyProductSetInput,
+  identifier?: { id: string },
+  fetchImpl: typeof fetch = fetch,
+): Promise<ProductSetOutcome> {
+  if (process.env.SHOPIFY_WRITE_MOCK === '1') {
+    return {
+      productId: `gid://shopify/Product/mock-${input.handle}`,
+      variantId: `gid://shopify/ProductVariant/mock-${input.handle}`,
+      handle: input.handle,
+      userErrors: [],
+      mock: true,
+    };
+  }
+
+  const data = await shopifyGraphQL<ProductSetData>(
+    token,
+    PRODUCT_SET_MUTATION,
+    { input, identifier },
+    fetchImpl,
+  );
+
+  const product = data.productSet.product;
+  return {
+    productId: product?.id ?? null,
+    variantId: product?.variants.nodes[0]?.id ?? null,
+    handle: product?.handle ?? null,
+    userErrors: data.productSet.userErrors,
+    mock: false,
+  };
+}

--- a/lib/shopify/importSet.test.ts
+++ b/lib/shopify/importSet.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { planCard, listImportableSets, type PlanContext, type LedgerRow } from './importSet';
+import { CARDS } from '@/lib/cards/generated/cardData';
+
+const rr2Card = CARDS.find(c => c.set === 'RR2')!; // any Roots 2 card
+
+function ctx(overrides: Partial<PlanContext> = {}): PlanContext {
+  return { aliasMap: new Map([['RR2', 'Roots 2']]), ledger: new Map(), existingHandles: new Set(), existingTitles: new Set(), ...overrides };
+}
+
+describe('planCard', () => {
+  it('plans create for an unknown card', () => {
+    const plan = planCard(rr2Card, ctx());
+    expect(plan.plannedAction).toBe('create');
+    expect(plan.cardKey).toBe(`${rr2Card.name}|${rr2Card.set}|${rr2Card.imgFile}`);
+    expect(plan.title.endsWith('(Roots 2)')).toBe(true);
+    expect(plan.warnings).not.toContain('no-price'); // suppressed at plan time
+  });
+
+  it('plans update when the ledger has a product id', () => {
+    const key = `${rr2Card.name}|${rr2Card.set}|${rr2Card.imgFile}`;
+    const row: LedgerRow = { card_key: key, set_code: 'RR2', shopify_product_id: 'gid://shopify/Product/9', shopify_variant_id: null, handle: 'x', status: 'created', media_attached: true, error: null };
+    const plan = planCard(rr2Card, ctx({ ledger: new Map([[key, row]]) }));
+    expect(plan.plannedAction).toBe('update');
+  });
+
+  it('plans skip-existing on handle collision with the store mirror', () => {
+    const first = planCard(rr2Card, ctx());
+    const plan = planCard(rr2Card, ctx({ existingHandles: new Set([first.handle]) }));
+    expect(plan.plannedAction).toBe('skip-existing');
+  });
+});
+
+describe('listImportableSets', () => {
+  it('includes RR2 with its official name and a plausible count', () => {
+    const sets = listImportableSets();
+    const rr2 = sets.find(s => s.code === 'RR2');
+    expect(rr2).toBeDefined();
+    expect(rr2!.name).toBe('Roots 2');
+    expect(rr2!.count).toBeGreaterThan(200);
+  });
+});

--- a/lib/shopify/importSet.test.ts
+++ b/lib/shopify/importSet.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { planCard, listImportableSets, type PlanContext, type LedgerRow } from './importSet';
+import { planCard, listImportableSets, normalizeLedgerRow, type PlanContext, type LedgerRow } from './importSet';
 import { CARDS } from '@/lib/cards/generated/cardData';
 
 const rr2Card = CARDS.find(c => c.set === 'RR2')!; // any Roots 2 card
@@ -28,6 +28,60 @@ describe('planCard', () => {
     const first = planCard(rr2Card, ctx());
     const plan = planCard(rr2Card, ctx({ existingHandles: new Set([first.handle]) }));
     expect(plan.plannedAction).toBe('skip-existing');
+  });
+
+  it('plans create (not update) when the ledger row is mock-poisoned', () => {
+    const key = `${rr2Card.name}|${rr2Card.set}|${rr2Card.imgFile}`;
+    const mockRow: LedgerRow = {
+      card_key: key,
+      set_code: 'RR2',
+      shopify_product_id: 'gid://shopify/Product/mock-some-handle',
+      shopify_variant_id: 'gid://shopify/ProductVariant/mock-some-handle',
+      handle: 'some-handle',
+      status: 'created',
+      media_attached: true,
+      error: null,
+    };
+    // Mirrors what buildPlanContext does: normalize every loaded ledger row.
+    const ledger = new Map([[key, normalizeLedgerRow(mockRow)]]);
+    const plan = planCard(rr2Card, ctx({ ledger }));
+    expect(plan.plannedAction).toBe('create');
+  });
+});
+
+describe('normalizeLedgerRow', () => {
+  const realRow: LedgerRow = {
+    card_key: 'x|RR2|y',
+    set_code: 'RR2',
+    shopify_product_id: 'gid://shopify/Product/123456',
+    shopify_variant_id: 'gid://shopify/ProductVariant/654321',
+    handle: 'x-roots-2',
+    status: 'created',
+    media_attached: true,
+    error: null,
+  };
+
+  it('neutralizes a mock-poisoned row: clears ids and media_attached', () => {
+    const mockRow: LedgerRow = { ...realRow, shopify_product_id: 'gid://shopify/Product/mock-x-roots-2', shopify_variant_id: 'gid://shopify/ProductVariant/mock-x-roots-2' };
+    const result = normalizeLedgerRow(mockRow);
+    expect(result.shopify_product_id).toBeNull();
+    expect(result.shopify_variant_id).toBeNull();
+    expect(result.media_attached).toBe(false);
+    // Untouched fields survive.
+    expect(result.card_key).toBe(mockRow.card_key);
+    expect(result.handle).toBe(mockRow.handle);
+    expect(result.status).toBe(mockRow.status);
+  });
+
+  it('leaves a real row untouched', () => {
+    const result = normalizeLedgerRow(realRow);
+    expect(result).toEqual(realRow);
+  });
+
+  it('leaves a row with a null product id untouched', () => {
+    const row: LedgerRow = { ...realRow, shopify_product_id: null, shopify_variant_id: null };
+    const result = normalizeLedgerRow(row);
+    expect(result).toEqual(row);
   });
 });
 

--- a/lib/shopify/importSet.ts
+++ b/lib/shopify/importSet.ts
@@ -9,12 +9,12 @@
 
 import type { CardData } from '@/lib/cards/generated/cardData';
 import { CARDS } from '@/lib/cards/generated/cardData';
-import { productFromCard, cardSku } from './productFromCard';
+import { productFromCard, cardSku, slugifyTitle } from './productFromCard';
 import { productSetUpsert } from './admin-write';
 import { getShopifyAccessToken } from '@/lib/pricing/shopify';
 import { getSupabaseAdmin } from '@/lib/pricing/supabase-admin';
 import { loadSetAliases, runMatchingPipeline, computeCheapestPrices } from '@/lib/pricing/matching';
-import { getCardImageUrl } from '@/app/shared/utils/cardImageUrl';
+import { getCardImageUrlOrNull } from '@/app/shared/utils/cardImageUrl';
 import { syncShopifyProducts } from '@/lib/pricing/syncShopifyProducts';
 
 export interface CardPlan {
@@ -24,7 +24,7 @@ export interface CardPlan {
   handle: string;
   sku: string;
   tags: string[];
-  imageUrl: string | null; // '' from getCardImageUrl is normalized to null
+  imageUrl: string | null; // null when NEXT_PUBLIC_BLOB_BASE_URL is unset or imgFile is empty
   plannedAction: 'create' | 'update' | 'skip-existing';
   warnings: string[];
 }
@@ -47,10 +47,25 @@ export interface PlanContext {
   existingTitles: Set<string>;
 }
 
+/**
+ * Pure: neutralize mock-mode ledger poisoning.
+ *
+ * Mock imports (`SHOPIFY_WRITE_MOCK=1`) write real ledger rows with a
+ * fabricated `gid://shopify/Product/mock-<handle>` product id and
+ * `media_attached: true`. A later real run must not treat that as an
+ * identifier to update against (it doesn't exist in Shopify) or assume
+ * media is already attached — so any row bearing a mock id is returned as
+ * if it had never been imported. Real rows pass through unchanged.
+ */
+export function normalizeLedgerRow(row: LedgerRow): LedgerRow {
+  if (!row.shopify_product_id?.startsWith('gid://shopify/Product/mock-')) return row;
+  return { ...row, shopify_product_id: null, shopify_variant_id: null, media_attached: false };
+}
+
 /** Pure: given a card and the current plan context, decide what would happen. */
 export function planCard(card: CardData, ctx: PlanContext): CardPlan {
   const cardKey = `${card.name}|${card.set}|${card.imgFile}`;
-  const imageUrl = getCardImageUrl(card.imgFile) || null;
+  const imageUrl = getCardImageUrlOrNull(card.imgFile);
   const alias = ctx.aliasMap.get(card.set) ?? null;
 
   const built = productFromCard(card, alias, {
@@ -128,7 +143,7 @@ async function buildPlanContext(setCode: string): Promise<PlanContext> {
 
   const ledger = new Map<string, LedgerRow>();
   for (const row of (ledgerResult.data ?? []) as LedgerRow[]) {
-    ledger.set(row.card_key, row);
+    ledger.set(row.card_key, normalizeLedgerRow(row));
   }
 
   return {
@@ -233,11 +248,32 @@ export async function executeImport(
       errors++;
       continue;
     }
+    if (card.set !== req.setCode) {
+      results.push({ cardKey: spec.cardKey, action: 'error', productId: null, error: 'card not in set', mock: isMock });
+      errors++;
+      continue;
+    }
 
     const ledgerRow = ctx.ledger.get(spec.cardKey) ?? null;
 
     try {
-      const plan = planCard(card, ctx);
+      let plan = planCard(card, ctx);
+
+      // A titleOverride can rescue a row that only collided under the
+      // computed title/handle — re-check the collision against the
+      // override before accepting the skip.
+      if (plan.plannedAction === 'skip-existing' && spec.titleOverride) {
+        const overrideTitle = spec.titleOverride;
+        const overrideHandle = slugifyTitle(overrideTitle);
+        if (!ctx.existingHandles.has(overrideHandle) && !ctx.existingTitles.has(overrideTitle)) {
+          plan = {
+            ...plan,
+            plannedAction: ledgerRow?.shopify_product_id ? 'update' : 'create',
+            title: overrideTitle,
+            handle: overrideHandle,
+          };
+        }
+      }
 
       if (plan.plannedAction === 'skip-existing') {
         results.push({ cardKey: spec.cardKey, action: 'skipped', productId: null, error: null, mock: isMock });
@@ -278,7 +314,11 @@ export async function executeImport(
 
       const identifier = ledgerRow?.shopify_product_id ? { id: ledgerRow.shopify_product_id } : undefined;
       const includeMedia = !ledgerRow?.media_attached;
-      const imageUrl = getCardImageUrl(card.imgFile) || null;
+      // Omitting `variants`/`productOptions` entirely (not sending price
+      // "0.00") leaves the live product's existing variant data untouched
+      // when a blank price is submitted against an update.
+      const includeVariants = !(identifier && price === null);
+      const imageUrl = getCardImageUrlOrNull(card.imgFile);
       const alias = ctx.aliasMap.get(card.set) ?? null;
 
       const built = productFromCard(card, alias, {
@@ -287,6 +327,7 @@ export async function executeImport(
         status: req.status,
         titleOverride: spec.titleOverride,
         includeMedia,
+        includeVariants,
       });
       const filesIncluded = built.input.files !== undefined;
 
@@ -302,7 +343,9 @@ export async function executeImport(
           shopify_variant_id: outcome.variantId,
           handle: outcome.handle,
           status: 'error',
-          media_attached: (ledgerRow?.media_attached ?? false) || filesIncluded,
+          // productSet is atomic — on userErrors nothing was attached,
+          // regardless of whether files were included in the attempted input.
+          media_attached: ledgerRow?.media_attached ?? false,
           error: errorMsg,
         });
         errors++;

--- a/lib/shopify/importSet.ts
+++ b/lib/shopify/importSet.ts
@@ -239,7 +239,7 @@ export async function executeImport(
     try {
       const plan = planCard(card, ctx);
 
-      if (plan.plannedAction === 'skip-existing' && !ledgerRow) {
+      if (plan.plannedAction === 'skip-existing') {
         results.push({ cardKey: spec.cardKey, action: 'skipped', productId: null, error: null, mock: isMock });
         await upsertLedgerRow(supabase, {
           card_key: spec.cardKey,

--- a/lib/shopify/importSet.ts
+++ b/lib/shopify/importSet.ts
@@ -1,0 +1,360 @@
+/**
+ * YTG Shopify set import orchestrator.
+ *
+ * Plans and executes bulk product creation/update for a single card set,
+ * writing a ledger row (`shopify_card_imports`) per card so re-runs can
+ * update rather than duplicate, then reconciles the store mirror + price
+ * matcher so newly-created cards get prices in the deck builder.
+ */
+
+import type { CardData } from '@/lib/cards/generated/cardData';
+import { CARDS } from '@/lib/cards/generated/cardData';
+import { productFromCard, cardSku } from './productFromCard';
+import { productSetUpsert } from './admin-write';
+import { getShopifyAccessToken } from '@/lib/pricing/shopify';
+import { getSupabaseAdmin } from '@/lib/pricing/supabase-admin';
+import { loadSetAliases, runMatchingPipeline, computeCheapestPrices } from '@/lib/pricing/matching';
+import { getCardImageUrl } from '@/app/shared/utils/cardImageUrl';
+import { syncShopifyProducts } from '@/lib/pricing/syncShopifyProducts';
+
+export interface CardPlan {
+  cardKey: string;
+  cardName: string;
+  title: string;
+  handle: string;
+  sku: string;
+  tags: string[];
+  imageUrl: string | null; // '' from getCardImageUrl is normalized to null
+  plannedAction: 'create' | 'update' | 'skip-existing';
+  warnings: string[];
+}
+
+export interface LedgerRow {
+  card_key: string;
+  set_code: string;
+  shopify_product_id: string | null;
+  shopify_variant_id: string | null;
+  handle: string | null;
+  status: string;
+  media_attached: boolean;
+  error: string | null;
+}
+
+export interface PlanContext {
+  aliasMap: Map<string, string>;
+  ledger: Map<string, LedgerRow>;
+  existingHandles: Set<string>;
+  existingTitles: Set<string>;
+}
+
+/** Pure: given a card and the current plan context, decide what would happen. */
+export function planCard(card: CardData, ctx: PlanContext): CardPlan {
+  const cardKey = `${card.name}|${card.set}|${card.imgFile}`;
+  const imageUrl = getCardImageUrl(card.imgFile) || null;
+  const alias = ctx.aliasMap.get(card.set) ?? null;
+
+  const built = productFromCard(card, alias, {
+    price: null,
+    imageUrl,
+    status: 'DRAFT',
+  });
+
+  const ledgerRow = ctx.ledger.get(cardKey);
+
+  let plannedAction: CardPlan['plannedAction'];
+  if (ledgerRow?.shopify_product_id) {
+    plannedAction = 'update';
+  } else if (ctx.existingHandles.has(built.input.handle) || ctx.existingTitles.has(built.input.title)) {
+    plannedAction = 'skip-existing';
+  } else {
+    plannedAction = 'create';
+  }
+
+  return {
+    cardKey,
+    cardName: card.name,
+    title: built.input.title,
+    handle: built.input.handle,
+    sku: cardSku(card),
+    tags: built.input.tags,
+    imageUrl,
+    plannedAction,
+    // Prices are entered by the admin later — the 'no-price' warning would
+    // otherwise fire for every single card at plan time.
+    warnings: built.warnings.filter((w) => w !== 'no-price'),
+  };
+}
+
+async function loadExistingHandlesAndTitles(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any,
+): Promise<{ existingHandles: Set<string>; existingTitles: Set<string> }> {
+  const existingHandles = new Set<string>();
+  const existingTitles = new Set<string>();
+  const pageSize = 1000;
+  let from = 0;
+
+  while (true) {
+    const { data, error } = await supabase
+      .from('shopify_products')
+      .select('handle, title')
+      .range(from, from + pageSize - 1);
+    if (error) throw new Error(`Failed to load shopify_products: ${error.message}`);
+
+    for (const row of (data ?? []) as { handle: string | null; title: string | null }[]) {
+      if (row.handle) existingHandles.add(row.handle);
+      if (row.title) existingTitles.add(row.title);
+    }
+
+    if (!data || data.length < pageSize) break;
+    from += pageSize;
+  }
+
+  return { existingHandles, existingTitles };
+}
+
+async function buildPlanContext(setCode: string): Promise<PlanContext> {
+  const supabase = getSupabaseAdmin();
+
+  const [aliasMap, ledgerResult, existing] = await Promise.all([
+    loadSetAliases(),
+    supabase.from('shopify_card_imports').select('*').eq('set_code', setCode),
+    loadExistingHandlesAndTitles(supabase),
+  ]);
+
+  if (ledgerResult.error) {
+    throw new Error(`Failed to load shopify_card_imports: ${ledgerResult.error.message}`);
+  }
+
+  const ledger = new Map<string, LedgerRow>();
+  for (const row of (ledgerResult.data ?? []) as LedgerRow[]) {
+    ledger.set(row.card_key, row);
+  }
+
+  return {
+    aliasMap,
+    ledger,
+    existingHandles: existing.existingHandles,
+    existingTitles: existing.existingTitles,
+  };
+}
+
+export async function planSetImport(setCode: string): Promise<CardPlan[]> {
+  const cards = CARDS.filter((c) => c.set === setCode);
+  const ctx = await buildPlanContext(setCode);
+  return cards.map((c) => planCard(c, ctx));
+}
+
+/** Distinct card.set values with their official set name and card count, sorted by name. */
+export function listImportableSets(): { code: string; name: string; count: number }[] {
+  const bySet = new Map<string, { code: string; name: string; count: number }>();
+  for (const card of CARDS) {
+    const existing = bySet.get(card.set);
+    if (existing) {
+      existing.count++;
+    } else {
+      bySet.set(card.set, { code: card.set, name: card.officialSet, count: 1 });
+    }
+  }
+  return Array.from(bySet.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export interface ImportCardSpec {
+  cardKey: string;
+  price: string | null;
+  include: boolean;
+  titleOverride?: string;
+}
+
+export interface ImportRequest {
+  setCode: string;
+  status: 'DRAFT' | 'ACTIVE';
+  cards: ImportCardSpec[];
+}
+
+export interface ImportResultRow {
+  cardKey: string;
+  action: 'created' | 'updated' | 'skipped' | 'error';
+  productId: string | null;
+  error: string | null;
+  mock: boolean;
+}
+
+export interface ImportSummary {
+  created: number;
+  updated: number;
+  skipped: number;
+  errors: number;
+  reconciled: boolean;
+  mock: boolean;
+}
+
+const PRICE_RE = /^\d+(\.\d{1,2})?$/;
+
+async function upsertLedgerRow(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any,
+  row: LedgerRow,
+): Promise<void> {
+  const { error } = await supabase
+    .from('shopify_card_imports')
+    .upsert({ ...row, updated_at: new Date().toISOString() }, { onConflict: 'card_key' });
+  if (error) {
+    console.error(`Ledger upsert failed for ${row.card_key}:`, error.message);
+  }
+}
+
+export async function executeImport(
+  req: ImportRequest,
+): Promise<{ results: ImportResultRow[]; summary: ImportSummary }> {
+  const ctx = await buildPlanContext(req.setCode);
+  const supabase = getSupabaseAdmin();
+
+  const cardByKey = new Map<string, CardData>();
+  for (const c of CARDS) {
+    cardByKey.set(`${c.name}|${c.set}|${c.imgFile}`, c);
+  }
+
+  const isMock = process.env.SHOPIFY_WRITE_MOCK === '1';
+  const token = isMock ? 'mock' : await getShopifyAccessToken();
+
+  const results: ImportResultRow[] = [];
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const spec of req.cards) {
+    if (!spec.include) continue;
+
+    const card = cardByKey.get(spec.cardKey);
+    if (!card) {
+      results.push({ cardKey: spec.cardKey, action: 'error', productId: null, error: 'unknown card_key', mock: isMock });
+      errors++;
+      continue;
+    }
+
+    const ledgerRow = ctx.ledger.get(spec.cardKey) ?? null;
+
+    try {
+      const plan = planCard(card, ctx);
+
+      if (plan.plannedAction === 'skip-existing' && !ledgerRow) {
+        results.push({ cardKey: spec.cardKey, action: 'skipped', productId: null, error: null, mock: isMock });
+        await upsertLedgerRow(supabase, {
+          card_key: spec.cardKey,
+          set_code: req.setCode,
+          shopify_product_id: null,
+          shopify_variant_id: null,
+          handle: plan.handle,
+          status: 'skipped',
+          media_attached: false,
+          error: null,
+        });
+        skipped++;
+        continue;
+      }
+
+      let price: string | null = null;
+      if (spec.price !== null) {
+        const trimmed = spec.price.trim();
+        if (!PRICE_RE.test(trimmed)) {
+          results.push({ cardKey: spec.cardKey, action: 'error', productId: null, error: 'invalid price', mock: isMock });
+          await upsertLedgerRow(supabase, {
+            card_key: spec.cardKey,
+            set_code: req.setCode,
+            shopify_product_id: ledgerRow?.shopify_product_id ?? null,
+            shopify_variant_id: ledgerRow?.shopify_variant_id ?? null,
+            handle: ledgerRow?.handle ?? null,
+            status: 'error',
+            media_attached: ledgerRow?.media_attached ?? false,
+            error: 'invalid price',
+          });
+          errors++;
+          continue;
+        }
+        price = Number(trimmed).toFixed(2);
+      }
+
+      const identifier = ledgerRow?.shopify_product_id ? { id: ledgerRow.shopify_product_id } : undefined;
+      const includeMedia = !ledgerRow?.media_attached;
+      const imageUrl = getCardImageUrl(card.imgFile) || null;
+      const alias = ctx.aliasMap.get(card.set) ?? null;
+
+      const built = productFromCard(card, alias, {
+        price,
+        imageUrl,
+        status: req.status,
+        titleOverride: spec.titleOverride,
+        includeMedia,
+      });
+      const filesIncluded = built.input.files !== undefined;
+
+      const outcome = await productSetUpsert(token, built.input, identifier);
+
+      if (outcome.userErrors.length > 0) {
+        const errorMsg = outcome.userErrors.map((e) => e.message).join('; ');
+        results.push({ cardKey: spec.cardKey, action: 'error', productId: outcome.productId, error: errorMsg, mock: outcome.mock });
+        await upsertLedgerRow(supabase, {
+          card_key: spec.cardKey,
+          set_code: req.setCode,
+          shopify_product_id: outcome.productId,
+          shopify_variant_id: outcome.variantId,
+          handle: outcome.handle,
+          status: 'error',
+          media_attached: (ledgerRow?.media_attached ?? false) || filesIncluded,
+          error: errorMsg,
+        });
+        errors++;
+        continue;
+      }
+
+      const action: 'created' | 'updated' = identifier ? 'updated' : 'created';
+      results.push({ cardKey: spec.cardKey, action, productId: outcome.productId, error: null, mock: outcome.mock });
+      await upsertLedgerRow(supabase, {
+        card_key: spec.cardKey,
+        set_code: req.setCode,
+        shopify_product_id: outcome.productId,
+        shopify_variant_id: outcome.variantId,
+        handle: outcome.handle,
+        status: action,
+        media_attached: (ledgerRow?.media_attached ?? false) || filesIncluded,
+        error: null,
+      });
+      if (action === 'created') created++;
+      else updated++;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      results.push({ cardKey: spec.cardKey, action: 'error', productId: null, error: message, mock: isMock });
+      await upsertLedgerRow(supabase, {
+        card_key: spec.cardKey,
+        set_code: req.setCode,
+        shopify_product_id: ledgerRow?.shopify_product_id ?? null,
+        shopify_variant_id: ledgerRow?.shopify_variant_id ?? null,
+        handle: ledgerRow?.handle ?? null,
+        status: 'error',
+        media_attached: ledgerRow?.media_attached ?? false,
+        error: message,
+      });
+      errors++;
+    }
+  }
+
+  let reconciled = false;
+  if (!isMock && (created > 0 || updated > 0)) {
+    try {
+      await syncShopifyProducts();
+      await runMatchingPipeline({ setCodes: [req.setCode] });
+      await computeCheapestPrices();
+      reconciled = true;
+    } catch (err) {
+      console.error('Post-import reconcile failed:', err);
+      reconciled = false;
+    }
+  }
+
+  return {
+    results,
+    summary: { created, updated, skipped, errors, reconciled, mock: isMock },
+  };
+}

--- a/lib/shopify/productFromCard.test.ts
+++ b/lib/shopify/productFromCard.test.ts
@@ -155,4 +155,17 @@ describe('productFromCard', () => {
     const built = productFromCard(dual, 'PoC', opts);
     expect(built.input.tags).toEqual(expect.arrayContaining(['Good Enhancement', 'Evil Enhancement', 'Dual Alignment']));
   });
+
+  it('omits variants/productOptions and the no-price warning when includeVariants is false', () => {
+    const built = productFromCard(I_AM_HAS_SENT_ME, 'PoC', { ...opts, price: null, includeVariants: false });
+    expect(built.input.variants).toBeUndefined();
+    expect(built.input.productOptions).toBeUndefined();
+    expect(built.warnings).not.toContain('no-price');
+  });
+
+  it('keeps variants/productOptions by default (includeVariants unset)', () => {
+    const built = productFromCard(I_AM_HAS_SENT_ME, 'PoC', opts);
+    expect(built.input.variants).toBeDefined();
+    expect(built.input.productOptions).toBeDefined();
+  });
 });

--- a/lib/shopify/productFromCard.test.ts
+++ b/lib/shopify/productFromCard.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import type { CardData } from '@/lib/cards/generated/cardData';
+import { productFromCard, baseCardName, slugifyTitle, cardSku } from './productFromCard';
+
+// Fixtures: EXACT rows from lib/cards/generated/cardData.json (Step 1 extraction).
+//
+// Note: the dump product for "I AM Has Sent Me" has title `"I AM" Has Sent Me (PoC)`
+// (quotes around "I AM"), but the underlying generated card record's `name` field is
+// literally `I AM Has Sent Me` — no quotes. That quoting is a one-off manual/editorial
+// choice on the Shopify side (not reproducible by a general baseCardName + ytgAbbrev
+// rule), so the title/alt assertions below use the real, unquoted fixture value. A
+// real import of this exact card would need `titleOverride` to reproduce the quoted
+// dump title verbatim — see the titleOverride test below for that path.
+const I_AM_HAS_SENT_ME: CardData = {
+  name: 'I AM Has Sent Me',
+  set: 'PoC',
+  imgFile: '021-I-AM-Has-Sent-Me',
+  officialSet: 'Prophecies of Christ',
+  type: 'GE',
+  brigade: 'Green/Teal',
+  strength: '3',
+  toughness: '2',
+  class: '',
+  identifier: '',
+  specialAbility:
+    '(Star) Shuffle a card from Reserve. (HE) If used by an Exodus or * Hero, interrupt the battle. Hero may band to any number of O.T. Heroes.',
+  rarity: 'Common',
+  reference: 'Exodus 3:14',
+  alignment: 'Good',
+  legality: 'Rotation',
+};
+
+const ABUSIVE_SOLDIERS: CardData = {
+  name: 'Abusive Soldiers (GoC)',
+  set: 'GoC',
+  imgFile: '217-Abusive-Soldiers',
+  officialSet: 'Gospel of Christ',
+  type: 'Evil Character',
+  brigade: 'Gold',
+  strength: '2',
+  toughness: '1',
+  class: 'Warrior',
+  identifier: 'Generic, Gospel',
+  specialAbility:
+    'You may reserve a Hero from opponent’s hand. Protect gold Evil Characters from the next good Enhancement played in battle.',
+  rarity: 'Common',
+  reference: 'Luke 23:11',
+  alignment: 'Evil',
+  legality: 'Rotation',
+};
+
+const ROMAN_SOLDIERS_FAITH: CardData = {
+  name: "A Roman Soldier's Faith",
+  set: 'Ap',
+  imgFile: "A_Roman_Soldier's_Faith_(Ap)",
+  officialSet: 'Apostles',
+  type: 'GE',
+  brigade: 'Red',
+  strength: '3',
+  toughness: '3',
+  class: '',
+  identifier: '',
+  specialAbility: 'Heal any Hero in play.',
+  rarity: 'Common',
+  reference: 'Matthew 8:5-6',
+  alignment: 'Good',
+  legality: '',
+};
+
+describe('baseCardName', () => {
+  it('strips a trailing set parenthetical', () => {
+    expect(baseCardName('Abusive Soldiers (GoC)')).toBe('Abusive Soldiers');
+  });
+  it('strips a trailing bracket qualifier', () => {
+    expect(baseCardName('7 Years of Famine [RR2]')).toBe('7 Years of Famine');
+  });
+  it('keeps internal quotes/parentheticals', () => {
+    expect(baseCardName('"I AM" Has Sent Me (PoC)')).toBe('"I AM" Has Sent Me');
+  });
+  it('returns names with no qualifier unchanged', () => {
+    expect(baseCardName('Son of God')).toBe('Son of God');
+  });
+});
+
+describe('slugifyTitle', () => {
+  it('matches YTG handle for quoted title', () => {
+    expect(slugifyTitle('"I AM" Has Sent Me (PoC)')).toBe('i-am-has-sent-me-poc');
+  });
+  it('collapses apostrophes without a hyphen', () => {
+    expect(slugifyTitle("A Roman Soldier's Faith (Ap)")).toBe('a-roman-soldiers-faith-ap');
+  });
+  it('handles commas and multiple parentheticals', () => {
+    expect(slugifyTitle('Abaddon, the Destroyer (AB) (RoJ)')).toBe('abaddon-the-destroyer-ab-roj');
+  });
+});
+
+describe('productFromCard', () => {
+  const opts = { price: '0.75', imageUrl: 'https://blob.example/card-images/x.jpg', status: 'DRAFT' as const };
+
+  it('reproduces the real YTG product shape for "I AM" Has Sent Me (PoC)', () => {
+    const built = productFromCard(I_AM_HAS_SENT_ME, 'PoC', opts);
+    // Real fixture name has no quotes (see fixture comment above) — computed title
+    // reflects that, unlike the dump's manually-quoted title.
+    expect(built.input.title).toBe('I AM Has Sent Me (PoC)');
+    expect(built.input.handle).toBe('i-am-has-sent-me-poc');
+    expect(built.input.tags).toEqual(['Good Enhancement', 'Green', 'Prophecies of Christ', 'Rotation Cards', 'Teal']);
+    expect(built.input.productType).toBe('Single');
+    expect(built.input.vendor).toBe('Your Turn Games');
+    expect(built.input.status).toBe('DRAFT');
+    expect(built.input.productOptions).toEqual([{ name: 'Title', values: [{ name: 'Default Title' }] }]);
+    expect(built.input.variants).toEqual([{ optionValues: [{ optionName: 'Title', name: 'Default Title' }], price: '0.75', sku: cardSku(I_AM_HAS_SENT_ME) }]);
+    expect(built.input.files).toEqual([{ originalSource: opts.imageUrl, contentType: 'IMAGE', alt: 'I AM Has Sent Me' }]);
+    expect(built.warnings).toEqual([]);
+  });
+
+  it('maps bare Gold brigade on an evil card to Evil Gold tag', () => {
+    const built = productFromCard(ABUSIVE_SOLDIERS, 'GoC', opts);
+    expect(built.input.tags).toContain('Evil Gold');
+    expect(built.input.tags).not.toContain('Gold');
+    expect(built.input.tags).toContain('Evil Character');
+    expect(built.input.tags).toContain('Gospel of Christ');
+  });
+
+  it('omits Rotation Cards for non-rotation cards', () => {
+    const built = productFromCard(ROMAN_SOLDIERS_FAITH, 'Ap', opts);
+    expect(built.input.tags).toEqual(['Apostles', 'Good Enhancement', 'Red']);
+  });
+
+  it('handles missing price / image / alias with warnings, never throws', () => {
+    const built = productFromCard(I_AM_HAS_SENT_ME, null, { price: null, imageUrl: null, status: 'DRAFT' });
+    expect(built.input.variants![0].price).toBe('0.00');
+    expect(built.input.files).toBeUndefined();
+    expect(built.input.title).toBe('I AM Has Sent Me (PoC)'); // falls back to card.set
+    expect(built.warnings).toEqual(expect.arrayContaining(['no-price', 'no-image', 'no-set-alias']));
+  });
+
+  it('omits files when includeMedia is false (update re-run)', () => {
+    const built = productFromCard(I_AM_HAS_SENT_ME, 'PoC', { ...opts, includeMedia: false });
+    expect(built.input.files).toBeUndefined();
+  });
+
+  it('uses titleOverride verbatim and slugs the handle from it', () => {
+    const built = productFromCard(I_AM_HAS_SENT_ME, 'PoC', { ...opts, titleOverride: '"I AM" Has Sent Me (Legacy Rare)' });
+    expect(built.input.title).toBe('"I AM" Has Sent Me (Legacy Rare)');
+    expect(built.input.handle).toBe('i-am-has-sent-me-legacy-rare');
+  });
+
+  it('always attaches the rtt_card_key metafield', () => {
+    const built = productFromCard(I_AM_HAS_SENT_ME, 'PoC', opts);
+    expect(built.input.metafields).toEqual([{ namespace: 'custom', key: 'rtt_card_key', value: built.cardKey, type: 'single_line_text_field' }]);
+  });
+
+  it('adds Dual Alignment for cross-alignment compound types', () => {
+    const dual: CardData = { ...I_AM_HAS_SENT_ME, type: 'GE/EE' };
+    const built = productFromCard(dual, 'PoC', opts);
+    expect(built.input.tags).toEqual(expect.arrayContaining(['Good Enhancement', 'Evil Enhancement', 'Dual Alignment']));
+  });
+});

--- a/lib/shopify/productFromCard.ts
+++ b/lib/shopify/productFromCard.ts
@@ -21,6 +21,7 @@ export interface ProductBuildOptions {
   status: 'DRAFT' | 'ACTIVE';
   titleOverride?: string;      // admin-entered title replaces the computed one verbatim
   includeMedia?: boolean;      // default true; false => omit files even if imageUrl set (update re-runs)
+  includeVariants?: boolean;   // default true; false => omit variants + productOptions (blank-price updates leave live variant data untouched)
 }
 
 export interface BuiltProduct {
@@ -103,7 +104,8 @@ export function productFromCard(card: CardData, ytgAbbrev: string | null, opts: 
   if (card.officialSet.startsWith('Promo')) tags.add('Promos');
 
   // --- variants / price ---
-  if (opts.price === null) warnings.push('no-price');
+  const includeVariants = opts.includeVariants !== false;
+  if (includeVariants && opts.price === null) warnings.push('no-price');
   const price = opts.price ?? '0.00';
 
   // --- files / image ---
@@ -119,8 +121,10 @@ export function productFromCard(card: CardData, ytgAbbrev: string | null, opts: 
     vendor: 'Your Turn Games',
     tags: Array.from(tags).sort(),
     status: opts.status,
-    productOptions: [{ name: 'Title', values: [{ name: 'Default Title' }] }],
-    variants: [{ optionValues: [{ optionName: 'Title', name: 'Default Title' }], price, sku: cardSku(card) }],
+    ...(includeVariants ? {
+      productOptions: [{ name: 'Title', values: [{ name: 'Default Title' }] }],
+      variants: [{ optionValues: [{ optionName: 'Title', name: 'Default Title' }], price, sku: cardSku(card) }],
+    } : {}),
     ...(files ? { files } : {}),
     metafields: [{ namespace: 'custom', key: 'rtt_card_key', value: cardKey, type: 'single_line_text_field' }],
   };

--- a/lib/shopify/productFromCard.ts
+++ b/lib/shopify/productFromCard.ts
@@ -1,0 +1,129 @@
+import type { CardData } from '@/lib/cards/generated/cardData';
+import { normalizeBrigadeField } from '@/app/decklist/card-search/utils';
+import { sanitizeImgFile } from '@/app/shared/utils/cardImageUrl';
+
+export interface ShopifyProductSetInput {
+  title: string;
+  handle: string;
+  productType: string;
+  vendor: string;
+  tags: string[];
+  status: 'DRAFT' | 'ACTIVE';
+  productOptions?: { name: string; values: { name: string }[] }[];
+  variants?: { optionValues: { optionName: string; name: string }[]; price: string; sku: string }[];
+  files?: { originalSource: string; contentType: 'IMAGE'; alt: string }[];
+  metafields?: { namespace: string; key: string; value: string; type: string }[];
+}
+
+export interface ProductBuildOptions {
+  price: string | null;        // normalized "1.50"; null => "0.00" + warning "no-price"
+  imageUrl: string | null;     // null => no files + warning "no-image"
+  status: 'DRAFT' | 'ACTIVE';
+  titleOverride?: string;      // admin-entered title replaces the computed one verbatim
+  includeMedia?: boolean;      // default true; false => omit files even if imageUrl set (update re-runs)
+}
+
+export interface BuiltProduct {
+  cardKey: string;
+  input: ShopifyProductSetInput;
+  warnings: string[];          // 'no-price' | 'no-image' | 'no-set-alias' | `brigade-unmapped:<value>` | `type-unmapped:<value>`
+}
+
+const TYPE_TAGS: Record<string, string> = {
+  'Hero': 'Hero', 'GE': 'Good Enhancement', 'EE': 'Evil Enhancement',
+  'Evil Character': 'Evil Character', 'Artifact': 'Artifact', 'Lost Soul': 'Lost Soul',
+  'Dominant': 'Dominant', 'Fortress': 'Fortress', 'Site': 'Site', 'City': 'City',
+  'Covenant': 'Covenant', 'Curse': 'Curse',
+  'Hero Token': 'Hero', 'Evil Character Token': 'Evil Character', 'Lost Soul Token': 'Lost Soul',
+};
+const GOOD_TYPE_PARTS = new Set(['Hero', 'GE']);
+const EVIL_TYPE_PARTS = new Set(['Evil Character', 'EE']);
+// Canonical brigade name -> YTG tag name (identity unless listed)
+const BRIGADE_TAGS: Record<string, string> = { 'Good Gold': 'Gold' };
+
+export function baseCardName(name: string): string {
+  return name.replace(/\s*[([][^)\]]*[)\]]\s*$/, '').trim();
+}
+
+export function slugifyTitle(title: string): string {
+  return title.toLowerCase().replace(/['‘’"“”]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+export function cardSku(card: CardData): string {
+  return `${card.set}-${sanitizeImgFile(card.imgFile)}`.replace(/\s+/g, '');
+}
+
+function normalizeRarity(rarity: string): string {
+  return rarity === 'Ultra-Rare' ? 'Ultra Rare' : rarity;
+}
+
+export function productFromCard(card: CardData, ytgAbbrev: string | null, opts: ProductBuildOptions): BuiltProduct {
+  const warnings: string[] = [];
+  const cardKey = `${card.name}|${card.set}|${card.imgFile}`;
+
+  if (!ytgAbbrev) warnings.push('no-set-alias');
+  const title = opts.titleOverride ?? `${baseCardName(card.name)} (${ytgAbbrev ?? card.set})`;
+  const handle = slugifyTitle(title);
+
+  // --- tags ---
+  const tags = new Set<string>();
+
+  const typeParts = card.type.split('/').map(p => p.trim()).filter(p => p.length > 0);
+  const matchedTypeParts: string[] = [];
+  for (const part of typeParts) {
+    const tag = TYPE_TAGS[part];
+    if (tag) {
+      tags.add(tag);
+      matchedTypeParts.push(part);
+    } else {
+      warnings.push(`type-unmapped:${part}`);
+    }
+  }
+  const hasGood = matchedTypeParts.some(p => GOOD_TYPE_PARTS.has(p));
+  const hasEvil = matchedTypeParts.some(p => EVIL_TYPE_PARTS.has(p));
+  if (hasGood && hasEvil) tags.add('Dual Alignment');
+
+  if (card.brigade) {
+    try {
+      const canonicalBrigades = normalizeBrigadeField(card.brigade, card.alignment, card.name);
+      for (const brigade of canonicalBrigades) {
+        tags.add(BRIGADE_TAGS[brigade] ?? brigade);
+      }
+    } catch {
+      warnings.push(`brigade-unmapped:${card.brigade}`);
+    }
+  }
+
+  if (card.officialSet) tags.add(card.officialSet);
+
+  const normalizedRarity = normalizeRarity(card.rarity);
+  if (normalizedRarity === 'Legacy Rare' || normalizedRarity === 'Ultra Rare') tags.add(normalizedRarity);
+
+  if (card.legality === 'Rotation') tags.add('Rotation Cards');
+  if (card.officialSet.startsWith('Promo')) tags.add('Promos');
+
+  // --- variants / price ---
+  if (opts.price === null) warnings.push('no-price');
+  const price = opts.price ?? '0.00';
+
+  // --- files / image ---
+  if (opts.imageUrl === null) warnings.push('no-image');
+  const files = opts.imageUrl !== null && opts.includeMedia !== false
+    ? [{ originalSource: opts.imageUrl, contentType: 'IMAGE' as const, alt: baseCardName(card.name) }]
+    : undefined;
+
+  const input: ShopifyProductSetInput = {
+    title,
+    handle,
+    productType: 'Single',
+    vendor: 'Your Turn Games',
+    tags: Array.from(tags).sort(),
+    status: opts.status,
+    productOptions: [{ name: 'Title', values: [{ name: 'Default Title' }] }],
+    variants: [{ optionValues: [{ optionName: 'Title', name: 'Default Title' }], price, sku: cardSku(card) }],
+    ...(files ? { files } : {}),
+    metafields: [{ namespace: 'custom', key: 'rtt_card_key', value: cardKey, type: 'single_line_text_field' }],
+  };
+
+  return { cardKey, input, warnings };
+}

--- a/supabase/migrations/080_create_shopify_card_imports.sql
+++ b/supabase/migrations/080_create_shopify_card_imports.sql
@@ -1,0 +1,23 @@
+-- 080_create_shopify_card_imports.sql
+-- Ledger for the YTG Shopify set importer (docs/superpowers/specs/2026-07-25-ytg-shopify-set-import-design.md §7).
+-- One row per card ever imported; keyed by the canonical card_key `${name}|${set}|${imgFile}`.
+-- Accessed exclusively via the service-role client — no anon/authenticated policies on purpose.
+
+CREATE TABLE public.shopify_card_imports (
+  card_key           TEXT PRIMARY KEY,
+  set_code           TEXT NOT NULL,
+  shopify_product_id TEXT,
+  shopify_variant_id TEXT,
+  handle             TEXT,
+  status             TEXT NOT NULL CHECK (status IN ('created', 'updated', 'skipped', 'error')),
+  media_attached     BOOLEAN NOT NULL DEFAULT false,
+  error              TEXT,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_shopify_card_imports_set_code ON public.shopify_card_imports (set_code);
+
+ALTER TABLE public.shopify_card_imports ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON public.shopify_card_imports FROM anon, authenticated;


### PR DESCRIPTION
## Summary
- Admin page (`/admin/import-set`) + API to create one Shopify product per card of a set in YTG's live store (spec + implementation plan included under `docs/superpowers/`)
- Pure `productFromCard` builder grounded in the real YTG dump conventions (title `Name (Abbrev)`, clean handle slugs, alphabetized tags: type + brigade colors + set name + rarity + grouping), unit-tested against real card rows and real dump products
- GraphQL `productSet` write client (Admin API 2026-07) with cost-based throttling, THROTTLED/429 retry, and a `SHOPIFY_WRITE_MOCK=1` mode (fabricated IDs, zero network) — mock rows are neutralized on ledger read so they can never poison a later real import
- `shopify_card_imports` ledger (migration 080, **already applied to prod** — empty, additive) for idempotent re-runs: creates get recorded, re-runs update via `identifier`, media is attached exactly once, blank-price updates omit `variants` entirely so live prices are never zeroed
- Draft-first with explicit ACTIVE toggle; per-card editable prices + bulk fill helpers; dry-run preview; per-card error isolation; post-import reconcile into the existing `shopify_products` → matcher → `card_prices` pipeline (skipped in mock mode; failure never fails the import)
- Route is admin-gated via `isRegistrationAdmin()` (deliberately stricter than the sibling pricing routes — this one writes to a live store)

## Verified
- 1520 tests passing, 0 new failures (3 pre-existing failing files on main: 2 env-dependent anon-leak, 1 forge-lackey assertion); `tsc --noEmit` clean for all new files
- Mock e2e sanity against prod Supabase: planned all 224 RR2 cards (correct tags/images), executed 2 cards in mock mode, ledger rows landed and were cleaned up
- Whole-branch review + per-task reviews via subagents; all Critical/Important findings fixed in-branch (skip-existing re-run guard, set-switch fetch race, mock-ledger neutralization, `media_attached` on failed mutations, titleOverride collision rescue, blank-price update safety)

## Blocked on YTG (before first live import)
- `write_products` scope on the custom app — until granted, real imports will fail auth; dry-run + mock mode fully work
- Add a `set_aliases` row for new sets (e.g. RR2 → whatever abbrev YTG uses in titles); the preview currently flags RR2 with `no-set-alias` and falls back to `(RR2)`
- Live small-set draft trial per spec §11.4 (verify image lands `READY` + price attaches, then reconcile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)