### PR TITLE
fix(auth): stop stranding users who sign up with an existing email

### DIFF
--- a/app/(auth-pages)/sign-up/page.tsx
+++ b/app/(auth-pages)/sign-up/page.tsx
@@ -25,6 +25,10 @@ export default async function Signup(props: {
         Already have an account?{" "}
         <Link className="text-primary hover:text-primary/80 font-medium underline" href="/sign-in">
           Sign in
+        </Link>{" "}
+        or{" "}
+        <Link className="text-primary hover:text-primary/80 font-medium underline" href="/forgot-password">
+          reset your password
         </Link>
       </p>
 

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -31,10 +31,15 @@ export const signUpAction = async (formData: FormData) => {
     console.error(error.code + " " + error.message);
     return encodedRedirect("error", "/sign-up", error.message);
   } else {
+    // Supabase deliberately returns no error when the email already belongs to a
+    // confirmed account, and sends no verification email — so a bare "check your
+    // email" here strands people who already have an account (they wait on a mail
+    // that never arrives). Cover both cases without confirming whether the account
+    // exists, which is what the obfuscation is protecting against.
     return encodedRedirect(
       "success",
       "/sign-up",
-      "Thanks for signing up! Please check your email for a verification link.",
+      "Thanks for signing up! If this email is new, check your inbox for a verification link. If you already have an account, no email was sent — sign in instead, or reset your password if you've forgotten it.",
     );
   }
 };


### PR DESCRIPTION
## The bug

`supabase.auth.signUp()` returns **no error** when the email already belongs to a confirmed account, and sends no verification email — deliberate user-enumeration protection. [`signUpAction`](app/actions.ts) treated no-error as success:

> Thanks for signing up! Please check your email for a verification link.

So anyone who already had an account was told to watch an inbox that would never receive anything, with no hint that a password reset was the actual way in.

## Evidence from production

Found while investigating a user who couldn't get set up:

- Account created 2026-05-08, email confirmed, password set, not banned.
- **Exactly one successful login, ever** — `last_sign_in_at` still reads 2026-05-08. Everything in the 2.5 months since is one session created that minute, refreshing server-side.
- On 2026-07-15 at 15:16 and 15:19 the audit log records `user_repeated_signup` twice — they were on the sign-up form in a browser without that cookie, got the success message, and stopped.
- `recovery_sent_at` is null and they have zero `user_recovery_requested` entries. They never found the reset flow.

Meanwhile they have 10 decks on that account, several complete.

## The fix

Reword the success message to be correct whichever case the user is in, and point at the recovery path:

> Thanks for signing up! If this email is new, check your inbox for a verification link. If you already have an account, no email was sent — sign in instead, or reset your password if you've forgotten it.

Plus a `reset your password` link next to the existing `Sign in` link on the sign-up page.

## Why not detect the existing account explicitly

The common fix is to check `data.user.identities.length === 0` and say "an account with this email already exists." Two reasons this PR doesn't:

1. That message **re-introduces the exact user-enumeration leak** Supabase's obfuscation exists to prevent — the sign-up form becomes an oracle for which emails are registered.
2. The empty-`identities` signal isn't documented; it's community folklore. The docs confirm only that you get "an obfuscated user response with no verification email sent." A false positive would tell a genuinely new user they already have an account — worse than the bug being fixed.

The wording here needs no behavioral assumption and leaks nothing. Happy to switch to explicit detection if you'd rather take the enumeration tradeoff.

## Verification

`npx tsc --noEmit` — zero errors in both changed files. (11 pre-existing errors remain in test files and a `react-easy-crop` resolution artifact from the shared `node_modules`; none touched by this change.) Copy-and-link change only, no behavioral logic added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)