### PR TITLE
feat(forge): visible upload progress in the candidate art gallery

### DIFF
--- a/app/forge/components/ArtCandidatesPanel.tsx
+++ b/app/forge/components/ArtCandidatesPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Trash2 } from "lucide-react";
+import { Loader2, Trash2 } from "lucide-react";
 import FilePicker from "@/app/forge/components/FilePicker";
 import CropCandidateModal from "@/app/forge/components/CropCandidateModal";
 import ConfirmationDialog from "@/components/ui/confirmation-dialog";
@@ -20,7 +20,7 @@ export default function ArtCandidatesPanel({
   cardName: string | null;
 }) {
   const router = useRouter();
-  const [progress, setProgress] = useState<string | null>(null);
+  const [progress, setProgress] = useState<{ done: number; total: number; name: string } | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [cropping, setCropping] = useState<string | null>(null); // candidate id
   const [pendingDelete, setPendingDelete] = useState<string | null>(null);
@@ -29,11 +29,14 @@ export default function ArtCandidatesPanel({
     setErr(null);
     const errors: string[] = [];
     for (let i = 0; i < files.length; i++) {
-      setProgress(`Uploading ${i + 1} of ${files.length}…`);
+      setProgress({ done: i, total: files.length, name: files[i].name });
       const fd = new FormData();
       fd.set("file", files[i]);
       const r = await addArtCandidate(cardId, fd);
       if (r.ok === false) errors.push(`${files[i].name}: ${r.error ?? "failed"}`);
+      // Refresh per file, not once per batch — each finished upload swaps its
+      // skeleton tile for the real thumbnail, so a slow batch never looks hung.
+      else router.refresh();
     }
     setProgress(null);
     if (errors.length > 0) setErr(errors.join(" · "));
@@ -51,10 +54,12 @@ export default function ArtCandidatesPanel({
     <div>
       <FilePicker label="Add images…" accept="image/jpeg,image/png,image/webp" multiple
         disabled={progress !== null} onFiles={onFiles}
-        hint={progress ?? `${candidates.length}/12 · click an image to crop`} />
+        hint={progress
+          ? `Uploading ${progress.done + 1} of ${progress.total} — ${progress.name}`
+          : `${candidates.length}/12 · click an image to crop`} />
       {err && <p className="mt-2 text-sm text-destructive">{err}</p>}
 
-      {candidates.length > 0 && (
+      {(candidates.length > 0 || progress !== null) && (
         <ul className="mt-3 grid grid-cols-3 gap-2 sm:grid-cols-4">
           {candidates.map((c) => (
             <li key={c.id} className="group relative">
@@ -75,6 +80,15 @@ export default function ArtCandidatesPanel({
               )}
             </li>
           ))}
+          {/* One skeleton per not-yet-landed file: the active upload spins, queued
+              ones pulse. Replaced by real thumbnails as each per-file refresh lands. */}
+          {progress !== null &&
+            Array.from({ length: progress.total - progress.done }, (_, i) => (
+              <li key={`uploading-${i}`} aria-hidden="true"
+                className="flex aspect-square w-full animate-pulse items-center justify-center rounded-md border border-dashed bg-muted/40">
+                {i === 0 && <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" aria-hidden="true" />}
+              </li>
+            ))}
         </ul>
       )}
 


### PR DESCRIPTION
## Summary

Follow-up to #245, from testing feedback: batch uploads looked hung because the gallery only refreshed once at the end, and the only signal was a small muted counter.

- **Skeleton tiles**: each not-yet-landed file renders a dashed, pulsing placeholder tile in the grid, with a spinner on the file currently uploading — motion is the liveness signal.
- **Per-file refresh**: each finished upload swaps its skeleton for the real thumbnail immediately instead of waiting for the whole batch.
- **Filename in the hint**: `Uploading 2 of 3 — goliath-art.jpg`, so a slow file is identifiable.

Known limit: granularity is per-file, not byte-level percent — server actions don't expose upload byte progress. A true percent bar would need an XHR/API-route upload path; ask if wanted.

## Test plan

- `tsc --noEmit` clean (only the 7 pre-existing baseline errors in test files).
- Behavior change is presentation-only in `ArtCandidatesPanel`; server actions untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)