### PR TITLE
Point host resources at the v2 deck-check sheets

### DIFF
--- a/components/top-nav.tsx
+++ b/components/top-nav.tsx
@@ -167,10 +167,10 @@ const TopNav: React.FC = () => {
     { href: "https://landofredemption.com/wp-content/uploads/2025/05/Redemption-Tournament-Host-Application-2025-1.pdf", label: "Hosting Application" },
     { href: "https://landofredemption.com/wp-content/uploads/2025/11/Redemption-Tournament-Host-Application-2025-08.pdf", label: "Hosting Application" },
     { href: "https://landofredemption.com/wp-content/uploads/2025/03/host_sign_in_sheets.pdf", label: "Sign In Sheet" },
-    { href: "https://landofredemption.com/wp-content/uploads/2026/02/t1_deck_check.pdf", label: "T1 Deck Check Sheet" },
+    { href: "https://landofredemption.com/wp-content/uploads/2026/07/t1_deck_check_v2.pdf", label: "T1 Deck Check Sheet" },
     { href: "https://landofredemption.com/wp-content/uploads/2025/03/Reserve-List-T1.pdf", label: "T1 Reserve List" },
-    { href: "https://landofredemption.com/wp-content/uploads/2026/02/t2_deck_check.pdf", label: "T2 Deck Check Sheet" },
-    { href: "https://landofredemption.com/wp-content/uploads/2025/03/Reserve-List-Type-2.pdf", label: "T2 Reserve List" },
+    { href: "https://landofredemption.com/wp-content/uploads/2026/07/t2_deck_check_v2.pdf", label: "T2 Deck Check Sheet" },
+    { href: "https://landofredemption.com/wp-content/uploads/2026/07/T2-Reserve-list.pdf", label: "T2 Reserve List" },
     { href: "https://landofredemption.com/wp-content/uploads/2025/03/host_winners_list.pdf", label: "Winners Form" },
   ];
 


### PR DESCRIPTION
Updates the Host Resources links in the top nav to the new v2 deck-check PDFs.

| Link | Change |
|---|---|
| T1 Deck Check Sheet | `2026/02/t1_deck_check.pdf` → `2026/07/t1_deck_check_v2.pdf` |
| T2 Deck Check Sheet | `2026/02/t2_deck_check.pdf` → `2026/07/t2_deck_check_v2.pdf` |
| T2 Reserve List | `2025/03/Reserve-List-Type-2.pdf` → `2026/07/T2-Reserve-list.pdf` |

**T1 Reserve List is unchanged** — there's no replacement upload for it yet.

## Verification

- all four links in that group (including the untouched T1 Reserve List) return HTTP 206 with `application/pdf`
- the two deck-check PDFs are **md5-identical** to `assets/pdfs/*_v2.pdf` in the API repo, so what players download matches exactly what the generator lays text onto

No changes were needed to deck validation here — `lib/formats.ts` already defines Limited/Unlimited main max 70 and T2 max 140, and both `deckValidation.ts` and `utils/deckcheck/rules.ts` read from it. The API repo was the only place still on the old 154/252 caps; that's fixed in timothestes/redemption-tournament-api#8, which also moves generation onto these v2 templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)