### PR TITLE
fix(forge): square/portrait crop aspects for candidate art

### DIFF
--- a/app/forge/components/CropCandidateModal.tsx
+++ b/app/forge/components/CropCandidateModal.tsx
@@ -7,8 +7,12 @@ import { Button } from "@/components/ui/button";
 import { applyCrop, activateCandidate } from "@/app/forge/lib/artCandidates";
 import { cropBackgroundStyle, type CropRect } from "@/app/forge/lib/cropPreview";
 
-// Frame aspect = the card face's art slot: full width × 48% of a 750×1050 face.
-const ART_SLOT_ASPECT = 750 / 504;
+// Redemption card art is square or portrait (never landscape), so those are the
+// two frame shapes on offer. Square default.
+const ASPECTS = [
+  { key: "square", label: "Square", value: 1 },
+  { key: "portrait", label: "Portrait", value: 3 / 4 },
+] as const;
 
 export default function CropCandidateModal({
   cardId, candidateId, imageUrl, cardName, onClose, onApplied,
@@ -22,6 +26,7 @@ export default function CropCandidateModal({
 }) {
   const [crop, setCrop] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
+  const [aspect, setAspect] = useState<number>(ASPECTS[0].value);
   // react-easy-crop reports croppedArea in PERCENTAGES of the source image.
   const [rect, setRect] = useState<CropRect | null>(null);
   const [busy, setBusy] = useState<"crop" | "full" | null>(null);
@@ -45,7 +50,17 @@ export default function CropCandidateModal({
         className="flex max-h-[90vh] w-full max-w-lg flex-col gap-3 overflow-y-auto rounded-lg border bg-background p-4 shadow-lg"
         onClick={(e) => e.stopPropagation()}
       >
-        <p className="text-sm font-medium">Crop artwork</p>
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-sm font-medium">Crop artwork</p>
+          <div className="flex gap-1">
+            {ASPECTS.map((a) => (
+              <Button key={a.key} size="sm" variant={aspect === a.value ? "secondary" : "outline"}
+                className="h-7 text-xs" onClick={() => setAspect(a.value)}>
+                {a.label}
+              </Button>
+            ))}
+          </div>
+        </div>
 
         <div className="flex flex-col gap-3 sm:flex-row">
           <div className="relative w-full sm:min-w-0 sm:flex-1" style={{ aspectRatio: "3 / 2", background: "black" }}>
@@ -53,7 +68,7 @@ export default function CropCandidateModal({
               image={imageUrl}
               crop={crop}
               zoom={zoom}
-              aspect={ART_SLOT_ASPECT}
+              aspect={aspect}
               onCropChange={setCrop}
               onZoomChange={setZoom}
               onCropComplete={(area: Area) =>
@@ -62,13 +77,13 @@ export default function CropCandidateModal({
             />
           </div>
 
-          {/* Live preview: the card face's art strip showing exactly the framed subrect. */}
+          {/* Live preview: exactly the framed subrect, at the chosen aspect. */}
           <div>
-            <p className="mb-1 text-xs text-muted-foreground">Preview on card</p>
+            <p className="mb-1 text-xs text-muted-foreground">Preview</p>
             <div className="w-40 overflow-hidden rounded-md border">
               <div
                 style={{
-                  aspectRatio: "750 / 504",
+                  aspectRatio: String(aspect),
                   backgroundImage: `url(${imageUrl})`,
                   backgroundRepeat: "no-repeat",
                   ...(rect ? cropBackgroundStyle(rect) : { backgroundSize: "cover", backgroundPosition: "center" }),


### PR DESCRIPTION
## Summary

Testing feedback on #245: the crop frame was locked to the card face's landscape art strip (750:504), but Redemption card art is square or portrait — never horizontal.

- Replaces the fixed landscape frame with an aspect toggle in the crop modal: **Square** (default) and **Portrait** (3:4).
- The live preview renders at the chosen aspect, showing exactly what the crop produces.

Note: the studio's text-tile card face still displays whatever art it gets `object-fit: cover` into its landscape strip, so a square/portrait crop shows its center band there — the stored artwork itself is the full square/portrait crop (that's what playtests, downloads, and finished-card composition get). If we'd rather the face render the full crop (e.g. `contain` or a squarer art slot), that's a separate face-layout change — say the word.

## Test plan

- `tsc --noEmit` clean (only pre-existing baseline errors).
- Presentation-only change in `CropCandidateModal`; server crop already accepts any rect aspect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)