### PR TITLE
feat(search): surface Flood survivor cards under Antediluvian searches

### DIFF
--- a/app/decklist/card-search/__tests__/searchableIdentifier.test.ts
+++ b/app/decklist/card-search/__tests__/searchableIdentifier.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { searchableIdentifier, type Card } from "../utils";
+
+// Minimal Card fixture — only type and identifier matter to searchableIdentifier.
+const card = (over: Partial<Card>): Card => ({
+  dataLine: "",
+  name: "",
+  set: "",
+  imgFile: "",
+  officialSet: "",
+  type: "",
+  brigade: "",
+  strength: "",
+  toughness: "",
+  class: "",
+  identifier: "",
+  specialAbility: "",
+  rarity: "",
+  reference: "",
+  alignment: "",
+  legality: "",
+  testament: "",
+  isGospel: false,
+  ...over,
+});
+
+// Flood survivors are Antediluvians in Redemption, but only newer printings
+// (LoC, RR2) carry the explicit "Antediluvian" identifier. The searchable
+// identifier appends it so a search for "Antediluvian" surfaces the older
+// Flood survivor characters too.
+describe("searchableIdentifier", () => {
+  it("appends Antediluvian to a Flood survivor character", () => {
+    // Shem (CoW)
+    const c = card({ type: "Hero", identifier: "Flood survivor" });
+    expect(searchableIdentifier(c)).toBe("Flood survivor, Antediluvian");
+  });
+
+  it("handles the capitalized 'Flood Survivor' variant", () => {
+    // Ham's Wife (FoM)
+    const c = card({ type: "Hero", identifier: "Flood Survivor" });
+    expect(searchableIdentifier(c)).toBe("Flood Survivor, Antediluvian");
+  });
+
+  it("augments identifiers with additional clauses", () => {
+    // Japheth (CoW)
+    const c = card({
+      type: "Hero",
+      identifier: "Flood survivor, X = # of flood survivors you control",
+    });
+    expect(searchableIdentifier(c)).toBe(
+      "Flood survivor, X = # of flood survivors you control, Antediluvian"
+    );
+  });
+
+  it("leaves cards already identified as Antediluvian unchanged", () => {
+    // Noah, the Righteous (LoC)
+    const c = card({
+      type: "Hero",
+      identifier: "Antediluvian, Flood survivor, Prophet",
+    });
+    expect(searchableIdentifier(c)).toBe("Antediluvian, Flood survivor, Prophet");
+  });
+
+  it("does not augment non-character cards that merely reference flood survivors", () => {
+    // A New Beginning (FoM) — a Good Enhancement, not an Antediluvian
+    const c = card({ type: "GE", identifier: "Unity Heroes (Flood Survivors)" });
+    expect(searchableIdentifier(c)).toBe("Unity Heroes (Flood Survivors)");
+  });
+
+  it("leaves ordinary identifiers unchanged", () => {
+    expect(searchableIdentifier(card({ type: "Hero", identifier: "Prophet" }))).toBe("Prophet");
+    expect(searchableIdentifier(card({ type: "Hero", identifier: "" }))).toBe("");
+  });
+});

--- a/app/decklist/card-search/client.tsx
+++ b/app/decklist/card-search/client.tsx
@@ -12,6 +12,7 @@ import {
   categorizeRarity,
   isNativityReference,
   iconPredicates,
+  searchableIdentifier,
 } from "./utils";
 import { DeckBuilderConfig, PUBLIC_BUILDER_CONFIG, BuilderConfigProvider } from "./builderConfig";
 import { readStickyFilters, writeStickyFilters, type AltArtMode } from "./stickyFilters";
@@ -982,11 +983,11 @@ export default function CardSearchClient({
               case 'setName':
                 return fieldMatches(c.officialSet, queryObj) || fieldMatches(c.set, queryObj);
               case 'identifier':
-                return fieldMatches(c.identifier, queryObj);
+                return fieldMatches(searchableIdentifier(c), queryObj);
               case 'reference':
                 return fieldMatches(c.reference, queryObj);
               default:
-                return fieldMatches(Object.values(c).join(" "), queryObj);
+                return fieldMatches(`${Object.values(c).join(" ")} ${searchableIdentifier(c)}`, queryObj);
             }
           };
           

--- a/app/decklist/card-search/utils.ts
+++ b/app/decklist/card-search/utils.ts
@@ -64,6 +64,23 @@ export const isNativityReference = (ref: string): boolean => {
   }
 };
 
+// Flood survivors are Antediluvians in Redemption, but only newer printings
+// (LoC, RR2) carry the explicit "Antediluvian" identifier. Append it for older
+// Flood survivor characters so an "Antediluvian" search surfaces them too.
+// Restricted to characters so enhancements that merely reference flood
+// survivors (A New Beginning, The Rainbow) are not tagged.
+export const searchableIdentifier = (c: Card): string => {
+  const isCharacter = c.type.includes("Hero") || c.type.includes("Character");
+  if (
+    isCharacter &&
+    /flood survivor/i.test(c.identifier) &&
+    !/antediluvian/i.test(c.identifier)
+  ) {
+    return `${c.identifier}, Antediluvian`;
+  }
+  return c.identifier;
+};
+
 // Define how each icon filter should be applied
 export const iconPredicates: Record<string, (c: Card) => boolean> = {
   Artifact: (c) => c.type === "Artifact",


### PR DESCRIPTION
## Problem

Typing **Antediluvian** into card search only matched the 37 cards whose printed identifier includes it (LoC / RR2 / CoW-era antediluvians). The 13 older Flood survivor printings — CoW/FoM Noah, Noah's Wife, Shem, Ham, Japheth, and their wives — never showed up, even though flood survivors are Antediluvians by game rules (the LoC/RR2 reprints of Noah and Shem carry both identifiers explicitly).

## Fix

New `searchableIdentifier(card)` helper in `app/decklist/card-search/utils.ts`: for character cards whose identifier includes "Flood survivor" but not "Antediluvian", it appends `, Antediluvian` to the **searchable** identifier. Wired into the search's `identifier` field and the default `everything` field in `client.tsx`. Display is untouched — card modals still show the printed identifier.

Follows the existing precedent of the City-under-Fortress filter augmentation in `iconPredicates`.

## Scope decisions

- **Characters only** — enhancements that merely reference flood survivors (*A New Beginning*, *The Rainbow*) are not tagged. Verified zero non-character false positives against the full card data.
- **One direction only** — searching "Flood survivor" does not pull in non-survivor antediluvians (Cain, Enoch, etc.), since flood survivors are a subset, not the reverse.
- **Pat-era Noah / Noah's Sons** carry no identifiers at all in the source card data (they predate the identifier system), so they remain unmatched — same as they are for a "Flood survivor" search today.
- The collection page's simpler search was deliberately left alone; happy to extend if wanted.

## Verification

- New vitest suite `searchableIdentifier.test.ts` (6 tests, written red-first): augmentation, case variants (`Flood Survivor`), multi-clause identifiers (Japheth), no double-tagging (LoC Noah), enhancement exclusion, no-op for ordinary cards.
- Full suite: 1544 passed; the 3 failures (`forge-lackey`, two anon-leak env suites) reproduce identically on untouched `main` at the same commit — pre-existing/env-dependent, unrelated.
- `tsc --noEmit`: same 7 pre-existing errors as `main`, none in card-search.
- Data-level simulation over `cardData.json`: identifier search for "antediluvian" goes 37 → 50 matches, the 13 new ones being exactly the missing Flood survivor printings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)