### PR TITLE
fix(decklist): keep the maybeboard out of every deck stat

### DIFF
--- a/app/decklist/[deckId]/client.tsx
+++ b/app/decklist/[deckId]/client.tsx
@@ -19,6 +19,7 @@ import { useCollectionState } from "../../collection/hooks/useCollectionState";
 import BuyDeckModal, { type BuyDeckCard } from "../card-search/components/BuyDeckModal";
 import CollectionCheckModal from "../card-search/components/CollectionCheckModal";
 import { aggregateOwnedByName } from "../card-search/utils/collectionCheck";
+import { statCards, countBy, sumQuantity } from "../card-search/utils/deckStats";
 import GeneratePDFModal from "../card-search/components/GeneratePDFModal";
 import GenerateDeckImageModal from "../card-search/components/GenerateDeckImageModal";
 import AodCountCard from "../card-search/components/AodCountCard";
@@ -399,7 +400,8 @@ export default function PublicDeckClient({ deck, isOwner, isLoggedIn }: Props) {
   const totalDeckPrice = useMemo(() => {
     let total = 0;
     let hasAnyPrice = false;
-    for (const card of enrichedCards) {
+    // Maybeboard is a scratchpad — it never counts toward the deck's price.
+    for (const card of statCards(enrichedCards)) {
       const priceKey = `${card.card_name}|${card.card_set}|${sanitizeImgFile(card.card_img_file || "")}`;
       const priceInfo = getPrice(priceKey);
       if (priceInfo) {
@@ -1249,12 +1251,10 @@ export default function PublicDeckClient({ deck, isOwner, isLoggedIn }: Props) {
               </h3>
               <div className="grid grid-cols-2 gap-3">
                 {(() => {
-                  const alignmentCounts = enrichedCards.reduce((acc, card) => {
-                    let alignment = card.alignment || "Neutral";
-                    if (alignment.includes("Good/Evil")) alignment = "Neutral";
-                    acc[alignment] = (acc[alignment] || 0) + card.quantity;
-                    return acc;
-                  }, {} as Record<string, number>);
+                  const alignmentCounts = countBy(enrichedCards, (card) => {
+                    const alignment = card.alignment || "Neutral";
+                    return alignment.includes("Good/Evil") ? "Neutral" : alignment;
+                  });
 
                   const alignmentConfig = [
                     { name: 'Good', color: 'bg-blue-100 dark:bg-blue-900/30 border-blue-300 dark:border-blue-700 text-blue-800 dark:text-blue-200' },
@@ -1293,7 +1293,7 @@ export default function PublicDeckClient({ deck, isOwner, isLoggedIn }: Props) {
                 </div>
                 <div className="flex justify-between">
                   <span>Unique Cards:</span>
-                  <span className="font-medium">{enrichedCards.length}</span>
+                  <span className="font-medium">{statCards(enrichedCards).length}</span>
                 </div>
                 <div className="flex justify-between">
                   <span>Main Deck:</span>
@@ -1309,13 +1309,13 @@ export default function PublicDeckClient({ deck, isOwner, isLoggedIn }: Props) {
                   <div className="flex justify-between">
                     <span>Lost Souls:</span>
                     <span className="font-medium">
-                      {enrichedCards.filter(c => c.type === 'LS' || c.type === 'Lost Soul').reduce((s, c) => s + c.quantity, 0)}
+                      {sumQuantity(enrichedCards.filter(c => c.type === 'LS' || c.type === 'Lost Soul'))}
                     </span>
                   </div>
                   <div className="flex justify-between">
                     <span>Dominants:</span>
                     <span className="font-medium">
-                      {enrichedCards.filter(c => c.type === 'Dom' || c.type === 'Dominant').reduce((s, c) => s + c.quantity, 0)}
+                      {sumQuantity(enrichedCards.filter(c => c.type === 'Dom' || c.type === 'Dominant'))}
                     </span>
                   </div>
                   {totalDeckPrice !== null && (
@@ -1357,11 +1357,9 @@ export default function PublicDeckClient({ deck, isOwner, isLoggedIn }: Props) {
               </h3>
               <div className="space-y-0.5 text-sm text-muted-foreground">
                 {(() => {
-                  const typeCounts = enrichedCards.reduce((acc, card) => {
-                    const type = prettifyTypeName(card.type || "Unknown");
-                    acc[type] = (acc[type] || 0) + card.quantity;
-                    return acc;
-                  }, {} as Record<string, number>);
+                  const typeCounts = countBy(enrichedCards, (card) =>
+                    prettifyTypeName(card.type || "Unknown")
+                  );
 
                   return Object.entries(typeCounts)
                     .sort(([, a], [, b]) => b - a)

--- a/app/decklist/card-search/components/DeckBuilderPanel.tsx
+++ b/app/decklist/card-search/components/DeckBuilderPanel.tsx
@@ -51,6 +51,7 @@ import ReactMarkdown from "react-markdown";
 import BuyDeckModal, { BuyDeckCard } from "./BuyDeckModal";
 import CollectionCheckModal from "./CollectionCheckModal";
 import { aggregateOwnedByName } from "../utils/collectionCheck";
+import { statCards, countBy } from "../utils/deckStats";
 import DeckLegalityChecklist from "./DeckLegalityChecklist";
 import type { DeckCheckResult } from "@/utils/deckcheck/types";
 import { useBudgetPricing } from '../hooks/useBudgetPricing';
@@ -3312,7 +3313,7 @@ export default function DeckBuilderPanel({
                 </div>
                 <div className="flex justify-between">
                   <span>Unique Cards:</span>
-                  <span className="font-medium">{deck.cards.length}</span>
+                  <span className="font-medium">{statCards(deck.cards).length}</span>
                 </div>
                 <div className="flex justify-between">
                   <span>Main Deck:</span>
@@ -3419,20 +3420,16 @@ export default function DeckBuilderPanel({
                   </div>
                   <div className="space-y-0.5">
                     {(() => {
-                      const brigadeCounts: Record<string, number> = {};
-                      for (const deckCard of deck.cards) {
+                      const brigadeCounts = countBy(deck.cards, (deckCard) => {
                         const raw = deckCard.card.brigade;
-                        if (!raw) continue;
+                        if (!raw) return null;
                         try {
-                          const brigades = normalizeBrigadeField(raw, deckCard.card.alignment || "", deckCard.card.name);
-                          for (const b of brigades) {
-                            brigadeCounts[b] = (brigadeCounts[b] || 0) + deckCard.quantity;
-                          }
+                          return normalizeBrigadeField(raw, deckCard.card.alignment || "", deckCard.card.name);
                         } catch {
                           // Fallback for cards that fail normalization
-                          brigadeCounts[raw] = (brigadeCounts[raw] || 0) + deckCard.quantity;
+                          return raw;
                         }
-                      }
+                      });
 
                       const sorted = Object.entries(brigadeCounts)
                         .sort(([, a], [, b]) => b - a);

--- a/app/decklist/card-search/hooks/useBudgetPricing.ts
+++ b/app/decklist/card-search/hooks/useBudgetPricing.ts
@@ -11,6 +11,7 @@ import {
   type BudgetCard,
 } from '@/lib/pricing/budgetPricing';
 import { useCardPrices } from './useCardPrices';
+import { statCards } from '../utils/deckStats';
 import type { Deck } from '../types/deck';
 
 // ---------------------------------------------------------------------------
@@ -107,7 +108,8 @@ export function useBudgetPricing(deck: Deck, allCards: BudgetCard[]): BudgetPric
     let budgetTotal = 0;
     let hasPricedCard = false;
 
-    for (const deckCard of deck.cards) {
+    // Maybeboard is a scratchpad — it never counts toward either total.
+    for (const deckCard of statCards(deck.cards)) {
       const { card, quantity } = deckCard;
 
       const budgetCard: BudgetCard = {

--- a/app/decklist/card-search/hooks/useDeckState.ts
+++ b/app/decklist/card-search/hooks/useDeckState.ts
@@ -639,7 +639,7 @@ export function useDeckState(
       mainDeckCount,
       reserveCount,
       maybeboardCount,
-      uniqueCards: deck.cards.length,
+      uniqueCards: mainDeckCards.length + reserveCards.length,
       cardsByType,
       cardsByBrigade,
     };

--- a/app/decklist/card-search/utils/__tests__/deckStats.test.ts
+++ b/app/decklist/card-search/utils/__tests__/deckStats.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { statCards, countBy, sumQuantity } from '../deckStats';
+
+interface Row {
+  name: string;
+  type: string;
+  brigade: string;
+  quantity: number;
+  zone: 'main' | 'reserve' | 'maybeboard';
+}
+
+function row(name: string, zone: Row['zone'], overrides: Partial<Row> = {}): Row {
+  return { name, type: 'Hero', brigade: 'Blue', quantity: 1, zone, ...overrides };
+}
+
+describe('statCards', () => {
+  it('keeps main and reserve, drops maybeboard', () => {
+    const cards = [row('A', 'main'), row('B', 'reserve'), row('C', 'maybeboard')];
+    expect(statCards(cards).map((c) => c.name)).toEqual(['A', 'B']);
+  });
+
+  it('returns an empty list for a maybeboard-only deck', () => {
+    expect(statCards([row('A', 'maybeboard'), row('B', 'maybeboard')])).toEqual([]);
+  });
+});
+
+describe('sumQuantity', () => {
+  it('sums copies across main and reserve only', () => {
+    const cards = [
+      row('A', 'main', { quantity: 3 }),
+      row('B', 'reserve', { quantity: 2 }),
+      row('C', 'maybeboard', { quantity: 40 }),
+    ];
+    expect(sumQuantity(cards)).toBe(5);
+  });
+});
+
+describe('countBy', () => {
+  it('excludes maybeboard cards from single-key aggregation', () => {
+    const cards = [
+      row('A', 'main', { type: 'Hero', quantity: 2 }),
+      row('B', 'reserve', { type: 'Hero', quantity: 1 }),
+      row('C', 'maybeboard', { type: 'Hero', quantity: 9 }),
+      row('D', 'maybeboard', { type: 'Evil Character', quantity: 5 }),
+    ];
+    expect(countBy(cards, (c) => c.type)).toEqual({ Hero: 3 });
+  });
+
+  it('counts a card once per key when the key function returns several', () => {
+    const cards = [
+      row('A', 'main', { brigade: 'Blue/Green', quantity: 2 }),
+      row('B', 'maybeboard', { brigade: 'Red', quantity: 7 }),
+    ];
+    expect(countBy(cards, (c) => c.brigade.split('/'))).toEqual({ Blue: 2, Green: 2 });
+  });
+
+  it('skips cards whose key function returns null', () => {
+    const cards = [row('A', 'main'), row('B', 'main', { brigade: '' })];
+    expect(countBy(cards, (c) => c.brigade || null)).toEqual({ Blue: 1 });
+  });
+
+  it('returns an empty record when every card is on the maybeboard', () => {
+    expect(countBy([row('A', 'maybeboard')], (c) => c.type)).toEqual({});
+  });
+});

--- a/app/decklist/card-search/utils/deckStats.ts
+++ b/app/decklist/card-search/utils/deckStats.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared helpers for every deck statistic the app displays.
+ *
+ * The maybeboard is a scratchpad of cards under consideration — it is not part
+ * of the deck, so it must never reach a stat, price, or composition figure.
+ * Routing all aggregation through these helpers keeps that guarantee in one
+ * place instead of relying on each call site to remember the zone filter.
+ */
+
+interface ZonedCard {
+  zone: string;
+}
+
+interface CountableCard extends ZonedCard {
+  quantity: number;
+}
+
+/** The cards that count toward deck stats: main + reserve, never maybeboard. */
+export function statCards<T extends ZonedCard>(cards: T[]): T[] {
+  return cards.filter((c) => c.zone !== "maybeboard");
+}
+
+/** Total number of copies in the deck (main + reserve). */
+export function sumQuantity<T extends CountableCard>(cards: T[]): number {
+  return statCards(cards).reduce((sum, c) => sum + c.quantity, 0);
+}
+
+/**
+ * Tally card copies by a caller-supplied key — card type, alignment, brigade.
+ * `keyOf` may return several keys (a multi-brigade card counts under each) or
+ * null to skip the card entirely.
+ */
+export function countBy<T extends CountableCard>(
+  cards: T[],
+  keyOf: (card: T) => string | string[] | null | undefined,
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const card of statCards(cards)) {
+    const key = keyOf(card);
+    if (key == null) continue;
+    const keys = Array.isArray(key) ? key : [key];
+    for (const k of keys) {
+      counts[k] = (counts[k] || 0) + card.quantity;
+    }
+  }
+  return counts;
+}


### PR DESCRIPTION
## The bug

The maybeboard is documented as a scratchpad that's "excluded from legality, tournament submission, game state, and deck totals" — but several stat aggregations still walked every deck row without checking `zone`.

Measured on deck `9e6521d5` (70 main + 10 reserve + 41 maybeboard), before → after:

**Builder → Stats tab**

| Stat | Before | After |
|---|---|---|
| Unique Cards | **121** | 80 |
| Brigades (sum / rows) | **144 / 16** | 85 / 14 |
| Min | **$1342.25 (save $934.50)** | $779.25 (save $798.50) |
| Total / Main / Reserve / Lost Souls / Dominants / Est. Price / Card Types | unchanged | unchanged |

**Shared deck page → Stats panel**

| Stat | Before | After |
|---|---|---|
| Unique Cards | **121** | 80 |
| Lost Souls | **12** | 10 |
| Dominants | **16** | 9 |
| Est. Price | **$2224.25** | $1525.25 |
| Alignment (G/E/N) | **60 / 33 / 28** | 40 / 21 / 19 |
| Card Types (sum / rows) | **121 / 13** | 80 / 11 |
| Min | $726.75 | unchanged (DB RPC already filtered) |

## The fix

New `app/decklist/card-search/utils/deckStats.ts` with three pure helpers — `statCards` (drop maybeboard), `sumQuantity`, `countBy` — and the leaking call sites routed through them:

- `DeckBuilderPanel` — Unique Cards, Brigades
- `useBudgetPricing` — both the budget and exact totals behind Min / savings
- `useDeckState.getDeckStats` — `uniqueCards`
- `[deckId]/client.tsx` — Alignment, Unique Cards, Lost Souls, Dominants, Card Types, Est. Price

Code that already filtered correctly (legality stats in `deckValidation`, the builder's type + alignment breakdowns, `get_deck_total_prices` / `get_deck_budget_prices`, `BuyDeckModal`, collection check, goldfish) is left alone.

## Verified

- `deckStats.test.ts` — 7 new unit tests (written failing first) covering maybeboard exclusion for each helper, multi-key counting, and null keys.
- Full suite: 1569 passed. The 3 pre-existing failures (`forge-anon-leak`, `superuser-anon-leak`, `forge-lackey`) fail identically on `origin/main`.
- `tsc --noEmit`: no errors in any touched file.
- Browser check against the real deck as its owner, with the numbers above captured by re-running the same script against unpatched code.

## Not changed (checked, no leak)

- **AoD Count** — `generateDeckText` emits the maybeboard under `Tokens:`; probing `/v1/aod-count` with and without that section returns identical results, so the API ignores it.
- **Builder Min vs deck page Min** ($779.25 vs $726.75) differ before and after this PR — the client uses duplicate-group equivalence, the DB RPC uses the `cheapest_price` column. Pre-existing, out of scope.
- **Builder "9/9" vs deck page "10" Lost Souls** — the builder's legality stat excludes hopper Lost Souls, the deck page counts raw type. Also pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)