### PR TITLE
chore(search): hide Scrolls legality mode

### DIFF
--- a/app/collection/client.tsx
+++ b/app/collection/client.tsx
@@ -25,7 +25,8 @@ const COLLECTION_CARDS = ALL_CARDS.filter((c) => !EXCLUDED_OFFICIAL_SETS.has(c.o
 
 // Tournament format filter, mirrored from the deck builder's legality logic.
 type FormatMode = "Limited" | "Unlimited" | "Scrolls" | "Banned" | "Paragon";
-const FORMAT_OPTIONS: FormatMode[] = ["Limited", "Unlimited", "Scrolls", "Banned", "Paragon"];
+// "Scrolls" hidden per Tim 2026-07-25 — filter logic kept; re-add here to restore
+const FORMAT_OPTIONS: FormatMode[] = ["Limited", "Unlimited", "Banned", "Paragon"];
 const DEFAULT_FORMAT: FormatMode = "Limited";
 
 function matchesFormat(card: Card, mode: FormatMode): boolean {

--- a/app/decklist/card-search/components/FilterGrid.tsx
+++ b/app/decklist/card-search/components/FilterGrid.tsx
@@ -189,7 +189,8 @@ export default function FilterGrid({
         <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-1.5">
           <span className="text-muted-foreground uppercase text-xs font-medium shrink-0">Legality</span>
           <div className="flex flex-wrap gap-1">
-            {['Limited','Unlimited','Banned','Scrolls','Paragon'].map((mode) => (
+            {/* 'Scrolls' hidden per Tim 2026-07-25 — filter logic kept; re-add to this list to restore */}
+            {['Limited','Unlimited','Banned','Paragon'].map((mode) => (
               <button
                 key={mode}
                 className={clsx(


### PR DESCRIPTION
Removes the Scrolls button from the legality filter row in both the deck-builder card search and the collection page, per Tim. The filter logic, type unions, and URL normalization are untouched — restoring it is a one-line re-add to each options list (comments mark the spots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)