### PR TITLE
fix(forge): Release update resolves open proposals instead of orphaning them

### DIFF
--- a/app/forge/cards/[cardId]/LifecycleControls.tsx
+++ b/app/forge/cards/[cardId]/LifecycleControls.tsx
@@ -4,7 +4,7 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { MoreHorizontal } from "lucide-react";
 import { shareToSet, sendToPrivate, publish, approve, unapprove, archive, unarchive, deleteCard } from "@/app/forge/lib/lifecycle";
-import { STATUS_PATH, STATUS_LABEL, ACTION_LABEL, releaseLabel, CONFIRM_COPY } from "@/app/forge/lib/lifecycleCopy";
+import { STATUS_PATH, STATUS_LABEL, ACTION_LABEL, releaseLabel, releaseProposalNotice, CONFIRM_COPY } from "@/app/forge/lib/lifecycleCopy";
 import type { ForgeSetSummary } from "@/app/forge/lib/sets";
 import type { ForgeCardFull } from "@/app/forge/lib/cards";
 import { Button } from "@/components/ui/button";
@@ -26,7 +26,18 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 
-export default function LifecycleControls({ card, sets }: { card: ForgeCardFull; sets: ForgeSetSummary[] }) {
+export default function LifecycleControls({
+  card,
+  sets,
+  openProposals = { count: 0, hasMatch: false },
+}: {
+  card: ForgeCardFull;
+  sets: ForgeSetSummary[];
+  // Releasing closes the card's open proposals (migration 083). `hasMatch` =
+  // one of them is exactly this draft, so the release records it as accepted
+  // instead of discarding it. Classified server-side in the page.
+  openProposals?: { count: number; hasMatch: boolean };
+}) {
   const router = useRouter();
   const [pending, start] = useTransition();
   const [picking, setPicking] = useState(false);
@@ -61,6 +72,7 @@ export default function LifecycleControls({ card, sets }: { card: ForgeCardFull;
     });
 
   const inSet = card.setId !== null;
+  const releaseNotices = releaseProposalNotice(openProposals.count, openProposals.hasMatch);
 
   return (
     <div className="flex flex-wrap items-center gap-2 text-xs">
@@ -140,6 +152,13 @@ export default function LifecycleControls({ card, sets }: { card: ForgeCardFull;
             </DialogDescription>
           </DialogHeader>
           <DialogBody className="space-y-2">
+            {releaseNotices.length > 0 && (
+              <ul className="space-y-1 rounded-md border bg-muted/50 px-2 py-1.5 text-xs text-muted-foreground">
+                {releaseNotices.map((n) => (
+                  <li key={n}>{n}</li>
+                ))}
+              </ul>
+            )}
             <label className="block text-xs font-medium text-muted-foreground">What changed? (optional)</label>
             <textarea
               autoFocus

--- a/app/forge/cards/[cardId]/StudioEditor.tsx
+++ b/app/forge/cards/[cardId]/StudioEditor.tsx
@@ -33,7 +33,7 @@ const arrowClass =
   "absolute top-1/2 z-10 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full border bg-background/70 text-muted-foreground shadow-sm backdrop-blur transition-colors hover:bg-background hover:text-foreground";
 
 export default function StudioEditor({
-  card, sets, currentUser, setId, setName, prevId, nextId, artCandidates,
+  card, sets, currentUser, setId, setName, prevId, nextId, artCandidates, openProposals,
 }: {
   card: ForgeCardFull;
   sets: ForgeSetSummary[];
@@ -43,6 +43,8 @@ export default function StudioEditor({
   prevId?: string | null;
   nextId?: string | null;
   artCandidates: ArtCandidate[];
+  // Passed straight to LifecycleControls for the release dialog's heads-up.
+  openProposals?: { count: number; hasMatch: boolean };
 }) {
   const [snapshot, setSnapshot] = useState<DesignCard>(card.snapshot ?? {});
   const [saved, setSaved] = useState<"idle" | "saving" | "saved" | "error">("idle");
@@ -159,7 +161,7 @@ export default function StudioEditor({
             {saved === "saving" ? "Saving…" : saved === "saved" ? "Saved" : saved === "error" ? "Save failed" : ""}
           </span>
         </div>
-        <LifecycleControls card={card} sets={sets} />
+        <LifecycleControls card={card} sets={sets} openProposals={openProposals} />
         {card.setId && (
           <p className="text-xs text-muted-foreground">
             Releases are visible to Forge playtesters only — they don’t change the public card database.

--- a/app/forge/cards/[cardId]/page.tsx
+++ b/app/forge/cards/[cardId]/page.tsx
@@ -4,6 +4,7 @@ import { getCard } from "@/app/forge/lib/cards";
 import { listArtCandidates } from "@/app/forge/lib/artCandidates";
 import { getSet, listSets, listSetCards } from "@/app/forge/lib/sets";
 import { sortSetCards } from "@/app/forge/lib/cardOrder";
+import { sameSnapshot } from "@/app/forge/lib/cardDiff";
 import { getOpenProposalDiffs, listProposals } from "@/app/forge/lib/proposals";
 import { listComments } from "@/app/forge/lib/comments";
 import { listVersions, listCardEvents } from "@/app/forge/lib/versions";
@@ -36,6 +37,14 @@ export default async function StudioPage({ params }: { params: Promise<{ cardId:
     : [[], [], [], [], [], []];
   const canReview = ctx.role === "elder" || ctx.role === "superadmin";
 
+  // Releasing closes every open proposal (migration 083); one that is exactly
+  // this working draft is recorded as accepted instead. Classified here so the
+  // release dialog can say which will happen. Wording only — the RPC decides.
+  const openProposals = {
+    count: openDiffs.length,
+    hasMatch: openDiffs.some((d) => sameSnapshot(d.proposal.proposedSnapshot, card.snapshot ?? {})),
+  };
+
   // Prev/next arrows on the card face walk the set in the same order as the grid.
   // No wrap: the boundary card gets null and hides that arrow.
   const ordered = sortSetCards(siblings);
@@ -52,7 +61,7 @@ export default async function StudioPage({ params }: { params: Promise<{ cardId:
 
   return (
     <>
-      <StudioEditor card={card} sets={sets} currentUser={currentUser} setId={card.setId ?? null} setName={set?.name ?? null} prevId={prevId} nextId={nextId} artCandidates={artCandidates} />
+      <StudioEditor card={card} sets={sets} currentUser={currentUser} setId={card.setId ?? null} setName={set?.name ?? null} prevId={prevId} nextId={nextId} artCandidates={artCandidates} openProposals={openProposals} />
       {inSet && (
         <ReviewPanel
           card={card}

--- a/app/forge/lib/__tests__/cardDiff.test.ts
+++ b/app/forge/lib/__tests__/cardDiff.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { diffCards, summarizeDiff, coerceFieldValue } from "../cardDiff";
+import { diffCards, summarizeDiff, coerceFieldValue, sameSnapshot } from "../cardDiff";
 
 describe("diffCards", () => {
   it("detects a changed scalar field", () => {
@@ -48,5 +48,25 @@ describe("coerceFieldValue", () => {
     expect(coerceFieldValue("strength", "nope")).toBeNull();
     expect(coerceFieldValue("brigades", "Blue, Green")).toEqual(["Blue", "Green"]);
     expect(coerceFieldValue("name", "  David  ")).toBe("David");
+  });
+});
+
+describe("sameSnapshot", () => {
+  it("ignores key order and compares nested values structurally", () => {
+    expect(sameSnapshot({ name: "David", reference: "1 Sam 17" }, { reference: "1 Sam 17", name: "David" })).toBe(true);
+    expect(sameSnapshot({ brigades: ["Blue", "Green"] }, { brigades: ["Blue", "Green"] })).toBe(true);
+    expect(sameSnapshot({ brigades: ["Blue", "Green"] }, { brigades: ["Green", "Blue"] })).toBe(false);
+  });
+
+  it("catches changes diffCards is blind to (DIFF_FIELDS omits rarity et al.)", () => {
+    const a = { name: "David", rarity: "Rare" } as any;
+    const b = { name: "David", rarity: "Common" } as any;
+    expect(diffCards(a, b)).toHaveLength(0);
+    expect(sameSnapshot(a, b)).toBe(false);
+  });
+
+  it("treats an empty snapshot as equal only to another empty one", () => {
+    expect(sameSnapshot({}, {})).toBe(true);
+    expect(sameSnapshot({}, { name: "David" })).toBe(false);
   });
 });

--- a/app/forge/lib/__tests__/lifecycleCopy.test.ts
+++ b/app/forge/lib/__tests__/lifecycleCopy.test.ts
@@ -1,7 +1,7 @@
 // app/forge/lib/__tests__/lifecycleCopy.test.ts
 import { describe, it, expect } from "vitest";
 import {
-  STATUS_LABEL, ACTION_LABEL, releaseLabel, isEligible, BULK_DONE_VERB,
+  STATUS_LABEL, ACTION_LABEL, releaseLabel, isEligible, BULK_DONE_VERB, releaseProposalNotice,
 } from "../lifecycleCopy";
 
 describe("lifecycleCopy", () => {
@@ -52,5 +52,34 @@ describe("lifecycleCopy", () => {
     for (const a of Object.keys(ACTION_LABEL)) {
       expect(BULK_DONE_VERB[a as keyof typeof BULK_DONE_VERB]).toBeTruthy();
     }
+  });
+});
+
+describe("releaseProposalNotice", () => {
+  it("says nothing when the card has no open proposals", () => {
+    expect(releaseProposalNotice(0, false)).toEqual([]);
+  });
+
+  it("reports the sole matching proposal as recorded-accepted, with nothing closed", () => {
+    const n = releaseProposalNotice(1, true);
+    expect(n).toHaveLength(1);
+    expect(n[0]).toMatch(/recorded as accepted/);
+  });
+
+  it("reports a sole non-matching proposal as closed out of date", () => {
+    const n = releaseProposalNotice(1, false);
+    expect(n).toHaveLength(1);
+    expect(n[0]).toMatch(/closed as out of date/);
+  });
+
+  it("counts only ONE accept per release — the rest are closed", () => {
+    const n = releaseProposalNotice(3, true);
+    expect(n).toHaveLength(2);
+    expect(n[0]).toMatch(/recorded as accepted/);
+    expect(n[1]).toMatch(/^2 open proposals will be closed as out of date/);
+  });
+
+  it("pluralizes the closed count with no match", () => {
+    expect(releaseProposalNotice(2, false)[0]).toMatch(/^2 open proposals will be closed/);
   });
 });

--- a/app/forge/lib/cardDiff.ts
+++ b/app/forge/lib/cardDiff.ts
@@ -40,6 +40,27 @@ export const SUGGESTABLE_FIELDS: (keyof DesignCard)[] = [
   "scripture", "artistCredit", "cardFrame",
 ];
 
+// Canonical (key-order-independent) deep equality, mirroring SQL jsonb '='.
+// Used ONLY to word the release dialog — migration 083 decides what a release
+// actually does to open proposals, server-side — so drift here can misword the
+// dialog but can never change behavior.
+// Deliberately NOT `diffCards(a, b).length === 0`: DIFF_FIELDS omits
+// specialAbility/legality/rarity/artistCredit/cardFrame, so a diff-based
+// compare would call two genuinely different snapshots equal.
+export function sameSnapshot(a: DesignCard, b: DesignCard): boolean {
+  return canonicalJson(a) === canonicalJson(b);
+}
+
+function canonicalJson(v: unknown): string {
+  if (v === null || typeof v !== "object") return JSON.stringify(v) ?? "null";
+  if (Array.isArray(v)) return `[${v.map(canonicalJson).join(",")}]`;
+  const o = v as Record<string, unknown>;
+  return `{${Object.keys(o)
+    .sort()
+    .map((k) => `${JSON.stringify(k)}:${canonicalJson(o[k])}`)
+    .join(",")}}`;
+}
+
 const ARRAY_FIELDS = new Set(["cardType", "brigades", "class", "icons", "identifiers"]);
 const NUMBER_FIELDS = new Set(["strength", "toughness"]);
 

--- a/app/forge/lib/lifecycleCopy.ts
+++ b/app/forge/lib/lifecycleCopy.ts
@@ -58,6 +58,26 @@ export function releaseLabel(status: string): string {
   return status === "draft" ? ACTION_LABEL.release : "Release update";
 }
 
+// What releasing will do to the card's open proposals, said before you commit
+// to it. Mirrors migration 083: forge_publish_card records at most ONE matching
+// proposal as accepted (the oldest) and closes the rest as out of date.
+export function releaseProposalNotice(openCount: number, hasMatch: boolean): string[] {
+  if (openCount <= 0) return [];
+  const notices: string[] = [];
+  if (hasMatch) {
+    notices.push(
+      "1 open proposal matches this draft and will be recorded as accepted by this release — its summary is kept in the card’s history.",
+    );
+  }
+  const closed = hasMatch ? openCount - 1 : openCount;
+  if (closed === 1) {
+    notices.push("1 open proposal will be closed as out of date. Review it first if you still want it.");
+  } else if (closed > 1) {
+    notices.push(`${closed} open proposals will be closed as out of date. Review them first if you still want them.`);
+  }
+  return notices;
+}
+
 const ACTION_ELIGIBLE: Record<LifecycleAction, readonly string[]> = {
   release: ["draft", "playtesting"],
   markFinal: ["playtesting"],

--- a/app/forge/lib/proposals.ts
+++ b/app/forge/lib/proposals.ts
@@ -119,7 +119,15 @@ export async function acceptProposal(
     p_proposal_id: proposalId,
   });
   if (error) return { ok: false, error: "Could not accept proposal" };
-  if (data === null) return { ok: false, error: "This proposal is out of date — please re-propose." };
+  // Since migration 083 a release closes open proposals itself, so a stale base
+  // here means a genuine race: someone released while this review was open.
+  if (data === null) {
+    return {
+      ok: false,
+      error:
+        "A newer version was released while this was open, so this proposal was closed. Re-propose from the current draft if the change is still needed.",
+    };
+  }
   // Lifecycle change ripples to set/card/queue views.
   revalidatePath("/forge", "layout");
   return { ok: true };

--- a/docs/superpowers/specs/2026-07-27-forge-release-resolves-proposals-design.md
+++ b/docs/superpowers/specs/2026-07-27-forge-release-resolves-proposals-design.md
@@ -1,0 +1,152 @@
+# Release resolves open proposals — design
+
+Written 2026-07-27. Fixes the friction where "Propose changes" followed by
+"Release update" leaves a proposal that can never be accepted, and greets the
+elder with "This proposal is out of date — please re-propose."
+
+Background reading: `prompt_context/forge_versioning.md`.
+
+## The friction
+
+A card has one working draft. Two separate controls both mint a version row
+from it:
+
+- **Propose changes** freezes `forge_cards.working_snapshot` into
+  `card_proposals` with `base_version_id` = the card's latest version row
+  (`forge_create_proposal`, migration 075). An elder later accepts, which mints
+  the version.
+- **Release update** mints a version directly from `working_snapshot`
+  (`forge_publish_card`, migration 072) and touches nothing about open
+  proposals.
+
+So Propose-then-Release leaves the proposal with a stale base. Three things go
+wrong, in this order:
+
+1. **The badge lies.** The proposal stays `status='open'`, so the corner icon on
+   the set grid (`listOpenProposalCounts`) keeps advertising a review that can
+   never happen.
+2. **The error fires late and reads like data loss.** Only on clicking Accept
+   does `forge_accept_proposal` notice `base_version_id <> latest`, close the
+   proposal as `superseded`, and return null — surfacing as "This proposal is
+   out of date — please re-propose." Nothing is actually broken (the content
+   *was* released), but the wording says otherwise.
+3. **The "why" is orphaned.** The proposal summary — often the only written
+   record of the reasoning — ends up on a `superseded` row instead of attached
+   to the version that shipped.
+
+## What this changes
+
+`forge_publish_card` resolves open proposals in the same transaction that mints
+the version, so the two doors stop colliding. The Release dialog says what will
+happen before you commit to it.
+
+### 1. Release resolves open proposals (migration 083)
+
+After the version insert, inside `forge_publish_card`:
+
+- **The matching proposal** — the oldest open proposal whose
+  `proposed_snapshot` equals the released `working_snapshot` — closes as
+  `accepted`, with `resulting_version_id` = the new version and
+  `closed_by = auth.uid()`. History then renders "Accepted → vN" with the
+  proposal's summary, beside the release note. This is the reported case, and
+  it now produces no error at all.
+- **Every other open proposal** closes as `superseded` with `closed_at` and
+  `closed_by` set, and `resulting_version_id` left null. The badge clears at
+  release time rather than lying until someone clicks Accept.
+
+Ordering matters: accept the match first, then sweep the rest excluding it.
+This mirrors the sibling sweep `forge_accept_proposal` already performs
+(075:80-82, 075:106-108), and the transaction-stable `now()` shared by both
+updates is what lets `deriveSupersededBy` attribute the sweep to the accepted
+proposal.
+
+**Only one proposal may be accepted per release.** Two `accepted` rows pointing
+at one version would render as two "Accepted → vN" entries in History. If
+several open proposals match, the oldest by `created_at` wins and the rest are
+superseded.
+
+**Snapshot equality is jsonb `=`.** Postgres normalizes `jsonb`, so key order
+and numeric form do not matter. A `::text` comparison would spuriously miss the
+common case.
+
+**The accept branch is gated on elder/superadmin.** `forge_publish_card` admits
+the card owner as well (072:26-29), while accepting is elder-only (075:39-42).
+A non-elder owner releasing supersedes every open proposal and accepts none, so
+`accepted` keeps meaning *an elder decided*. Reaching that path requires
+calling the RPC directly — `publish()` in `app/forge/lib/lifecycle.ts` is
+already behind `requireElder()`.
+
+No signature change, so `CREATE OR REPLACE` preserves existing grants.
+
+### 2. The Release dialog says what will happen
+
+`app/forge/cards/[cardId]/page.tsx` already loads `openDiffs`; it passes the
+open proposals to `StudioEditor` → `LifecycleControls`, which classifies them
+against `card.snapshot` (the working draft) and renders one line in the release
+dialog above the note field:
+
+- a proposal matches → "1 open proposal will be recorded as accepted by this
+  release. Its summary is kept in the card's history."
+- none matches → "1 open proposal will be closed as out of date. Review it
+  first if you still want it."
+- both → both lines.
+
+Classification uses a new `sameSnapshot(a, b)` helper in
+`app/forge/lib/cardDiff.ts`: a sorted-key canonical compare that mirrors SQL
+jsonb equality. It exists only to choose dialog wording — behavior is decided
+server-side — so drift can misword the dialog but can never change what the
+release does.
+
+`sameSnapshot` is deliberately NOT `diffCards(a, b).length === 0`.
+`DIFF_FIELDS` omits `specialAbility`, `legality`, `rarity`, `artistCredit` and
+`cardFrame`, so a diff-based comparison would call two genuinely different
+snapshots equal.
+
+### 3. Honest copy on the residual race
+
+After (1), a stale base is only reachable when someone releases the card while
+another elder has the review open. `acceptProposal` in
+`app/forge/lib/proposals.ts` stops saying "please re-propose" and says what
+happened: "A newer version was released while this was open, so this proposal
+was closed. Re-propose from the current draft if the change is still needed."
+
+## What this deliberately does not change
+
+- **The stale-base guard in `forge_accept_proposal` stays.** It is now a
+  backstop for the concurrent-release race rather than the routine path.
+- **No re-basing of stale proposals.** Re-basing was considered and rejected.
+  A proposal is not a branch: `createProposal` freezes the *shared*
+  `working_snapshot`, and everyone who can propose can also write it, so a
+  non-matching open proposal is almost always an earlier point on the same
+  timeline, not a competing idea. Re-basing would make "Accept" a one-click
+  rollback of the release that just happened. Its only justification — that the
+  recomputed diff shows the elder what they are applying — is false, because
+  Accept writes the whole snapshot while the diff renders only `DIFF_FIELDS`.
+- **`historyView.ts` and `CardHistory.tsx` are untouched.** Both cases already
+  render correctly: an accepted match shows "Accepted → vN", and a superseded
+  proposal with no accepted sibling shows "Out of date — a direct release
+  replaced the version it was based on" (`CardHistory.tsx:82-84`).
+- **The authorization asymmetry between `forge_publish_card` (owner allowed)
+  and `forge_accept_proposal` (elder only) is left alone**, beyond the gate in
+  (1). Tightening the release gate is a separate decision.
+
+## Known gap, not fixed here
+
+If elder X proposes and elder Y then reshapes the shared draft and releases,
+X's proposal closes as superseded with no deny reason and no review. Its
+`proposed_snapshot` survives on the row forever, but nothing in the UI can
+restore it. Re-basing would not fix this either — accepting the rebased
+proposal would clobber Y's release. The real fix is a "load this proposal into
+the working draft" action on closed proposals, which is separate work.
+
+## Testing
+
+- `app/forge/lib/__tests__/cardDiff.test.ts` — `sameSnapshot`: key order and
+  nesting ignored; a change confined to a non-`DIFF_FIELDS` key (e.g.
+  `rarity`) reports NOT equal, where `diffCards` reports no changes.
+- `app/forge/lib/__tests__/lifecycleCopy.test.ts` — the release-dialog warning
+  builder, over: no open proposals (no line), one matching, one non-matching,
+  and both.
+- Migration 083 is exercised manually against the Forge on a preview
+  deployment: propose → release → confirm History shows "Accepted → vN" with
+  the summary, the grid badge is gone, and no error appears.

--- a/prompt_context/forge_versioning.md
+++ b/prompt_context/forge_versioning.md
@@ -69,9 +69,19 @@ iteration).
   `superseded`. On a Draft card the dialog says so explicitly: nothing is
   released.
 - **Deny** (elder): requires a reason, stored as a proposal-anchored comment.
-- **Stale base**: if the card gained a newer version after the proposal was
-  made, accepting returns "out of date — please re-propose" and the proposal
-  closes as `superseded`.
+- **Release resolves open proposals** (migration 083). Releasing also mints a
+  version, so it would otherwise leave open proposals permanently
+  un-acceptable. Instead, in the same transaction: the oldest open proposal
+  whose snapshot **equals what is being released** closes as `accepted`,
+  pointing at the new version — the release *is* the acceptance, and its
+  summary lands in History beside the release note. Every other open proposal
+  closes as `superseded`. Propose-then-Release is therefore a supported path,
+  not an error. Only one accept per release; a non-elder owner calling the RPC
+  directly supersedes all and accepts none.
+- **Stale base**: a proposal whose base is no longer the card's latest version
+  cannot be accepted — accepting closes it as `superseded` and returns null.
+  Since 083 this is only reachable as a race (someone releases while another
+  elder has the review open), not the routine Propose-then-Release path.
 - Proposal-anchored comments (deny reasons, accept notes) are **undeletable**
   — they are the decision record.
 
@@ -115,6 +125,6 @@ pipeline + manual Lackey export).
 | History timeline | `CardHistory.tsx` + pure assembly in `app/forge/lib/historyView.ts` |
 | Readers | `app/forge/lib/versions.ts` (listVersions / listCardEvents / listSetActivity) |
 | Server actions | `app/forge/lib/proposals.ts`, `lifecycle.ts` |
-| RPCs (current bodies) | migrations `072` (publish + audit events + undeletable reasons), `075` (draft versions, unified base/guard, sweep exclusions) |
+| RPCs (current bodies) | migrations `083` (**current `forge_publish_card`** — resolves open proposals), `072` (publish note + audit events + undeletable reasons), `075` (draft versions, unified base/guard, sweep exclusions) |
 | Enum + backfill | `074` (`version_status` gains 'draft'), `076` (backfilled the one 073-era lost accept) |
 | Design history | `docs/superpowers/specs/2026-07-06-forge-version-history-design.md` (incl. addendum) |

--- a/supabase/migrations/083_forge_release_resolves_proposals.sql
+++ b/supabase/migrations/083_forge_release_resolves_proposals.sql
@@ -1,0 +1,105 @@
+-- 083: "Release update" resolves open proposals instead of orphaning them.
+--
+-- A card has ONE working draft, and two controls both mint a version from it:
+-- "Propose changes" (forge_create_proposal -> an elder accepts) and "Release
+-- update" (forge_publish_card). Release used to ignore open proposals, so
+-- Propose-then-Release left a proposal whose base_version_id no longer matched
+-- the card's latest version: it stayed 'open' (the set-grid badge kept
+-- advertising it) and only on clicking Accept did forge_accept_proposal's
+-- stale-base guard close it as 'superseded' and return null -- surfacing as
+-- "out of date -- please re-propose" even though the content HAD shipped.
+--
+-- forge_publish_card now closes them in the same transaction as the version
+-- insert:
+--   * the oldest open proposal whose proposed_snapshot equals what is being
+--     released closes as 'accepted', pointing at the new version -- the release
+--     IS the acceptance, and History renders "Accepted -> vN" with the
+--     proposal's summary beside the release note;
+--   * every other open proposal closes as 'superseded'. Their base is stale the
+--     moment this version lands, so they were unacceptable anyway; closing now
+--     clears the badge honestly instead of erroring on the next click.
+--
+-- Deliberate choices:
+--   * ONE accept per release (oldest by created_at). Two 'accepted' rows
+--     pointing at one version would double-render in History.
+--   * jsonb '=' for the match. Postgres normalizes jsonb, so key order and
+--     numeric form do not matter; a ::text compare would miss the common case.
+--   * The accept branch is gated on elder/superadmin. This function also admits
+--     the card owner (072), while accepting is elder-only (075), so a non-elder
+--     owner supersedes every open proposal and accepts none -- 'accepted' keeps
+--     meaning "an elder decided". Unreachable through the app (publish() is
+--     behind requireElder()), but the RPC is callable directly.
+--   * resulting_version_id is NEVER set on a superseded row; History keys its
+--     "-> vN" rendering off that column.
+--   * The transaction-stable now() shared by both updates is what lets
+--     deriveSupersededBy (app/forge/lib/historyView.ts) attribute the sweep to
+--     the accepted proposal, exactly as forge_accept_proposal's own sibling
+--     sweep does. With no match, it correctly falls back to "Out of date -- a
+--     direct release replaced the version it was based on".
+--
+-- forge_accept_proposal is UNCHANGED: its stale-base guard stays as the
+-- backstop for the concurrent-release race (someone releases while another
+-- elder has the review open).
+-- Body = 072 verbatim + the resolution block. Signature unchanged, so
+-- CREATE OR REPLACE preserves existing grants.
+-- Design: docs/superpowers/specs/2026-07-27-forge-release-resolves-proposals-design.md
+
+create or replace function public.forge_publish_card(p_card_id uuid, p_note text default null)
+returns uuid language plpgsql security definer set search_path = '' as $$
+declare v_card public.forge_cards%rowtype; v_next int; v_version_id uuid;
+        v_can_accept boolean; v_matched uuid;
+begin
+  select * into v_card from public.forge_cards where id = p_card_id for update;
+  if not found then raise exception 'card not found'; end if;
+  if not (v_card.owner_id = auth.uid() or public.is_forge_superadmin()
+          or (v_card.set_id is not null and public.is_forge_set_elder(v_card.set_id))) then
+    raise exception 'not authorized to publish this card';
+  end if;
+  if v_card.set_id is null then raise exception 'only cards in a set can be published'; end if;
+  if v_card.status not in ('draft','playtesting') then
+    raise exception 'only a draft or playtesting card can be published';
+  end if;
+  select coalesce(max(version_number), 0) + 1 into v_next
+    from public.card_versions where card_id = p_card_id;
+  update public.card_versions set status = 'superseded'
+    where card_id = p_card_id and status = 'published';
+  insert into public.card_versions
+    (card_id, version_number, status, data, art_key, art_is_placeholder, art_original_key, finished_key, created_by, note)
+  values
+    (p_card_id, v_next, 'published', v_card.working_snapshot,
+     v_card.working_art_key, v_card.working_art_is_placeholder, v_card.working_art_original_key,
+     v_card.working_finished_key, auth.uid(), nullif(btrim(coalesce(p_note, '')), ''))
+  returning id into v_version_id;
+  update public.forge_cards
+     set published_version_id = v_version_id, status = 'playtesting', updated_at = now()
+   where id = p_card_id;
+
+  -- Resolve open proposals. The card row is locked FOR UPDATE above and
+  -- forge_create_proposal takes FOR SHARE on it, so no proposal can be created
+  -- between the version insert and this sweep.
+  v_can_accept := public.is_forge_superadmin() or public.is_forge_set_elder(v_card.set_id);
+  if v_can_accept then
+    select id into v_matched
+      from public.card_proposals
+     where card_id = p_card_id
+       and status = 'open'
+       and proposed_snapshot = v_card.working_snapshot
+     order by created_at, id
+     limit 1
+       for update;
+    if v_matched is not null then
+      update public.card_proposals
+         set status = 'accepted', resulting_version_id = v_version_id,
+             closed_at = now(), closed_by = auth.uid()
+       where id = v_matched;
+    end if;
+  end if;
+
+  -- The accepted row (if any) is no longer 'open', so this sweep skips it
+  -- without needing to name it.
+  update public.card_proposals
+     set status = 'superseded', closed_at = now(), closed_by = auth.uid()
+   where card_id = p_card_id and status = 'open';
+
+  return v_version_id;
+end; $$;


### PR DESCRIPTION
## The friction

> *"I've posted in Propose Changes… then clicked Release Update… This has left open proposals that I can no longer accept or deny. A message comes up that says 'The Proposal is out of date - please re-propose.'"*

A card has **one** working draft, and two controls both mint a version from it:

- **Propose changes** freezes `working_snapshot` with `base_version_id` = the card's latest version, for an elder to accept.
- **Release update** mints a version directly from `working_snapshot` — and used to ignore open proposals entirely.

So Propose-then-Release left the proposal with a stale base. Three things went wrong, in order:

1. **The badge lied.** The proposal stayed `status='open'`, so the corner icon on the set grid kept advertising a review that could never happen.
2. **The error fired late and read like data loss.** Only on clicking Accept did `forge_accept_proposal` notice, close it as `superseded`, and return null. Nothing was actually broken — the content *had* shipped — but "please re-propose" says otherwise.
3. **The "why" was orphaned.** The proposal summary, often the only written record of the reasoning, ended up on a `superseded` row instead of attached to the version that shipped.

## The fix

**1. `forge_publish_card` resolves open proposals** (migration `083`), in the same transaction as the version insert:

- The **oldest open proposal whose snapshot equals what's being released** closes as `accepted`, with `resulting_version_id` = the new version. The release *is* the acceptance — History renders "Accepted → vN" with the summary, beside the release note. This is the reported case, and it now produces no error at all.
- **Every other open proposal** closes as `superseded`. Their base is stale the moment this version lands, so they were unacceptable anyway; closing now clears the badge honestly instead of erroring on the next click.

Deliberate choices, all documented in the migration header: one accept per release (two `accepted` rows pointing at one version would double-render in History); jsonb `=` for the match, not `::text`; the accept branch gated on elder/superadmin, since this RPC also admits the card owner while accepting is elder-only — so `accepted` keeps meaning *an elder decided*.

**2. The release dialog says what will happen** before you commit to it — "1 open proposal matches this draft and will be recorded as accepted…" or "…will be closed as out of date. Review it first if you still want it."

**3. Honest copy on the residual race.** After (1), a stale base is only reachable when someone releases while another elder has the review open, so the message now explains that instead of implying lost work.

## Why not re-base stale proposals

Considered and rejected. A proposal isn't a branch: `createProposal` freezes the **shared** `working_snapshot`, and everyone who can propose can also write it — so a non-matching open proposal is almost always an earlier point on the same timeline, not a competing idea. Re-basing would make "Accept" a one-click rollback of the release that just happened. Its only justification — that the recomputed diff shows the elder what they're applying — is false, because Accept writes the whole snapshot while the diff renders only `DIFF_FIELDS` (which omits `specialAbility`, `legality`, `rarity`, `artistCredit`, `cardFrame`).

## Not changed

- `forge_accept_proposal` — its stale-base guard stays as the race backstop.
- `historyView.ts` / `CardHistory.tsx` — both cases already render correctly, including "Out of date — a direct release replaced the version it was based on" when nothing matched.
- No RPC signature change, so `CREATE OR REPLACE` preserves all grants.

## Known gap, flagged not fixed

If elder X proposes and elder Y reshapes the shared draft and releases, X's proposal closes as superseded with no deny reason. Its `proposed_snapshot` survives on the row, but nothing in the UI can restore it. Re-basing wouldn't fix this either. The real fix is a "load this proposal into the working draft" action on closed proposals — separate work.

## Testing

- `sameSnapshot` — key order and nesting ignored; catches a `rarity`-only change that `diffCards` reports as no changes.
- `releaseProposalNotice` — no open proposals, one matching, one non-matching, and the one-accept-per-release cap.
- Full suite: 1570 passed. Three pre-existing failures unrelated to this branch (two anon-leak files need env and skip cleanly with it; `forge-lackey.test.ts` fails identically on `origin/main`).

**Migration 083 has NOT been applied to prod** — it needs to go in with the merge.

Design: `docs/superpowers/specs/2026-07-27-forge-release-resolves-proposals-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)