### PR TITLE
feat: QR tournament join + decklist submission + public results

### DIFF
--- a/app/join/[code]/DeckPicker.tsx
+++ b/app/join/[code]/DeckPicker.tsx
@@ -72,10 +72,18 @@ export default function DeckPicker({ tournamentFormat, onSelect }: DeckPickerPro
   useEffect(() => {
     if (myDecks !== null) return;
     setMyLoading(true);
-    loadUserDecksAction().then((res) => {
-      setMyLoading(false);
-      setMyDecks(res.success === true ? (res.decks as MyDeck[]) : []);
-    });
+    loadUserDecksAction()
+      .then((res) => {
+        setMyDecks(res.success === true ? (res.decks as MyDeck[]) : []);
+      })
+      .catch(() => {
+        // Network drop: fall back to the same empty state the non-throw
+        // failure path already uses, rather than leaving myLoading stuck.
+        setMyDecks([]);
+      })
+      .finally(() => {
+        setMyLoading(false);
+      });
     // Load once regardless of which tab is active first — cheap and avoids a
     // spinner if the player switches to "My decks" after browsing others.
   }, [myDecks]);
@@ -101,9 +109,15 @@ export default function DeckPicker({ tournamentFormat, onSelect }: DeckPickerPro
     }
     const t = setTimeout(async () => {
       setCommunityLoading(true);
-      const res = await searchDecksForTournamentAction(term);
-      setCommunityLoading(false);
-      if (res.success === true) setCommunityResults(res.decks);
+      try {
+        const res = await searchDecksForTournamentAction(term);
+        if (res.success === true) setCommunityResults(res.decks);
+      } catch {
+        // Network drop: don't leave communityLoading stuck true forever.
+        setCommunityResults([]);
+      } finally {
+        setCommunityLoading(false);
+      }
     }, 300);
     return () => clearTimeout(t);
   }, [communityQuery]);
@@ -123,12 +137,18 @@ export default function DeckPicker({ tournamentFormat, onSelect }: DeckPickerPro
       return;
     }
     setLinkLoading(true);
-    const res = await loadPublicDeckAction(match[1]);
-    setLinkLoading(false);
-    if (res.success === true && res.deck) {
-      setLinkPreview({ id: res.deck.id, name: res.deck.name, format: res.deck.format ?? null });
-    } else {
-      setLinkError(res.error ?? "Couldn't load that deck.");
+    try {
+      const res = await loadPublicDeckAction(match[1]);
+      if (res.success === true && res.deck) {
+        setLinkPreview({ id: res.deck.id, name: res.deck.name, format: res.deck.format ?? null });
+      } else {
+        setLinkError(res.error ?? "Couldn't load that deck.");
+      }
+    } catch {
+      // Network drop: don't leave linkLoading stuck true forever.
+      setLinkError("Something went wrong — try again.");
+    } finally {
+      setLinkLoading(false);
     }
   }
 

--- a/app/join/[code]/DeckPicker.tsx
+++ b/app/join/[code]/DeckPicker.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Search } from "lucide-react";
+import { loadUserDecksAction, loadPublicDeckAction } from "@/app/decklist/actions";
+import { searchDecksForTournamentAction, type DeckSearchResult } from "@/app/tracker/tournaments/actions";
+import { FORMATS, normalizeFormat, type FormatId } from "@/lib/formats";
+
+interface MyDeck {
+  id: string;
+  name: string;
+  format: string | null;
+}
+
+type Tab = "mine" | "community" | "link";
+
+interface DeckPickerProps {
+  tournamentFormat: FormatId | "Other" | null;
+  onSelect: (deckId: string, deckName: string) => void;
+}
+
+// Compatibility is a sorting hint, not a gate — checkDeck (server-side, on
+// submit) is the real legality check. A Limited deck is compatible with an
+// Unlimited event (pool subset); an ungated tournament (null/'Other') treats
+// everything as compatible.
+function isCompatible(deckFormat: string | null | undefined, tf: FormatId | "Other" | null): boolean {
+  if (tf === null || tf === "Other") return true;
+  const df = normalizeFormat(deckFormat);
+  return df === tf || (tf === "Unlimited" && df === "Limited");
+}
+
+function badgeClasses(format?: string | null) {
+  const id = normalizeFormat(format);
+  const base = "min-w-[2.5rem] flex-shrink-0 text-center inline-block px-1.5 py-0.5 rounded text-xs font-medium";
+  if (id === "T2") return `${base} bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-200`;
+  if (id === "Paragon") return `${base} bg-amber-100 dark:bg-amber-900 text-amber-800 dark:text-amber-200`;
+  return `${base} bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200`;
+}
+
+function DeckRow({
+  name,
+  format,
+  subtitle,
+  onClick,
+}: {
+  name: string;
+  format: string | null | undefined;
+  subtitle?: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm hover:bg-muted"
+    >
+      <span className={badgeClasses(format)}>{FORMATS[normalizeFormat(format)].badge}</span>
+      <span className="min-w-0 flex-1 truncate text-foreground">{name}</span>
+      {subtitle && <span className="flex-shrink-0 text-xs text-muted-foreground">{subtitle}</span>}
+    </button>
+  );
+}
+
+export default function DeckPicker({ tournamentFormat, onSelect }: DeckPickerProps) {
+  const [tab, setTab] = useState<Tab>("mine");
+
+  // My decks
+  const [myDecks, setMyDecks] = useState<MyDeck[] | null>(null);
+  const [myLoading, setMyLoading] = useState(false);
+  const [myQuery, setMyQuery] = useState("");
+
+  useEffect(() => {
+    if (myDecks !== null) return;
+    setMyLoading(true);
+    loadUserDecksAction().then((res) => {
+      setMyLoading(false);
+      setMyDecks(res.success === true ? (res.decks as MyDeck[]) : []);
+    });
+    // Load once regardless of which tab is active first — cheap and avoids a
+    // spinner if the player switches to "My decks" after browsing others.
+  }, [myDecks]);
+
+  const filteredMine = (myDecks ?? []).filter((d) =>
+    d.name.toLowerCase().includes(myQuery.trim().toLowerCase())
+  );
+  const compatibleMine = filteredMine.filter((d) => isCompatible(d.format, tournamentFormat));
+  const incompatibleMine = filteredMine.filter((d) => !isCompatible(d.format, tournamentFormat));
+  const otherFormatLabel =
+    tournamentFormat && tournamentFormat !== "Other" ? FORMATS[tournamentFormat].label : "this event's format";
+
+  // Community
+  const [communityQuery, setCommunityQuery] = useState("");
+  const [communityResults, setCommunityResults] = useState<DeckSearchResult[]>([]);
+  const [communityLoading, setCommunityLoading] = useState(false);
+
+  useEffect(() => {
+    const term = communityQuery.trim();
+    if (!term) {
+      setCommunityResults([]);
+      return;
+    }
+    const t = setTimeout(async () => {
+      setCommunityLoading(true);
+      const res = await searchDecksForTournamentAction(term);
+      setCommunityLoading(false);
+      if (res.success === true) setCommunityResults(res.decks);
+    }, 300);
+    return () => clearTimeout(t);
+  }, [communityQuery]);
+
+  // Paste a link
+  const [linkInput, setLinkInput] = useState("");
+  const [linkPreview, setLinkPreview] = useState<{ id: string; name: string; format: string | null } | null>(null);
+  const [linkError, setLinkError] = useState<string | null>(null);
+  const [linkLoading, setLinkLoading] = useState(false);
+
+  async function handleLinkLookup() {
+    setLinkError(null);
+    setLinkPreview(null);
+    const match = linkInput.match(/([0-9a-f-]{36})/i);
+    if (!match) {
+      setLinkError("Paste a deck link or ID.");
+      return;
+    }
+    setLinkLoading(true);
+    const res = await loadPublicDeckAction(match[1]);
+    setLinkLoading(false);
+    if (res.success === true && res.deck) {
+      setLinkPreview({ id: res.deck.id, name: res.deck.name, format: res.deck.format ?? null });
+    } else {
+      setLinkError(res.error ?? "Couldn't load that deck.");
+    }
+  }
+
+  return (
+    <div className="mt-2 rounded-lg border border-border">
+      <div className="flex border-b border-border text-sm">
+        {(["mine", "community", "link"] as Tab[]).map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => setTab(t)}
+            className={`flex-1 px-3 py-2 font-medium transition-colors ${
+              tab === t
+                ? "border-b-2 border-primary text-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {t === "mine" ? "My decks" : t === "community" ? "Community" : "Paste a link"}
+          </button>
+        ))}
+      </div>
+
+      <div className="p-3">
+        {tab === "mine" && (
+          <div>
+            <div className="relative">
+              <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <input
+                value={myQuery}
+                onChange={(e) => setMyQuery(e.target.value)}
+                placeholder="Search your decks..."
+                className="w-full rounded-md border border-border bg-background py-2 pl-8 pr-3 text-sm text-foreground"
+              />
+            </div>
+            {myLoading && <p className="mt-3 text-sm text-muted-foreground">Loading your decks…</p>}
+            {!myLoading && myDecks !== null && filteredMine.length === 0 && (
+              <p className="mt-3 text-sm text-muted-foreground">No decks found.</p>
+            )}
+            <div className="mt-2 max-h-72 space-y-1 overflow-y-auto">
+              {compatibleMine.map((d) => (
+                <DeckRow key={d.id} name={d.name} format={d.format} onClick={() => onSelect(d.id, d.name)} />
+              ))}
+              {incompatibleMine.length > 0 && (
+                <>
+                  <div className="my-2 border-t border-border pt-2 text-xs text-muted-foreground">
+                    Different format
+                  </div>
+                  {incompatibleMine.map((d) => (
+                    <div key={d.id}>
+                      <DeckRow name={d.name} format={d.format} onClick={() => onSelect(d.id, d.name)} />
+                      <p className="pl-3 pb-1 text-xs text-amber-600 dark:text-amber-400">
+                        Different format — will be validated as {otherFormatLabel}
+                      </p>
+                    </div>
+                  ))}
+                </>
+              )}
+            </div>
+          </div>
+        )}
+
+        {tab === "community" && (
+          <div>
+            <div className="relative">
+              <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <input
+                value={communityQuery}
+                onChange={(e) => setCommunityQuery(e.target.value)}
+                placeholder="Search public decks..."
+                className="w-full rounded-md border border-border bg-background py-2 pl-8 pr-3 text-sm text-foreground"
+              />
+            </div>
+            {communityLoading && <p className="mt-3 text-sm text-muted-foreground">Searching…</p>}
+            {!communityLoading && communityQuery.trim() && communityResults.length === 0 && (
+              <p className="mt-3 text-sm text-muted-foreground">No decks found.</p>
+            )}
+            <div className="mt-2 max-h-72 space-y-1 overflow-y-auto">
+              {communityResults.map((d) => (
+                <DeckRow
+                  key={d.id}
+                  name={d.name}
+                  format={d.format}
+                  subtitle={d.username && d.username !== "You" ? `by ${d.username}` : undefined}
+                  onClick={() => onSelect(d.id, d.name)}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {tab === "link" && (
+          <div>
+            <div className="flex gap-2">
+              <input
+                value={linkInput}
+                onChange={(e) => {
+                  setLinkInput(e.target.value);
+                  setLinkPreview(null);
+                  setLinkError(null);
+                }}
+                placeholder="Paste a deck link or ID"
+                className="min-w-0 flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground"
+              />
+              <button
+                type="button"
+                onClick={handleLinkLookup}
+                disabled={linkLoading || !linkInput.trim()}
+                className="flex-shrink-0 rounded-md border border-border px-3 py-2 text-sm font-medium text-foreground hover:bg-muted disabled:opacity-50"
+              >
+                {linkLoading ? "Looking up…" : "Find"}
+              </button>
+            </div>
+            {linkError && <p className="mt-2 text-sm text-destructive">{linkError}</p>}
+            {linkPreview && (
+              <div className="mt-3">
+                <DeckRow
+                  name={linkPreview.name}
+                  format={linkPreview.format}
+                  onClick={() => onSelect(linkPreview.id, linkPreview.name)}
+                />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/join/[code]/JoinClient.tsx
+++ b/app/join/[code]/JoinClient.tsx
@@ -131,14 +131,20 @@ export default function JoinClient({
   const [result, setResult] = useState<{ res: JoinResult; deckId?: string } | null>(null);
 
   async function refresh() {
-    const fresh = await getJoinInfoAction(code);
-    setInfo(fresh);
-    // A refresh always means the UI is about to reflect a real state
-    // transition (joined, resubmitted, or bounced back to the join form
-    // after a host removal) — any action-result banner from the call that
-    // triggered this refresh (e.g. the transient "already registered —
-    // refreshing…" notice) is now stale and must not persist past it.
-    setResult(null);
+    try {
+      const fresh = await getJoinInfoAction(code);
+      setInfo(fresh);
+      // A refresh always means the UI is about to reflect a real state
+      // transition (joined, resubmitted, or bounced back to the join form
+      // after a host removal) — any action-result banner from the call that
+      // triggered this refresh (e.g. the transient "already registered —
+      // refreshing…" notice) is now stale and must not persist past it.
+      setResult(null);
+    } catch {
+      // Network drop mid-refresh: don't leave a stale "refreshing…" banner
+      // up forever, surface the generic retry message instead.
+      setResult({ res: { success: false, error: "join_failed" } });
+    }
   }
 
   async function handleJoin(e: React.FormEvent) {
@@ -146,24 +152,36 @@ export default function JoinClient({
     if (submitting) return;
     setSubmitting(true);
     const deckId = selectedDeck?.id;
-    const r = await joinTournamentAction(code, { displayName, deckId });
-    setSubmitting(false);
-    setResult({ res: r, deckId });
-    if (r.success === true || (r.success === false && r.error === "already_joined")) {
-      await refresh();
+    try {
+      const r = await joinTournamentAction(code, { displayName, deckId });
+      setResult({ res: r, deckId });
+      if (r.success === true || (r.success === false && r.error === "already_joined")) {
+        await refresh();
+      }
+    } catch {
+      // A thrown server action (network drop — venue wifi on a phone, the
+      // primary environment) must not leave `submitting` stuck true forever.
+      setResult({ res: { success: false, error: "join_failed" }, deckId });
+    } finally {
+      setSubmitting(false);
     }
   }
 
   async function handleResubmit(deckId: string) {
     setSubmitting(true);
-    const r = await resubmitDeckAction(code, deckId);
-    setSubmitting(false);
-    setResult({ res: r, deckId });
-    if (r.success === true) {
-      setShowChangeDeck(false);
-      await refresh();
-    } else if (r.error === "not_joined") {
-      await refresh();
+    try {
+      const r = await resubmitDeckAction(code, deckId);
+      setResult({ res: r, deckId });
+      if (r.success === true) {
+        setShowChangeDeck(false);
+        await refresh();
+      } else if (r.error === "not_joined") {
+        await refresh();
+      }
+    } catch {
+      setResult({ res: { success: false, error: "join_failed" }, deckId });
+    } finally {
+      setSubmitting(false);
     }
   }
 

--- a/app/join/[code]/JoinClient.tsx
+++ b/app/join/[code]/JoinClient.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import DeckPicker from "./DeckPicker";
+import {
+  getJoinInfoAction,
+  joinTournamentAction,
+  resubmitDeckAction,
+  type JoinInfo,
+  type JoinResult,
+} from "../actions";
+import { FORMATS } from "@/lib/formats";
+
+type JoinedState = Extract<JoinInfo, { success: true }>;
+type FailedResult = Extract<JoinResult, { success: false }>;
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return <main className="mx-auto max-w-md px-4 py-8">{children}</main>;
+}
+
+function EventHeader({ info }: { info: JoinedState }) {
+  const badge = info.deckFormat ? FORMATS[info.deckFormat]?.badge : undefined;
+  return (
+    <div className="mb-6 text-center">
+      <h1 className="font-cinzel text-2xl font-bold text-foreground sm:text-3xl">
+        {info.tournamentName}
+      </h1>
+      <div className="mt-2 flex flex-wrap items-center justify-center gap-2 text-sm text-muted-foreground">
+        {info.category && <span>{info.category}</span>}
+        {badge && (
+          <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium text-foreground">
+            {badge}
+          </span>
+        )}
+        {info.hostName && <span>Hosted by {info.hostName}</span>}
+      </div>
+    </div>
+  );
+}
+
+function ErrorCard({ title, message }: { title: string; message: string }) {
+  return (
+    <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-center">
+      <p className="font-medium text-foreground">{title}</p>
+      <p className="mt-1 text-sm text-muted-foreground">{message}</p>
+    </div>
+  );
+}
+
+function LegalityBadge({ isLegal }: { isLegal: boolean | null }) {
+  if (isLegal === true) {
+    return (
+      <span className="rounded bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary">
+        Legal
+      </span>
+    );
+  }
+  if (isLegal === false) {
+    return (
+      <span className="rounded bg-destructive/10 px-1.5 py-0.5 text-xs font-medium text-destructive">
+        Illegal
+      </span>
+    );
+  }
+  return null;
+}
+
+const ERROR_MESSAGES: Partial<Record<FailedResult["error"], string>> = {
+  blocked: "The host has blocked you from this event.",
+  already_joined: "You're already registered for this event — refreshing…",
+  started: "This event has already started.",
+  not_signed_in: "You need to sign in to join.",
+  decklist_required: "This event requires a decklist to join.",
+  deck_not_found: "That deck couldn't be found.",
+  deck_not_accessible: "You don't have access to that deck.",
+  invalid_name: "Enter a display name.",
+  not_joined: "You're not registered for this event yet.",
+  invalid_code: "This code isn't valid anymore.",
+  join_failed: "Something went wrong — try again.",
+};
+
+function ActionErrorNotice({ res, deckId }: { res: FailedResult; deckId?: string }) {
+  if (res.error === "deck_illegal") {
+    const rank = (t: string) => (t === "error" ? 0 : t === "warning" ? 1 : 2);
+    const issues = (res.issues ?? []).slice().sort((a, b) => rank(a.type) - rank(b.type));
+    return (
+      <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm">
+        <p className="font-medium text-foreground">This deck isn&apos;t legal for this event</p>
+        <ul className="mt-2 list-disc space-y-1 pl-5 text-muted-foreground">
+          {issues.map((issue, i) => (
+            <li key={i}>{issue.message}</li>
+          ))}
+        </ul>
+        {deckId && (
+          <Link
+            href={`/decklist/card-search?deckId=${deckId}`}
+            className="mt-2 inline-block text-primary hover:underline"
+          >
+            Open in deck builder
+          </Link>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+      {ERROR_MESSAGES[res.error] ?? "Something went wrong — try again."}
+    </div>
+  );
+}
+
+export default function JoinClient({
+  info: initialInfo,
+  code,
+  signedIn,
+  defaultName,
+}: {
+  info: JoinInfo;
+  code: string;
+  signedIn: boolean;
+  defaultName: string;
+}) {
+  const [info, setInfo] = useState<JoinInfo>(initialInfo);
+  const [displayName, setDisplayName] = useState(defaultName);
+  const [selectedDeck, setSelectedDeck] = useState<{ id: string; name: string } | null>(null);
+  const [showChangeDeck, setShowChangeDeck] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<{ res: JoinResult; deckId?: string } | null>(null);
+
+  async function refresh() {
+    const fresh = await getJoinInfoAction(code);
+    setInfo(fresh);
+  }
+
+  async function handleJoin(e: React.FormEvent) {
+    e.preventDefault();
+    if (submitting) return;
+    setSubmitting(true);
+    const deckId = selectedDeck?.id;
+    const r = await joinTournamentAction(code, { displayName, deckId });
+    setSubmitting(false);
+    setResult({ res: r, deckId });
+    if (r.success === true || (r.success === false && r.error === "already_joined")) {
+      await refresh();
+    }
+  }
+
+  async function handleResubmit(deckId: string) {
+    setSubmitting(true);
+    const r = await resubmitDeckAction(code, deckId);
+    setSubmitting(false);
+    setResult({ res: r, deckId });
+    if (r.success === true) {
+      setShowChangeDeck(false);
+      await refresh();
+    } else if (r.error === "not_joined") {
+      await refresh();
+    }
+  }
+
+  // 1. Invalid code / rate-limited.
+  if (info.success === false) {
+    return (
+      <Shell>
+        <ErrorCard
+          title="Can't join right now"
+          message={
+            info.error === "rate_limited"
+              ? "Too many attempts from this connection — wait a minute and try again."
+              : "That code isn't valid, or QR join isn't enabled for this event."
+          }
+        />
+        <Link href="/join" className="mt-4 block text-center text-sm text-primary hover:underline">
+          Enter a code
+        </Link>
+      </Shell>
+    );
+  }
+
+  // 2. Event already started and this player never joined — hard lock.
+  if (info.hasStarted === true && info.joined === null) {
+    return (
+      <Shell>
+        <EventHeader info={info} />
+        <ErrorCard
+          title="This event has already started"
+          message="Joining is closed. Check with the host if you think this is a mistake."
+        />
+      </Shell>
+    );
+  }
+
+  // 3. Not signed in — show what they're joining, then send them to sign in.
+  if (signedIn === false) {
+    return (
+      <Shell>
+        <EventHeader info={info} />
+        <Button asChild className="w-full">
+          <Link href={`/sign-in?redirectTo=${encodeURIComponent(`/join/${code}`)}`}>
+            Sign in to join
+          </Link>
+        </Button>
+      </Shell>
+    );
+  }
+
+  // 4. Already registered.
+  if (info.joined !== null) {
+    const { joined } = info;
+    return (
+      <Shell>
+        <EventHeader info={info} />
+        <div className="rounded-lg border border-border bg-card p-4">
+          <p className="text-sm text-muted-foreground">Registered as</p>
+          <p className="text-lg font-medium text-foreground">{joined.displayName}</p>
+
+          {info.requiresDecklist && (
+            <div className="mt-3 border-t border-border pt-3">
+              {joined.submission ? (
+                <>
+                  <p className="text-sm text-muted-foreground">Decklist</p>
+                  <div className="mt-1 flex items-center gap-2">
+                    <span className="font-medium text-foreground">{joined.submission.deckName}</span>
+                    <LegalityBadge isLegal={joined.submission.isLegal} />
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Submitted {new Date(joined.submission.submittedAt).toLocaleString()}
+                  </p>
+                </>
+              ) : (
+                <p className="text-sm text-amber-600 dark:text-amber-400">No decklist submitted yet.</p>
+              )}
+
+              {info.hasStarted ? (
+                <p className="mt-3 text-xs text-muted-foreground">
+                  This event has started — decklist changes are locked.
+                </p>
+              ) : (
+                <>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="mt-3 w-full"
+                    onClick={() => setShowChangeDeck((v) => !v)}
+                  >
+                    {showChangeDeck ? "Cancel" : "Change decklist"}
+                  </Button>
+                  {showChangeDeck && (
+                    <DeckPicker
+                      tournamentFormat={info.deckFormat}
+                      onSelect={(id) => handleResubmit(id)}
+                    />
+                  )}
+                </>
+              )}
+            </div>
+          )}
+        </div>
+
+        {result && result.res.success === false && (
+          <div className="mt-3">
+            <ActionErrorNotice res={result.res} deckId={result.deckId} />
+          </div>
+        )}
+      </Shell>
+    );
+  }
+
+  // 5. Join form.
+  const canSubmit =
+    displayName.trim().length > 0 && (!info.requiresDecklist || selectedDeck !== null) && !submitting;
+
+  return (
+    <Shell>
+      <EventHeader info={info} />
+      <form onSubmit={handleJoin} className="space-y-4">
+        <label className="block text-sm font-medium text-foreground">
+          Display name
+          <input
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            maxLength={40}
+            required
+            placeholder="Your name"
+            className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground"
+          />
+        </label>
+
+        {info.requiresDecklist && (
+          <div>
+            <p className="text-sm font-medium text-foreground">Decklist</p>
+            {selectedDeck ? (
+              <div className="mt-1 flex items-center justify-between rounded-md border border-border bg-card px-3 py-2 text-sm">
+                <span className="truncate font-medium text-foreground">{selectedDeck.name}</span>
+                <button
+                  type="button"
+                  onClick={() => setSelectedDeck(null)}
+                  className="ml-2 flex-shrink-0 text-xs text-muted-foreground hover:text-foreground"
+                >
+                  Change
+                </button>
+              </div>
+            ) : (
+              <DeckPicker
+                tournamentFormat={info.deckFormat}
+                onSelect={(id, name) => setSelectedDeck({ id, name })}
+              />
+            )}
+          </div>
+        )}
+
+        {result && result.res.success === false && (
+          <ActionErrorNotice res={result.res} deckId={result.deckId} />
+        )}
+
+        <p className="text-xs text-muted-foreground">
+          Your decklist will be visible to the host. When the event ends, your display name, final
+          standing, and decklist will be published with the results unless the host withholds them.
+        </p>
+
+        <Button type="submit" disabled={!canSubmit} className="w-full">
+          {submitting ? "Joining…" : "Join"}
+        </Button>
+      </form>
+    </Shell>
+  );
+}

--- a/app/join/[code]/JoinClient.tsx
+++ b/app/join/[code]/JoinClient.tsx
@@ -133,6 +133,12 @@ export default function JoinClient({
   async function refresh() {
     const fresh = await getJoinInfoAction(code);
     setInfo(fresh);
+    // A refresh always means the UI is about to reflect a real state
+    // transition (joined, resubmitted, or bounced back to the join form
+    // after a host removal) — any action-result banner from the call that
+    // triggered this refresh (e.g. the transient "already registered —
+    // refreshing…" notice) is now stale and must not persist past it.
+    setResult(null);
   }
 
   async function handleJoin(e: React.FormEvent) {

--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -1,0 +1,33 @@
+import { createClient } from "@/utils/supabase/server";
+import { getJoinInfoAction } from "../actions";
+import JoinClient from "./JoinClient";
+
+export const dynamic = "force-dynamic";
+
+export default async function JoinCodePage({
+  params,
+}: {
+  params: Promise<{ code: string }>;
+}) {
+  const { code } = await params;
+  const info = await getJoinInfoAction(code);
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  let defaultName = "";
+  if (user) {
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("username")
+      .eq("id", user.id)
+      .maybeSingle();
+    defaultName = profile?.username ?? "";
+  }
+
+  return (
+    <JoinClient info={info} code={code} signedIn={!!user} defaultName={defaultName} />
+  );
+}

--- a/app/join/__tests__/actions.test.ts
+++ b/app/join/__tests__/actions.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// vi.mock specifiers MUST match the implementation's "@/"-aliased imports
+// exactly (plus "next/headers") or the mocks silently don't apply.
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => new Headers()),
+}));
+
+const mockGetUser = vi.fn();
+vi.mock("@/utils/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ auth: { getUser: mockGetUser } })),
+}));
+
+const mockRateLimitForUnauthIp = vi.fn();
+vi.mock("@/lib/api/rateLimit", () => ({
+  extractClientIp: vi.fn(() => "1.2.3.4"),
+  rateLimitForUnauthIp: (ip: string) => mockRateLimitForUnauthIp(ip),
+}));
+
+let mockAdminImpl: any = null;
+vi.mock("@/lib/pricing/supabase-admin", () => ({
+  getSupabaseAdmin: vi.fn(() => mockAdminImpl),
+}));
+
+const mockBuildDeckSubmission = vi.fn();
+vi.mock("@/lib/tournament/deckSubmission", () => ({
+  buildDeckSubmission: (...args: any[]) => mockBuildDeckSubmission(...args),
+}));
+
+import { getJoinInfoAction, joinTournamentAction, resubmitDeckAction } from "../actions";
+
+// --- fake PostgREST chain: .from(table).select().eq()[.eq()][.in()].maybeSingle()/.single() ---
+function chainFrom(data: any) {
+  const node: any = {
+    select: () => node,
+    eq: () => node,
+    in: () => node,
+    maybeSingle: async () => ({ data, error: null }),
+    single: async () => ({ data, error: data ? null : { message: "not found" } }),
+  };
+  return node;
+}
+
+function makeAdmin(tables: Record<string, any>, rpcResult?: { data?: any; error?: any }) {
+  return {
+    from: (table: string) => chainFrom(tables[table] ?? null),
+    rpc: vi.fn(async (_name: string, _args: any) => rpcResult ?? { data: { ok: true }, error: null }),
+  };
+}
+
+const VALID_CODE = "ABCDEF"; // 6 chars, all in the Crockford alphabet used by normalizeJoinCode
+
+function baseTournament(overrides: Record<string, any> = {}) {
+  return {
+    id: "t1",
+    name: "Spring Open",
+    category: "Standard",
+    deck_format: "Limited",
+    require_decklists: false,
+    has_started: false,
+    host_id: "host1",
+    code: VALID_CODE,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUser.mockResolvedValue({ data: { user: null } });
+  mockRateLimitForUnauthIp.mockResolvedValue({ success: true, limit: 30, remaining: 29, reset: 0 });
+  mockAdminImpl = null;
+});
+
+describe("getJoinInfoAction", () => {
+  it("invalid code short-circuits before any client/limiter call", async () => {
+    const r = await getJoinInfoAction("not-a-code");
+    expect(r).toEqual({ success: false, error: "invalid_code" });
+    expect(mockRateLimitForUnauthIp).not.toHaveBeenCalled();
+  });
+
+  it("rate-limited (anonymous only)", async () => {
+    mockRateLimitForUnauthIp.mockResolvedValue({ success: false, limit: 30, remaining: 0, reset: 0 });
+    const r = await getJoinInfoAction(VALID_CODE);
+    expect(r).toEqual({ success: false, error: "rate_limited" });
+  });
+
+  it("signed-in user skips the IP limiter entirely", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockRateLimitForUnauthIp.mockResolvedValue({ success: false, limit: 30, remaining: 0, reset: 0 });
+    mockAdminImpl = makeAdmin({
+      tournaments: baseTournament(),
+      profiles: { username: "hosty" },
+      participants: null,
+    });
+    const r = await getJoinInfoAction(VALID_CODE);
+    expect(mockRateLimitForUnauthIp).not.toHaveBeenCalled();
+    expect(r.success).toBe(true);
+  });
+
+  it("limiter throwing fails open (info still succeeds)", async () => {
+    mockRateLimitForUnauthIp.mockImplementation(async () => {
+      throw new Error("KV_REST_API_URL/TOKEN not set");
+    });
+    mockAdminImpl = makeAdmin({
+      tournaments: baseTournament(),
+      profiles: { username: "hosty" },
+      participants: null,
+    });
+    const r = await getJoinInfoAction(VALID_CODE);
+    expect(r.success).toBe(true);
+    if (r.success === true) {
+      expect(r.tournamentName).toBe("Spring Open");
+      expect(r.hostName).toBe("hosty");
+      expect(r.joined).toBeNull();
+    }
+  });
+
+  it("unknown code -> invalid_code", async () => {
+    mockAdminImpl = makeAdmin({ tournaments: null });
+    const r = await getJoinInfoAction(VALID_CODE);
+    expect(r).toEqual({ success: false, error: "invalid_code" });
+  });
+
+  it("signed-in + already joined surfaces displayName and submission", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockAdminImpl = makeAdmin({
+      tournaments: baseTournament({ require_decklists: true }),
+      profiles: { username: "hosty" },
+      participants: { id: "p1", name: "Timmy" },
+      tournament_deck_submissions: {
+        deck_snapshot: { deckName: "My Deck" },
+        submitted_at: "2026-07-27T00:00:00Z",
+        is_legal: true,
+      },
+    });
+    const r = await getJoinInfoAction(VALID_CODE);
+    expect(r.success).toBe(true);
+    if (r.success === true) {
+      expect(r.requiresDecklist).toBe(true);
+      expect(r.joined).toEqual({
+        displayName: "Timmy",
+        submission: { deckName: "My Deck", submittedAt: "2026-07-27T00:00:00Z", isLegal: true },
+      });
+    }
+  });
+});
+
+describe("joinTournamentAction", () => {
+  it("signed-out -> not_signed_in", async () => {
+    const r = await joinTournamentAction(VALID_CODE, { displayName: "Timmy" });
+    expect(r).toEqual({ success: false, error: "not_signed_in" });
+  });
+
+  it("started -> started", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockAdminImpl = makeAdmin({ tournaments: baseTournament({ has_started: true }) });
+    const r = await joinTournamentAction(VALID_CODE, { displayName: "Timmy" });
+    expect(r).toEqual({ success: false, error: "started" });
+  });
+
+  it("decklist required but no deckId -> decklist_required", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockAdminImpl = makeAdmin({ tournaments: baseTournament({ require_decklists: true }) });
+    const r = await joinTournamentAction(VALID_CODE, { displayName: "Timmy" });
+    expect(r).toEqual({ success: false, error: "decklist_required" });
+    expect(mockBuildDeckSubmission).not.toHaveBeenCalled();
+  });
+
+  it("format Other + require_decklists -> decklist_required (misconfigured event), never calls buildDeckSubmission", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockAdminImpl = makeAdmin({
+      tournaments: baseTournament({ require_decklists: true, deck_format: "Draft" }),
+    });
+    const r = await joinTournamentAction(VALID_CODE, { displayName: "Timmy", deckId: "d1" });
+    expect(r).toEqual({ success: false, error: "decklist_required" });
+    expect(mockBuildDeckSubmission).not.toHaveBeenCalled();
+  });
+
+  it("illegal deck -> deck_illegal with issues passed through", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockAdminImpl = makeAdmin({
+      tournaments: baseTournament({ require_decklists: true, deck_format: "Limited" }),
+    });
+    const issues = [{ type: "error", rule: "min-main", message: "too few cards", cards: [] }];
+    mockBuildDeckSubmission.mockResolvedValue({
+      success: true,
+      snapshot: { deckName: "D", deckFormat: "Limited", cards: [] },
+      isLegal: false,
+      issues,
+      hasUnresolvedCards: false,
+    });
+    const r = await joinTournamentAction(VALID_CODE, { displayName: "Timmy", deckId: "d1" });
+    expect(r).toEqual({ success: false, error: "deck_illegal", issues });
+  });
+
+  it("unresolved cards also -> deck_illegal even if isLegal is true", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockAdminImpl = makeAdmin({
+      tournaments: baseTournament({ require_decklists: true, deck_format: "Limited" }),
+    });
+    const issues = [{ type: "warning", rule: "card-not-found", message: "?", cards: ["Bogus"] }];
+    mockBuildDeckSubmission.mockResolvedValue({
+      success: true,
+      snapshot: { deckName: "D", deckFormat: "Limited", cards: [] },
+      isLegal: true,
+      issues,
+      hasUnresolvedCards: true,
+    });
+    const r = await joinTournamentAction(VALID_CODE, { displayName: "Timmy", deckId: "d1" });
+    expect(r).toEqual({ success: false, error: "deck_illegal", issues });
+  });
+
+  it("deck_not_found / deck_not_accessible pass through from the builder", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockAdminImpl = makeAdmin({
+      tournaments: baseTournament({ require_decklists: true, deck_format: "Limited" }),
+    });
+    mockBuildDeckSubmission.mockResolvedValue({ success: false, error: "deck_not_accessible" });
+    const r = await joinTournamentAction(VALID_CODE, { displayName: "Timmy", deckId: "d1" });
+    expect(r).toEqual({ success: false, error: "deck_not_accessible" });
+  });
+
+  it("legal path: rpc called with p_resubmit=false and the SAME snapshot object the builder returned", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    const admin = makeAdmin(
+      { tournaments: baseTournament({ require_decklists: true, deck_format: "Limited" }) },
+      { data: { ok: true, participant_id: "p1" }, error: null }
+    );
+    mockAdminImpl = admin;
+    const snapshotObj = { deckName: "D", deckFormat: "Limited", cards: [] };
+    mockBuildDeckSubmission.mockResolvedValue({
+      success: true,
+      snapshot: snapshotObj,
+      isLegal: true,
+      issues: [],
+      hasUnresolvedCards: false,
+    });
+    const r = await joinTournamentAction(VALID_CODE, { displayName: "  Timmy  ", deckId: "d1" });
+    expect(r).toEqual({ success: true });
+    expect(admin.rpc).toHaveBeenCalledTimes(1);
+    const [rpcName, rpcArgs] = admin.rpc.mock.calls[0];
+    expect(rpcName).toBe("tournament_qr_join");
+    expect(rpcArgs.p_snapshot).toBe(snapshotObj); // reference equality, not deep-equal
+    expect(rpcArgs.p_resubmit).toBe(false);
+    expect(rpcArgs.p_display_name).toBe("Timmy");
+    expect(rpcArgs.p_deck_id).toBe("d1");
+    expect(rpcArgs.p_code).toBe(VALID_CODE);
+  });
+
+  it("display name sanitized: control chars stripped, trimmed, capped at 40", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    const admin = makeAdmin({ tournaments: baseTournament() });
+    mockAdminImpl = admin;
+    const dirty = "  Tim my" + "x".repeat(50) + "  ";
+    const expected = dirty.replace(/[\u0000-\u001f\u007f]/g, "").trim().slice(0, 40);
+    expect(expected.length).toBe(40); // sanity: input really does exceed the cap
+    const r = await joinTournamentAction(VALID_CODE, { displayName: dirty });
+    expect(r).toEqual({ success: true });
+    const rpcArgs = admin.rpc.mock.calls[0][1];
+    expect(rpcArgs.p_display_name).toBe(expected);
+  });
+
+  it("blank display name after sanitization -> invalid_name", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockAdminImpl = makeAdmin({ tournaments: baseTournament() });
+    const r = await joinTournamentAction(VALID_CODE, { displayName: "      " });
+    expect(r).toEqual({ success: false, error: "invalid_name" });
+  });
+
+  it("RPC already_joined surfaces verbatim", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockAdminImpl = makeAdmin(
+      { tournaments: baseTournament() },
+      { data: { ok: false, error: "already_joined" }, error: null }
+    );
+    const r = await joinTournamentAction(VALID_CODE, { displayName: "Timmy" });
+    expect(r).toEqual({ success: false, error: "already_joined" });
+  });
+
+  it("RPC blocked surfaces verbatim", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockAdminImpl = makeAdmin(
+      { tournaments: baseTournament() },
+      { data: { ok: false, error: "blocked" }, error: null }
+    );
+    const r = await joinTournamentAction(VALID_CODE, { displayName: "Timmy" });
+    expect(r).toEqual({ success: false, error: "blocked" });
+  });
+
+  it("RPC not_found maps to invalid_code", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockAdminImpl = makeAdmin(
+      { tournaments: baseTournament() },
+      { data: { ok: false, error: "not_found" }, error: null }
+    );
+    const r = await joinTournamentAction(VALID_CODE, { displayName: "Timmy" });
+    expect(r).toEqual({ success: false, error: "invalid_code" });
+  });
+
+  it("unknown RPC error string maps to join_failed", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockAdminImpl = makeAdmin(
+      { tournaments: baseTournament() },
+      { data: { ok: false, error: "some_new_sql_error" }, error: null }
+    );
+    const r = await joinTournamentAction(VALID_CODE, { displayName: "Timmy" });
+    expect(r).toEqual({ success: false, error: "join_failed" });
+  });
+
+  it("rpc-level transport error -> join_failed", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockAdminImpl = makeAdmin(
+      { tournaments: baseTournament() },
+      { data: null, error: { message: "connection reset" } }
+    );
+    const r = await joinTournamentAction(VALID_CODE, { displayName: "Timmy" });
+    expect(r).toEqual({ success: false, error: "join_failed" });
+  });
+});
+
+describe("resubmitDeckAction", () => {
+  it("passes p_resubmit=true and p_display_name=null (no display-name requirement)", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    const admin = makeAdmin(
+      { tournaments: baseTournament({ require_decklists: true, deck_format: "Limited" }) },
+      { data: { ok: true, participant_id: "p1" }, error: null }
+    );
+    mockAdminImpl = admin;
+    const snapshotObj = { deckName: "D2", deckFormat: "Limited", cards: [] };
+    mockBuildDeckSubmission.mockResolvedValue({
+      success: true,
+      snapshot: snapshotObj,
+      isLegal: true,
+      issues: [],
+      hasUnresolvedCards: false,
+    });
+    const r = await resubmitDeckAction(VALID_CODE, "d2");
+    expect(r).toEqual({ success: true });
+    const rpcArgs = admin.rpc.mock.calls[0][1];
+    expect(rpcArgs.p_resubmit).toBe(true);
+    expect(rpcArgs.p_display_name).toBeNull();
+    expect(rpcArgs.p_snapshot).toBe(snapshotObj);
+  });
+
+  it("RPC not_joined surfaces verbatim", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockAdminImpl = makeAdmin(
+      { tournaments: baseTournament() },
+      { data: { ok: false, error: "not_joined" }, error: null }
+    );
+    const r = await resubmitDeckAction(VALID_CODE, "d2");
+    expect(r).toEqual({ success: false, error: "not_joined" });
+  });
+});

--- a/app/join/__tests__/actions.test.ts
+++ b/app/join/__tests__/actions.test.ts
@@ -252,13 +252,17 @@ describe("joinTournamentAction", () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
     const admin = makeAdmin({ tournaments: baseTournament() });
     mockAdminImpl = admin;
-    const dirty = "  Tim my" + "x".repeat(50) + "  ";
-    const expected = dirty.replace(/[\u0000-\u001f\u007f]/g, "").trim().slice(0, 40);
-    expect(expected.length).toBe(40); // sanity: input really does exceed the cap
+    // Real C0 control chars (BEL, NUL) spliced in on purpose -- the point of
+    // this test is to exercise the strip-control-chars path, not just
+    // trim/slice. "  Tim" + BEL + "my" + NUL + 50 x's + "  "
+    const dirty = "  Tim" + String.fromCharCode(7) + "my" + String.fromCharCode(0) + "x".repeat(50) + "  ";
     const r = await joinTournamentAction(VALID_CODE, { displayName: dirty });
     expect(r).toEqual({ success: true });
     const rpcArgs = admin.rpc.mock.calls[0][1];
-    expect(rpcArgs.p_display_name).toBe(expected);
+    // Literal expected string (not re-derived via the same strip/trim/slice
+    // pipeline as the implementation) so a regression in that pipeline --
+    // including the control-char strip specifically -- actually fails this.
+    expect(rpcArgs.p_display_name).toBe("Timmy" + "x".repeat(35));
   });
 
   it("blank display name after sanitization -> invalid_name", async () => {

--- a/app/join/actions.ts
+++ b/app/join/actions.ts
@@ -1,0 +1,214 @@
+"use server";
+
+import { headers } from "next/headers";
+import { createClient } from "@/utils/supabase/server";
+import { getSupabaseAdmin } from "@/lib/pricing/supabase-admin";
+import { normalizeJoinCode } from "@/lib/tournament/joinCodes";
+import { buildDeckSubmission } from "@/lib/tournament/deckSubmission";
+import { normalizeTournamentFormat, type FormatId } from "@/lib/formats";
+import { rateLimitForUnauthIp, extractClientIp } from "@/lib/api/rateLimit";
+import type { DeckCheckIssue } from "@/utils/deckcheck";
+
+const NAME_MAX = 40;
+
+export type JoinInfo =
+  | {
+      success: true;
+      tournamentName: string;
+      category: string | null;
+      deckFormat: FormatId | "Other" | null;
+      requiresDecklist: boolean;
+      hasStarted: boolean;
+      hostName: string | null;
+      joined: null | {
+        displayName: string;
+        submission: null | { deckName: string; submittedAt: string; isLegal: boolean | null };
+      };
+    }
+  | { success: false; error: "invalid_code" | "rate_limited" };
+
+export type JoinResult =
+  | { success: true }
+  | {
+      success: false;
+      error:
+        | "invalid_code"
+        | "not_signed_in"
+        | "started"
+        | "blocked"
+        | "already_joined"
+        | "not_joined"
+        | "decklist_required"
+        | "deck_not_found"
+        | "deck_not_accessible"
+        | "deck_illegal"
+        | "invalid_name"
+        | "join_failed";
+      issues?: DeckCheckIssue[];
+    };
+
+async function findTournamentByCode(code: string) {
+  const admin = getSupabaseAdmin();
+  const { data } = await admin
+    .from("tournaments")
+    .select("id, name, category, deck_format, require_decklists, has_started, host_id, code")
+    .eq("code", code)
+    .maybeSingle();
+  return data;
+}
+
+export async function getJoinInfoAction(rawCode: string): Promise<JoinInfo> {
+  const code = normalizeJoinCode(rawCode);
+  if (!code) return { success: false, error: "invalid_code" };
+
+  // Auth-aware first: signed-in users skip the IP throttle (the limiter
+  // guards the ANONYMOUS enumeration surface; 30 players behind one venue
+  // NAT must not exhaust it at QR-reveal time).
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    try {
+      const h = await headers();
+      const ip = extractClientIp(new Request("http://x", { headers: h }));
+      const rl = await rateLimitForUnauthIp(ip);
+      if (rl.success === false) return { success: false, error: "rate_limited" };
+    } catch {
+      // Fail open: rateLimitForUnauthIp throws when KV_REST_API_* is unset
+      // (fresh dev env, e2e CI). A missing limiter must not 500 the page.
+    }
+  }
+
+  const t = await findTournamentByCode(code);
+  if (!t) return { success: false, error: "invalid_code" };
+
+  const admin = getSupabaseAdmin();
+  const { data: hostProfile } = await admin
+    .from("profiles")
+    .select("username")
+    .eq("id", t.host_id)
+    .maybeSingle();
+
+  // Auth-aware extras (user client for identity only; reads stay admin-side).
+  type JoinedInfo = Extract<JoinInfo, { success: true }>["joined"];
+  let joined: JoinedInfo = null;
+  if (user) {
+    const { data: p } = await admin
+      .from("participants")
+      .select("id, name")
+      .eq("tournament_id", t.id)
+      .eq("user_id", user.id)
+      .maybeSingle();
+    if (p) {
+      const { data: sub } = await admin
+        .from("tournament_deck_submissions")
+        .select("deck_snapshot, submitted_at, is_legal")
+        .eq("participant_id", p.id)
+        .maybeSingle();
+      joined = {
+        displayName: p.name ?? "",
+        submission: sub
+          ? {
+              deckName: (sub.deck_snapshot as any)?.deckName ?? "Deck",
+              submittedAt: sub.submitted_at,
+              isLegal: sub.is_legal,
+            }
+          : null,
+      };
+    }
+  }
+
+  return {
+    success: true,
+    tournamentName: t.name,
+    category: t.category,
+    deckFormat: normalizeTournamentFormat(t.deck_format),
+    requiresDecklist: t.require_decklists === true,
+    hasStarted: t.has_started === true,
+    hostName: hostProfile?.username ?? null,
+    joined,
+  };
+}
+
+async function submitToTournament(
+  rawCode: string,
+  deckId: string | undefined,
+  displayName: string | null,
+  resubmit: boolean
+): Promise<JoinResult> {
+  const code = normalizeJoinCode(rawCode);
+  if (!code) return { success: false, error: "invalid_code" };
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { success: false, error: "not_signed_in" };
+
+  const t = await findTournamentByCode(code);
+  if (!t) return { success: false, error: "invalid_code" };
+  if (t.has_started === true) return { success: false, error: "started" };
+
+  let name: string | null = null;
+  if (!resubmit) {
+    name = (displayName ?? "").replace(/[\p{Cc}]/gu, "").trim().slice(0, NAME_MAX);
+    if (!name) return { success: false, error: "invalid_name" };
+  }
+
+  const admin = getSupabaseAdmin();
+  let snapshot = null,
+    isLegal: boolean | null = null,
+    issues: DeckCheckIssue[] = [];
+  const format = normalizeTournamentFormat(t.deck_format);
+  if (t.require_decklists === true) {
+    if (!deckId) return { success: false, error: "decklist_required" };
+    if (format === null || format === "Other")
+      return { success: false, error: "decklist_required" }; // misconfigured event; host must set a format
+    const built = await buildDeckSubmission(admin, deckId, user.id, format);
+    if (built.success === false) return { success: false, error: built.error };
+    if (built.isLegal === false || built.hasUnresolvedCards === true)
+      return { success: false, error: "deck_illegal", issues: built.issues };
+    snapshot = built.snapshot;
+    isLegal = built.isLegal;
+    issues = built.issues;
+  }
+
+  const { data, error } = await admin.rpc("tournament_qr_join", {
+    p_code: code,
+    p_user_id: user.id,
+    p_display_name: name,
+    p_deck_id: snapshot ? deckId : null,
+    p_snapshot: snapshot,
+    p_is_legal: isLegal,
+    p_issues: issues.length ? issues : null,
+    p_resubmit: resubmit,
+  });
+  if (error) return { success: false, error: "join_failed" };
+  const out = data as { ok: boolean; error?: string };
+  if (out.ok !== true) {
+    // Explicit map from the SQL function's error strings; unknown -> join_failed.
+    const SQL_ERRORS: Record<string, Extract<JoinResult, { success: false }>["error"]> = {
+      not_found: "invalid_code",
+      started: "started",
+      blocked: "blocked",
+      decklist_required: "decklist_required",
+      already_joined: "already_joined",
+      not_joined: "not_joined",
+    };
+    return { success: false, error: SQL_ERRORS[out.error ?? ""] ?? "join_failed" };
+  }
+  return { success: true };
+}
+
+export async function joinTournamentAction(
+  rawCode: string,
+  params: { displayName: string; deckId?: string }
+): Promise<JoinResult> {
+  return submitToTournament(rawCode, params.deckId, params.displayName, false);
+}
+
+export async function resubmitDeckAction(rawCode: string, deckId: string): Promise<JoinResult> {
+  return submitToTournament(rawCode, deckId, null, true);
+}

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { normalizeJoinCode } from "@/lib/tournament/joinCodeShared";
+
+export default function JoinLandingPage() {
+  const router = useRouter();
+  const [value, setValue] = useState("");
+  const [error, setError] = useState(false);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const code = normalizeJoinCode(value);
+    if (code === null) {
+      setError(true);
+      return;
+    }
+    router.push(`/join/${code}`);
+  }
+
+  return (
+    <main className="mx-auto max-w-sm px-4 py-16">
+      <div className="rounded-lg border border-border bg-card p-6">
+        <h1 className="text-2xl font-semibold text-foreground">Join a tournament</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Enter the code your host gave you.
+        </p>
+        <form onSubmit={handleSubmit} className="mt-4">
+          <label className="block text-sm font-medium text-foreground">
+            Join code
+            <input
+              value={value}
+              onChange={(e) => {
+                setValue(e.target.value.toUpperCase());
+                setError(false);
+              }}
+              inputMode="text"
+              autoCapitalize="characters"
+              autoComplete="off"
+              autoCorrect="off"
+              spellCheck={false}
+              maxLength={12}
+              placeholder="T7K2QF"
+              className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-center text-lg uppercase tracking-[0.3em] text-foreground"
+            />
+          </label>
+          {error && (
+            <p className="mt-2 text-sm text-destructive">
+              That doesn&apos;t look like a valid code. Double-check and try again.
+            </p>
+          )}
+          <Button type="submit" className="mt-4 w-full">
+            Continue
+          </Button>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/app/tournaments/__tests__/resultsLoaders.test.ts
+++ b/app/tournaments/__tests__/resultsLoaders.test.ts
@@ -142,7 +142,14 @@ describe("loadPublicResultsAction", () => {
     expect(calls.decklists).toBe(0); // gated on decklists_published, never queried
   });
 
-  it("payload never contains a deck_snapshot field", async () => {
+  it("payload never contains a deck_snapshot field, even when the underlying rows carry one", async () => {
+    // Hostile-input guard: these rows carry deck_snapshot/deckcheck_issues
+    // (as if a careless `.select("*")` or a row spread let them through the
+    // query layer). If the loader ever starts spreading raw participant/
+    // decklist rows into its output instead of naming fields explicitly,
+    // this fixture data would leak and the assertion below would catch it.
+    // Without these fields present here, the assertion could only ever
+    // prove "the mock lacks the key" — not "the loader strips it."
     vi.mocked(getSupabaseAdmin).mockReturnValue(
       fakeAdmin({
         tournament: {
@@ -154,15 +161,35 @@ describe("loadPublicResultsAction", () => {
           results_published: true,
           decklists_published: true,
         },
-        participants: [{ id: "p1", place: 1, name: "Alice", match_points: 12, differential: 10 }],
-        decklists: [{ participant_id: "p1", published_deck_id: "d1" }],
+        participants: [
+          {
+            id: "p1",
+            place: 1,
+            name: "Alice",
+            match_points: 12,
+            differential: 10,
+            deck_snapshot: { deckName: "Secret Deck", cards: [{ name: "Hidden Card" }] },
+            deckcheck_issues: [{ type: "warning", rule: "x", message: "y", cards: [] }],
+          },
+        ],
+        decklists: [
+          {
+            participant_id: "p1",
+            published_deck_id: "d1",
+            deck_snapshot: { deckName: "Other Secret Deck", cards: [{ name: "Other Hidden Card" }] },
+          },
+        ],
       })
     );
 
     const r = await loadPublicResultsAction("t1");
 
     expect(r.success).toBe(true);
-    expect(JSON.stringify(r)).not.toContain("deck_snapshot");
+    const serialized = JSON.stringify(r);
+    expect(serialized).not.toContain("deck_snapshot");
+    expect(serialized).not.toContain("deckcheck_issues");
+    expect(serialized).not.toContain("Secret Deck");
+    expect(serialized).not.toContain("Hidden Card");
   });
 });
 

--- a/app/tournaments/__tests__/resultsLoaders.test.ts
+++ b/app/tournaments/__tests__/resultsLoaders.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/pricing/supabase-admin", () => ({ // MUST match the implementation's "@/" specifier exactly or the mock silently doesn't apply
+  getSupabaseAdmin: vi.fn(),
+}));
+
+import { getSupabaseAdmin } from "@/lib/pricing/supabase-admin";
+import { loadPublicResultsAction, loadPublicResultsIndexAction } from "../actions";
+
+// Minimal PostgREST chain stub, same shape as Task 4's deckSubmission.test.ts:
+// .from().select().eq().maybeSingle() for the single-tournament lookup,
+// .from().select().eq() resolving directly for plain filtered lists,
+// .from().select().eq().in() for the index's grouped participant count.
+// `calls` records how many times participants/decklists were queried so gating
+// (early-return on unpublished; decklists skipped when not published) is
+// actually asserted, not just inferred from the output.
+function fakeAdmin(opts: {
+  tournament?: any;
+  tournamentsIndex?: any[];
+  participants?: any[];
+  decklists?: any[];
+  calls?: { participants: number; decklists: number };
+}) {
+  const calls = opts.calls ?? { participants: 0, decklists: 0 };
+  return {
+    from: (table: string) => ({
+      select: () => ({
+        eq: (col: string) => {
+          if (table === "tournaments" && col === "id") {
+            return {
+              maybeSingle: async () => ({ data: opts.tournament ?? null, error: null }),
+            };
+          }
+          if (table === "tournaments") {
+            // results_published index filter
+            return Promise.resolve({ data: opts.tournamentsIndex ?? [], error: null });
+          }
+          if (table === "participants") {
+            calls.participants++;
+            return Promise.resolve({ data: opts.participants ?? [], error: null });
+          }
+          if (table === "tournament_decklists") {
+            calls.decklists++;
+            return Promise.resolve({ data: opts.decklists ?? [], error: null });
+          }
+          return Promise.resolve({ data: [], error: null });
+        },
+        in: () => {
+          calls.participants++;
+          return Promise.resolve({ data: opts.participants ?? [], error: null });
+        },
+      }),
+    }),
+  } as any;
+}
+
+beforeEach(() => {
+  vi.mocked(getSupabaseAdmin).mockReset();
+});
+
+describe("loadPublicResultsAction", () => {
+  it("unpublished tournament returns success:false and never touches participants/decklists", async () => {
+    const calls = { participants: 0, decklists: 0 };
+    vi.mocked(getSupabaseAdmin).mockReturnValue(
+      fakeAdmin({
+        tournament: {
+          id: "t1",
+          name: "Spring Open",
+          category: "State",
+          deck_format: "Limited",
+          ended_at: "2026-01-01",
+          results_published: false,
+          decklists_published: true,
+        },
+        participants: [{ id: "p1", place: 1, name: "Alice", match_points: 12, differential: 10 }],
+        decklists: [{ participant_id: "p1", published_deck_id: "d1" }],
+        calls,
+      })
+    );
+
+    const r = await loadPublicResultsAction("t1");
+
+    expect(r.success).toBe(false);
+    expect(calls.participants).toBe(0);
+    expect(calls.decklists).toBe(0);
+  });
+
+  it("published tournament returns standings ordered place-nulls-last then match_points desc", async () => {
+    vi.mocked(getSupabaseAdmin).mockReturnValue(
+      fakeAdmin({
+        tournament: {
+          id: "t1",
+          name: "Spring Open",
+          category: "State",
+          deck_format: "Limited",
+          ended_at: "2026-01-01",
+          results_published: true,
+          decklists_published: false,
+        },
+        participants: [
+          { id: "p1", place: null, name: "Zeke", match_points: 9, differential: -2 },
+          { id: "p2", place: 1, name: "Alice", match_points: 12, differential: 10 },
+          { id: "p3", place: null, name: "Sam", match_points: 15, differential: 5 },
+          { id: "p4", place: 2, name: "Bob", match_points: 9, differential: 3 },
+        ],
+      })
+    );
+
+    const r = await loadPublicResultsAction("t1");
+
+    expect(r.success).toBe(true);
+    if (r.success === true) {
+      expect(r.standings.map((s) => s.name)).toEqual(["Alice", "Bob", "Sam", "Zeke"]);
+    }
+  });
+
+  it("publishedDeckId is null when decklists_published is false, even though the row has one", async () => {
+    const calls = { participants: 0, decklists: 0 };
+    vi.mocked(getSupabaseAdmin).mockReturnValue(
+      fakeAdmin({
+        tournament: {
+          id: "t1",
+          name: "Spring Open",
+          category: "State",
+          deck_format: "Limited",
+          ended_at: "2026-01-01",
+          results_published: true,
+          decklists_published: false,
+        },
+        participants: [{ id: "p1", place: 1, name: "Alice", match_points: 12, differential: 10 }],
+        decklists: [{ participant_id: "p1", published_deck_id: "d1" }],
+        calls,
+      })
+    );
+
+    const r = await loadPublicResultsAction("t1");
+
+    expect(r.success).toBe(true);
+    if (r.success === true) {
+      expect(r.standings[0].publishedDeckId).toBeNull();
+    }
+    expect(calls.decklists).toBe(0); // gated on decklists_published, never queried
+  });
+
+  it("payload never contains a deck_snapshot field", async () => {
+    vi.mocked(getSupabaseAdmin).mockReturnValue(
+      fakeAdmin({
+        tournament: {
+          id: "t1",
+          name: "Spring Open",
+          category: "State",
+          deck_format: "Limited",
+          ended_at: "2026-01-01",
+          results_published: true,
+          decklists_published: true,
+        },
+        participants: [{ id: "p1", place: 1, name: "Alice", match_points: 12, differential: 10 }],
+        decklists: [{ participant_id: "p1", published_deck_id: "d1" }],
+      })
+    );
+
+    const r = await loadPublicResultsAction("t1");
+
+    expect(r.success).toBe(true);
+    expect(JSON.stringify(r)).not.toContain("deck_snapshot");
+  });
+});
+
+describe("loadPublicResultsIndexAction", () => {
+  it("returns published events sorted by ended_at desc with grouped player counts", async () => {
+    vi.mocked(getSupabaseAdmin).mockReturnValue(
+      fakeAdmin({
+        tournamentsIndex: [
+          { id: "t1", name: "Event A", category: "State", deck_format: "Limited", ended_at: "2026-01-10" },
+          { id: "t2", name: "Event B", category: "Regional", deck_format: "T2", ended_at: "2026-02-01" },
+        ],
+        participants: [
+          { tournament_id: "t1" },
+          { tournament_id: "t1" },
+          { tournament_id: "t2" },
+        ],
+      })
+    );
+
+    const r = await loadPublicResultsIndexAction();
+
+    expect(r.success).toBe(true);
+    expect(r.events.map((e) => e.id)).toEqual(["t2", "t1"]);
+    expect(r.events.find((e) => e.id === "t1")?.playerCount).toBe(2);
+    expect(r.events.find((e) => e.id === "t2")?.playerCount).toBe(1);
+  });
+});

--- a/app/tournaments/actions.ts
+++ b/app/tournaments/actions.ts
@@ -1,6 +1,8 @@
 "use server";
 
 import { createClient } from "@/utils/supabase/server";
+import { getSupabaseAdmin } from "@/lib/pricing/supabase-admin";
+import { normalizeTournamentFormat, type FormatId } from "@/lib/formats";
 
 export interface TournamentListing {
   id: string;
@@ -45,4 +47,146 @@ export async function loadUpcomingListings(): Promise<TournamentListing[]> {
   }
 
   return (data as TournamentListing[]) || [];
+}
+
+// ─── Public results (published only) ─────────────────────────────────
+//
+// Admin client, no auth — but every loader below checks results_published
+// === true FIRST and returns { success: false } otherwise. deck_snapshot is
+// never read/returned here; decklist links come from
+// tournament_decklists.published_deck_id, and only when decklists_published
+// === true.
+
+export interface PublicResultsIndexEvent {
+  id: string;
+  name: string;
+  category: string | null;
+  deckFormat: string | null;
+  endedAt: string | null;
+  playerCount: number;
+}
+
+export async function loadPublicResultsIndexAction(
+  limit = 50
+): Promise<{ success: boolean; events: PublicResultsIndexEvent[] }> {
+  const admin = getSupabaseAdmin();
+
+  const { data: tournaments, error } = await admin
+    .from("tournaments")
+    .select("id, name, category, deck_format, ended_at")
+    .eq("results_published", true);
+
+  if (error || !tournaments) {
+    return { success: false, events: [] };
+  }
+
+  const limited = [...tournaments]
+    .sort((a: any, b: any) => {
+      const aTime = a.ended_at ? new Date(a.ended_at).getTime() : 0;
+      const bTime = b.ended_at ? new Date(b.ended_at).getTime() : 0;
+      return bTime - aTime;
+    })
+    .slice(0, limit);
+
+  // One in-grouped query for all participant counts, rather than one count
+  // query per event.
+  const ids = limited.map((t: any) => t.id);
+  const counts = new Map<string, number>();
+  if (ids.length > 0) {
+    const { data: participantRows } = await admin
+      .from("participants")
+      .select("tournament_id")
+      .in("tournament_id", ids);
+    for (const p of participantRows ?? []) {
+      counts.set(p.tournament_id, (counts.get(p.tournament_id) ?? 0) + 1);
+    }
+  }
+
+  const events: PublicResultsIndexEvent[] = limited.map((t: any) => ({
+    id: t.id,
+    name: t.name,
+    category: t.category,
+    deckFormat: t.deck_format,
+    endedAt: t.ended_at,
+    playerCount: counts.get(t.id) ?? 0,
+  }));
+
+  return { success: true, events };
+}
+
+export interface PublicResultsStandingRow {
+  place: number | null;
+  name: string | null;
+  matchPoints: number | null;
+  differential: number | null;
+  publishedDeckId: string | null;
+}
+
+export async function loadPublicResultsAction(tournamentId: string): Promise<
+  | { success: false }
+  | {
+      success: true;
+      name: string;
+      category: string | null;
+      deckFormat: FormatId | "Other" | null;
+      endedAt: string | null;
+      decklistsPublished: boolean;
+      standings: PublicResultsStandingRow[];
+    }
+> {
+  const admin = getSupabaseAdmin();
+
+  const { data: tournament, error } = await admin
+    .from("tournaments")
+    .select("id, name, category, deck_format, ended_at, results_published, decklists_published")
+    .eq("id", tournamentId)
+    .maybeSingle();
+
+  // Gate FIRST: unpublished tournaments never reach the participants/decklist
+  // queries below, let alone anything that could expose deck_snapshot.
+  if (error || !tournament || tournament.results_published !== true) {
+    return { success: false };
+  }
+
+  const { data: participants } = await admin
+    .from("participants")
+    .select("id, place, name, match_points, differential")
+    .eq("tournament_id", tournamentId);
+
+  const decklistMap = new Map<string, string>(); // participant_id -> published_deck_id
+  if (tournament.decklists_published === true) {
+    const { data: decklists } = await admin
+      .from("tournament_decklists")
+      .select("participant_id, published_deck_id")
+      .eq("tournament_id", tournamentId);
+    for (const d of decklists ?? []) {
+      if (d.published_deck_id) decklistMap.set(d.participant_id, d.published_deck_id);
+    }
+  }
+
+  const standings: PublicResultsStandingRow[] = (participants ?? [])
+    .slice()
+    .sort((a: any, b: any) => {
+      if (a.place !== null && b.place !== null) return a.place - b.place;
+      if (a.place !== null) return -1;
+      if (b.place !== null) return 1;
+      return (b.match_points ?? 0) - (a.match_points ?? 0);
+    })
+    .map((p: any) => ({
+      place: p.place,
+      name: p.name,
+      matchPoints: p.match_points,
+      differential: p.differential,
+      publishedDeckId: decklistMap.get(p.id) ?? null,
+    }));
+
+  return {
+    success: true,
+    name: tournament.name,
+    category: tournament.category,
+    deckFormat: normalizeTournamentFormat(tournament.deck_format),
+    endedAt: tournament.ended_at,
+    decklistsPublished: tournament.decklists_published === true,
+    standings,
+  };
 }

--- a/app/tournaments/history/NavTabs.tsx
+++ b/app/tournaments/history/NavTabs.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Link from "next/link";
+
 export type ViewId =
   | "tournaments"
   | "champions"
@@ -43,6 +45,15 @@ export default function NavTabs({ view, setView }: NavTabsProps) {
           {tab.label}
         </button>
       ))}
+      {/* Pattern-break: this is a real navigation link (to /tournaments/results),
+          not a view-state switch like the buttons above — Results is its own
+          page, not a HistoryClient view. Styled to match the other tabs. */}
+      <Link
+        href="/tournaments/results"
+        className="shrink-0 px-4 py-3 text-sm font-medium text-muted-foreground hover:text-foreground border-b-2 border-transparent"
+      >
+        Results
+      </Link>
     </div>
   );
 }

--- a/app/tournaments/results/[id]/page.tsx
+++ b/app/tournaments/results/[id]/page.tsx
@@ -1,0 +1,129 @@
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import TopNav from "@/components/top-nav";
+import SponsorFooter from "@/components/sponsor-footer";
+import { loadPublicResultsAction } from "../../actions";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params;
+  const result = await loadPublicResultsAction(id);
+
+  if (result.success !== true) {
+    return { title: "Results Not Found" };
+  }
+
+  return { title: `${result.name} - Results | Redemption CCG` };
+}
+
+function ordinal(n: number): string {
+  const s = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] || s[v] || s[0]);
+}
+
+function formatEndedAt(endedAt: string | null): string | null {
+  if (!endedAt) return null;
+  return new Date(endedAt).toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export default async function TournamentResultsPage({ params }: PageProps) {
+  const { id } = await params;
+  const result = await loadPublicResultsAction(id);
+
+  if (result.success !== true) {
+    notFound();
+  }
+
+  const dateLabel = formatEndedAt(result.endedAt);
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <TopNav />
+      <main className="flex-1 max-w-3xl mx-auto px-4 pt-8 pb-16 w-full">
+        <div className="mb-6">
+          <h1 className="font-cinzel text-2xl font-bold text-foreground">{result.name}</h1>
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+            {dateLabel && <span>{dateLabel}</span>}
+            {result.category && (
+              <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-semibold tracking-wide text-muted-foreground">
+                {result.category}
+              </span>
+            )}
+            {result.deckFormat && (
+              <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-semibold tracking-wide text-muted-foreground">
+                {result.deckFormat}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {result.standings.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No standings recorded.</p>
+        ) : (
+          <div className="rounded-lg border border-border bg-card overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border bg-muted/50">
+                  <th className="text-left px-4 py-2.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                    Place
+                  </th>
+                  <th className="text-left px-4 py-2.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                    Player
+                  </th>
+                  <th className="text-left px-4 py-2.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                    Points
+                  </th>
+                  <th className="text-left px-4 py-2.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                    Diff
+                  </th>
+                  <th className="text-left px-4 py-2.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                    Decklist
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {result.standings.map((row, i) => (
+                  <tr key={i} className="border-b border-border last:border-0 odd:bg-muted/40">
+                    <td className="px-4 py-2.5 font-medium text-foreground">
+                      {row.place !== null ? ordinal(row.place) : "—"}
+                    </td>
+                    <td className="px-4 py-2.5 text-foreground">{row.name ?? "—"}</td>
+                    <td className="px-4 py-2.5 text-muted-foreground">
+                      {row.matchPoints ?? "—"}
+                    </td>
+                    <td className="px-4 py-2.5 text-muted-foreground">
+                      {row.differential ?? "—"}
+                    </td>
+                    <td className="px-4 py-2.5">
+                      {row.publishedDeckId ? (
+                        <Link
+                          href={`/decklist/${row.publishedDeckId}`}
+                          className="text-foreground underline underline-offset-2 hover:text-primary transition-colors"
+                        >
+                          View
+                        </Link>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </main>
+      <SponsorFooter />
+    </div>
+  );
+}

--- a/app/tournaments/results/page.tsx
+++ b/app/tournaments/results/page.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link";
+import TopNav from "@/components/top-nav";
+import SponsorFooter from "@/components/sponsor-footer";
+import { loadPublicResultsIndexAction } from "../actions";
+
+export const metadata = {
+  title: "Tournament Results | Redemption CCG",
+  description: "Browse published standings and decklists from past Redemption CCG tournaments.",
+};
+
+export default async function TournamentResultsIndexPage() {
+  const result = await loadPublicResultsIndexAction();
+  const events = result.success ? result.events : [];
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <TopNav />
+      <main className="flex-1 max-w-3xl mx-auto px-4 pt-8 pb-16 w-full">
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">
+          Tournament Results
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Published standings from completed tournaments.
+        </p>
+
+        <div className="mt-6 space-y-2">
+          {events.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No published results yet.</p>
+          ) : (
+            events.map((e) => (
+              <Link
+                key={e.id}
+                href={`/tournaments/results/${e.id}`}
+                className="block border border-border rounded-lg bg-card/80 backdrop-blur-sm hover:bg-card/90 transition-colors px-4 py-3"
+              >
+                <span className="text-sm font-medium text-foreground">{e.name}</span>
+                <span className="text-sm text-muted-foreground">
+                  {" "}
+                  — {e.playerCount} player{e.playerCount !== 1 ? "s" : ""}
+                </span>
+              </Link>
+            ))
+          )}
+        </div>
+      </main>
+      <SponsorFooter />
+    </div>
+  );
+}

--- a/app/tournaments/tournaments-client.tsx
+++ b/app/tournaments/tournaments-client.tsx
@@ -604,6 +604,12 @@ export default function TournamentsClient({
             {filtered.length} event{filtered.length !== 1 ? "s" : ""} scheduled
             {stateFilter !== "all" ? ` in ${stateFilter}` : ""}
           </p>
+          <Link
+            href="/tournaments/results"
+            className="mt-1 inline-block text-xs text-muted-foreground hover:text-primary hover:underline transition-colors"
+          >
+            Recent results
+          </Link>
         </div>
 
         {/* View toggle */}

--- a/app/tournaments/tournaments-client.tsx
+++ b/app/tournaments/tournaments-client.tsx
@@ -325,7 +325,7 @@ function ListingCard({
 
           <div className="mt-4 flex items-center gap-3">
             <Link
-              href={`/tracker/tournaments?from_listing=${listing.id}&name=${encodeURIComponent(`${listing.city} ${listing.tournament_type || ""} ${listing.start_date.slice(5)}`.trim())}${listing.formats.length > 0 ? `&formats=${encodeURIComponent(listing.formats.map((f) => f.format).join("|"))}` : ""}`}
+              href={`/tracker/tournaments?from_listing=${listing.id}&city=${encodeURIComponent(listing.city)}${listing.formats.length > 0 ? `&formats=${encodeURIComponent(listing.formats.map((f) => f.format).join("|"))}` : ""}`}
               className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
             >
               <FaTrophy className="w-3 h-3" />

--- a/app/tracker/tournaments/[id]/page.tsx
+++ b/app/tracker/tournaments/[id]/page.tsx
@@ -11,6 +11,7 @@ import EditParticipantModal from "../../../../components/ui/EditParticipantModal
 import EditTournamentNameModal from "../../../../components/ui/EditTournamentNameModal";
 import TournamentStartModal from "../../../../components/ui/TournamentStartModal";
 import TournamentTabs from "../../../../components/ui/TournamentTabs";
+import QRJoinDialog from "../../../../components/ui/QRJoinDialog";
 import Breadcrumb from "../../../../components/ui/breadcrumb";
 import ToastNotification from "../../../../components/ui/toast-notification";
 import { createClient } from "../../../../utils/supabase/client";
@@ -76,6 +77,7 @@ export default function TournamentPage({
   const [showPairingNotice, setShowPairingNotice] = useState(true);
   const [decklists, setDecklists] = useState<TournamentDecklistRow[]>([]);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [qrJoinDialogOpen, setQrJoinDialogOpen] = useState(false);
 
   // Confirmation dialogs
   const [endTournamentConfirmOpen, setEndTournamentConfirmOpen] = useState(false);
@@ -661,6 +663,13 @@ export default function TournamentPage({
   const isHost = !!(tournament?.host_id && currentUserId && tournament.host_id === currentUserId);
   const numberingMode: "tables" | "seats" =
     tournament?.numbering_mode === "seats" ? "seats" : "tables";
+  // "N of M participants have decklists" — tournament_decklists has at most
+  // one row per participant, so decklists.length is exactly the submitted
+  // count regardless of source (player QR submission or host attach).
+  const decklistSummary =
+    tournament?.require_decklists === true
+      ? { submitted: decklists.length, total: participants.length }
+      : null;
 
   return (
     <div className="flex min-h-screen px-3 sm:px-5 w-full jayden-gradient-bg">
@@ -949,6 +958,8 @@ export default function TournamentPage({
             fetchParticipants={fetchParticipants}
             decklists={decklists}
             onDecklistsChange={fetchDecklists}
+            onOpenQrJoin={() => setQrJoinDialogOpen(true)}
+            decklistSummary={decklistSummary}
             onRepairCompleted={() => {
               fetchParticipants();
               fetchTournamentDetails();
@@ -1108,7 +1119,16 @@ export default function TournamentPage({
           defaultByeDifferential={tournament?.bye_differential}
           defaultStartingTableNumber={tournament?.starting_table_number}
           defaultSoundNotifications={tournament?.sound_notifications}
+          decklistSummary={decklistSummary}
         />
+        {tournament && !tournament.has_started && !tournament.has_ended && (
+          <QRJoinDialog
+            tournament={tournament}
+            isOpen={qrJoinDialogOpen}
+            onClose={() => setQrJoinDialogOpen(false)}
+            onTournamentUpdated={fetchTournamentDetails}
+          />
+        )}
         {tournament && (
           // Typed-confirmation gate — owner explicitly wanted a higher bar
           // than the standard ConfirmationDialog primitive for the only host

--- a/app/tracker/tournaments/[id]/page.tsx
+++ b/app/tracker/tournaments/[id]/page.tsx
@@ -19,7 +19,12 @@ import { suggestNumberOfRounds } from "../../../../utils/tournamentUtils";
 import { createPairing } from "../../../../utils/tournament/pairingUtilsV2";
 import { buildStateFromSupabase } from "../../../../utils/tournament/stateAdapter";
 import { recomputeTotalsFromHistory } from "../../../../lib/tournament/results";
-import { loadTournamentDecklistsAction, type TournamentDecklistRow } from "../actions";
+import {
+  loadTournamentDecklistsAction,
+  setResultsPublishedAction,
+  publishTournamentDecklistsAction,
+  type TournamentDecklistRow,
+} from "../actions";
 import PublishDecklistsSection from "../../../../components/ui/PublishDecklistsSection";
 import { RegeneratePairingsButton } from "../../../../components/ui/RegeneratePairingsButton";
 import { UnlockAndRepairDialog, type ScoredMatch } from "../../../../components/ui/UnlockAndRepairDialog";
@@ -270,7 +275,37 @@ export default function TournamentPage({
     setEndTournamentConfirmOpen(true);
   };
 
-  const performEndTournament = async () => {
+  // Called after has_ended is committed, from either end path:
+  //  - Manual end (performEndTournament, below) — honors the confirm
+  //    dialog's checkbox. A single call there covers both of its internal
+  //    branches (the round gets finalized via handleEndRound first when it
+  //    wasn't already completed, but performEndTournament's own update always
+  //    runs after, so hooking it once here is sufficient — no double-fire).
+  //  - Auto end on the final round (TournamentRounds' "End Round" button —
+  //    the common case; most tournaments end this way, not via the admin
+  //    menu) — wired unconditionally with publish=true via the
+  //    onTournamentAutoPublish callback threaded through TournamentTabs,
+  //    since that path has no publish-choice dialog; the host's opt-out
+  //    there is unpublishing afterward from the Publish section.
+  // "No decklists to publish" is NORMAL for events without submissions —
+  // treated as success for the toast, not a failure.
+  const publishOnEnd = async (publish: boolean) => {
+    if (!publish) return;
+    const results = await setResultsPublishedAction(id, true);
+    const decks = await publishTournamentDecklistsAction(
+      id,
+      tournament?.deck_format ?? "Other"
+    );
+    const deckFailure =
+      decks.success === false && decks.error !== "No decklists to publish";
+    if (results.success === false || deckFailure) {
+      showToast("Ended, but publishing failed — use the Publish section.", "warning");
+    } else {
+      showToast("Tournament ended — results published.", "success");
+    }
+  };
+
+  const performEndTournament = async (publish: boolean) => {
     if (!tournament) return;
     setTogglingStatus(true);
 
@@ -315,7 +350,9 @@ export default function TournamentPage({
       if (error) throw error;
       setTournament(data);
       setActiveTab(2); // jump to Standings — the tournament is now complete
-      showToast("Tournament ended successfully!", "success");
+      // Publishing never rolls back the end — it already committed above.
+      await publishOnEnd(publish);
+      if (!publish) showToast("Tournament ended successfully!", "success");
     } catch (error) {
       showToast("Error updating tournament status.", "error");
       console.error("Error updating tournament status:", error);
@@ -901,6 +938,7 @@ export default function TournamentPage({
                     decklistCount={decklists.length}
                     isPublished={tournament.decklists_published || false}
                     currentFormat={tournament.deck_format || null}
+                    resultsPublished={tournament.results_published || false}
                     onPublishChange={() => {
                       fetchTournamentDetails();
                       fetchDecklists();
@@ -969,6 +1007,11 @@ export default function TournamentPage({
               // refresh both so Standings doesn't render stale zeros.
               await Promise.all([fetchTournamentDetails(), fetchParticipants()]);
             }}
+            // Fires only when the FINAL round's End Round button completes the
+            // tournament — the common way tournaments end (no confirm dialog
+            // exists on this path, unlike the admin-menu End Tournament flow),
+            // so it always publishes.
+            onTournamentAutoPublish={() => publishOnEnd(true)}
             onRoundActiveChange={(isActive, roundStartTime) => {
               setIsRoundActive(isActive);
               fetchTournamentDetails();
@@ -1162,8 +1205,8 @@ export default function TournamentPage({
             onOpenChange={setEndTournamentConfirmOpen}
             tournamentName={tournament.name ?? ""}
             isEnding={togglingStatus}
-            onConfirm={async () => {
-              await performEndTournament();
+            onConfirm={async (publish) => {
+              await performEndTournament(publish);
               setEndTournamentConfirmOpen(false);
             }}
           />

--- a/app/tracker/tournaments/[id]/page.tsx
+++ b/app/tracker/tournaments/[id]/page.tsx
@@ -76,6 +76,7 @@ export default function TournamentPage({
   const [unlockDialogOpen, setUnlockDialogOpen] = useState(false);
   const [showPairingNotice, setShowPairingNotice] = useState(true);
   const [decklists, setDecklists] = useState<TournamentDecklistRow[]>([]);
+  const [usernames, setUsernames] = useState<Map<string, string>>(new Map());
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [qrJoinDialogOpen, setQrJoinDialogOpen] = useState(false);
 
@@ -184,6 +185,28 @@ export default function TournamentPage({
       setLoading(false);
     }
   };
+
+  // Batched profile lookup for the account-linkage badge (Task 9 Step 1) —
+  // one query for every distinct user_id currently on the roster. Profiles
+  // are publicly readable, so this runs on the regular client, not admin.
+  useEffect(() => {
+    const userIds = [...new Set(participants.map((p: any) => p.user_id).filter(Boolean))];
+    if (userIds.length === 0) {
+      setUsernames(new Map());
+      return;
+    }
+    supabase
+      .from("profiles")
+      .select("id, username")
+      .in("id", userIds)
+      .then(({ data }) => {
+        const map = new Map<string, string>();
+        for (const p of data ?? []) {
+          if (p.username) map.set(p.id, p.username);
+        }
+        setUsernames(map);
+      });
+  }, [participants]);
 
   const updateParticipant = async () => {
     if (!currentParticipant || !newParticipantName.trim()) return;
@@ -958,6 +981,7 @@ export default function TournamentPage({
             fetchParticipants={fetchParticipants}
             decklists={decklists}
             onDecklistsChange={fetchDecklists}
+            usernames={usernames}
             onOpenQrJoin={() => setQrJoinDialogOpen(true)}
             decklistSummary={decklistSummary}
             onRepairCompleted={() => {

--- a/app/tracker/tournaments/__tests__/joinHostActions.test.ts
+++ b/app/tracker/tournaments/__tests__/joinHostActions.test.ts
@@ -43,6 +43,7 @@ import { createClient } from "@/utils/supabase/server";
 import {
   setQrJoinEnabledAction,
   updateJoinSettingsAction,
+  attachDeckToParticipantAction,
   detachDeckFromParticipantAction,
   removeParticipantWithBlockAction,
   recheckAllSubmissionsAction,
@@ -153,6 +154,112 @@ describe("updateJoinSettingsAction", () => {
 
     expect(r).toEqual({ success: true });
     expect(tournaments.update).toHaveBeenCalledWith({ deck_format: "Limited", require_decklists: true });
+  });
+
+  // Regression: "Sealed"/"Draft" normalize to 'Other' via normalizeTournamentFormat,
+  // so comparing raw input against the literal "Other" alone let a caller
+  // bypass the format_required gate by passing "Sealed" instead of "Other" —
+  // persisting exactly the state (require_decklists=true, no real format)
+  // the gate exists to prevent. The whitelist must reject it outright,
+  // regardless of requireDecklists.
+  it("'Sealed' (not the literal 'Other', but normalizes to it) is rejected outright", async () => {
+    const r = await updateJoinSettingsAction("t1", {
+      deckFormat: "Sealed" as any,
+      requireDecklists: true,
+    });
+
+    expect(r).toEqual({ success: false, error: "invalid_format" });
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it("junk format string is rejected outright, even with requireDecklists=false", async () => {
+    const r = await updateJoinSettingsAction("t1", {
+      deckFormat: "asdf" as any,
+      requireDecklists: false,
+    });
+
+    expect(r).toEqual({ success: false, error: "invalid_format" });
+    expect(createClient).not.toHaveBeenCalled();
+  });
+});
+
+// ─── attachDeckToParticipantAction — no-format path access control ──────
+//
+// On a tournament with no declared format, host-attach can't route through
+// buildDeckSubmission (it requires a FormatId) and instead reads the deck
+// via the admin client directly. That read bypasses RLS entirely, so it
+// must re-enforce buildDeckSubmission's own access rule by hand: owner OR
+// not-private. Otherwise a host could attach ANY deck UUID — not just ones
+// surfaced by searchDecksForTournamentAction — and read a stranger's
+// private decklist back via the submission snapshot.
+
+describe("attachDeckToParticipantAction — no-format path", () => {
+  function setupNoFormatHost(deck: { name: string; user_id: string; visibility: string }) {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "host1" } } });
+
+    const tournamentDecklists = makeNode();
+    tournamentDecklists._resp = { data: null, error: null }; // no existing row -> insert branch
+
+    const tournaments = makeNode();
+    tournaments.maybeSingle
+      .mockResolvedValueOnce({ data: { id: "t1" }, error: null }) // requireHost
+      .mockResolvedValueOnce({ data: { deck_format: null }, error: null }); // deck_format lookup
+
+    userClientImpl = makeClient({ tournament_decklists: tournamentDecklists, tournaments });
+
+    const decks = makeNode();
+    decks.maybeSingle.mockResolvedValue({ data: deck, error: null });
+    const deckCards = makeNode();
+    const submissions = makeNode();
+    adminImpl = makeClient({ decks, deck_cards: deckCards, tournament_deck_submissions: submissions });
+
+    return { decks, deckCards, submissions };
+  }
+
+  it("private deck owned by someone else -> no card read, no submission upsert", async () => {
+    const { deckCards, submissions } = setupNoFormatHost({
+      name: "Victim's Private Deck",
+      user_id: "victim1",
+      visibility: "private",
+    });
+
+    const r = await attachDeckToParticipantAction("t1", "p1", "victim-deck-1");
+
+    // The attach itself (tournament_decklists) still succeeds — only the
+    // submission-snapshot side effect is blocked.
+    expect(r).toEqual({ success: true });
+    expect(deckCards.select).not.toHaveBeenCalled();
+    expect(submissions.upsert).not.toHaveBeenCalled();
+  });
+
+  it("the host's OWN private deck is still snapshotted", async () => {
+    const { deckCards, submissions } = setupNoFormatHost({
+      name: "My Own Private Deck",
+      user_id: "host1",
+      visibility: "private",
+    });
+    deckCards._resp = { data: [], error: null };
+
+    const r = await attachDeckToParticipantAction("t1", "p1", "own-deck-1");
+
+    expect(r).toEqual({ success: true });
+    expect(deckCards.select).toHaveBeenCalledTimes(1);
+    expect(submissions.upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it("a public deck owned by someone else is still snapshotted", async () => {
+    const { deckCards, submissions } = setupNoFormatHost({
+      name: "Public Deck",
+      user_id: "someoneElse",
+      visibility: "public",
+    });
+    deckCards._resp = { data: [], error: null };
+
+    const r = await attachDeckToParticipantAction("t1", "p1", "public-deck-1");
+
+    expect(r).toEqual({ success: true });
+    expect(deckCards.select).toHaveBeenCalledTimes(1);
+    expect(submissions.upsert).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/app/tracker/tournaments/__tests__/joinHostActions.test.ts
+++ b/app/tracker/tournaments/__tests__/joinHostActions.test.ts
@@ -207,11 +207,19 @@ describe("attachDeckToParticipantAction — no-format path", () => {
 
     userClientImpl = makeClient({ tournament_decklists: tournamentDecklists, tournaments });
 
+    const participants = makeNode();
+    participants._resp = { data: { id: "p1" }, error: null }; // participant belongs to t1
+
     const decks = makeNode();
     decks.maybeSingle.mockResolvedValue({ data: deck, error: null });
     const deckCards = makeNode();
     const submissions = makeNode();
-    adminImpl = makeClient({ decks, deck_cards: deckCards, tournament_deck_submissions: submissions });
+    adminImpl = makeClient({
+      participants,
+      decks,
+      deck_cards: deckCards,
+      tournament_deck_submissions: submissions,
+    });
 
     return { decks, deckCards, submissions };
   }
@@ -260,6 +268,60 @@ describe("attachDeckToParticipantAction — no-format path", () => {
     expect(r).toEqual({ success: true });
     expect(deckCards.select).toHaveBeenCalledTimes(1);
     expect(submissions.upsert).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── attachDeckToParticipantAction — participant/tournament scoping ─────
+//
+// requireHost only proves the caller hosts SOME tournament (their own). The
+// admin upsert into tournament_deck_submissions is keyed onConflict:
+// "participant_id" and bypasses RLS entirely, so a hostile host of their
+// own tournament could otherwise pass a victim's participantId (from a
+// DIFFERENT tournament) and repoint/overwrite the victim's submission row.
+// Guard: admin-read the participant scoped to (id, tournament_id) and bail
+// before any write when it doesn't match — same pattern
+// removeParticipantWithBlockAction already uses.
+
+describe("attachDeckToParticipantAction — participant/tournament scoping", () => {
+  it("participantId belongs to a different tournament -> failure, no tournament_decklists or submissions writes", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "host1" } } });
+
+    const tournaments = makeNode();
+    tournaments._resp = { data: { id: "t1" }, error: null }; // requireHost: caller hosts t1
+
+    const tournamentDecklists = makeNode();
+    userClientImpl = makeClient({ tournaments, tournament_decklists: tournamentDecklists });
+
+    const participants = makeNode();
+    // Admin-scoped lookup for (id: "p1", tournament_id: "t1") finds nothing —
+    // p1 actually belongs to a different (victim's) tournament.
+    participants._resp = { data: null, error: null };
+    const submissions = makeNode();
+    adminImpl = makeClient({ participants, tournament_deck_submissions: submissions });
+
+    const r = await attachDeckToParticipantAction("t1", "p1", "some-deck");
+
+    expect(r).toEqual({ success: false, error: "not_found" });
+    expect(participants.eq).toHaveBeenCalledWith("id", "p1");
+    expect(participants.eq).toHaveBeenCalledWith("tournament_id", "t1");
+    expect(tournamentDecklists.select).not.toHaveBeenCalled();
+    expect(tournamentDecklists.insert).not.toHaveBeenCalled();
+    expect(tournamentDecklists.update).not.toHaveBeenCalled();
+    expect(submissions.upsert).not.toHaveBeenCalled();
+  });
+
+  it("non-host -> failure before any participant lookup", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "intruder" } } });
+    const tournaments = makeNode();
+    tournaments._resp = { data: null, error: null }; // RLS: not visible to non-host
+    userClientImpl = makeClient({ tournaments });
+    const adminFrom = vi.fn();
+    adminImpl = { from: adminFrom };
+
+    const r = await attachDeckToParticipantAction("t1", "p1", "some-deck");
+
+    expect(r).toEqual({ success: false, error: "not_found" });
+    expect(adminFrom).not.toHaveBeenCalled();
   });
 });
 

--- a/app/tracker/tournaments/__tests__/joinHostActions.test.ts
+++ b/app/tracker/tournaments/__tests__/joinHostActions.test.ts
@@ -1,0 +1,516 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// vi.mock specifiers MUST match the implementation's "@/"-aliased imports
+// exactly or the mocks silently don't apply (see app/join/__tests__/actions.test.ts).
+
+const mockGetUser = vi.fn();
+let userClientImpl: any = null;
+vi.mock("@/utils/supabase/server", () => ({
+  createClient: vi.fn(async () => userClientImpl),
+}));
+
+let adminImpl: any = null;
+vi.mock("@/lib/pricing/supabase-admin", () => ({
+  getSupabaseAdmin: vi.fn(() => adminImpl),
+}));
+
+const mockBuildDeckSubmission = vi.fn();
+vi.mock("@/lib/tournament/deckSubmission", () => ({
+  buildDeckSubmission: (...args: any[]) => mockBuildDeckSubmission(...args),
+}));
+
+const mockGenerateJoinCode = vi.fn();
+vi.mock("@/lib/tournament/joinCodes", () => ({
+  generateJoinCode: () => mockGenerateJoinCode(),
+}));
+
+const mockCheckDeck = vi.fn();
+vi.mock("@/utils/deckcheck", () => ({
+  checkDeck: (...args: any[]) => mockCheckDeck(...args),
+}));
+
+const mockBuildStateFromSupabase = vi.fn();
+vi.mock("@/utils/tournament/stateAdapter", () => ({
+  buildStateFromSupabase: (...args: any[]) => mockBuildStateFromSupabase(...args),
+}));
+
+const mockComputeFinalStandings = vi.fn();
+vi.mock("@/lib/tournament/standings", () => ({
+  computeFinalStandings: (...args: any[]) => mockComputeFinalStandings(...args),
+}));
+
+import { createClient } from "@/utils/supabase/server";
+import {
+  setQrJoinEnabledAction,
+  updateJoinSettingsAction,
+  detachDeckFromParticipantAction,
+  removeParticipantWithBlockAction,
+  recheckAllSubmissionsAction,
+  setResultsPublishedAction,
+  publishTournamentDecklistsAction,
+} from "../actions";
+
+const REDEMPTIONCCG_USER_ID = "a0a8e980-f372-4ebd-be25-d2f26507e98f";
+
+// --- fake PostgREST chain builder --------------------------------------
+// Every chain call returns the SAME node so the final resolved value can be
+// configured directly on it (`_resp`) or via the terminal-method vi.fn's
+// (`.single`/`.maybeSingle`), which support .mockResolvedValueOnce() for
+// sequential-call scenarios (e.g. a retry loop).
+function makeNode() {
+  const node: any = { _resp: { data: null, error: null } };
+  const self = () => node;
+  node.select = vi.fn(self);
+  node.eq = vi.fn(self);
+  node.in = vi.fn(self);
+  node.order = vi.fn(self);
+  node.limit = vi.fn(self);
+  node.update = vi.fn(self);
+  node.delete = vi.fn(self);
+  node.insert = vi.fn(self);
+  node.upsert = vi.fn(self);
+  node.single = vi.fn(async () => node._resp);
+  node.maybeSingle = vi.fn(async () => node._resp);
+  // Lets code `await` a chain that ends on .eq()/.update()/.delete()/.insert()/
+  // .upsert() directly, without an explicit .single()/.maybeSingle().
+  node.then = (resolve: any) => resolve(node._resp);
+  return node;
+}
+
+function makeClient(tables: Record<string, ReturnType<typeof makeNode>>) {
+  return {
+    auth: { getUser: mockGetUser },
+    from: vi.fn((table: string) => tables[table] ?? makeNode()),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  userClientImpl = null;
+  adminImpl = null;
+});
+
+// ─── setQrJoinEnabledAction ─────────────────────────────────────────────
+
+describe("setQrJoinEnabledAction", () => {
+  it("non-host: zero-row update -> failure, no retry", async () => {
+    const tournaments = makeNode();
+    tournaments._resp = { data: null, error: null }; // RLS filtered out the row
+    userClientImpl = makeClient({ tournaments });
+    mockGenerateJoinCode.mockReturnValue("AAAAAA");
+
+    const r = await setQrJoinEnabledAction("t1", true);
+
+    expect(r).toEqual({ success: false, error: "not_found" });
+    expect(tournaments.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("23505 collision retries with a freshly generated code", async () => {
+    const tournaments = makeNode();
+    tournaments.maybeSingle
+      .mockResolvedValueOnce({ data: null, error: { code: "23505", message: "duplicate key" } })
+      .mockResolvedValueOnce({ data: { code: "CODE02" }, error: null });
+    userClientImpl = makeClient({ tournaments });
+    mockGenerateJoinCode.mockReturnValueOnce("CODE01").mockReturnValueOnce("CODE02");
+
+    const r = await setQrJoinEnabledAction("t1", true);
+
+    expect(r).toEqual({ success: true, code: "CODE02" });
+    expect(mockGenerateJoinCode).toHaveBeenCalledTimes(2);
+    expect(tournaments.update).toHaveBeenCalledTimes(2);
+    expect(tournaments.update).toHaveBeenNthCalledWith(1, { code: "CODE01" });
+    expect(tournaments.update).toHaveBeenNthCalledWith(2, { code: "CODE02" });
+  });
+
+  it("disabling clears the code", async () => {
+    const tournaments = makeNode();
+    tournaments._resp = { data: { code: null }, error: null };
+    userClientImpl = makeClient({ tournaments });
+
+    const r = await setQrJoinEnabledAction("t1", false);
+
+    expect(r).toEqual({ success: true, code: null });
+    expect(tournaments.update).toHaveBeenCalledWith({ code: null });
+  });
+});
+
+// ─── updateJoinSettingsAction ───────────────────────────────────────────
+
+describe("updateJoinSettingsAction", () => {
+  it("rejects require_decklists=true with deckFormat='Other', never touches the DB", async () => {
+    const r = await updateJoinSettingsAction("t1", { deckFormat: "Other", requireDecklists: true });
+
+    expect(r).toEqual({ success: false, error: "format_required" });
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it("accepts require_decklists=true with a real format", async () => {
+    const tournaments = makeNode();
+    tournaments._resp = { data: null, error: null };
+    userClientImpl = makeClient({ tournaments });
+
+    const r = await updateJoinSettingsAction("t1", { deckFormat: "Limited", requireDecklists: true });
+
+    expect(r).toEqual({ success: true });
+    expect(tournaments.update).toHaveBeenCalledWith({ deck_format: "Limited", require_decklists: true });
+  });
+});
+
+// ─── detachDeckFromParticipantAction ────────────────────────────────────
+
+describe("detachDeckFromParticipantAction", () => {
+  it("zero-row user-client delete (not the host) touches NO submission row", async () => {
+    const tournamentDecklists = makeNode();
+    tournamentDecklists._resp = { data: [], error: null }; // RLS blocked the delete
+    userClientImpl = makeClient({ tournament_decklists: tournamentDecklists });
+    const adminFrom = vi.fn();
+    adminImpl = { from: adminFrom };
+
+    const r = await detachDeckFromParticipantAction("p1");
+
+    expect(r).toEqual({ success: false, error: "not_found" });
+    expect(adminFrom).not.toHaveBeenCalled();
+  });
+
+  it("a real deleted row admin-deletes the submission", async () => {
+    const tournamentDecklists = makeNode();
+    tournamentDecklists._resp = { data: [{ tournament_id: "t1" }], error: null };
+    userClientImpl = makeClient({ tournament_decklists: tournamentDecklists });
+    const submissions = makeNode();
+    adminImpl = makeClient({ tournament_deck_submissions: submissions });
+
+    const r = await detachDeckFromParticipantAction("p1");
+
+    expect(r).toEqual({ success: true });
+    expect(submissions.delete).toHaveBeenCalledTimes(1);
+    expect(submissions.eq).toHaveBeenCalledWith("participant_id", "p1");
+  });
+});
+
+// ─── removeParticipantWithBlockAction ───────────────────────────────────
+
+describe("removeParticipantWithBlockAction", () => {
+  function setupHost(participantUserId: string | null) {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "host1" } } });
+    const tournaments = makeNode();
+    tournaments._resp = { data: { id: "t1" }, error: null };
+    const participantsUser = makeNode();
+    participantsUser._resp = { data: null, error: null };
+    userClientImpl = makeClient({ tournaments, participants: participantsUser });
+
+    const participantsAdmin = makeNode();
+    participantsAdmin._resp = { data: { user_id: participantUserId }, error: null };
+    const joinBlocks = makeNode();
+    adminImpl = makeClient({ participants: participantsAdmin, tournament_join_blocks: joinBlocks });
+    return { joinBlocks };
+  }
+
+  it("block=true + user-linked participant -> inserts the block", async () => {
+    const { joinBlocks } = setupHost("u1");
+
+    const r = await removeParticipantWithBlockAction("t1", "p1", true);
+
+    expect(r).toEqual({ success: true });
+    expect(joinBlocks.upsert).toHaveBeenCalledWith(
+      { tournament_id: "t1", user_id: "u1" },
+      expect.objectContaining({ ignoreDuplicates: true })
+    );
+  });
+
+  it("block=false -> no block row inserted even though the participant is user-linked", async () => {
+    const { joinBlocks } = setupHost("u1");
+
+    const r = await removeParticipantWithBlockAction("t1", "p1", false);
+
+    expect(r).toEqual({ success: true });
+    expect(joinBlocks.upsert).not.toHaveBeenCalled();
+  });
+
+  it("block=true but participant was never account-linked -> no block row inserted", async () => {
+    const { joinBlocks } = setupHost(null);
+
+    const r = await removeParticipantWithBlockAction("t1", "p1", true);
+
+    expect(r).toEqual({ success: true });
+    expect(joinBlocks.upsert).not.toHaveBeenCalled();
+  });
+
+  it("non-host -> failure, admin client never touched", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "intruder" } } });
+    const tournaments = makeNode();
+    tournaments._resp = { data: null, error: null }; // RLS: not visible to non-host
+    userClientImpl = makeClient({ tournaments });
+    const adminFrom = vi.fn();
+    adminImpl = { from: adminFrom };
+
+    const r = await removeParticipantWithBlockAction("t1", "p1", true);
+
+    expect(r).toEqual({ success: false, error: "not_found" });
+    expect(adminFrom).not.toHaveBeenCalled();
+  });
+});
+
+// ─── recheckAllSubmissionsAction ────────────────────────────────────────
+
+describe("recheckAllSubmissionsAction", () => {
+  it("updates is_legal/deckcheck_issues from each submission's snapshot and counts newly-illegal", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "host1" } } });
+    const tournaments = makeNode();
+    tournaments._resp = { data: { id: "t1", deck_format: "Limited" }, error: null };
+    userClientImpl = makeClient({ tournaments });
+
+    const submissions = makeNode();
+    submissions._resp = {
+      data: [
+        {
+          id: "s1",
+          is_legal: true,
+          deck_snapshot: {
+            deckName: "D1",
+            deckFormat: "Limited",
+            cards: [
+              { name: "Card A", set: "TPC", imgFile: null, quantity: 40, zone: "main" },
+              { name: "Card B", set: "TPC", imgFile: null, quantity: 10, zone: "reserve" },
+            ],
+          },
+        },
+        {
+          id: "s2",
+          is_legal: false,
+          deck_snapshot: {
+            deckName: "D2",
+            deckFormat: "Limited",
+            cards: [{ name: "Card C", set: "TPC", imgFile: null, quantity: 50, zone: "main" }],
+          },
+        },
+      ],
+      error: null,
+    };
+    adminImpl = makeClient({ tournament_deck_submissions: submissions });
+
+    mockCheckDeck
+      .mockResolvedValueOnce({ valid: false, issues: [{ type: "error", rule: "x", message: "now illegal" }] })
+      .mockResolvedValueOnce({ valid: true, issues: [] });
+
+    const r = await recheckAllSubmissionsAction("t1");
+
+    expect(r).toEqual({ success: true, rechecked: 2, nowIllegal: 1 });
+    expect(mockCheckDeck).toHaveBeenNthCalledWith(
+      1,
+      [{ name: "Card A", set: "TPC", quantity: 40, imgFile: undefined }],
+      [{ name: "Card B", set: "TPC", quantity: 10, imgFile: undefined }],
+      "Limited"
+    );
+    expect(submissions.update).toHaveBeenNthCalledWith(1, {
+      is_legal: false,
+      deckcheck_issues: [{ type: "error", rule: "x", message: "now illegal" }],
+    });
+    expect(submissions.update).toHaveBeenNthCalledWith(2, { is_legal: true, deckcheck_issues: null });
+  });
+
+  it("format null/'Other' -> fails fast, never calls checkDeck", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "host1" } } });
+    const tournaments = makeNode();
+    tournaments._resp = { data: { id: "t1", deck_format: null }, error: null };
+    userClientImpl = makeClient({ tournaments });
+    const submissions = makeNode();
+    adminImpl = makeClient({ tournament_deck_submissions: submissions });
+
+    const r = await recheckAllSubmissionsAction("t1");
+
+    expect(r).toEqual({ success: false, rechecked: 0, nowIllegal: 0, error: "format_required" });
+    expect(mockCheckDeck).not.toHaveBeenCalled();
+    expect(submissions.select).not.toHaveBeenCalled();
+  });
+});
+
+// ─── setResultsPublishedAction / persistFinalPlaces ─────────────────────
+
+describe("setResultsPublishedAction", () => {
+  it("published=true persists final places (via the shared persistFinalPlaces helper)", async () => {
+    const participants = makeNode();
+    participants._resp = { data: null, error: null };
+    const tournaments = makeNode();
+    tournaments._resp = { data: null, error: null };
+    userClientImpl = makeClient({ participants, tournaments });
+
+    mockBuildStateFromSupabase.mockResolvedValue({ fake: "state" });
+    mockComputeFinalStandings.mockReturnValue([
+      { participantId: "p1", place: 1 },
+      { participantId: "p2", place: 2 },
+    ]);
+
+    const r = await setResultsPublishedAction("t1", true);
+
+    expect(r).toEqual({ success: true });
+    expect(mockBuildStateFromSupabase).toHaveBeenCalledWith(userClientImpl, "t1");
+    expect(mockComputeFinalStandings).toHaveBeenCalledWith({ fake: "state" });
+    // place writes for both placed participants, plus the dropped-out clear.
+    expect(participants.update).toHaveBeenCalledWith({ place: 1 });
+    expect(participants.update).toHaveBeenCalledWith({ place: 2 });
+    expect(participants.update).toHaveBeenCalledWith({ place: null });
+    expect(tournaments.update).toHaveBeenCalledWith({ results_published: true });
+  });
+
+  it("published=false does NOT recompute standings, only flips the flag", async () => {
+    const tournaments = makeNode();
+    tournaments._resp = { data: null, error: null };
+    userClientImpl = makeClient({ tournaments });
+
+    const r = await setResultsPublishedAction("t1", false);
+
+    expect(r).toEqual({ success: true });
+    expect(mockBuildStateFromSupabase).not.toHaveBeenCalled();
+    expect(tournaments.update).toHaveBeenCalledWith({ results_published: false });
+  });
+});
+
+// ─── publishTournamentDecklistsAction ───────────────────────────────────
+
+describe("publishTournamentDecklistsAction — snapshot-first", () => {
+  it("prefers the submission snapshot over the live deck when both exist", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "host1" } } });
+
+    const tournaments = makeNode();
+    tournaments.single.mockResolvedValue({ data: { name: "Spring Open" }, error: null });
+    tournaments.maybeSingle.mockResolvedValue({ data: { id: "t1" }, error: null }); // requireHost
+    tournaments._resp = { data: null, error: null }; // final decklists_published update
+
+    const tournamentDecklists = makeNode();
+    tournamentDecklists._resp = {
+      data: [
+        {
+          id: "dl1",
+          deck_id: "live-deck-1",
+          published_deck_id: null,
+          participant_id: "p1",
+          participants: { name: "Timmy" },
+        },
+      ],
+      error: null,
+    };
+
+    const participants = makeNode();
+    participants._resp = { data: null, error: null };
+
+    userClientImpl = makeClient({
+      tournaments,
+      tournament_decklists: tournamentDecklists,
+      participants,
+    });
+
+    mockBuildStateFromSupabase.mockResolvedValue({ fake: "state" });
+    mockComputeFinalStandings.mockReturnValue([{ participantId: "p1", place: 1 }]);
+
+    const submissions = makeNode();
+    submissions._resp = {
+      data: [
+        {
+          participant_id: "p1",
+          is_legal: true,
+          deckcheck_issues: null,
+          deck_snapshot: {
+            deckName: "Timmy's Submitted Deck",
+            deckFormat: "Limited",
+            cards: [
+              { name: "Snapshot Card", set: "TPC", imgFile: "snap.jpg", quantity: 3, zone: "main" },
+            ],
+          },
+        },
+      ],
+      error: null,
+    };
+
+    const decks = makeNode();
+    decks.single.mockResolvedValue({ data: { id: "new-deck-1" }, error: null });
+
+    const deckCards = makeNode();
+    deckCards._resp = { data: null, error: null };
+
+    adminImpl = makeClient({
+      tournament_deck_submissions: submissions,
+      decks,
+      deck_cards: deckCards,
+      tournament_decklists: tournamentDecklists,
+    });
+
+    const r = await publishTournamentDecklistsAction("t1", "Limited");
+
+    expect(r).toEqual({ success: true });
+
+    // The live-deck path must never fire: only the insert-then-select("id")
+    // chain touches decks.select, never the "name, description, format..."
+    // live-deck fetch.
+    expect(decks.select).toHaveBeenCalledTimes(1);
+    expect(decks.select).toHaveBeenCalledWith("id");
+
+    expect(decks.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: REDEMPTIONCCG_USER_ID,
+        name: "Timmy - 1st Place - Spring Open",
+        card_count: 3,
+        is_legal: true,
+        deckcheck_issues: null,
+        visibility: "public",
+      })
+    );
+
+    expect(deckCards.insert).toHaveBeenCalledWith([
+      {
+        deck_id: "new-deck-1",
+        card_name: "Snapshot Card",
+        card_set: "TPC",
+        card_img_file: "snap.jpg",
+        quantity: 3,
+        zone: "main",
+      },
+    ]);
+
+    expect(tournamentDecklists.update).toHaveBeenCalledWith({ published_deck_id: "new-deck-1" });
+  });
+
+  it("no submission and no live deck (deck_id null) skips the participant without erroring", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "host1" } } });
+
+    const tournaments = makeNode();
+    tournaments.single.mockResolvedValue({ data: { name: "Spring Open" }, error: null });
+    tournaments.maybeSingle.mockResolvedValue({ data: { id: "t1" }, error: null });
+    tournaments._resp = { data: null, error: null };
+
+    const tournamentDecklists = makeNode();
+    tournamentDecklists._resp = {
+      data: [
+        {
+          id: "dl1",
+          deck_id: null,
+          published_deck_id: null,
+          participant_id: "p1",
+          participants: { name: "Ghost" },
+        },
+      ],
+      error: null,
+    };
+
+    const participants = makeNode();
+    participants._resp = { data: null, error: null };
+
+    userClientImpl = makeClient({ tournaments, tournament_decklists: tournamentDecklists, participants });
+
+    mockBuildStateFromSupabase.mockResolvedValue(null); // no state -> placementMap stays empty, that's fine
+
+    const submissions = makeNode();
+    submissions._resp = { data: [], error: null };
+    const decks = makeNode();
+
+    adminImpl = makeClient({
+      tournament_deck_submissions: submissions,
+      decks,
+      tournament_decklists: tournamentDecklists,
+    });
+
+    const r = await publishTournamentDecklistsAction("t1", "Limited");
+
+    expect(r).toEqual({ success: true });
+    expect(decks.insert).not.toHaveBeenCalled();
+  });
+});

--- a/app/tracker/tournaments/actions.ts
+++ b/app/tracker/tournaments/actions.ts
@@ -1,9 +1,13 @@
 "use server";
 
-import { createClient } from "../../../utils/supabase/server";
-import { getSupabaseAdmin } from "../../../lib/pricing/supabase-admin";
-import { computeFinalStandings } from "../../../lib/tournament/standings";
-import { buildStateFromSupabase } from "../../../utils/tournament/stateAdapter";
+import { createClient } from "@/utils/supabase/server";
+import { getSupabaseAdmin } from "@/lib/pricing/supabase-admin";
+import { computeFinalStandings } from "@/lib/tournament/standings";
+import { buildStateFromSupabase } from "@/utils/tournament/stateAdapter";
+import { generateJoinCode } from "@/lib/tournament/joinCodes";
+import { buildDeckSubmission, type DeckSnapshot } from "@/lib/tournament/deckSubmission";
+import { normalizeTournamentFormat, type FormatId } from "@/lib/formats";
+import { checkDeck, type DeckCheckCard, type DeckCheckIssue } from "@/utils/deckcheck";
 
 // System user that owns published tournament deck copies
 const REDEMPTIONCCG_USER_ID = "a0a8e980-f372-4ebd-be25-d2f26507e98f";
@@ -14,18 +18,44 @@ function ordinal(n: number): string {
   return n + (s[(v - 20) % 10] || s[v] || s[0]);
 }
 
+// Reads on the default-deny tables (tournament_deck_submissions,
+// tournament_join_blocks) go through the admin client, which bypasses RLS
+// entirely — so authority must be proven first. A user-scoped read of the
+// tournament row only succeeds (RLS: host_can_access_tournaments) if the
+// caller IS the host; that's the proof.
+async function requireHost(tournamentId: string): Promise<{ userId: string } | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+  const { data: t } = await supabase
+    .from("tournaments")
+    .select("id")
+    .eq("id", tournamentId)
+    .maybeSingle();
+  return t ? { userId: user.id } : null;
+}
+
 // ─── Types ──────────────────────────────────────────────────────────
 
 export interface TournamentDecklistRow {
   id: string;
   tournament_id: string;
   participant_id: string;
-  deck_id: string;
+  deck_id: string | null;
   deck_name: string;
   deck_format: string | null;
   deck_card_count: number;
   preview_card_1: string | null;
   preview_card_2: string | null;
+  submission: {
+    deckName: string;
+    cardCount: number;
+    isLegal: boolean | null;
+    submittedAt: string;
+    source: "player" | "host";
+  } | null;
 }
 
 export interface DeckSearchResult {
@@ -66,17 +96,53 @@ export async function loadTournamentDecklistsAction(tournamentId: string) {
     return { success: false, error: error.message, decklists: [] };
   }
 
-  const decklists: TournamentDecklistRow[] = (data || []).map((row: any) => ({
-    id: row.id,
-    tournament_id: row.tournament_id,
-    participant_id: row.participant_id,
-    deck_id: row.deck_id,
-    deck_name: row.decks?.name || "Unknown",
-    deck_format: row.decks?.format || null,
-    deck_card_count: row.decks?.card_count || 0,
-    preview_card_1: row.decks?.preview_card_1 || null,
-    preview_card_2: row.decks?.preview_card_2 || null,
-  }));
+  // Submissions live in a default-deny table (host-only). Only merge them in
+  // for confirmed hosts; anyone else still gets the plain decklist rows.
+  const submissionMap = new Map<string, any>();
+  const host = await requireHost(tournamentId);
+  if (host) {
+    const admin = getSupabaseAdmin();
+    const { data: subs } = await admin
+      .from("tournament_deck_submissions")
+      .select("participant_id, deck_snapshot, is_legal, submitted_at, source")
+      .eq("tournament_id", tournamentId);
+    for (const s of subs ?? []) {
+      submissionMap.set(s.participant_id, s);
+    }
+  }
+
+  const decklists: TournamentDecklistRow[] = (data || []).map((row: any) => {
+    const sub = submissionMap.get(row.participant_id);
+    const snapshot = sub?.deck_snapshot as DeckSnapshot | undefined;
+    const cardCountFromSnapshot = snapshot
+      ? snapshot.cards.reduce((n, c) => n + c.quantity, 0)
+      : 0;
+    // The `decks` join fails when deck_id is null (deck deleted) or the deck
+    // is private and inaccessible under RLS. Fall back to the submission
+    // snapshot for name/count in that case rather than showing "Unknown".
+    const deckJoinFailed = !row.decks;
+
+    return {
+      id: row.id,
+      tournament_id: row.tournament_id,
+      participant_id: row.participant_id,
+      deck_id: row.deck_id,
+      deck_name: deckJoinFailed && snapshot ? snapshot.deckName : row.decks?.name || "Unknown",
+      deck_format: row.decks?.format || null,
+      deck_card_count: deckJoinFailed && snapshot ? cardCountFromSnapshot : row.decks?.card_count || 0,
+      preview_card_1: row.decks?.preview_card_1 || null,
+      preview_card_2: row.decks?.preview_card_2 || null,
+      submission: sub
+        ? {
+            deckName: snapshot?.deckName ?? "Deck",
+            cardCount: cardCountFromSnapshot,
+            isLegal: sub.is_legal,
+            submittedAt: sub.submitted_at,
+            source: sub.source,
+          }
+        : null,
+    };
+  });
 
   return { success: true, decklists };
 }
@@ -195,6 +261,76 @@ export async function attachDeckToParticipantAction(
     }
   }
 
+  // Record a host-side submission snapshot (default-deny table — admin
+  // client, gated on host authority). Best-effort: if the deck turns out to
+  // be private/inaccessible to the host, leave the tournament_decklists
+  // attach above intact and simply skip the snapshot.
+  const host = await requireHost(tournamentId);
+  if (host) {
+    const admin = getSupabaseAdmin();
+    const { data: tournament } = await supabase
+      .from("tournaments")
+      .select("deck_format")
+      .eq("id", tournamentId)
+      .maybeSingle();
+    const format = normalizeTournamentFormat(tournament?.deck_format);
+
+    let snapshot: DeckSnapshot | null = null;
+    let isLegal: boolean | null = null;
+    let issues: DeckCheckIssue[] | null = null;
+
+    if (format === null || format === "Other") {
+      // No declared tournament format -> a legality verdict would be
+      // meaningless. Still snapshot the cards so the host has a record.
+      const { data: deck } = await admin
+        .from("decks")
+        .select("name")
+        .eq("id", deckId)
+        .maybeSingle();
+      if (deck) {
+        const { data: rows } = await admin
+          .from("deck_cards")
+          .select("card_name, card_set, card_img_file, quantity, zone")
+          .eq("deck_id", deckId)
+          .in("zone", ["main", "reserve"]);
+        snapshot = {
+          deckName: deck.name ?? "Untitled Deck",
+          deckFormat: "",
+          cards: (rows ?? []).map((r: any) => ({
+            name: r.card_name,
+            set: r.card_set,
+            imgFile: r.card_img_file ?? null,
+            quantity: r.quantity,
+            zone: r.zone,
+          })),
+        };
+      }
+    } else {
+      const built = await buildDeckSubmission(admin, deckId, host.userId, format);
+      if (built.success === true) {
+        snapshot = built.snapshot;
+        isLegal = built.isLegal;
+        issues = built.issues;
+      }
+    }
+
+    if (snapshot) {
+      await admin.from("tournament_deck_submissions").upsert(
+        {
+          tournament_id: tournamentId,
+          participant_id: participantId,
+          deck_id: deckId,
+          submitted_by: host.userId,
+          source: "host",
+          deck_snapshot: snapshot,
+          is_legal: isLegal,
+          deckcheck_issues: issues && issues.length > 0 ? issues : null,
+        },
+        { onConflict: "participant_id" }
+      );
+    }
+  }
+
   return { success: true };
 }
 
@@ -203,16 +339,321 @@ export async function attachDeckToParticipantAction(
 export async function detachDeckFromParticipantAction(participantId: string) {
   const supabase = await createClient();
 
-  const { error } = await supabase
+  // Proof-of-delete: only when the user-scoped delete actually removed a row
+  // (i.e. RLS let it through because the caller is the host) do we touch the
+  // admin-only submissions table. Without this, any authenticated caller
+  // could pass an arbitrary participantId and admin-delete someone else's
+  // submission through this open server action.
+  const { data, error } = await supabase
     .from("tournament_decklists")
     .delete()
-    .eq("participant_id", participantId);
+    .eq("participant_id", participantId)
+    .select("tournament_id");
 
   if (error) {
     console.error("Error detaching deck:", error);
     return { success: false, error: error.message };
   }
 
+  if (!data || data.length === 0) {
+    return { success: false, error: "not_found" };
+  }
+
+  const admin = getSupabaseAdmin();
+  await admin.from("tournament_deck_submissions").delete().eq("participant_id", participantId);
+
+  return { success: true };
+}
+
+// ─── QR join controls ────────────────────────────────────────────────
+
+export async function setQrJoinEnabledAction(
+  tournamentId: string,
+  enabled: boolean
+): Promise<{ success: boolean; code?: string | null; error?: string }> {
+  const supabase = await createClient();
+
+  if (enabled === false) {
+    const { data, error } = await supabase
+      .from("tournaments")
+      .update({ code: null })
+      .eq("id", tournamentId)
+      .select("code")
+      .maybeSingle();
+    if (error) return { success: false, error: error.message };
+    // RLS makes a non-host's update touch zero rows -> data comes back null
+    // with no error. Treat that as "not found" (can't tell it apart from a
+    // truly missing tournament, which is fine — same response either way).
+    if (!data) return { success: false, error: "not_found" };
+    return { success: true, code: null };
+  }
+
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const code = generateJoinCode();
+    const { data, error } = await supabase
+      .from("tournaments")
+      .update({ code })
+      .eq("id", tournamentId)
+      .select("code")
+      .maybeSingle();
+    if (error) {
+      if (error.code === "23505") continue; // code collision — try another
+      return { success: false, error: error.message };
+    }
+    if (!data) return { success: false, error: "not_found" };
+    return { success: true, code: data.code };
+  }
+  return { success: false, error: "code_generation_failed" };
+}
+
+export async function updateJoinSettingsAction(
+  tournamentId: string,
+  s: { deckFormat: FormatId | "Other"; requireDecklists: boolean }
+): Promise<{ success: boolean; error?: string }> {
+  if (s.requireDecklists === true && s.deckFormat === "Other") {
+    return { success: false, error: "format_required" };
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("tournaments")
+    .update({ deck_format: s.deckFormat, require_decklists: s.requireDecklists })
+    .eq("id", tournamentId);
+
+  if (error) return { success: false, error: error.message };
+  return { success: true };
+}
+
+// ─── Final placements ────────────────────────────────────────────────
+//
+// participants.place is written in exactly one spot: here. Both a
+// results-only publish (setResultsPublishedAction) and a decklist publish
+// (publishTournamentDecklistsAction) need it computed and persisted, so it's
+// factored out rather than duplicated.
+
+async function persistFinalPlaces(tournamentId: string): Promise<Map<string, number>> {
+  const supabase = await createClient();
+  const placementMap = new Map<string, number>(); // participant_id → place
+
+  const state = await buildStateFromSupabase(supabase, tournamentId);
+  if (state) {
+    const standings = computeFinalStandings(state);
+    for (const placement of standings) {
+      placementMap.set(placement.participantId, placement.place);
+      await supabase
+        .from("participants")
+        .update({ place: placement.place })
+        .eq("id", placement.participantId);
+    }
+    // Dropped players are excluded from `standings` per algorithm.md
+    // ("no place value at all"). Clear any stale `place` left over from a
+    // prior publish so the data accurately reflects their dropped status.
+    await supabase
+      .from("participants")
+      .update({ place: null })
+      .eq("tournament_id", tournamentId)
+      .eq("dropped_out", true);
+  }
+
+  return placementMap;
+}
+
+// ─── Join stats ───────────────────────────────────────────────────────
+
+export async function getJoinStatsAction(
+  tournamentId: string
+): Promise<{ success: boolean; joined: number; submitted: number }> {
+  const host = await requireHost(tournamentId);
+  if (!host) return { success: false, joined: 0, submitted: 0 };
+
+  const supabase = await createClient();
+  const { count: joined } = await supabase
+    .from("participants")
+    .select("id", { count: "exact", head: true })
+    .eq("tournament_id", tournamentId);
+
+  const admin = getSupabaseAdmin();
+  const { count: submitted } = await admin
+    .from("tournament_deck_submissions")
+    .select("id", { count: "exact", head: true })
+    .eq("tournament_id", tournamentId);
+
+  return { success: true, joined: joined ?? 0, submitted: submitted ?? 0 };
+}
+
+// ─── Single submission (host review modal) ────────────────────────────
+
+export async function getSubmissionAction(
+  tournamentId: string,
+  participantId: string
+): Promise<{
+  success: boolean;
+  submission?: {
+    snapshot: DeckSnapshot;
+    isLegal: boolean | null;
+    issues: DeckCheckIssue[];
+    submittedAt: string;
+    source: "player" | "host";
+    submittedByUsername: string | null;
+  };
+  error?: string;
+}> {
+  const host = await requireHost(tournamentId);
+  if (!host) return { success: false, error: "not_found" };
+
+  const admin = getSupabaseAdmin();
+  const { data: sub, error } = await admin
+    .from("tournament_deck_submissions")
+    .select("deck_snapshot, is_legal, deckcheck_issues, submitted_at, source, submitted_by")
+    .eq("tournament_id", tournamentId)
+    .eq("participant_id", participantId)
+    .maybeSingle();
+
+  if (error) return { success: false, error: error.message };
+  if (!sub) return { success: false, error: "not_found" };
+
+  let submittedByUsername: string | null = null;
+  if (sub.submitted_by) {
+    const { data: profile } = await admin
+      .from("profiles")
+      .select("username")
+      .eq("id", sub.submitted_by)
+      .maybeSingle();
+    submittedByUsername = profile?.username ?? null;
+  }
+
+  return {
+    success: true,
+    submission: {
+      snapshot: sub.deck_snapshot as DeckSnapshot,
+      isLegal: sub.is_legal,
+      issues: (sub.deckcheck_issues as DeckCheckIssue[] | null) ?? [],
+      submittedAt: sub.submitted_at,
+      source: sub.source,
+      submittedByUsername,
+    },
+  };
+}
+
+// ─── Remove participant (with optional rejoin block) ───────────────────
+
+export async function removeParticipantWithBlockAction(
+  tournamentId: string,
+  participantId: string,
+  block: boolean
+): Promise<{ success: boolean; error?: string }> {
+  const host = await requireHost(tournamentId);
+  if (!host) return { success: false, error: "not_found" };
+
+  const admin = getSupabaseAdmin();
+  const { data: participant } = await admin
+    .from("participants")
+    .select("user_id")
+    .eq("id", participantId)
+    .eq("tournament_id", tournamentId)
+    .maybeSingle();
+
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("participants")
+    .delete()
+    .eq("id", participantId)
+    .eq("tournament_id", tournamentId);
+
+  if (error) return { success: false, error: error.message };
+
+  if (block === true && participant?.user_id != null) {
+    await admin
+      .from("tournament_join_blocks")
+      .upsert(
+        { tournament_id: tournamentId, user_id: participant.user_id },
+        { onConflict: "tournament_id,user_id", ignoreDuplicates: true }
+      );
+  }
+
+  return { success: true };
+}
+
+// ─── Recheck all submissions against current format ────────────────────
+
+export async function recheckAllSubmissionsAction(
+  tournamentId: string
+): Promise<{ success: boolean; rechecked: number; nowIllegal: number; error?: string }> {
+  const host = await requireHost(tournamentId);
+  if (!host) return { success: false, rechecked: 0, nowIllegal: 0, error: "not_found" };
+
+  const supabase = await createClient();
+  const { data: tournament } = await supabase
+    .from("tournaments")
+    .select("deck_format")
+    .eq("id", tournamentId)
+    .maybeSingle();
+
+  const format = normalizeTournamentFormat(tournament?.deck_format);
+  if (format === null || format === "Other") {
+    // No declared format -> a legality verdict is meaningless (same rule as
+    // host-attach). Nothing to recheck.
+    return { success: false, rechecked: 0, nowIllegal: 0, error: "format_required" };
+  }
+
+  const admin = getSupabaseAdmin();
+  const { data: subs, error } = await admin
+    .from("tournament_deck_submissions")
+    .select("id, deck_snapshot, is_legal")
+    .eq("tournament_id", tournamentId);
+
+  if (error) return { success: false, rechecked: 0, nowIllegal: 0, error: error.message };
+
+  let rechecked = 0;
+  let nowIllegal = 0;
+
+  for (const sub of subs ?? []) {
+    const snapshot = sub.deck_snapshot as DeckSnapshot;
+    const toCheckCard = (c: DeckSnapshot["cards"][number]): DeckCheckCard => ({
+      name: c.name,
+      set: c.set,
+      quantity: c.quantity,
+      imgFile: c.imgFile ?? undefined,
+    });
+    const main = snapshot.cards.filter((c) => c.zone === "main").map(toCheckCard);
+    const reserve = snapshot.cards.filter((c) => c.zone === "reserve").map(toCheckCard);
+    const result = await checkDeck(main, reserve, format);
+
+    if (sub.is_legal === true && result.valid === false) nowIllegal++;
+
+    await admin
+      .from("tournament_deck_submissions")
+      .update({
+        is_legal: result.valid,
+        deckcheck_issues: result.issues.length > 0 ? result.issues : null,
+      })
+      .eq("id", sub.id);
+
+    rechecked++;
+  }
+
+  return { success: true, rechecked, nowIllegal };
+}
+
+// ─── Publish / unpublish results ────────────────────────────────────────
+
+export async function setResultsPublishedAction(
+  tournamentId: string,
+  published: boolean
+): Promise<{ success: boolean; error?: string }> {
+  if (published === true) {
+    // Results page shows the Place column — compute + persist it here since
+    // this path may run without ever publishing decklists.
+    await persistFinalPlaces(tournamentId);
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("tournaments")
+    .update({ results_published: published })
+    .eq("id", tournamentId);
+
+  if (error) return { success: false, error: error.message };
   return { success: true };
 }
 
@@ -261,25 +702,22 @@ export async function publishTournamentDecklistsAction(
   // Uses the pure standings module so head-to-head tiebreakers are applied
   // (previous code only sorted by match_points then differential, which missed
   // the head-to-head step required by algorithm.md).
-  const placementMap = new Map<string, number>(); // participant_id → place
-  const state = await buildStateFromSupabase(supabase, tournamentId);
-  if (state) {
-    const standings = computeFinalStandings(state);
-    for (const placement of standings) {
-      placementMap.set(placement.participantId, placement.place);
-      await supabase
-        .from("participants")
-        .update({ place: placement.place })
-        .eq("id", placement.participantId);
+  const placementMap = await persistFinalPlaces(tournamentId);
+
+  // Submissions live in a default-deny table — admin client, so authority
+  // must be proven first. The tournament read above already proved it (RLS
+  // returned a row), but re-check explicitly right at the point of admin
+  // access so the gate is obvious and doesn't rely on code above staying put.
+  const host = await requireHost(tournamentId);
+  const submissionMap = new Map<string, any>();
+  if (host) {
+    const { data: subs } = await admin
+      .from("tournament_deck_submissions")
+      .select("participant_id, deck_snapshot, is_legal, deckcheck_issues")
+      .eq("tournament_id", tournamentId);
+    for (const s of subs ?? []) {
+      submissionMap.set(s.participant_id, s);
     }
-    // Dropped players are excluded from `standings` per algorithm.md
-    // ("no place value at all"). Clear any stale `place` left over from a
-    // prior publish so the data accurately reflects their dropped status.
-    await supabase
-      .from("participants")
-      .update({ place: null })
-      .eq("tournament_id", tournamentId)
-      .eq("dropped_out", true);
   }
 
   // Check if copies already exist (previous publish that was unpublished)
@@ -320,25 +758,96 @@ export async function publishTournamentDecklistsAction(
   // No existing copies — create them fresh
   for (const dl of decklists as any[]) {
     const participantName = dl.participants?.name || "Unknown";
+    const submission = submissionMap.get(dl.participant_id);
 
-    // Fetch original deck metadata. Carry is_legal/deckcheck_issues forward so
-    // PDF generation on the published copy renders the legal/illegal seal —
-    // the cards are copied 1:1, so legality is identical to the original.
-    const { data: origDeck } = await admin
-      .from("decks")
-      .select("name, description, format, paragon, preview_card_1, preview_card_2, card_count, is_legal, deckcheck_issues")
-      .eq("id", dl.deck_id)
-      .single();
+    // Snapshot-first: a submission is an immutable record of what the
+    // player/host actually entered, and survives the live deck being
+    // deleted or edited. Carry is_legal/deckcheck_issues forward so PDF
+    // generation on the published copy renders the legal/illegal seal.
+    // (Note: the published deck's `name` is always participant + place +
+    // tournament name, below — never the original/snapshot deck name, same
+    // as the pre-existing behavior.)
+    let deckMeta: {
+      description: string | null;
+      format: string | null;
+      paragon: string | null;
+      preview_card_1: string | null;
+      preview_card_2: string | null;
+      card_count: number;
+      is_legal: boolean | null;
+      deckcheck_issues: unknown;
+    };
+    let cardsToInsert: {
+      card_name: string;
+      card_set: string | null;
+      card_img_file: string | null;
+      quantity: number;
+      zone: string;
+    }[];
 
-    if (!origDeck) continue;
+    if (submission) {
+      const snapshot = submission.deck_snapshot as DeckSnapshot;
+      deckMeta = {
+        description: null,
+        format: snapshot.deckFormat || null,
+        paragon: null,
+        preview_card_1: null,
+        preview_card_2: null,
+        card_count: snapshot.cards.reduce((n, c) => n + c.quantity, 0),
+        is_legal: submission.is_legal ?? null,
+        deckcheck_issues: submission.deckcheck_issues ?? null,
+      };
+      cardsToInsert = snapshot.cards.map((c) => ({
+        card_name: c.name,
+        card_set: c.set || null,
+        card_img_file: c.imgFile || null,
+        quantity: c.quantity,
+        zone: c.zone,
+      }));
+    } else if (dl.deck_id !== null) {
+      // Fetch original deck metadata.
+      const { data: origDeck } = await admin
+        .from("decks")
+        .select("name, description, format, paragon, preview_card_1, preview_card_2, card_count, is_legal, deckcheck_issues")
+        .eq("id", dl.deck_id)
+        .single();
 
-    // Fetch original deck cards. Maybeboard rows are excluded from the
-    // tournament submission — only main + reserve get published.
-    const { data: origCards } = await admin
-      .from("deck_cards")
-      .select("card_name, card_set, card_img_file, quantity, zone")
-      .eq("deck_id", dl.deck_id)
-      .in("zone", ["main", "reserve"]);
+      if (!origDeck) continue;
+
+      // Fetch original deck cards. Maybeboard rows are excluded from the
+      // tournament submission — only main + reserve get published.
+      const { data: origCards } = await admin
+        .from("deck_cards")
+        .select("card_name, card_set, card_img_file, quantity, zone")
+        .eq("deck_id", dl.deck_id)
+        .in("zone", ["main", "reserve"]);
+
+      deckMeta = {
+        description: origDeck.description || null,
+        format: origDeck.format,
+        paragon: origDeck.paragon || null,
+        preview_card_1: origDeck.preview_card_1 || null,
+        preview_card_2: origDeck.preview_card_2 || null,
+        card_count: origDeck.card_count || 0,
+        is_legal: origDeck.is_legal ?? null,
+        deckcheck_issues: origDeck.deckcheck_issues ?? null,
+      };
+      cardsToInsert = (origCards ?? []).map((c: any) => ({
+        card_name: c.card_name,
+        card_set: c.card_set || null,
+        card_img_file: c.card_img_file || null,
+        quantity: c.quantity,
+        zone: c.zone,
+      }));
+    } else {
+      // Neither a submission snapshot nor a live deck (deck was deleted and
+      // this participant never submitted through the join flow) — nothing
+      // to publish for this participant.
+      console.warn(
+        `publishTournamentDecklistsAction: participant ${dl.participant_id} has neither a submission nor a live deck; skipping.`
+      );
+      continue;
+    }
 
     // Create copy owned by RedemptionCCG.app
     const place = placementMap.get(dl.participant_id);
@@ -349,15 +858,15 @@ export async function publishTournamentDecklistsAction(
       .insert({
         user_id: REDEMPTIONCCG_USER_ID,
         name: deckName,
-        description: origDeck.description || null,
-        format: deckFormat !== "Other" ? deckFormat : origDeck.format,
-        paragon: origDeck.paragon || null,
-        preview_card_1: origDeck.preview_card_1 || null,
-        preview_card_2: origDeck.preview_card_2 || null,
-        card_count: origDeck.card_count || 0,
+        description: deckMeta.description,
+        format: deckFormat !== "Other" ? deckFormat : deckMeta.format,
+        paragon: deckMeta.paragon,
+        preview_card_1: deckMeta.preview_card_1,
+        preview_card_2: deckMeta.preview_card_2,
+        card_count: deckMeta.card_count,
         visibility: "public",
-        is_legal: origDeck.is_legal ?? null,
-        deckcheck_issues: origDeck.deckcheck_issues ?? null,
+        is_legal: deckMeta.is_legal,
+        deckcheck_issues: deckMeta.deckcheck_issues,
       })
       .select("id")
       .single();
@@ -368,14 +877,10 @@ export async function publishTournamentDecklistsAction(
     }
 
     // Copy cards to the new deck
-    if (origCards && origCards.length > 0) {
-      const cardRows = origCards.map((c: any) => ({
+    if (cardsToInsert.length > 0) {
+      const cardRows = cardsToInsert.map((c) => ({
         deck_id: newDeck.id,
-        card_name: c.card_name,
-        card_set: c.card_set || null,
-        card_img_file: c.card_img_file || null,
-        quantity: c.quantity,
-        zone: c.zone,
+        ...c,
       }));
 
       await admin.from("deck_cards").insert(cardRows);

--- a/app/tracker/tournaments/actions.ts
+++ b/app/tracker/tournaments/actions.ts
@@ -227,6 +227,27 @@ export async function attachDeckToParticipantAction(
   participantId: string,
   deckId: string
 ) {
+  // Only the tournament's host may attach a deck, and participantId must
+  // actually belong to tournamentId. requireHost alone only proves the
+  // caller hosts SOME tournament (their own) — the admin upsert further
+  // below (onConflict: "participant_id") bypasses RLS entirely, so without
+  // this check a host of tournament T_a could pass a victim's participantId
+  // (participant UUIDs of published tournaments are publicly readable via
+  // migration 017's published-decklists policy) and repoint the victim's
+  // tournament_deck_submissions row at T_a, destroying that immutable
+  // record. Same pattern removeParticipantWithBlockAction already uses.
+  const host = await requireHost(tournamentId);
+  if (!host) return { success: false, error: "not_found" };
+
+  const admin = getSupabaseAdmin();
+  const { data: participant } = await admin
+    .from("participants")
+    .select("id")
+    .eq("id", participantId)
+    .eq("tournament_id", tournamentId)
+    .maybeSingle();
+  if (!participant) return { success: false, error: "not_found" };
+
   const supabase = await createClient();
 
   // Upsert: if participant already has a deck, replace it
@@ -234,6 +255,7 @@ export async function attachDeckToParticipantAction(
     .from("tournament_decklists")
     .select("id")
     .eq("participant_id", participantId)
+    .eq("tournament_id", tournamentId)
     .single();
 
   if (existing) {
@@ -262,83 +284,79 @@ export async function attachDeckToParticipantAction(
   }
 
   // Record a host-side submission snapshot (default-deny table — admin
-  // client, gated on host authority). Best-effort: if the deck turns out to
-  // be private/inaccessible to the host, leave the tournament_decklists
-  // attach above intact and simply skip the snapshot.
-  const host = await requireHost(tournamentId);
-  if (host) {
-    const admin = getSupabaseAdmin();
-    const { data: tournament } = await supabase
-      .from("tournaments")
-      .select("deck_format")
-      .eq("id", tournamentId)
+  // client, host authority already confirmed above). Best-effort: if the
+  // deck turns out to be private/inaccessible to the host, leave the
+  // tournament_decklists attach above intact and simply skip the snapshot.
+  const { data: tournament } = await supabase
+    .from("tournaments")
+    .select("deck_format")
+    .eq("id", tournamentId)
+    .maybeSingle();
+  const format = normalizeTournamentFormat(tournament?.deck_format);
+
+  let snapshot: DeckSnapshot | null = null;
+  let isLegal: boolean | null = null;
+  let issues: DeckCheckIssue[] | null = null;
+
+  if (format === null || format === "Other") {
+    // No declared tournament format -> a legality verdict would be
+    // meaningless, so we can't route this through buildDeckSubmission
+    // (which requires a FormatId). Still snapshot the cards so the host
+    // has a record — but this reads via the ADMIN client, which bypasses
+    // RLS entirely, so we must re-enforce the same access rule
+    // buildDeckSubmission enforces by hand (deckSubmission.ts:47-49):
+    // the requester must own the deck OR it must not be private. Without
+    // this, a host on a no-format tournament could attach ANY deck UUID
+    // (not just ones surfaced by searchDecksForTournamentAction) and read
+    // back a private deck's full card list via the submission snapshot.
+    const { data: deck } = await admin
+      .from("decks")
+      .select("name, user_id, visibility")
+      .eq("id", deckId)
       .maybeSingle();
-    const format = normalizeTournamentFormat(tournament?.deck_format);
-
-    let snapshot: DeckSnapshot | null = null;
-    let isLegal: boolean | null = null;
-    let issues: DeckCheckIssue[] | null = null;
-
-    if (format === null || format === "Other") {
-      // No declared tournament format -> a legality verdict would be
-      // meaningless, so we can't route this through buildDeckSubmission
-      // (which requires a FormatId). Still snapshot the cards so the host
-      // has a record — but this reads via the ADMIN client, which bypasses
-      // RLS entirely, so we must re-enforce the same access rule
-      // buildDeckSubmission enforces by hand (deckSubmission.ts:47-49):
-      // the requester must own the deck OR it must not be private. Without
-      // this, a host on a no-format tournament could attach ANY deck UUID
-      // (not just ones surfaced by searchDecksForTournamentAction) and read
-      // back a private deck's full card list via the submission snapshot.
-      const { data: deck } = await admin
-        .from("decks")
-        .select("name, user_id, visibility")
-        .eq("id", deckId)
-        .maybeSingle();
-      const isOwner = deck?.user_id === host.userId;
-      const isAccessible = !!deck && (isOwner || deck.visibility !== "private");
-      if (isAccessible && deck) {
-        const { data: rows } = await admin
-          .from("deck_cards")
-          .select("card_name, card_set, card_img_file, quantity, zone")
-          .eq("deck_id", deckId)
-          .in("zone", ["main", "reserve"]);
-        snapshot = {
-          deckName: deck.name ?? "Untitled Deck",
-          deckFormat: "",
-          cards: (rows ?? []).map((r: any) => ({
-            name: r.card_name,
-            set: r.card_set,
-            imgFile: r.card_img_file ?? null,
-            quantity: r.quantity,
-            zone: r.zone,
-          })),
-        };
-      }
-    } else {
-      const built = await buildDeckSubmission(admin, deckId, host.userId, format);
-      if (built.success === true) {
-        snapshot = built.snapshot;
-        isLegal = built.isLegal;
-        issues = built.issues;
-      }
+    const isOwner = deck?.user_id === host.userId;
+    const isAccessible = !!deck && (isOwner || deck.visibility !== "private");
+    if (isAccessible && deck) {
+      const { data: rows } = await admin
+        .from("deck_cards")
+        .select("card_name, card_set, card_img_file, quantity, zone")
+        .eq("deck_id", deckId)
+        .in("zone", ["main", "reserve"]);
+      snapshot = {
+        deckName: deck.name ?? "Untitled Deck",
+        deckFormat: "",
+        cards: (rows ?? []).map((r: any) => ({
+          name: r.card_name,
+          set: r.card_set,
+          imgFile: r.card_img_file ?? null,
+          quantity: r.quantity,
+          zone: r.zone,
+        })),
+      };
     }
-
-    if (snapshot) {
-      await admin.from("tournament_deck_submissions").upsert(
-        {
-          tournament_id: tournamentId,
-          participant_id: participantId,
-          deck_id: deckId,
-          submitted_by: host.userId,
-          source: "host",
-          deck_snapshot: snapshot,
-          is_legal: isLegal,
-          deckcheck_issues: issues && issues.length > 0 ? issues : null,
-        },
-        { onConflict: "participant_id" }
-      );
+  } else {
+    const built = await buildDeckSubmission(admin, deckId, host.userId, format);
+    if (built.success === true) {
+      snapshot = built.snapshot;
+      isLegal = built.isLegal;
+      issues = built.issues;
     }
+  }
+
+  if (snapshot) {
+    await admin.from("tournament_deck_submissions").upsert(
+      {
+        tournament_id: tournamentId,
+        participant_id: participantId,
+        deck_id: deckId,
+        submitted_by: host.userId,
+        source: "host",
+        deck_snapshot: snapshot,
+        is_legal: isLegal,
+        deckcheck_issues: issues && issues.length > 0 ? issues : null,
+      },
+      { onConflict: "participant_id" }
+    );
   }
 
   return { success: true };

--- a/app/tracker/tournaments/actions.ts
+++ b/app/tracker/tournaments/actions.ts
@@ -6,7 +6,7 @@ import { computeFinalStandings } from "@/lib/tournament/standings";
 import { buildStateFromSupabase } from "@/utils/tournament/stateAdapter";
 import { generateJoinCode } from "@/lib/tournament/joinCodes";
 import { buildDeckSubmission, type DeckSnapshot } from "@/lib/tournament/deckSubmission";
-import { normalizeTournamentFormat, type FormatId } from "@/lib/formats";
+import { normalizeTournamentFormat, FORMAT_IDS, type FormatId } from "@/lib/formats";
 import { checkDeck, type DeckCheckCard, type DeckCheckIssue } from "@/utils/deckcheck";
 
 // System user that owns published tournament deck copies
@@ -281,13 +281,23 @@ export async function attachDeckToParticipantAction(
 
     if (format === null || format === "Other") {
       // No declared tournament format -> a legality verdict would be
-      // meaningless. Still snapshot the cards so the host has a record.
+      // meaningless, so we can't route this through buildDeckSubmission
+      // (which requires a FormatId). Still snapshot the cards so the host
+      // has a record — but this reads via the ADMIN client, which bypasses
+      // RLS entirely, so we must re-enforce the same access rule
+      // buildDeckSubmission enforces by hand (deckSubmission.ts:47-49):
+      // the requester must own the deck OR it must not be private. Without
+      // this, a host on a no-format tournament could attach ANY deck UUID
+      // (not just ones surfaced by searchDecksForTournamentAction) and read
+      // back a private deck's full card list via the submission snapshot.
       const { data: deck } = await admin
         .from("decks")
-        .select("name")
+        .select("name, user_id, visibility")
         .eq("id", deckId)
         .maybeSingle();
-      if (deck) {
+      const isOwner = deck?.user_id === host.userId;
+      const isAccessible = !!deck && (isOwner || deck.visibility !== "private");
+      if (isAccessible && deck) {
         const { data: rows } = await admin
           .from("deck_cards")
           .select("card_name, card_set, card_img_file, quantity, zone")
@@ -410,6 +420,15 @@ export async function updateJoinSettingsAction(
   tournamentId: string,
   s: { deckFormat: FormatId | "Other"; requireDecklists: boolean }
 ): Promise<{ success: boolean; error?: string }> {
+  // The declared type is FormatId | "Other", but nothing stops a caller from
+  // bypassing TS and passing an arbitrary string. normalizeTournamentFormat
+  // maps things like "Sealed"/"Draft" to 'Other' and unrecognized junk to
+  // 'Limited', so comparing the raw input against the literal "Other" below
+  // is only safe once we've confirmed it's actually one of the real ids.
+  const isValidFormat = s.deckFormat === "Other" || (FORMAT_IDS as readonly string[]).includes(s.deckFormat);
+  if (!isValidFormat) {
+    return { success: false, error: "invalid_format" };
+  }
   if (s.requireDecklists === true && s.deckFormat === "Other") {
     return { success: false, error: "format_required" };
   }

--- a/app/tracker/tournaments/page.tsx
+++ b/app/tracker/tournaments/page.tsx
@@ -9,7 +9,7 @@ import { Button } from "../../../components/ui/button";
 import { HiPencil, HiTrash, HiPlus, HiOutlineDesktopComputer } from "react-icons/hi";
 import { useRouter, useSearchParams } from "next/navigation";
 import TournamentFormModal from "../../../components/ui/tournament-form-modal";
-import { categoryDefaults } from "../../../utils/tournament/categoryDefaults";
+import { categoryDefaults, requireDecklistsDefault } from "../../../utils/tournament/categoryDefaults";
 import { getFormatDef } from "@/lib/formats";
 
 const supabase = createClient();
@@ -24,7 +24,7 @@ function TournamentsPageInner() {
     useState(false);
   const [currentTournament, setCurrentTournament] = useState(null);
   const [newTournamentName, setNewTournamentName] = useState("");
-  const [prefillName, setPrefillName] = useState("");
+  const [listingCity, setListingCity] = useState("");
   const [fromListingId, setFromListingId] = useState<string | null>(null);
   const [listingFormats, setListingFormats] = useState<string[]>([]);
   const router = useRouter();
@@ -37,10 +37,10 @@ function TournamentsPageInner() {
 
     // Auto-open modal if coming from "Host This Event" on /tournaments
     const listingId = searchParams.get("from_listing");
-    const name = searchParams.get("name");
+    const city = searchParams.get("city");
     const formats = searchParams.get("formats");
-    if (listingId && name) {
-      setPrefillName(name);
+    if (listingId) {
+      setListingCity(city ?? "");
       setFromListingId(listingId);
       setListingFormats(formats ? formats.split("|").filter(Boolean) : []);
       setisAddTournamentModalOpen(true);
@@ -94,6 +94,7 @@ function TournamentsPageInner() {
         // host can still change later in Tournament Settings.
         if (category) {
           row.category = category;
+          row.require_decklists = requireDecklistsDefault(category);
           const defaults = categoryDefaults(category);
           row.deck_format = defaults.deck_format;
           row.max_score = defaults.max_score;
@@ -117,7 +118,6 @@ function TournamentsPageInner() {
             .update({ linked_tournament_id: data[0].id })
             .eq("id", fromListingId);
           setFromListingId(null);
-          setPrefillName("");
           setListingFormats([]);
           // Clean up URL params
           router.replace("/tracker/tournaments", { scroll: false });
@@ -132,9 +132,15 @@ function TournamentsPageInner() {
 
   // Open the create modal pre-targeted at an existing event's listing so the
   // host can add a category that was played later (or skipped on the day).
-  const openHostAnotherCategory = (listingId: string, baseName: string) => {
+  // Names are generated ("Aug 2, 2026 Type 2 Tournament — Wichita"), so the
+  // city is pulled off an existing sibling's name to match the new category's
+  // generated name to the rest of the event. Note: the generated date is
+  // today's, not the original event date — a category added after the fact
+  // carries the date it was created.
+  const openHostAnotherCategory = (listingId: string, group: any[]) => {
     setFromListingId(listingId);
-    setPrefillName(baseName);
+    const city = group[0]?.name?.split(" — ")[1] ?? "";
+    setListingCity(city);
     setListingFormats([]);
     setisAddTournamentModalOpen(true);
   };
@@ -327,13 +333,13 @@ function TournamentsPageInner() {
               setisAddTournamentModalOpen(false);
               if (fromListingId) {
                 setFromListingId(null);
-                setPrefillName("");
+                setListingCity("");
                 setListingFormats([]);
                 router.replace("/tracker/tournaments", { scroll: false });
               }
             }}
             onSubmit={handleAddTournament}
-            defaultName={prefillName}
+            listingCity={listingCity}
             categoryOptions={listingFormats.length > 0 ? listingFormats : undefined}
           />
         </div>
@@ -371,7 +377,7 @@ function TournamentsPageInner() {
                   <Button
                     variant="outline"
                     onClick={() =>
-                      openHostAnotherCategory(listingId, group[0].name)
+                      openHostAnotherCategory(listingId, group)
                     }
                     className="flex items-center gap-1.5 flex-shrink-0 text-xs px-2.5 py-1.5"
                   >

--- a/app/tracker/tournaments/page.tsx
+++ b/app/tracker/tournaments/page.tsx
@@ -118,6 +118,7 @@ function TournamentsPageInner() {
             .update({ linked_tournament_id: data[0].id })
             .eq("id", fromListingId);
           setFromListingId(null);
+          setListingCity("");
           setListingFormats([]);
           // Clean up URL params
           router.replace("/tracker/tournaments", { scroll: false });
@@ -139,7 +140,10 @@ function TournamentsPageInner() {
   // carries the date it was created.
   const openHostAnotherCategory = (listingId: string, group: any[]) => {
     setFromListingId(listingId);
-    const city = group[0]?.name?.split(" — ")[1] ?? "";
+    // Not every sibling's name necessarily carries a city (Unofficial /
+    // pre-feature names don't), so check the whole group, not just the most
+    // recent one.
+    const city = group.map((t) => t.name?.split(" — ")[1]).find(Boolean) ?? "";
     setListingCity(city);
     setListingFormats([]);
     setisAddTournamentModalOpen(true);

--- a/components/ui/EndTournamentDialog.tsx
+++ b/components/ui/EndTournamentDialog.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { AlertTriangle } from "lucide-react";
 import { Button } from "./button";
+import { Checkbox } from "./checkbox";
 import {
   Dialog,
   DialogBody,
@@ -18,7 +19,7 @@ interface EndTournamentDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   tournamentName: string;
-  onConfirm: () => Promise<void> | void;
+  onConfirm: (publish: boolean) => Promise<void> | void;
   isEnding?: boolean;
 }
 
@@ -44,6 +45,9 @@ export function EndTournamentDialog({
   isEnding = false,
 }: EndTournamentDialogProps) {
   const [typed, setTyped] = useState("");
+  // Publishing is opt-out, not opt-in — checked by default so ending a
+  // tournament publishes results + decklists unless the host unchecks it.
+  const [publish, setPublish] = useState(true);
   const matches =
     typed.trim().toLowerCase() === tournamentName.trim().toLowerCase();
   // Only nag once the user has actually typed something — don't yell at
@@ -53,7 +57,10 @@ export function EndTournamentDialog({
   // Reset the input every time the dialog opens so a previous attempt
   // doesn't pre-fill the confirmation gate.
   useEffect(() => {
-    if (open) setTyped("");
+    if (open) {
+      setTyped("");
+      setPublish(true);
+    }
   }, [open]);
 
   return (
@@ -108,6 +115,18 @@ export function EndTournamentDialog({
               enable End tournament.
             </p>
           )}
+          <p className="text-sm text-muted-foreground pt-1">
+            Results and decklists publish automatically when the event ends.
+          </p>
+          <label className="flex items-start gap-2 text-sm">
+            <Checkbox
+              checked={publish}
+              onCheckedChange={(v) => setPublish(v === true)}
+              disabled={isEnding}
+              className="mt-0.5"
+            />
+            <span>Publish results and decklists</span>
+          </label>
         </DialogBody>
         <DialogFooter className="justify-end">
           <Button
@@ -120,7 +139,7 @@ export function EndTournamentDialog({
           <Button
             variant="destructive"
             disabled={!matches || isEnding}
-            onClick={onConfirm}
+            onClick={() => onConfirm(publish)}
           >
             {isEnding ? "Ending…" : "End tournament"}
           </Button>

--- a/components/ui/ParticipantTable.tsx
+++ b/components/ui/ParticipantTable.tsx
@@ -70,6 +70,10 @@ const ParticipantTable: React.FC<ParticipantTableProps> = ({
   const [deleteTarget, setDeleteTarget] = useState<Participant | null>(null);
   const [removeBlockTarget, setRemoveBlockTarget] = useState<Participant | null>(null);
   const [submissionTarget, setSubmissionTarget] = useState<Participant | null>(null);
+  // Detaching a player-submitted decklist deletes the immutable submission
+  // record (spec §8) — that needs a confirmation step. Detaching a
+  // host-attached deck (no submission) stays a single click.
+  const [detachSubmissionTarget, setDetachSubmissionTarget] = useState<Participant | null>(null);
   const [toast, setToast] = useState<{
     message: string;
     show: boolean;
@@ -255,7 +259,9 @@ const ParticipantTable: React.FC<ParticipantTableProps> = ({
             {sub ? sub.cardCount : linkedDeck.deck_card_count}c
           </span>
           <button
-            onClick={() => handleDetachDeck(participant.id)}
+            onClick={() =>
+              sub ? setDetachSubmissionTarget(participant) : handleDetachDeck(participant.id)
+            }
             className="p-1 -m-0.5 rounded text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors flex-shrink-0"
             title="Remove deck"
             aria-label={`Remove deck from ${participant.name}`}
@@ -460,6 +466,22 @@ const ParticipantTable: React.FC<ParticipantTableProps> = ({
         title={deleteTarget ? `Delete ${deleteTarget.name}?` : ""}
         description="This permanently removes them from the tournament."
         confirmLabel="Delete"
+        cancelLabel="Cancel"
+      />
+
+      {/* Detach on a player-submitted row deletes the immutable submission
+          record (spec §8) — unlike a host-attached deck, that needs a
+          confirmation step. */}
+      <ConfirmationDialog
+        open={detachSubmissionTarget !== null}
+        onOpenChange={(open) => { if (!open) setDetachSubmissionTarget(null); }}
+        onConfirm={() => {
+          if (detachSubmissionTarget) handleDetachDeck(detachSubmissionTarget.id);
+        }}
+        variant="destructive"
+        title={detachSubmissionTarget ? `Remove ${detachSubmissionTarget.name}'s deck?` : ""}
+        description="This player submitted this decklist themselves. Removing it deletes their submitted record — this cannot be undone."
+        confirmLabel="Remove deck"
         cancelLabel="Cancel"
       />
 

--- a/components/ui/ParticipantTable.tsx
+++ b/components/ui/ParticipantTable.tsx
@@ -1,11 +1,19 @@
 import React, { useMemo, useState } from "react";
 import { Table } from "flowbite-react";
 import { HiPencil, HiTrash } from "react-icons/hi";
-import { BookOpen, CircleMinus, CirclePlus, Crown, Link2Off } from "lucide-react";
+import { BookOpen, CircleMinus, CirclePlus, Crown, Link2Off, RefreshCw } from "lucide-react";
 import AttachDeckDialog from "./AttachDeckDialog";
 import type { TournamentDecklistRow, DeckSearchResult } from "../../app/tracker/tournaments/actions";
-import { attachDeckToParticipantAction, detachDeckFromParticipantAction } from "../../app/tracker/tournaments/actions";
+import {
+  attachDeckToParticipantAction,
+  detachDeckFromParticipantAction,
+  recheckAllSubmissionsAction,
+  removeParticipantWithBlockAction,
+} from "../../app/tracker/tournaments/actions";
 import ConfirmationDialog from "./confirmation-dialog";
+import SubmissionModal, { LegalityDot } from "./SubmissionModal";
+import ToastNotification from "./toast-notification";
+import { Dialog, DialogContent, DialogHeader, DialogFooter } from "./dialog";
 
 interface Participant {
   id: string;
@@ -14,6 +22,7 @@ interface Participant {
   differential: number;
   dropped_out: boolean;
   assigned_seat?: number | null;
+  user_id?: string | null;
 }
 
 interface ParticipantTableProps {
@@ -31,6 +40,11 @@ interface ParticipantTableProps {
   decklists: TournamentDecklistRow[];
   onDecklistsChange: () => void;
   numberingMode: "tables" | "seats";
+  // participant.user_id -> profiles.username, batched once on the page.
+  usernames?: Map<string, string>;
+  isHost?: boolean;
+  // Refreshes the participant roster — used after Remove & block deletes a row.
+  fetchParticipants?: () => void;
 }
 
 const ParticipantTable: React.FC<ParticipantTableProps> = ({
@@ -46,11 +60,28 @@ const ParticipantTable: React.FC<ParticipantTableProps> = ({
   decklists,
   onDecklistsChange,
   numberingMode,
+  usernames = new Map(),
+  isHost = false,
+  fetchParticipants,
 }) => {
   const [attachDialogOpen, setAttachDialogOpen] = useState(false);
   const [attachTarget, setAttachTarget] = useState<Participant | null>(null);
   const [dropTarget, setDropTarget] = useState<Participant | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Participant | null>(null);
+  const [removeBlockTarget, setRemoveBlockTarget] = useState<Participant | null>(null);
+  const [submissionTarget, setSubmissionTarget] = useState<Participant | null>(null);
+  const [toast, setToast] = useState<{
+    message: string;
+    show: boolean;
+    type?: "success" | "error" | "warning" | "info";
+  }>({ message: "", show: false, type: "success" });
+
+  const showToast = (
+    message: string,
+    type: "success" | "error" | "warning" | "info" = "success"
+  ) => {
+    setToast({ message, show: true, type });
+  };
 
   const decklistMap = useMemo(() => {
     const map = new Map<string, TournamentDecklistRow>();
@@ -101,6 +132,41 @@ const ParticipantTable: React.FC<ParticipantTableProps> = ({
     }
   }
 
+  async function handleRemoveWithBlock(participant: Participant, block: boolean) {
+    setRemoveBlockTarget(null);
+    const result = await removeParticipantWithBlockAction(tournamentId, participant.id, block);
+    if (result.success) {
+      fetchParticipants?.();
+      showToast(
+        block
+          ? `Removed ${participant.name} and blocked their account from rejoining.`
+          : `Removed ${participant.name}.`,
+        "success"
+      );
+    } else {
+      showToast("Error removing participant.", "error");
+    }
+  }
+
+  // Season-boundary tool (spec §7): re-validates every submission against the
+  // tournament's current format. No declared format -> no legality verdict is
+  // possible, which the action reports as "format_required" — that's expected
+  // configuration state, not a failure, so it gets an informational toast.
+  async function handleRecheckAll() {
+    const result = await recheckAllSubmissionsAction(tournamentId);
+    if (result.success) {
+      showToast(
+        `${result.rechecked} re-checked, ${result.nowIllegal} now illegal`,
+        result.nowIllegal > 0 ? "warning" : "success"
+      );
+      onDecklistsChange();
+    } else if (result.error === "format_required") {
+      showToast("Set a format for this tournament first, then re-check decklists.", "info");
+    } else {
+      showToast("Error re-checking decklists.", "error");
+    }
+  }
+
   function renderActionButtons(participant: Participant) {
     return (
       <div className="flex items-center gap-1">
@@ -133,7 +199,11 @@ const ParticipantTable: React.FC<ParticipantTableProps> = ({
           )
         ) : (
           <button
-            onClick={() => setDeleteTarget(participant)}
+            onClick={() =>
+              participant.user_id != null
+                ? setRemoveBlockTarget(participant)
+                : setDeleteTarget(participant)
+            }
             className="p-2 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 touch-manipulation transition-colors"
             aria-label={`Delete ${participant.name}`}
             title="Remove participant"
@@ -148,19 +218,41 @@ const ParticipantTable: React.FC<ParticipantTableProps> = ({
   function renderDeckCell(participant: Participant) {
     const linkedDeck = decklistMap.get(participant.id);
     if (linkedDeck) {
+      const sub = linkedDeck.submission;
+      // The `decks` join fails when deck_id is null (deleted) or private/
+      // inaccessible — loadTournamentDecklistsAction then falls back
+      // deck_name to the literal "Unknown". Only link out when there's an
+      // actual deck to land on.
+      const linkable = linkedDeck.deck_id != null && linkedDeck.deck_name !== "Unknown";
+
       return (
         <div className="flex items-center gap-2 min-w-0">
-          <a
-            href={`/decklist/${linkedDeck.deck_id}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm text-primary hover:underline truncate"
-            title={linkedDeck.deck_name}
-          >
-            {linkedDeck.deck_name}
-          </a>
+          {sub ? (
+            <button
+              onClick={() => setSubmissionTarget(participant)}
+              className="flex items-center gap-1.5 min-w-0 text-sm text-foreground hover:text-primary transition-colors"
+              title={`${sub.deckName} — view submission`}
+            >
+              <LegalityDot isLegal={sub.isLegal} />
+              <span className="truncate">{sub.deckName}</span>
+            </button>
+          ) : linkable ? (
+            <a
+              href={`/decklist/${linkedDeck.deck_id}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-primary hover:underline truncate"
+              title={linkedDeck.deck_name}
+            >
+              {linkedDeck.deck_name}
+            </a>
+          ) : (
+            <span className="text-sm text-muted-foreground truncate" title={linkedDeck.deck_name}>
+              {linkedDeck.deck_name}
+            </span>
+          )}
           <span className="text-xs text-muted-foreground tabular-nums flex-shrink-0">
-            {linkedDeck.deck_card_count}c
+            {sub ? sub.cardCount : linkedDeck.deck_card_count}c
           </span>
           <button
             onClick={() => handleDetachDeck(participant.id)}
@@ -187,8 +279,21 @@ const ParticipantTable: React.FC<ParticipantTableProps> = ({
     );
   }
 
+  const hasAnySubmission = decklists.some((dl) => dl.submission !== null);
+
   return (
     <>
+      {isHost && hasAnySubmission && (
+        <div className="mb-3 flex justify-end">
+          <button
+            onClick={handleRecheckAll}
+            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-primary transition-colors"
+          >
+            <RefreshCw className="w-3.5 h-3.5" />
+            Re-check all decklists
+          </button>
+        </div>
+      )}
       {/* Mobile card list */}
       <ul className="md:hidden space-y-2">
         {sortedParticipants.map((participant) => {
@@ -211,6 +316,14 @@ const ParticipantTable: React.FC<ParticipantTableProps> = ({
                     <span className="font-medium text-foreground truncate">
                       {participant.name}
                     </span>
+                    {participant.user_id != null && usernames.get(participant.user_id) && (
+                      <span
+                        className="text-xs text-muted-foreground flex-shrink-0"
+                        title={`Joined via QR with account @${usernames.get(participant.user_id)}`}
+                      >
+                        @{usernames.get(participant.user_id)}
+                      </span>
+                    )}
                     {participant.dropped_out && (
                       <span className="text-destructive text-[11px] flex-shrink-0 uppercase tracking-wide">
                         Dropped
@@ -281,6 +394,14 @@ const ParticipantTable: React.FC<ParticipantTableProps> = ({
                         <Crown className="w-4 h-4 text-orange-300 flex-shrink-0" />
                       )}
                       <span className="truncate">{participant.name}</span>
+                      {participant.user_id != null && usernames.get(participant.user_id) && (
+                        <span
+                          className="text-xs text-muted-foreground flex-shrink-0"
+                          title={`Joined via QR with account @${usernames.get(participant.user_id)}`}
+                        >
+                          @{usernames.get(participant.user_id)}
+                        </span>
+                      )}
                       {participant.dropped_out && (
                         <span className="text-destructive text-[11px] flex-shrink-0 uppercase tracking-wide">Dropped</span>
                       )}
@@ -340,6 +461,61 @@ const ParticipantTable: React.FC<ParticipantTableProps> = ({
         description="This permanently removes them from the tournament."
         confirmLabel="Delete"
         cancelLabel="Cancel"
+      />
+
+      {/* Remove & block — user-linked rows only. ConfirmationDialog only
+          supports a single confirm action, so this is a bespoke two-button
+          confirm built from the same Dialog primitives. */}
+      <Dialog
+        open={removeBlockTarget !== null}
+        onOpenChange={(open) => { if (!open) setRemoveBlockTarget(null); }}
+      >
+        <DialogContent size="md">
+          <DialogHeader className="bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800">
+            <h3 className="text-lg font-semibold text-foreground">
+              {removeBlockTarget ? `Remove ${removeBlockTarget.name}?` : ""}
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              This permanently removes them from the tournament. They joined with a linked
+              account — you can also block that account from rejoining this event.
+            </p>
+          </DialogHeader>
+          <DialogFooter className="justify-end flex-wrap">
+            <button
+              onClick={() => setRemoveBlockTarget(null)}
+              className="px-4 py-2 text-sm font-medium text-foreground bg-card border border-border rounded-lg hover:bg-muted transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={() => removeBlockTarget && handleRemoveWithBlock(removeBlockTarget, false)}
+              className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-lg transition-colors"
+            >
+              Remove
+            </button>
+            <button
+              onClick={() => removeBlockTarget && handleRemoveWithBlock(removeBlockTarget, true)}
+              className="px-4 py-2 text-sm font-medium text-white bg-red-800 hover:bg-red-900 rounded-lg transition-colors"
+            >
+              Remove &amp; block
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <SubmissionModal
+        open={submissionTarget !== null}
+        onOpenChange={(open) => { if (!open) setSubmissionTarget(null); }}
+        tournamentId={tournamentId}
+        participantId={submissionTarget?.id ?? null}
+        participantName={submissionTarget?.name ?? ""}
+      />
+
+      <ToastNotification
+        message={toast.message}
+        show={toast.show}
+        type={toast.type}
+        onClose={() => setToast((prev) => ({ ...prev, show: false }))}
       />
     </>
   );

--- a/components/ui/PublishDecklistsSection.tsx
+++ b/components/ui/PublishDecklistsSection.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { BookOpen, Globe, Undo2 } from "lucide-react";
+import Link from "next/link";
+import { BookOpen, Globe, Trophy, Undo2 } from "lucide-react";
 import { Button } from "./button";
 import {
   Dialog,
@@ -12,7 +13,11 @@ import {
   DialogBody,
   DialogFooter,
 } from "./dialog";
-import { publishTournamentDecklistsAction, unpublishTournamentDecklistsAction } from "../../app/tracker/tournaments/actions";
+import {
+  publishTournamentDecklistsAction,
+  unpublishTournamentDecklistsAction,
+  setResultsPublishedAction,
+} from "../../app/tracker/tournaments/actions";
 
 interface PublishDecklistsSectionProps {
   tournamentId: string;
@@ -20,6 +25,7 @@ interface PublishDecklistsSectionProps {
   decklistCount: number;
   isPublished: boolean;
   currentFormat: string | null;
+  resultsPublished: boolean;
   onPublishChange: () => void;
 }
 
@@ -29,15 +35,17 @@ export default function PublishDecklistsSection({
   decklistCount,
   isPublished,
   currentFormat,
+  resultsPublished,
   onPublishChange,
 }: PublishDecklistsSectionProps) {
   const [showDialog, setShowDialog] = useState(false);
   const [selectedFormat, setSelectedFormat] = useState(currentFormat || "Limited");
   const [publishing, setPublishing] = useState(false);
   const [unpublishing, setUnpublishing] = useState(false);
+  const [togglingResults, setTogglingResults] = useState(false);
 
-  // Don't show if tournament hasn't ended or no decklists attached
-  if (!tournamentEnded || decklistCount === 0) return null;
+  // Don't show if tournament hasn't ended
+  if (!tournamentEnded) return null;
 
   async function handlePublish() {
     setPublishing(true);
@@ -58,53 +66,117 @@ export default function PublishDecklistsSection({
     }
   }
 
+  async function handleToggleResults() {
+    setTogglingResults(true);
+    const result = await setResultsPublishedAction(tournamentId, !resultsPublished);
+    setTogglingResults(false);
+    if (result.success) {
+      onPublishChange();
+    }
+  }
+
+  const resultsRow = resultsPublished ? (
+    <div className="flex items-center gap-3 px-4 py-3 bg-primary/5 border border-primary/20 rounded-lg">
+      <Trophy className="w-4 h-4 text-primary flex-shrink-0" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium">Results published</p>
+        <Link
+          href={`/tournaments/results/${tournamentId}`}
+          className="text-xs text-primary hover:underline"
+        >
+          View public results page
+        </Link>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleToggleResults}
+        disabled={togglingResults}
+        className="flex-shrink-0 gap-1.5"
+      >
+        <Undo2 className="w-3.5 h-3.5" />
+        {togglingResults ? "Unpublishing..." : "Unpublish"}
+      </Button>
+    </div>
+  ) : (
+    <div className="flex items-center gap-3 px-4 py-3 bg-muted/50 border border-border rounded-lg">
+      <Trophy className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium">Results private</p>
+        <p className="text-xs text-muted-foreground">
+          Publish to show final standings on a public results page
+        </p>
+      </div>
+      <Button
+        variant="success"
+        size="sm"
+        onClick={handleToggleResults}
+        disabled={togglingResults}
+        className="flex-shrink-0 gap-1.5"
+      >
+        <Globe className="w-3.5 h-3.5" />
+        {togglingResults ? "Publishing..." : "Publish"}
+      </Button>
+    </div>
+  );
+
+  if (decklistCount === 0) {
+    return <div className="space-y-2">{resultsRow}</div>;
+  }
+
   if (isPublished) {
     return (
-      <div className="flex items-center gap-3 px-4 py-3 bg-primary/5 border border-primary/20 rounded-lg">
-        <Globe className="w-4 h-4 text-primary flex-shrink-0" />
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium">
-            {decklistCount} {decklistCount === 1 ? "decklist" : "decklists"} published
-          </p>
-          <p className="text-xs text-muted-foreground">
-            Visible on community decks page · {currentFormat || "Limited"}
-          </p>
+      <div className="space-y-2">
+        {resultsRow}
+        <div className="flex items-center gap-3 px-4 py-3 bg-primary/5 border border-primary/20 rounded-lg">
+          <Globe className="w-4 h-4 text-primary flex-shrink-0" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium">
+              {decklistCount} {decklistCount === 1 ? "decklist" : "decklists"} published
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Visible on community decks page · {currentFormat || "Limited"}
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleUnpublish}
+            disabled={unpublishing}
+            className="flex-shrink-0 gap-1.5"
+          >
+            <Undo2 className="w-3.5 h-3.5" />
+            {unpublishing ? "Unpublishing..." : "Unpublish"}
+          </Button>
         </div>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={handleUnpublish}
-          disabled={unpublishing}
-          className="flex-shrink-0 gap-1.5"
-        >
-          <Undo2 className="w-3.5 h-3.5" />
-          {unpublishing ? "Unpublishing..." : "Unpublish"}
-        </Button>
       </div>
     );
   }
 
   return (
     <>
-      <div className="flex items-center gap-3 px-4 py-3 bg-muted/50 border border-border rounded-lg">
-        <BookOpen className="w-4 h-4 text-muted-foreground flex-shrink-0" />
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium">
-            {decklistCount} {decklistCount === 1 ? "decklist" : "decklists"} attached
-          </p>
-          <p className="text-xs text-muted-foreground">
-            Publish to make them visible on the community decks page
-          </p>
+      <div className="space-y-2">
+        {resultsRow}
+        <div className="flex items-center gap-3 px-4 py-3 bg-muted/50 border border-border rounded-lg">
+          <BookOpen className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium">
+              {decklistCount} {decklistCount === 1 ? "decklist" : "decklists"} attached
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Publish to make them visible on the community decks page
+            </p>
+          </div>
+          <Button
+            variant="success"
+            size="sm"
+            onClick={() => setShowDialog(true)}
+            className="flex-shrink-0 gap-1.5"
+          >
+            <Globe className="w-3.5 h-3.5" />
+            Publish All
+          </Button>
         </div>
-        <Button
-          variant="success"
-          size="sm"
-          onClick={() => setShowDialog(true)}
-          className="flex-shrink-0 gap-1.5"
-        >
-          <Globe className="w-3.5 h-3.5" />
-          Publish All
-        </Button>
       </div>
 
       <Dialog open={showDialog} onOpenChange={setShowDialog}>

--- a/components/ui/QRJoinDialog.tsx
+++ b/components/ui/QRJoinDialog.tsx
@@ -44,8 +44,14 @@ const ERROR_MESSAGES: Record<string, string> = {
   format_required: "Choose a specific format before requiring decklists.",
 };
 
+// Shown when a server action throws outright (network drop, expired
+// session, uncaught server exception) instead of resolving to
+// {success:false, error} — and reused as friendlyError()'s fallback for any
+// error code that isn't one of the known ones above.
+const GENERIC_ERROR_MESSAGE = "Something went wrong — try again.";
+
 function friendlyError(code: string): string {
-  return ERROR_MESSAGES[code] ?? "Something went wrong. Please try again.";
+  return ERROR_MESSAGES[code] ?? GENERIC_ERROR_MESSAGE;
 }
 
 function initialFormat(tournament: QRJoinTournament): FormatId | "Other" {
@@ -123,61 +129,92 @@ export default function QRJoinDialog({
   async function handleEnable() {
     setSaving(true);
     setError(null);
-    const settingsRes = await updateJoinSettingsAction(tournament.id, {
-      deckFormat,
-      requireDecklists,
-    });
-    if (settingsRes.success === false) {
-      setError(friendlyError(settingsRes.error ?? ""));
+    try {
+      const settingsRes = await updateJoinSettingsAction(tournament.id, {
+        deckFormat,
+        requireDecklists,
+      });
+      if (settingsRes.success === false) {
+        setError(friendlyError(settingsRes.error ?? ""));
+        return;
+      }
+      const enableRes = await setQrJoinEnabledAction(tournament.id, true);
+      if (enableRes.success === false) {
+        setError(friendlyError(enableRes.error ?? ""));
+        return;
+      }
+      onTournamentUpdated();
+    } catch {
+      // Server actions can throw outright (network drop, expired session,
+      // uncaught server exception) rather than resolving to {success:false}.
+      // Without this catch, `saving` never gets reset and the dialog locks
+      // up for the rest of the session.
+      setError(GENERIC_ERROR_MESSAGE);
+    } finally {
       setSaving(false);
-      return;
     }
-    const enableRes = await setQrJoinEnabledAction(tournament.id, true);
-    setSaving(false);
-    if (enableRes.success === false) {
-      setError(friendlyError(enableRes.error ?? ""));
-      return;
-    }
-    onTournamentUpdated();
   }
 
   async function handleDisable() {
     setSaving(true);
     setError(null);
-    const res = await setQrJoinEnabledAction(tournament.id, false);
-    setSaving(false);
-    if (res.success === false) {
-      setError(friendlyError(res.error ?? ""));
-      return;
+    try {
+      const res = await setQrJoinEnabledAction(tournament.id, false);
+      if (res.success === false) {
+        setError(friendlyError(res.error ?? ""));
+        return;
+      }
+      onTournamentUpdated();
+    } catch {
+      setError(GENERIC_ERROR_MESSAGE);
+    } finally {
+      setSaving(false);
     }
-    onTournamentUpdated();
   }
 
   // Auto-save knob edits once QR Join is already live — there's no separate
-  // "save" step once a code has been handed out.
-  async function persistSettings(next: { deckFormat: FormatId | "Other"; requireDecklists: boolean }) {
+  // "save" step once a code has been handed out. `previous` is the
+  // pre-optimistic-update {deckFormat, requireDecklists} pair so a failed or
+  // thrown save can roll the local (already-changed) state back to the
+  // last-known-persisted values instead of leaving the UI showing something
+  // the server never saved.
+  async function persistSettings(
+    next: { deckFormat: FormatId | "Other"; requireDecklists: boolean },
+    previous: { deckFormat: FormatId | "Other"; requireDecklists: boolean }
+  ) {
     if (!enabled) return;
     setSaving(true);
     setError(null);
-    const res = await updateJoinSettingsAction(tournament.id, next);
-    setSaving(false);
-    if (res.success === false) {
-      setError(friendlyError(res.error ?? ""));
-      return;
+    try {
+      const res = await updateJoinSettingsAction(tournament.id, next);
+      if (res.success === false) {
+        setError(friendlyError(res.error ?? ""));
+        setDeckFormat(previous.deckFormat);
+        setRequireDecklists(previous.requireDecklists);
+        return;
+      }
+      onTournamentUpdated();
+    } catch {
+      setError(GENERIC_ERROR_MESSAGE);
+      setDeckFormat(previous.deckFormat);
+      setRequireDecklists(previous.requireDecklists);
+    } finally {
+      setSaving(false);
     }
-    onTournamentUpdated();
   }
 
   function handleFormatChange(next: FormatId | "Other") {
+    const previous = { deckFormat, requireDecklists };
     const nextRequire = next === "Other" ? false : requireDecklists;
     setDeckFormat(next);
     setRequireDecklists(nextRequire);
-    if (enabled) persistSettings({ deckFormat: next, requireDecklists: nextRequire });
+    if (enabled) persistSettings({ deckFormat: next, requireDecklists: nextRequire }, previous);
   }
 
   function handleRequireChange(checked: boolean) {
+    const previous = { deckFormat, requireDecklists };
     setRequireDecklists(checked);
-    if (enabled) persistSettings({ deckFormat, requireDecklists: checked });
+    if (enabled) persistSettings({ deckFormat, requireDecklists: checked }, previous);
   }
 
   function copyUrl() {

--- a/components/ui/QRJoinDialog.tsx
+++ b/components/ui/QRJoinDialog.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { QRCodeSVG } from "qrcode.react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogBody,
+  DialogFooter,
+} from "./dialog";
+import { Button } from "./button";
+import {
+  setQrJoinEnabledAction,
+  updateJoinSettingsAction,
+  getJoinStatsAction,
+} from "../../app/tracker/tournaments/actions";
+import { FORMAT_IDS, normalizeTournamentFormat, type FormatId } from "../../lib/formats";
+import { requireDecklistsDefault } from "../../utils/tournament/categoryDefaults";
+
+// Only the columns this dialog reads/writes — callers pass the full
+// tournament row (typed `any` at the page level), which satisfies this shape.
+interface QRJoinTournament {
+  id: string;
+  code: string | null;
+  deck_format: string | null;
+  require_decklists: boolean | null;
+  category: string | null;
+}
+
+interface QRJoinDialogProps {
+  tournament: QRJoinTournament;
+  isOpen: boolean;
+  onClose: () => void;
+  onTournamentUpdated: () => void;
+}
+
+const ERROR_MESSAGES: Record<string, string> = {
+  not_found: "You don't have access to this tournament.",
+  code_generation_failed: "Couldn't generate a join code — please try again.",
+  invalid_format: "That format isn't valid.",
+  format_required: "Choose a specific format before requiring decklists.",
+};
+
+function friendlyError(code: string): string {
+  return ERROR_MESSAGES[code] ?? "Something went wrong. Please try again.";
+}
+
+function initialFormat(tournament: QRJoinTournament): FormatId | "Other" {
+  return normalizeTournamentFormat(tournament.deck_format) ?? "Other";
+}
+
+// The category-based suggestion only applies before QR Join has ever been
+// configured (code is null). Once enabled, `require_decklists` is an
+// explicit choice the host already made through this dialog — re-deriving
+// it from the category on every reopen would silently override a "no" the
+// host picked on purpose.
+function initialRequireDecklists(tournament: QRJoinTournament): boolean {
+  if (tournament.code) return tournament.require_decklists === true;
+  return tournament.require_decklists === true || requireDecklistsDefault(tournament.category);
+}
+
+export default function QRJoinDialog({
+  tournament,
+  isOpen,
+  onClose,
+  onTournamentUpdated,
+}: QRJoinDialogProps) {
+  const enabled = !!tournament.code;
+
+  const [deckFormat, setDeckFormat] = useState<FormatId | "Other">(() => initialFormat(tournament));
+  const [requireDecklists, setRequireDecklists] = useState<boolean>(() =>
+    initialRequireDecklists(tournament)
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [stats, setStats] = useState<{ joined: number; submitted: number }>({
+    joined: 0,
+    submitted: 0,
+  });
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Re-sync the form with the tournament's persisted values whenever the
+  // dialog opens (covers reopening after an external change).
+  useEffect(() => {
+    if (!isOpen) return;
+    setDeckFormat(initialFormat(tournament));
+    setRequireDecklists(initialRequireDecklists(tournament));
+    setError(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, tournament.deck_format, tournament.require_decklists, tournament.category, tournament.code]);
+
+  // Poll the join/decklist counter every 5s, but only while the dialog is
+  // open AND a code is live — never in the background, never pre-enable.
+  useEffect(() => {
+    if (!isOpen || !enabled) return;
+
+    let cancelled = false;
+    const poll = async () => {
+      const res = await getJoinStatsAction(tournament.id);
+      if (!cancelled && res.success === true) {
+        setStats({ joined: res.joined, submitted: res.submitted });
+      }
+    };
+    poll();
+    pollRef.current = setInterval(poll, 5000);
+
+    return () => {
+      cancelled = true;
+      if (pollRef.current) clearInterval(pollRef.current);
+      pollRef.current = null;
+    };
+  }, [isOpen, enabled, tournament.id]);
+
+  const joinUrl =
+    typeof window !== "undefined" && tournament.code
+      ? `${window.location.origin}/join/${tournament.code}`
+      : "";
+
+  async function handleEnable() {
+    setSaving(true);
+    setError(null);
+    const settingsRes = await updateJoinSettingsAction(tournament.id, {
+      deckFormat,
+      requireDecklists,
+    });
+    if (settingsRes.success === false) {
+      setError(friendlyError(settingsRes.error ?? ""));
+      setSaving(false);
+      return;
+    }
+    const enableRes = await setQrJoinEnabledAction(tournament.id, true);
+    setSaving(false);
+    if (enableRes.success === false) {
+      setError(friendlyError(enableRes.error ?? ""));
+      return;
+    }
+    onTournamentUpdated();
+  }
+
+  async function handleDisable() {
+    setSaving(true);
+    setError(null);
+    const res = await setQrJoinEnabledAction(tournament.id, false);
+    setSaving(false);
+    if (res.success === false) {
+      setError(friendlyError(res.error ?? ""));
+      return;
+    }
+    onTournamentUpdated();
+  }
+
+  // Auto-save knob edits once QR Join is already live — there's no separate
+  // "save" step once a code has been handed out.
+  async function persistSettings(next: { deckFormat: FormatId | "Other"; requireDecklists: boolean }) {
+    if (!enabled) return;
+    setSaving(true);
+    setError(null);
+    const res = await updateJoinSettingsAction(tournament.id, next);
+    setSaving(false);
+    if (res.success === false) {
+      setError(friendlyError(res.error ?? ""));
+      return;
+    }
+    onTournamentUpdated();
+  }
+
+  function handleFormatChange(next: FormatId | "Other") {
+    const nextRequire = next === "Other" ? false : requireDecklists;
+    setDeckFormat(next);
+    setRequireDecklists(nextRequire);
+    if (enabled) persistSettings({ deckFormat: next, requireDecklists: nextRequire });
+  }
+
+  function handleRequireChange(checked: boolean) {
+    setRequireDecklists(checked);
+    if (enabled) persistSettings({ deckFormat, requireDecklists: checked });
+  }
+
+  function copyUrl() {
+    if (!joinUrl) return;
+    navigator.clipboard
+      .writeText(joinUrl)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => {});
+  }
+
+  const selectClasses =
+    "w-full bg-background border border-border text-foreground rounded-lg p-2.5 focus:outline-none focus:border-primary/60 transition-colors disabled:opacity-60 disabled:cursor-not-allowed";
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent size="md" className="max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>QR Join</DialogTitle>
+          <DialogDescription>
+            {enabled
+              ? "Players can scan this code or use the link below to join."
+              : "Let players join by scanning a QR code instead of you typing every name."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogBody className="space-y-5">
+          {error && <p className="text-sm text-destructive">{error}</p>}
+
+          {enabled && (
+            <>
+              <div className="flex flex-col items-center gap-3 py-2">
+                <div className="bg-white p-3 rounded-lg border border-border">
+                  <QRCodeSVG value={joinUrl} size={280} />
+                </div>
+                <p className="text-3xl font-mono font-bold tracking-widest text-foreground">
+                  {tournament.code}
+                </p>
+                <div className="w-full">
+                  <label className="block text-xs font-medium text-muted-foreground mb-1">
+                    Join link
+                  </label>
+                  <div className="flex gap-2">
+                    <input
+                      readOnly
+                      value={joinUrl}
+                      onFocus={(e) => e.currentTarget.select()}
+                      className="flex-1 min-w-0 rounded-md border border-border bg-muted px-3 py-2 text-sm text-foreground"
+                    />
+                    <Button type="button" variant="outline" size="sm" onClick={copyUrl} className="flex-shrink-0">
+                      {copied ? "Copied!" : "Copy"}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div className="rounded-lg bg-muted/40 border border-border p-3 text-center">
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Joined</p>
+                  <p className="text-2xl font-semibold text-foreground tabular-nums">{stats.joined}</p>
+                </div>
+                <div className="rounded-lg bg-muted/40 border border-border p-3 text-center">
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Decklists</p>
+                  <p className="text-2xl font-semibold text-foreground tabular-nums">{stats.submitted}</p>
+                </div>
+              </div>
+            </>
+          )}
+
+          <div className="space-y-4">
+            <label className="block">
+              <span className="text-sm font-medium text-foreground mb-1.5 block">Format</span>
+              <select
+                value={deckFormat}
+                onChange={(e) => handleFormatChange(e.target.value as FormatId | "Other")}
+                disabled={saving}
+                className={selectClasses}
+              >
+                {FORMAT_IDS.map((id) => (
+                  <option key={id} value={id}>
+                    {id}
+                  </option>
+                ))}
+                <option value="Other">Other</option>
+              </select>
+            </label>
+
+            <label
+              className={`flex items-start gap-3 rounded-lg border border-border bg-background p-3 transition-colors ${
+                deckFormat === "Other" ? "opacity-60" : "cursor-pointer hover:bg-muted/40"
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={requireDecklists}
+                disabled={deckFormat === "Other" || saving}
+                onChange={(e) => handleRequireChange(e.target.checked)}
+                className="mt-0.5 h-4 w-4 rounded border-2 border-border text-primary bg-card focus:outline-none focus:ring-0 flex-shrink-0"
+              />
+              <div className="min-w-0">
+                <span className="text-sm font-medium text-foreground">
+                  Require decklist to join
+                </span>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  {deckFormat === "Other"
+                    ? "Choose a format above to require a validated decklist."
+                    : "Players must submit a deck that passes deck check for this format."}
+                </p>
+              </div>
+            </label>
+          </div>
+        </DialogBody>
+
+        <DialogFooter className="justify-end">
+          {enabled ? (
+            <Button type="button" variant="outline" onClick={handleDisable} disabled={saving}>
+              {saving ? "Working…" : "Disable QR Join"}
+            </Button>
+          ) : (
+            <Button type="button" variant="success" onClick={handleEnable} disabled={saving}>
+              {saving ? "Enabling…" : "Enable QR Join"}
+            </Button>
+          )}
+          <Button type="button" variant="cancel" onClick={onClose}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/ui/SubmissionModal.tsx
+++ b/components/ui/SubmissionModal.tsx
@@ -121,15 +121,28 @@ export default function SubmissionModal({
     let cancelled = false;
     setLoading(true);
     setError(null);
-    getSubmissionAction(tournamentId, participantId).then((res) => {
-      if (cancelled) return;
-      if (res.success === true && res.submission) {
-        setSubmission(res.submission);
-      } else {
-        setError(res.error ?? "not_found");
-      }
-      setLoading(false);
-    });
+    getSubmissionAction(tournamentId, participantId)
+      .then((res) => {
+        if (cancelled) return;
+        if (res.success === true && res.submission) {
+          setSubmission(res.submission);
+        } else {
+          setError(res.error ?? "not_found");
+        }
+      })
+      .catch(() => {
+        // Thrown server action / network failure — distinct from the
+        // `{ success: false }` path above, which the action returns
+        // normally. Without this, a rejection leaves `loading` true
+        // forever and the modal is stuck on "Loading…" until closed and
+        // reopened.
+        if (cancelled) return;
+        setError("load_failed");
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+      });
     return () => {
       cancelled = true;
     };
@@ -160,7 +173,7 @@ export default function SubmissionModal({
         <DialogBody className="space-y-4">
           {loading && <p className="text-sm text-muted-foreground">Loading…</p>}
           {!loading && error && (
-            <p className="text-sm text-destructive">Couldn't load this submission.</p>
+            <p className="text-sm text-destructive">Couldn't load the submission — try again.</p>
           )}
           {!loading && submission && (
             <>

--- a/components/ui/SubmissionModal.tsx
+++ b/components/ui/SubmissionModal.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+  DialogFooter,
+} from "./dialog";
+import { getSubmissionAction } from "@/app/tracker/tournaments/actions";
+import { findCard } from "@/lib/cards/lookup";
+import type { DeckSnapshot, DeckSnapshotCard } from "@/lib/tournament/deckSubmission";
+import type { DeckCheckIssue } from "@/utils/deckcheck";
+
+interface SubmissionModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  tournamentId: string;
+  participantId: string | null;
+  participantName: string;
+}
+
+interface SubmissionDetail {
+  snapshot: DeckSnapshot;
+  isLegal: boolean | null;
+  issues: DeckCheckIssue[];
+  submittedAt: string;
+  source: "player" | "host";
+  submittedByUsername: string | null;
+}
+
+/** green/red/gray for true/false/null — shared between the participant table's
+ * decklist cell and this modal's header so the two never drift apart. */
+export function LegalityDot({ isLegal }: { isLegal: boolean | null }) {
+  const color =
+    isLegal === true
+      ? "bg-primary"
+      : isLegal === false
+        ? "bg-destructive"
+        : "bg-muted-foreground/50";
+  const label = isLegal === true ? "Legal" : isLegal === false ? "Illegal" : "Legality unknown";
+  return (
+    <span
+      className={`inline-block h-2 w-2 flex-shrink-0 rounded-full ${color}`}
+      title={label}
+      aria-label={label}
+    />
+  );
+}
+
+function groupByType(cards: DeckSnapshotCard[]): { type: string; cards: DeckSnapshotCard[] }[] {
+  const groups = new Map<string, DeckSnapshotCard[]>();
+  for (const c of cards) {
+    const resolved = findCard(c.name, c.set, c.imgFile ?? undefined);
+    const type = resolved?.type || "Other";
+    if (!groups.has(type)) groups.set(type, []);
+    groups.get(type)!.push(c);
+  }
+  return [...groups.entries()]
+    .sort(([a], [b]) => {
+      if (a === "Other") return 1;
+      if (b === "Other") return -1;
+      return a.localeCompare(b);
+    })
+    .map(([type, typeCards]) => ({
+      type,
+      cards: [...typeCards].sort((a, b) => a.name.localeCompare(b.name)),
+    }));
+}
+
+function ZoneSection({ title, cards }: { title: string; cards: DeckSnapshotCard[] }) {
+  if (cards.length === 0) return null;
+  const groups = groupByType(cards);
+  const total = cards.reduce((n, c) => n + c.quantity, 0);
+  return (
+    <div>
+      <h4 className="text-sm font-semibold text-foreground">
+        {title} <span className="font-normal text-muted-foreground">({total})</span>
+      </h4>
+      <div className="mt-1.5 space-y-2">
+        {groups.map((g) => (
+          <div key={g.type}>
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {g.type}
+            </p>
+            <ul className="text-sm text-foreground">
+              {g.cards.map((c, i) => (
+                <li key={`${c.name}-${c.set}-${i}`} className="truncate">
+                  {c.quantity}× {c.name} <span className="text-muted-foreground">({c.set})</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const ISSUE_COLOR: Record<DeckCheckIssue["type"], string> = {
+  error: "text-destructive",
+  warning: "text-amber-600 dark:text-amber-400",
+  info: "text-blue-600 dark:text-blue-400",
+};
+
+export default function SubmissionModal({
+  open,
+  onOpenChange,
+  tournamentId,
+  participantId,
+  participantName,
+}: SubmissionModalProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submission, setSubmission] = useState<SubmissionDetail | null>(null);
+
+  useEffect(() => {
+    if (!open || !participantId) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getSubmissionAction(tournamentId, participantId).then((res) => {
+      if (cancelled) return;
+      if (res.success === true && res.submission) {
+        setSubmission(res.submission);
+      } else {
+        setError(res.error ?? "not_found");
+      }
+      setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, participantId, tournamentId]);
+
+  // Clear stale data once the dialog closes so the next open doesn't briefly
+  // flash the previous participant's deck before the fresh fetch resolves.
+  useEffect(() => {
+    if (!open) {
+      setSubmission(null);
+      setError(null);
+    }
+  }, [open]);
+
+  const mainCards = submission?.snapshot.cards.filter((c) => c.zone === "main") ?? [];
+  const reserveCards = submission?.snapshot.cards.filter((c) => c.zone === "reserve") ?? [];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="lg">
+        <DialogHeader>
+          <div className="flex items-center justify-between gap-2">
+            <DialogTitle>{submission?.snapshot.deckName ?? "Decklist"}</DialogTitle>
+            {submission && <LegalityDot isLegal={submission.isLegal} />}
+          </div>
+          <p className="text-sm text-muted-foreground">{participantName}</p>
+        </DialogHeader>
+        <DialogBody className="space-y-4">
+          {loading && <p className="text-sm text-muted-foreground">Loading…</p>}
+          {!loading && error && (
+            <p className="text-sm text-destructive">Couldn't load this submission.</p>
+          )}
+          {!loading && submission && (
+            <>
+              <p className="text-xs text-muted-foreground">
+                {submission.source === "player" ? "Submitted" : "Attached"} by{" "}
+                {submission.submittedByUsername ? `@${submission.submittedByUsername}` : "unknown"}
+                {" · "}
+                {new Date(submission.submittedAt).toLocaleString()}
+              </p>
+              {submission.isLegal === false && submission.issues.length > 0 && (
+                <div className="space-y-1 rounded-md border border-destructive/30 bg-destructive/5 p-3">
+                  {submission.issues.map((issue, i) => (
+                    <p key={i} className={`text-xs ${ISSUE_COLOR[issue.type]}`}>
+                      {issue.message}
+                    </p>
+                  ))}
+                </div>
+              )}
+              <ZoneSection title="Main deck" cards={mainCards} />
+              <ZoneSection title="Reserve" cards={reserveCards} />
+            </>
+          )}
+        </DialogBody>
+        <DialogFooter className="justify-end">
+          <button
+            onClick={() => onOpenChange(false)}
+            className="px-4 py-2 text-sm font-medium text-foreground bg-card border border-border rounded-lg hover:bg-muted transition-colors"
+          >
+            Close
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/ui/TournamentStartModal.tsx
+++ b/components/ui/TournamentStartModal.tsx
@@ -26,6 +26,10 @@ interface TournamentStartModalProps {
   defaultByeDifferential?: number | null;
   defaultStartingTableNumber?: number | null;
   defaultSoundNotifications?: boolean | null;
+  // "N of M participants have decklists" — same figure shown pre-start under
+  // the Participants toolbar; null/omitted hides the line (tournament doesn't
+  // require decklists).
+  decklistSummary?: { submitted: number; total: number } | null;
 }
 
 export default function TournamentStartModal({
@@ -40,6 +44,7 @@ export default function TournamentStartModal({
   defaultByeDifferential,
   defaultStartingTableNumber,
   defaultSoundNotifications,
+  decklistSummary,
 }: TournamentStartModalProps) {
   const initialRoundLength = defaultRoundLength ?? 45;
   const initialMaxScore = defaultMaxScore ?? 5;
@@ -108,6 +113,14 @@ export default function TournamentStartModal({
         </DialogHeader>
 
         <DialogBody className="space-y-6">
+          {decklistSummary && (
+            <p className="text-sm text-center text-muted-foreground">
+              <span className="font-medium text-foreground">
+                {decklistSummary.submitted} of {decklistSummary.total}
+              </span>{" "}
+              participants have decklists
+            </p>
+          )}
           {/* Number of Rounds */}
           <div className="flex flex-col items-center jayden-gradient-bg rounded-lg border border-border p-5">
             <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">

--- a/components/ui/TournamentTabs.tsx
+++ b/components/ui/TournamentTabs.tsx
@@ -4,7 +4,7 @@ import { Tabs } from "flowbite-react";
 import PodGenerationModal from "./PodGenerationModal";
 import { Dispatch, ReactNode, SetStateAction, useEffect, useRef, useState } from "react";
 import { HiUserGroup } from "react-icons/hi";
-import { FaGear, FaClipboardList } from "react-icons/fa6";
+import { FaGear, FaClipboardList, FaQrcode } from "react-icons/fa6";
 import { MdPeople } from "react-icons/md";
 import TournamentSettings from "./TournamentSettings";
 import TournamentRounds from "./TournamentRounds";
@@ -52,6 +52,11 @@ interface TournamentTabsProps {
   decklists: TournamentDecklistRow[];
   onDecklistsChange: () => void;
   isHost?: boolean;
+  /** Opens the QR Join dialog (mounted at the page level). */
+  onOpenQrJoin?: () => void;
+  /** "N of M participants have decklists" — only meaningful pre-start when
+   * the tournament requires decklists; null hides the line entirely. */
+  decklistSummary?: { submitted: number; total: number } | null;
   numberingMode: "tables" | "seats";
   onRepairCompleted?: () => void;
   matchesRefreshNonce?: number;
@@ -91,6 +96,8 @@ export default function TournamentTabs({
   decklists,
   onDecklistsChange,
   isHost = false,
+  onOpenQrJoin,
+  decklistSummary,
   numberingMode,
   onRepairCompleted,
   matchesRefreshNonce,
@@ -176,6 +183,21 @@ export default function TournamentTabs({
                 <span className="sm:hidden">Print</span>
               </Button>
             )}
+            {/* QR Join — same eligibility window as the Start button: the
+                join code can only be generated/used before the tournament
+                has started, and it's moot once the event has ended. */}
+            {!tournamentStarted && !tournamentEnded && onOpenQrJoin && (
+              <Button
+                type="button"
+                onClick={onOpenQrJoin}
+                variant="outline"
+                size="sm"
+                className="gap-1.5"
+              >
+                <FaQrcode className="w-4 h-4" />
+                <span className="hidden sm:inline">QR Join</span>
+              </Button>
+            )}
             {!tournamentEnded && (
               <div className="relative group">
                 <Button
@@ -218,6 +240,14 @@ export default function TournamentTabs({
             />
           </div>
         </div>
+        {!tournamentStarted && decklistSummary && (
+          <p className="text-sm text-muted-foreground -mt-4 mb-4">
+            <span className="font-medium text-foreground">
+              {decklistSummary.submitted} of {decklistSummary.total}
+            </span>{" "}
+            participants have decklists
+          </p>
+        )}
         {loading ? (
           <p>Loading participants...</p>
         ) : participants.length === 0 ? (

--- a/components/ui/TournamentTabs.tsx
+++ b/components/ui/TournamentTabs.tsx
@@ -52,6 +52,9 @@ interface TournamentTabsProps {
   decklists: TournamentDecklistRow[];
   onDecklistsChange: () => void;
   isHost?: boolean;
+  // participant.user_id -> profiles.username, batched once on the page —
+  // threaded down to ParticipantTable's account-linkage badge.
+  usernames?: Map<string, string>;
   /** Opens the QR Join dialog (mounted at the page level). */
   onOpenQrJoin?: () => void;
   /** "N of M participants have decklists" — only meaningful pre-start when
@@ -96,6 +99,7 @@ export default function TournamentTabs({
   decklists,
   onDecklistsChange,
   isHost = false,
+  usernames,
   onOpenQrJoin,
   decklistSummary,
   numberingMode,
@@ -276,6 +280,9 @@ export default function TournamentTabs({
               decklists={decklists}
               onDecklistsChange={onDecklistsChange}
               numberingMode={numberingMode}
+              usernames={usernames}
+              isHost={isHost}
+              fetchParticipants={fetchParticipants}
             />
           </div>
         )}

--- a/components/ui/TournamentTabs.tsx
+++ b/components/ui/TournamentTabs.tsx
@@ -38,6 +38,10 @@ interface TournamentTabsProps {
   // AttachDeckDialog for its attach gate.
   tournamentFormat?: string | null;
   onTournamentEnd?: () => void;
+  /** Fired only when the FINAL round's End Round button completes the
+   * tournament (not on every round end, and not on the admin-menu End
+   * Tournament path, which handles its own publish choice separately). */
+  onTournamentAutoPublish?: () => void | Promise<void>;
   setLatestRound: Dispatch<SetStateAction<any>>;
   onRoundActiveChange?: (
     isActive: boolean,
@@ -89,6 +93,7 @@ export default function TournamentTabs({
   tournamentName,
   tournamentFormat,
   onTournamentEnd,
+  onTournamentAutoPublish,
   setLatestRound,
   createPairing,
   matchErrorIndex,
@@ -308,7 +313,10 @@ export default function TournamentTabs({
             isActive={activeTab === 1}
             key={activeTab} // Force re-render when tab becomes active
             onTournamentEnd={onTournamentEnd}
-            onTournamentEnded={() => setActiveTab(2)} // jump to Standings (index 2) when the tournament finishes
+            onTournamentEnded={() => {
+              setActiveTab(2); // jump to Standings (index 2) when the tournament finishes
+              onTournamentAutoPublish?.();
+            }}
             setLatestRound={setLatestRound}
             createPairing={createPairing}
             matchErrorIndex={matchErrorIndex}

--- a/components/ui/tournament-form-modal.tsx
+++ b/components/ui/tournament-form-modal.tsx
@@ -99,7 +99,7 @@ const TournamentFormModal: React.FC<TournamentFormModalProps> = ({
     if (frozen) {
       onSubmit([
         {
-          name: buildTournamentName(selected[0], { city: listingCity }),
+          name: buildTournamentName(cleanCategory(selected[0]), { city: listingCity }),
           category: selected[0],
         },
       ]);
@@ -189,7 +189,7 @@ const TournamentFormModal: React.FC<TournamentFormModalProps> = ({
                   Tournament name
                 </span>
                 <div className="rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm text-foreground truncate">
-                  {buildTournamentName(selected[0], { city: listingCity })}
+                  {buildTournamentName(cleanCategory(selected[0]), { city: listingCity })}
                 </div>
                 <p className="mt-1 text-xs text-muted-foreground">
                   Official events use standardized names.

--- a/components/ui/tournament-form-modal.tsx
+++ b/components/ui/tournament-form-modal.tsx
@@ -90,7 +90,7 @@ const TournamentFormModal: React.FC<TournamentFormModalProps> = ({
     if (isMulti) {
       onSubmit(
         selected.map((c) => ({
-          name: buildTournamentName(cleanCategory(c)),
+          name: buildTournamentName(cleanCategory(c), { city: listingCity }),
           category: c,
         }))
       );
@@ -173,9 +173,9 @@ const TournamentFormModal: React.FC<TournamentFormModalProps> = ({
                     <li
                       key={c}
                       className="text-sm text-foreground truncate"
-                      title={buildTournamentName(cleanCategory(c))}
+                      title={buildTournamentName(cleanCategory(c), { city: listingCity })}
                     >
-                      {buildTournamentName(cleanCategory(c))}
+                      {buildTournamentName(cleanCategory(c), { city: listingCity })}
                     </li>
                   ))}
                 </ul>

--- a/components/ui/tournament-form-modal.tsx
+++ b/components/ui/tournament-form-modal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Button } from "./button";
 import { STANDARD_CATEGORIES } from "../../utils/tournament/categoryDefaults";
+import { buildTournamentName, isNameFrozen } from "../../utils/tournament/naming";
 import {
   Dialog,
   DialogContent,
@@ -16,7 +17,8 @@ interface TournamentFormModalProps {
   // Create one tournament per item. With 0/1 category selected this is a single
   // item carrying the (editable) name; with 2+ it's one auto-named item per type.
   onSubmit: (items: { name: string; category: string | null }[]) => void;
-  defaultName?: string;
+  // City to append to generated names for events hosted from a public listing.
+  listingCity?: string;
   // Categories to offer. Defaults to the standard list when omitted (e.g. an
   // official listing passes its own formats here).
   categoryOptions?: string[];
@@ -25,22 +27,11 @@ interface TournamentFormModalProps {
 // Drop a trailing "- 2P" / "2P" player-count suffix; it reads as clutter.
 const cleanCategory = (label: string) => label.replace(/\s*-?\s*2P$/i, "").trim();
 
-// Build a name like "Jun 29, 2026 Type 1 Tournament" from the selected category.
-const buildAutoName = (type: string) => {
-  if (!type) return "";
-  const date = new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  }).format(new Date());
-  return `${date} ${type} Tournament`;
-};
-
 const TournamentFormModal: React.FC<TournamentFormModalProps> = ({
   isOpen,
   onClose,
   onSubmit,
-  defaultName,
+  listingCity,
   categoryOptions,
 }) => {
   const firstCheckboxRef = useRef<HTMLInputElement>(null);
@@ -66,17 +57,19 @@ const TournamentFormModal: React.FC<TournamentFormModalProps> = ({
     const initial = options[0] ? [options[0]] : [];
     setSelected(initial);
     setNameTouched(false);
-    // A listing-provided name wins; otherwise auto-build from the first category.
-    setName(defaultName ? defaultName : buildAutoName(initial[0] ?? ""));
+    setName(buildTournamentName(cleanCategory(initial[0] ?? "")));
     requestAnimationFrame(() => {
       firstCheckboxRef.current?.focus();
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, defaultName]);
+  }, [isOpen]);
 
   // Creating multiple tournaments at once: each gets an auto-built name, so the
   // single editable name field is replaced by a preview list.
   const isMulti = selected.length >= 2;
+  // A single official category freezes the name to the generated form; only
+  // Unofficial (or no category yet) keeps the field editable.
+  const frozen = selected.length === 1 && isNameFrozen(selected[0]);
 
   const toggleCategory = (value: string) => {
     const next = selected.includes(value)
@@ -84,10 +77,10 @@ const TournamentFormModal: React.FC<TournamentFormModalProps> = ({
       : [...selected, value];
     setSelected(next);
     // Keep the single name field in sync while exactly one type is checked and the
-    // host hasn't taken over the name (and we're not preserving a listing name).
-    // Going to 0 or 2+ leaves the field for the host / preview to drive.
-    if (!nameTouched && !defaultName) {
-      if (next.length === 1) setName(buildAutoName(next[0]));
+    // host hasn't taken over the name. Going to 0 or 2+ leaves the field for the
+    // host / preview to drive.
+    if (!nameTouched) {
+      if (next.length === 1) setName(buildTournamentName(cleanCategory(next[0])));
       else if (next.length === 0) setName("");
     }
   };
@@ -95,7 +88,21 @@ const TournamentFormModal: React.FC<TournamentFormModalProps> = ({
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (isMulti) {
-      onSubmit(selected.map((c) => ({ name: buildAutoName(c), category: c })));
+      onSubmit(
+        selected.map((c) => ({
+          name: buildTournamentName(cleanCategory(c)),
+          category: c,
+        }))
+      );
+      return;
+    }
+    if (frozen) {
+      onSubmit([
+        {
+          name: buildTournamentName(selected[0], { city: listingCity }),
+          category: selected[0],
+        },
+      ]);
       return;
     }
     const trimmed = name.trim();
@@ -106,7 +113,8 @@ const TournamentFormModal: React.FC<TournamentFormModalProps> = ({
   const fieldClasses =
     "w-full rounded-lg border border-border bg-card text-foreground px-3 py-2 text-sm focus:outline-none";
 
-  const canSubmit = isMulti || name.trim().length > 0;
+  const canSubmit =
+    selected.length >= 1 && (isMulti || frozen || name.trim().length > 0);
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
@@ -165,14 +173,26 @@ const TournamentFormModal: React.FC<TournamentFormModalProps> = ({
                     <li
                       key={c}
                       className="text-sm text-foreground truncate"
-                      title={buildAutoName(c)}
+                      title={buildTournamentName(cleanCategory(c))}
                     >
-                      {buildAutoName(c)}
+                      {buildTournamentName(cleanCategory(c))}
                     </li>
                   ))}
                 </ul>
                 <p className="mt-1 text-xs text-muted-foreground">
-                  Rename any of them later from the tournaments list.
+                  Official event names are standardized.
+                </p>
+              </div>
+            ) : frozen ? (
+              <div>
+                <span className="block text-xs font-medium text-muted-foreground mb-1">
+                  Tournament name
+                </span>
+                <div className="rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm text-foreground truncate">
+                  {buildTournamentName(selected[0], { city: listingCity })}
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Official events use standardized names.
                 </p>
               </div>
             ) : (

--- a/e2e/qr-join.spec.ts
+++ b/e2e/qr-join.spec.ts
@@ -106,21 +106,27 @@ function pickMainDeck(): DeckCardSeed[] {
 
 // ─── Seed: host + player accounts, a require_decklists Limited tournament, ───
 // ─── and a legal deck for the player.                                     ───
-
+//
+// `Seeded` fields are populated INCREMENTALLY, in-place, as each row/user is
+// created — never assigned only at the end. If any step throws partway
+// through (e.g. pickMainDeck() finding the card database changed shape),
+// whatever was already created is still recorded on this same object, so
+// `cleanup()` (which runs in afterAll regardless of whether beforeAll threw)
+// can still find and delete it instead of orphaning rows in prod.
 interface Seeded {
-  tournamentId: string;
-  code: string;
-  hostId: string;
-  hostEmail: string;
-  hostPassword: string;
-  playerId: string;
-  playerEmail: string;
-  playerPassword: string;
-  deckId: string;
-  deckName: string;
+  tournamentId?: string;
+  code?: string;
+  hostId?: string;
+  hostEmail?: string;
+  hostPassword?: string;
+  playerId?: string;
+  playerEmail?: string;
+  playerPassword?: string;
+  deckId?: string;
+  deckName?: string;
 }
 
-async function seed(): Promise<Seeded> {
+async function seed(state: Seeded): Promise<void> {
   if (!admin) throw new Error("qr-join e2e seed requires SUPABASE_SERVICE_ROLE_KEY + NEXT_PUBLIC_SUPABASE_URL");
   const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
   const password = "Testpass12345";
@@ -132,6 +138,9 @@ async function seed(): Promise<Seeded> {
     email_confirm: true,
   });
   if (hostErr || !hostUser?.user) throw new Error(`Failed to create host: ${hostErr?.message}`);
+  state.hostId = hostUser.user.id;
+  state.hostEmail = hostEmail;
+  state.hostPassword = password;
 
   const playerEmail = `qr-join-player-${stamp}@e2e.test`;
   const { data: playerUser, error: playerErr } = await admin.auth.admin.createUser({
@@ -140,6 +149,9 @@ async function seed(): Promise<Seeded> {
     email_confirm: true,
   });
   if (playerErr || !playerUser?.user) throw new Error(`Failed to create player: ${playerErr?.message}`);
+  state.playerId = playerUser.user.id;
+  state.playerEmail = playerEmail;
+  state.playerPassword = password;
 
   // Retry on join-code collision, mirroring the production regenerateJoinCode path.
   let tournamentId: string | null = null;
@@ -165,6 +177,8 @@ async function seed(): Promise<Seeded> {
     tournamentId = tournament!.id;
   }
   if (!tournamentId) throw new Error("qr-join e2e: could not allocate a unique join code");
+  state.tournamentId = tournamentId;
+  state.code = code;
 
   const deckName = `QR Join E2E Deck ${stamp}`;
   const { data: deck, error: deckErr } = await admin
@@ -173,7 +187,13 @@ async function seed(): Promise<Seeded> {
     .select("id")
     .single();
   if (deckErr || !deck) throw new Error(`Failed to create deck: ${deckErr?.message}`);
+  state.deckId = deck.id;
+  state.deckName = deckName;
 
+  // Everything above this point creates rows that MUST be tracked before we
+  // touch anything that can throw for reasons unrelated to Supabase (a card
+  // database shape change) — pickMainDeck() runs only now, after state.deckId
+  // is already recorded, so a throw here still leaves a cleanable (empty) deck.
   const mainDeck = pickMainDeck();
   const { error: cardsErr } = await admin.from("deck_cards").insert(
     mainDeck.map((c) => ({
@@ -186,34 +206,40 @@ async function seed(): Promise<Seeded> {
     }))
   );
   if (cardsErr) throw new Error(`Failed to insert deck cards: ${cardsErr.message}`);
-
-  return {
-    tournamentId,
-    code,
-    hostId: hostUser.user.id,
-    hostEmail,
-    hostPassword: password,
-    playerId: playerUser.user.id,
-    playerEmail,
-    playerPassword: password,
-    deckId: deck.id,
-    deckName,
-  };
 }
 
-async function cleanup(seeded: Seeded) {
+// Best-effort over whatever `state` has recorded so far: every delete is
+// guarded on its ID being present, and no single failed/skipped delete stops
+// the rest from being attempted. Any delete that comes back with an `.error`
+// is logged via console.warn so a real cleanup gap is visible on the first
+// live run rather than silently swallowed.
+async function cleanup(state: Seeded) {
   if (!admin) return;
+
   // Tournament delete cascades participants, matches, rounds,
   // tournament_decklists, tournament_deck_submissions, tournament_join_blocks.
-  await admin.from("tournaments").delete().eq("id", seeded.tournamentId);
+  if (state.tournamentId) {
+    const { error } = await admin.from("tournaments").delete().eq("id", state.tournamentId);
+    if (error) console.warn(`qr-join e2e cleanup: failed to delete tournament ${state.tournamentId}:`, error.message);
+  }
+
   // decks.user_id -> auth.users has no ON DELETE action, so the deck (and its
   // cascaded deck_cards) must go before the owning user.
-  await admin.from("decks").delete().eq("id", seeded.deckId);
-  for (const userId of [seeded.hostId, seeded.playerId]) {
+  if (state.deckId) {
+    const { error } = await admin.from("decks").delete().eq("id", state.deckId);
+    if (error) console.warn(`qr-join e2e cleanup: failed to delete deck ${state.deckId}:`, error.message);
+  }
+
+  for (const [label, userId] of [
+    ["host", state.hostId],
+    ["player", state.playerId],
+  ] as const) {
+    if (!userId) continue;
     try {
-      await admin.auth.admin.deleteUser(userId);
-    } catch {
-      // best-effort — matches the cleanup pattern in e2e/seed.ts / forgeSeed.ts
+      const { error } = await admin.auth.admin.deleteUser(userId);
+      if (error) console.warn(`qr-join e2e cleanup: failed to delete ${label} user ${userId}:`, error.message);
+    } catch (err) {
+      console.warn(`qr-join e2e cleanup: failed to delete ${label} user ${userId}:`, err);
     }
   }
 }
@@ -229,10 +255,14 @@ async function signIn(page: Page, email: string, password: string) {
 test.describe("QR join + decklist submission", () => {
   test.skip(!adminAvailable, "requires SUPABASE_SERVICE_ROLE_KEY + NEXT_PUBLIC_SUPABASE_URL");
 
-  let seeded: Seeded;
+  // Created up front (not assigned from seed()'s return value) so afterAll
+  // can always find it — even if beforeAll throws partway through seeding,
+  // Playwright still runs afterAll, and this object already carries whatever
+  // IDs were recorded before the throw.
+  const seeded: Seeded = {};
 
   test.beforeAll(async () => {
-    seeded = await seed();
+    await seed(seeded);
   });
 
   test.afterAll(async () => {

--- a/e2e/qr-join.spec.ts
+++ b/e2e/qr-join.spec.ts
@@ -1,0 +1,310 @@
+import { test, expect, type Page } from "@playwright/test";
+import { createClient } from "@supabase/supabase-js";
+import { CARDS, type CardData } from "@/lib/cards/lookup";
+import { FORMATS } from "@/lib/formats";
+import { matchesBanListEntry } from "@/utils/deckcheck/rules";
+import { generateJoinCode } from "@/lib/tournament/joinCodes";
+
+// This spec exercises migration 084 (tournament_deck_submissions,
+// participants.user_id, tournaments.require_decklists) end-to-end. It is
+// self-contained: seeds its own host/player accounts, tournament, and a real
+// legal deck, and cleans everything up in afterAll. See
+// .claude/skills/verify/SKILL.md for the account/session conventions this
+// mirrors.
+
+const URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+const SERVICE = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
+const adminAvailable = !!URL && !!SERVICE;
+const admin = adminAvailable
+  ? createClient(URL, SERVICE, { auth: { persistSession: false } })
+  : null;
+
+// ─── Build a real, Limited-legal 50-card main deck straight off the live ───
+// ─── card database — no hardcoded card names, so a future                ───
+// ─── `make update-cards` regen can't silently go stale.                  ───
+//
+// Filler needs more than 3 copies per card to reach the 43 non-Lost-Soul
+// slots without an unreasonable number of distinct printings, so this leans
+// on two real properties of checkDeck's Type 1 rules (utils/deckcheck/rules.ts):
+//   - checkVanillaLimit only caps types whose lowercased string is exactly
+//     "hero" / "evil character" / "enhancement" — real "Hero Token" / "Evil
+//     Character Token" printings fall outside that set and are uncapped.
+//   - non-special-ability cards outside Hero/Evil Character/Enhancement have
+//     no quantity rule at all in the Type 1 rule set.
+// Both are genuine behavior of the app's own validator (is_legal reflects
+// exactly what tournament_qr_join will record), not a workaround of it —
+// verified directly against validateT1Rules in code review for this task.
+interface DeckCardSeed {
+  name: string;
+  set: string;
+  imgFile: string | null;
+  quantity: number;
+}
+
+function pickMainDeck(): DeckCardSeed[] {
+  const isRotationLegal = (c: CardData) => c.legality === "Rotation";
+  const noAbility = (c: CardData) => !c.specialAbility || c.specialAbility.trim() === "";
+  const isBanned = (c: CardData) =>
+    FORMATS.Limited.banList.some((entry) => matchesBanListEntry(c, entry));
+  const isSingleBrigade = (c: CardData) => {
+    const b = c.brigade.trim().toLowerCase();
+    if (!b || b === "colorless" || b === "multi") return false;
+    return !b.includes("/") && !b.includes(",");
+  };
+  // Strip a trailing "(Set)" / "[Variant]" annotation so two different
+  // printings of the same character (e.g. "Subjugating Egyptians [K]" vs.
+  // "Subjugating Egyptians (1st Print - K)") are never both picked — the
+  // same-card grouping in checkDeck could merge them and trip the 3-copy cap.
+  const baseName = (name: string) =>
+    name.replace(/\s*\[[^\]]+\]\s*$/, "").replace(/\s*\([^)]+\)\s*$/, "").trim().toLowerCase();
+
+  const lostSoul = CARDS.find(
+    (c) =>
+      c.type.toLowerCase().includes("lost soul") &&
+      isRotationLegal(c) &&
+      noAbility(c) &&
+      c.reference !== "Proverbs 22:14" && // the one Limited-banned LS reference
+      !isBanned(c)
+  );
+  if (!lostSoul) throw new Error("qr-join e2e: no eligible Lost Soul in the card database");
+
+  const seenBase = new Set<string>();
+  const vanilla = CARDS.filter((c) => {
+    const t = c.type.trim().toLowerCase();
+    if (t !== "hero" && t !== "evil character") return false;
+    if (!isRotationLegal(c) || !noAbility(c) || !isSingleBrigade(c) || isBanned(c)) return false;
+    const base = baseName(c.name);
+    if (seenBase.has(base)) return false;
+    seenBase.add(base);
+    return true;
+  }).sort((a, b) => a.name.localeCompare(b.name));
+
+  const tokens = CARDS.filter((c) => {
+    const t = c.type.trim().toLowerCase();
+    if (t !== "hero token" && t !== "evil character token") return false;
+    return isRotationLegal(c) && noAbility(c) && !isBanned(c);
+  }).sort((a, b) => a.name.localeCompare(b.name));
+
+  const main: DeckCardSeed[] = [
+    { name: lostSoul.name, set: lostSoul.set, imgFile: lostSoul.imgFile || null, quantity: 7 },
+  ];
+  let remaining = 43; // 50-card main deck (Limited minimum) minus the 7 Lost Souls
+  for (const c of [...vanilla, ...tokens]) {
+    if (remaining <= 0) break;
+    const cap = vanilla.includes(c) ? 3 : 5; // vanilla capped at 3; tokens uncapped, 5 is just a tidy batch size
+    const qty = Math.min(cap, remaining);
+    main.push({ name: c.name, set: c.set, imgFile: c.imgFile || null, quantity: qty });
+    remaining -= qty;
+  }
+  if (remaining > 0) {
+    throw new Error(
+      `qr-join e2e: card database doesn't have enough eligible filler cards (${remaining} short of 43) — the seed deck builder needs updating`
+    );
+  }
+  return main;
+}
+
+// ─── Seed: host + player accounts, a require_decklists Limited tournament, ───
+// ─── and a legal deck for the player.                                     ───
+
+interface Seeded {
+  tournamentId: string;
+  code: string;
+  hostId: string;
+  hostEmail: string;
+  hostPassword: string;
+  playerId: string;
+  playerEmail: string;
+  playerPassword: string;
+  deckId: string;
+  deckName: string;
+}
+
+async function seed(): Promise<Seeded> {
+  if (!admin) throw new Error("qr-join e2e seed requires SUPABASE_SERVICE_ROLE_KEY + NEXT_PUBLIC_SUPABASE_URL");
+  const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+  const password = "Testpass12345";
+
+  const hostEmail = `qr-join-host-${stamp}@e2e.test`;
+  const { data: hostUser, error: hostErr } = await admin.auth.admin.createUser({
+    email: hostEmail,
+    password,
+    email_confirm: true,
+  });
+  if (hostErr || !hostUser?.user) throw new Error(`Failed to create host: ${hostErr?.message}`);
+
+  const playerEmail = `qr-join-player-${stamp}@e2e.test`;
+  const { data: playerUser, error: playerErr } = await admin.auth.admin.createUser({
+    email: playerEmail,
+    password,
+    email_confirm: true,
+  });
+  if (playerErr || !playerUser?.user) throw new Error(`Failed to create player: ${playerErr?.message}`);
+
+  // Retry on join-code collision, mirroring the production regenerateJoinCode path.
+  let tournamentId: string | null = null;
+  let code = "";
+  for (let attempt = 0; attempt < 5 && !tournamentId; attempt++) {
+    code = generateJoinCode();
+    const { data: tournament, error: tErr } = await admin
+      .from("tournaments")
+      .insert({
+        name: `QR Join E2E ${stamp}`,
+        host_id: hostUser.user.id,
+        code,
+        has_started: false,
+        require_decklists: true,
+        deck_format: "Limited",
+      })
+      .select("id")
+      .single();
+    if (tErr) {
+      if (tErr.code === "23505") continue; // code collision — try another
+      throw new Error(`Failed to create tournament: ${tErr.message}`);
+    }
+    tournamentId = tournament!.id;
+  }
+  if (!tournamentId) throw new Error("qr-join e2e: could not allocate a unique join code");
+
+  const deckName = `QR Join E2E Deck ${stamp}`;
+  const { data: deck, error: deckErr } = await admin
+    .from("decks")
+    .insert({ user_id: playerUser.user.id, name: deckName, format: "Limited", visibility: "private" })
+    .select("id")
+    .single();
+  if (deckErr || !deck) throw new Error(`Failed to create deck: ${deckErr?.message}`);
+
+  const mainDeck = pickMainDeck();
+  const { error: cardsErr } = await admin.from("deck_cards").insert(
+    mainDeck.map((c) => ({
+      deck_id: deck.id,
+      card_name: c.name,
+      card_set: c.set,
+      card_img_file: c.imgFile,
+      quantity: c.quantity,
+      zone: "main",
+    }))
+  );
+  if (cardsErr) throw new Error(`Failed to insert deck cards: ${cardsErr.message}`);
+
+  return {
+    tournamentId,
+    code,
+    hostId: hostUser.user.id,
+    hostEmail,
+    hostPassword: password,
+    playerId: playerUser.user.id,
+    playerEmail,
+    playerPassword: password,
+    deckId: deck.id,
+    deckName,
+  };
+}
+
+async function cleanup(seeded: Seeded) {
+  if (!admin) return;
+  // Tournament delete cascades participants, matches, rounds,
+  // tournament_decklists, tournament_deck_submissions, tournament_join_blocks.
+  await admin.from("tournaments").delete().eq("id", seeded.tournamentId);
+  // decks.user_id -> auth.users has no ON DELETE action, so the deck (and its
+  // cascaded deck_cards) must go before the owning user.
+  await admin.from("decks").delete().eq("id", seeded.deckId);
+  for (const userId of [seeded.hostId, seeded.playerId]) {
+    try {
+      await admin.auth.admin.deleteUser(userId);
+    } catch {
+      // best-effort — matches the cleanup pattern in e2e/seed.ts / forgeSeed.ts
+    }
+  }
+}
+
+// ─── Drive the flow ───
+
+async function signIn(page: Page, email: string, password: string) {
+  await page.getByLabel(/email/i).fill(email);
+  await page.getByLabel(/password/i).fill(password);
+  await page.getByRole("button", { name: /sign in/i }).click();
+}
+
+test.describe("QR join + decklist submission", () => {
+  test.skip(!adminAvailable, "requires SUPABASE_SERVICE_ROLE_KEY + NEXT_PUBLIC_SUPABASE_URL");
+
+  let seeded: Seeded;
+
+  test.beforeAll(async () => {
+    seeded = await seed();
+  });
+
+  test.afterAll(async () => {
+    await cleanup(seeded);
+  });
+
+  test("player joins via code, submits a legal decklist, and the host sees it", async ({ browser }) => {
+    const playerContext = await browser.newContext();
+    const playerPage = await playerContext.newPage();
+
+    // 1. Visit /join/<code> signed out — join info loads, sign-in is offered.
+    await playerPage.goto(`/join/${seeded.code}`);
+    const signInLink = playerPage.getByRole("link", { name: /sign in to join/i });
+    await expect(signInLink).toBeVisible();
+    await expect(signInLink).toHaveAttribute(
+      "href",
+      `/sign-in?redirectTo=${encodeURIComponent(`/join/${seeded.code}`)}`
+    );
+
+    // 2. Follow it — the redirectTo is honored back to /join/<code> after sign-in.
+    await signInLink.click();
+    await playerPage.waitForURL(new RegExp(`/sign-in\\?redirectTo=${encodeURIComponent(`/join/${seeded.code}`)}`));
+    await signIn(playerPage, seeded.playerEmail, seeded.playerPassword);
+    await playerPage.waitForURL(new RegExp(`/join/${seeded.code}$`));
+
+    // 3. Join form: display name + the seeded legal deck from "My decks".
+    await playerPage.getByLabel(/display name/i).fill("E2E Player");
+    await playerPage.getByText(seeded.deckName, { exact: true }).click();
+    await expect(playerPage.getByText(seeded.deckName, { exact: true })).toBeVisible();
+    await playerPage.getByRole("button", { name: /^join$/i }).click();
+
+    // 4. Registered state — deck accepted as legal.
+    await expect(playerPage.getByText("Registered as")).toBeVisible();
+    await expect(playerPage.getByText("E2E Player", { exact: true })).toBeVisible();
+    await expect(playerPage.getByText(seeded.deckName, { exact: true })).toBeVisible();
+    await expect(playerPage.getByText("Legal", { exact: true })).toBeVisible();
+
+    await playerContext.close();
+
+    // 5. DB assertions: participant linked to the account, submission recorded and legal.
+    const { data: participant, error: pErr } = await admin!
+      .from("participants")
+      .select("id, user_id, name")
+      .eq("tournament_id", seeded.tournamentId)
+      .single();
+    expect(pErr).toBeNull();
+    expect(participant!.user_id).toBe(seeded.playerId);
+    expect(participant!.name).toBe("E2E Player");
+
+    const { data: submission, error: sErr } = await admin!
+      .from("tournament_deck_submissions")
+      .select("is_legal, deck_snapshot, source")
+      .eq("participant_id", participant!.id)
+      .single();
+    expect(sErr).toBeNull();
+    expect(submission!.is_legal).toBe(true);
+    expect(submission!.source).toBe("player");
+    expect(Array.isArray(submission!.deck_snapshot?.cards)).toBe(true);
+    expect(submission!.deck_snapshot.cards.length).toBeGreaterThan(0);
+
+    // 6. Host view: the decklist summary shows the submission.
+    const hostContext = await browser.newContext();
+    const hostPage = await hostContext.newPage();
+    await hostPage.goto("/sign-in");
+    await signIn(hostPage, seeded.hostEmail, seeded.hostPassword);
+    await hostPage.waitForURL(/.*/);
+
+    await hostPage.goto(`/tracker/tournaments/${seeded.tournamentId}`);
+    await expect(hostPage.getByText("1 of 1")).toBeVisible();
+    await expect(hostPage.getByText(/participants have decklists/i)).toBeVisible();
+    await expect(hostPage.getByTitle(`${seeded.deckName} — view submission`)).toBeVisible();
+
+    await hostContext.close();
+  });
+});

--- a/lib/tournament/__tests__/deckSubmission.test.ts
+++ b/lib/tournament/__tests__/deckSubmission.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/utils/deckcheck", () => ({ // MUST match the implementation's "@/" specifier exactly or the mock silently doesn't apply
+  checkDeck: vi.fn(async (cards, reserve) => ({
+    valid: true,
+    format: "Limited",
+    issues: [{ type: "warning", rule: "card-not-found", message: "x", cards: ["Bogus"] }],
+    stats: { mainDeckSize: cards.length, reserveSize: reserve.length },
+  })),
+}));
+import { buildDeckSubmission } from "../deckSubmission";
+
+function fakeAdmin(deckRow: any, cardRows: any[], calls: { in: any[] } = { in: [] }) {
+  // Minimal PostgREST chain stub: .from().select().eq().single() for decks,
+  // .from().select().eq().in() resolving cardRows for deck_cards.
+  // Records .in() args so the maybeboard exclusion is actually asserted.
+  return {
+    from: (table: string) => ({
+      select: () => ({
+        eq: () => ({
+          single: async () => ({ data: deckRow, error: deckRow ? null : { message: "not found" } }),
+          in: async (col: string, vals: string[]) => {
+            calls.in.push([col, vals]);
+            return { data: cardRows, error: null };
+          },
+        }),
+      }),
+    }),
+  } as any;
+}
+
+const deck = { id: "d1", user_id: "owner", name: "My Deck", format: "Limited", visibility: "private" };
+const cards = [
+  { card_name: "Son of God", card_set: "I/J", card_img_file: "sog.jpg", quantity: 1, zone: "main" },
+  { card_name: "Burial", card_set: "I/J", card_img_file: null, quantity: 1, zone: "reserve" },
+];
+
+describe("buildDeckSubmission", () => {
+  it("owner can submit a private deck; snapshot mirrors the validated rows; maybeboard excluded at the query", async () => {
+    const calls = { in: [] as any[] };
+    const r = await buildDeckSubmission(fakeAdmin(deck, cards, calls), "d1", "owner", "Limited");
+    expect(r.success).toBe(true);
+    if (r.success === true) {
+      expect(r.snapshot.cards).toEqual([
+        { name: "Son of God", set: "I/J", imgFile: "sog.jpg", quantity: 1, zone: "main" },
+        { name: "Burial", set: "I/J", imgFile: null, quantity: 1, zone: "reserve" },
+      ]);
+      expect(r.hasUnresolvedCards).toBe(true); // card-not-found warning present
+    }
+    expect(calls.in).toContainEqual(["zone", ["main", "reserve"]]);
+  });
+  it("stranger blocked from private deck", async () => {
+    const r = await buildDeckSubmission(fakeAdmin(deck, cards), "d1", "other", "Limited");
+    expect(r.success).toBe(false);
+    if (r.success === false) expect(r.error).toBe("deck_not_accessible");
+  });
+  it("stranger allowed on unlisted/public deck", async () => {
+    const r = await buildDeckSubmission(
+      fakeAdmin({ ...deck, visibility: "unlisted" }, cards), "d1", "other", "Limited");
+    expect(r.success).toBe(true);
+  });
+  it("missing deck", async () => {
+    const r = await buildDeckSubmission(fakeAdmin(null, []), "nope", "u", "Limited");
+    expect(r.success).toBe(false);
+  });
+});

--- a/lib/tournament/__tests__/joinCodes.test.ts
+++ b/lib/tournament/__tests__/joinCodes.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { generateJoinCode, normalizeJoinCode } from "../joinCodes";
+
+const ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+describe("generateJoinCode", () => {
+  it("returns 6 chars from the Crockford alphabet", () => {
+    for (let i = 0; i < 200; i++) {
+      const code = generateJoinCode();
+      expect(code).toHaveLength(6);
+      for (const ch of code) expect(ALPHABET).toContain(ch);
+    }
+  });
+  it("varies between calls", () => {
+    const s = new Set(Array.from({ length: 50 }, () => generateJoinCode()));
+    expect(s.size).toBeGreaterThan(45);
+  });
+});
+
+describe("normalizeJoinCode", () => {
+  it("uppercases and maps Crockford aliases", () => {
+    // i/l -> 1, o -> 0, u -> V is NOT a Crockford alias — u is simply invalid.
+    expect(normalizeJoinCode("abio1l")).toBe("AB1011");
+  });
+  it("strips whitespace and hyphens", () => {
+    expect(normalizeJoinCode(" ab-c 123 ")).toBe("ABC123"); // cleans to 6 valid chars
+    expect(normalizeJoinCode("abc-123")).toBe("ABC123");
+  });
+  it("rejects wrong length or invalid chars", () => {
+    expect(normalizeJoinCode("ABCDE")).toBe(null);
+    expect(normalizeJoinCode("ABCDEFG")).toBe(null);
+    expect(normalizeJoinCode("ABC12U")).toBe(null);
+    expect(normalizeJoinCode("")).toBe(null);
+  });
+});

--- a/lib/tournament/deckSubmission.ts
+++ b/lib/tournament/deckSubmission.ts
@@ -1,0 +1,90 @@
+import { checkDeck, type DeckCheckCard, type DeckCheckIssue } from "@/utils/deckcheck";
+import type { FormatId } from "@/lib/formats";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export interface DeckSnapshotCard {
+  name: string;
+  set: string;
+  imgFile: string | null;
+  quantity: number;
+  zone: "main" | "reserve";
+}
+
+export interface DeckSnapshot {
+  deckName: string;
+  deckFormat: string;
+  cards: DeckSnapshotCard[];
+}
+
+export type SubmissionBuild =
+  | {
+      success: true;
+      snapshot: DeckSnapshot;
+      isLegal: boolean;
+      issues: DeckCheckIssue[];
+      hasUnresolvedCards: boolean;
+    }
+  | { success: false; error: "deck_not_found" | "deck_not_accessible" };
+
+/**
+ * Single point where a deck is read, validated with checkDeck, and
+ * serialized into an immutable snapshot. Access rule enforced here:
+ * requester must own the deck OR the deck's visibility !== 'private'.
+ * Callers decide policy (join/resubmit require isLegal && !hasUnresolvedCards;
+ * host attach records the verdict but does not block).
+ */
+export async function buildDeckSubmission(
+  admin: SupabaseClient,
+  deckId: string,
+  requestingUserId: string,
+  tournamentFormat: FormatId
+): Promise<SubmissionBuild> {
+  const { data: deck, error } = await admin
+    .from("decks")
+    .select("id, user_id, name, format, visibility")
+    .eq("id", deckId)
+    .single();
+  if (error || !deck) return { success: false, error: "deck_not_found" };
+  const isOwner = deck.user_id === requestingUserId;
+  if (isOwner === false && deck.visibility === "private")
+    return { success: false, error: "deck_not_accessible" };
+
+  const { data: rows, error: cardsError } = await admin
+    .from("deck_cards")
+    .select("card_name, card_set, card_img_file, quantity, zone")
+    .eq("deck_id", deckId)
+    .in("zone", ["main", "reserve"]); // maybeboard NEVER ships
+  if (cardsError) return { success: false, error: "deck_not_found" };
+
+  // ONE read: these rows are both what we validate and what we snapshot.
+  const toCheckCard = (r: any): DeckCheckCard => ({
+    name: r.card_name,
+    set: r.card_set,
+    quantity: r.quantity,
+    imgFile: r.card_img_file ?? undefined,
+  });
+  const main = (rows ?? []).filter((r) => r.zone === "main").map(toCheckCard);
+  const reserve = (rows ?? []).filter((r) => r.zone === "reserve").map(toCheckCard);
+
+  const result = await checkDeck(main, reserve, tournamentFormat);
+
+  return {
+    success: true,
+    snapshot: {
+      deckName: deck.name ?? "Untitled Deck",
+      // Provenance: the deck's DECLARED format. The validation format is
+      // implied by the tournament + is_legal; don't overwrite the record.
+      deckFormat: deck.format ?? "",
+      cards: (rows ?? []).map((r) => ({
+        name: r.card_name,
+        set: r.card_set,
+        imgFile: r.card_img_file ?? null,
+        quantity: r.quantity,
+        zone: r.zone,
+      })),
+    },
+    isLegal: result.valid,
+    issues: result.issues,
+    hasUnresolvedCards: result.issues.some((i) => i.rule === "card-not-found"),
+  };
+}

--- a/lib/tournament/joinCodeShared.ts
+++ b/lib/tournament/joinCodeShared.ts
@@ -1,0 +1,19 @@
+// Crockford base32 alphabet + normalization only — split out of joinCodes.ts
+// so client components can import normalization logic without pulling in
+// node's `crypto` (used only by generateJoinCode, which stays server-only).
+const ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+const ALIASES: Record<string, string> = { I: "1", L: "1", O: "0" };
+export const JOIN_CODE_LENGTH = 6;
+
+/** Uppercase, strip separators, map Crockford aliases. Null if not exactly 6 valid chars. */
+export function normalizeJoinCode(input: string): string | null {
+  const cleaned = input
+    .toUpperCase()
+    .replace(/[\s-]/g, "")
+    .split("")
+    .map((ch) => ALIASES[ch] ?? ch)
+    .join("");
+  if (cleaned.length !== JOIN_CODE_LENGTH) return null;
+  for (const ch of cleaned) if (!ALPHABET.includes(ch)) return null;
+  return cleaned;
+}

--- a/lib/tournament/joinCodes.ts
+++ b/lib/tournament/joinCodes.ts
@@ -1,0 +1,26 @@
+import { randomBytes } from "crypto";
+
+// Crockford base32: no I, L, O, U. Codes are hand-typed from whiteboards.
+const ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+const ALIASES: Record<string, string> = { I: "1", L: "1", O: "0" };
+export const JOIN_CODE_LENGTH = 6;
+
+export function generateJoinCode(): string {
+  const bytes = randomBytes(JOIN_CODE_LENGTH);
+  let out = "";
+  for (let i = 0; i < JOIN_CODE_LENGTH; i++) out += ALPHABET[bytes[i] % 32];
+  return out;
+}
+
+/** Uppercase, strip separators, map Crockford aliases. Null if not exactly 6 valid chars. */
+export function normalizeJoinCode(input: string): string | null {
+  const cleaned = input
+    .toUpperCase()
+    .replace(/[\s-]/g, "")
+    .split("")
+    .map((ch) => ALIASES[ch] ?? ch)
+    .join("");
+  if (cleaned.length !== JOIN_CODE_LENGTH) return null;
+  for (const ch of cleaned) if (!ALPHABET.includes(ch)) return null;
+  return cleaned;
+}

--- a/lib/tournament/joinCodes.ts
+++ b/lib/tournament/joinCodes.ts
@@ -1,26 +1,14 @@
 import { randomBytes } from "crypto";
+import { JOIN_CODE_LENGTH, normalizeJoinCode } from "./joinCodeShared";
 
 // Crockford base32: no I, L, O, U. Codes are hand-typed from whiteboards.
 const ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
-const ALIASES: Record<string, string> = { I: "1", L: "1", O: "0" };
-export const JOIN_CODE_LENGTH = 6;
+
+export { JOIN_CODE_LENGTH, normalizeJoinCode };
 
 export function generateJoinCode(): string {
   const bytes = randomBytes(JOIN_CODE_LENGTH);
   let out = "";
   for (let i = 0; i < JOIN_CODE_LENGTH; i++) out += ALPHABET[bytes[i] % 32];
   return out;
-}
-
-/** Uppercase, strip separators, map Crockford aliases. Null if not exactly 6 valid chars. */
-export function normalizeJoinCode(input: string): string | null {
-  const cleaned = input
-    .toUpperCase()
-    .replace(/[\s-]/g, "")
-    .split("")
-    .map((ch) => ALIASES[ch] ?? ch)
-    .join("");
-  if (cleaned.length !== JOIN_CODE_LENGTH) return null;
-  for (const ch of cleaned) if (!ALPHABET.includes(ch)) return null;
-  return cleaned;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "lucide-react": "^0.456.0",
         "next": "^15.2.1",
         "next-themes": "^0.4.3",
+        "qrcode.react": "^4.2.0",
         "react": "^19.0.0",
         "react-colorful": "^5.6.1",
         "react-dom": "^19.0.0",
@@ -9051,6 +9052,14 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lucide-react": "^0.456.0",
     "next": "^15.2.1",
     "next-themes": "^0.4.3",
+    "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-colorful": "^5.6.1",
     "react-dom": "^19.0.0",

--- a/supabase/migrations/084_qr_join_and_deck_submissions.sql
+++ b/supabase/migrations/084_qr_join_and_deck_submissions.sql
@@ -1,0 +1,140 @@
+-- 084: QR join + decklist submissions.
+-- New surface is default-deny: service-role only, accessed via server actions.
+
+-- 1) Link participants to accounts (host manual adds keep NULL).
+alter table public.participants
+  add column user_id uuid references auth.users(id) on delete set null;
+
+create unique index participants_tournament_user_uniq
+  on public.participants (tournament_id, user_id)
+  where user_id is not null;
+
+-- 2) Tournament policy knobs. code (join code) already exists + UNIQUE.
+alter table public.tournaments
+  add column require_decklists boolean not null default false,
+  add column results_published boolean not null default false;
+
+-- 3) The immutable submission record. Default-deny by construction.
+create table public.tournament_deck_submissions (
+  id uuid primary key default gen_random_uuid(),
+  tournament_id uuid not null references public.tournaments(id) on delete cascade,
+  participant_id uuid not null unique references public.participants(id) on delete cascade,
+  deck_id uuid references public.decks(id) on delete set null, -- provenance only
+  submitted_by uuid references auth.users(id) on delete set null,
+  source text not null check (source in ('player', 'host')),
+  deck_snapshot jsonb not null,
+  is_legal boolean,
+  deckcheck_issues jsonb,
+  submitted_at timestamptz not null default now()
+);
+alter table public.tournament_deck_submissions enable row level security;
+revoke all on public.tournament_deck_submissions from anon, authenticated;
+-- No policies on purpose: service-role only (forge_invites precedent, 049).
+
+-- 4) Rejoin blocks ("Remove & block").
+create table public.tournament_join_blocks (
+  tournament_id uuid not null references public.tournaments(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (tournament_id, user_id)
+);
+alter table public.tournament_join_blocks enable row level security;
+revoke all on public.tournament_join_blocks from anon, authenticated;
+
+-- 5) Fix submission rot: deleting a live deck must not destroy the event
+-- record. published_deck_id is already SET NULL; deck_id was CASCADE.
+alter table public.tournament_decklists
+  alter column deck_id drop not null;
+alter table public.tournament_decklists
+  drop constraint tournament_decklists_deck_id_fkey;
+alter table public.tournament_decklists
+  add constraint tournament_decklists_deck_id_fkey
+  foreign key (deck_id) references public.decks(id) on delete set null;
+
+-- 6) Atomic join. Locks the tournament row so joins serialize against the
+-- host's Start update (has_started); inserts participant + submission +
+-- decklist link in one transaction. Service-role only.
+create or replace function public.tournament_qr_join(
+  p_code text,
+  p_user_id uuid,
+  p_display_name text,
+  p_deck_id uuid,
+  p_snapshot jsonb,
+  p_is_legal boolean,
+  p_issues jsonb,
+  p_resubmit boolean default false
+) returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_t record;
+  v_participant_id uuid;
+begin
+  select id, has_started, require_decklists into v_t
+    from public.tournaments
+    where code = p_code
+    for update;
+  if not found then
+    return jsonb_build_object('ok', false, 'error', 'not_found');
+  end if;
+  if v_t.has_started then
+    return jsonb_build_object('ok', false, 'error', 'started');
+  end if;
+  if exists (
+    select 1 from public.tournament_join_blocks b
+    where b.tournament_id = v_t.id and b.user_id = p_user_id
+  ) then
+    return jsonb_build_object('ok', false, 'error', 'blocked');
+  end if;
+  if v_t.require_decklists and p_snapshot is null then
+    return jsonb_build_object('ok', false, 'error', 'decklist_required');
+  end if;
+
+  select id into v_participant_id
+    from public.participants
+    where tournament_id = v_t.id and user_id = p_user_id;
+
+  if p_resubmit then
+    if v_participant_id is null then
+      return jsonb_build_object('ok', false, 'error', 'not_joined');
+    end if;
+  else
+    if v_participant_id is not null then
+      return jsonb_build_object('ok', false, 'error', 'already_joined');
+    end if;
+    insert into public.participants (tournament_id, name, user_id)
+      values (v_t.id, p_display_name, p_user_id)
+      returning id into v_participant_id;
+  end if;
+
+  if p_snapshot is not null then
+    insert into public.tournament_deck_submissions
+      (tournament_id, participant_id, deck_id, submitted_by, source,
+       deck_snapshot, is_legal, deckcheck_issues)
+    values
+      (v_t.id, v_participant_id, p_deck_id, p_user_id, 'player',
+       p_snapshot, p_is_legal, p_issues)
+    on conflict (participant_id) do update set
+      deck_id = excluded.deck_id,
+      submitted_by = excluded.submitted_by,
+      source = excluded.source,
+      deck_snapshot = excluded.deck_snapshot,
+      is_legal = excluded.is_legal,
+      deckcheck_issues = excluded.deckcheck_issues,
+      submitted_at = now();
+
+    if p_deck_id is not null then
+      insert into public.tournament_decklists (tournament_id, participant_id, deck_id)
+        values (v_t.id, v_participant_id, p_deck_id)
+        on conflict (participant_id) do update set deck_id = excluded.deck_id;
+    end if;
+  end if;
+
+  return jsonb_build_object('ok', true, 'participant_id', v_participant_id);
+end
+$$;
+
+revoke execute on function public.tournament_qr_join(text, uuid, text, uuid, jsonb, boolean, jsonb, boolean)
+  from public, anon, authenticated;

--- a/utils/tournament/__tests__/naming.test.ts
+++ b/utils/tournament/__tests__/naming.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { buildTournamentName, isNameFrozen } from "../naming";
+import { requireDecklistsDefault, categoryDefaults, STANDARD_CATEGORIES } from "../categoryDefaults";
+
+describe("buildTournamentName", () => {
+  const d = new Date(2026, 7, 2); // Aug 2, 2026
+  it("formats date + category", () => {
+    expect(buildTournamentName("Type 2", { date: d })).toBe("Aug 2, 2026 Type 2 Tournament");
+  });
+  it("appends listing city", () => {
+    expect(buildTournamentName("Type 1 Limited", { date: d, city: "Wichita" }))
+      .toBe("Aug 2, 2026 Type 1 Limited Tournament — Wichita");
+  });
+});
+
+describe("isNameFrozen", () => {
+  it("frozen for official categories, free for Unofficial and none", () => {
+    expect(isNameFrozen("Type 2")).toBe(true);
+    expect(isNameFrozen("Unofficial")).toBe(false);
+    expect(isNameFrozen(null)).toBe(false);
+  });
+});
+
+describe("requireDecklistsDefault", () => {
+  it("on when the category RESOLVES to L/U/T2 (listing strings included)", () => {
+    expect(requireDecklistsDefault("Type 1 Limited")).toBe(true);
+    expect(requireDecklistsDefault("Type 1 Unlimited")).toBe(true);
+    expect(requireDecklistsDefault("Type 2")).toBe(true);
+    // Listing-derived categories resolve through categoryDefaults' fuzzy match:
+    expect(requireDecklistsDefault("Type 1")).toBe(true); // -> Limited fallthrough
+    expect(requireDecklistsDefault("T2 - 2P")).toBe(true);
+    // "Closed Deck - 2 Player" is the 2nd-most-common listing format (46 in
+    // prod) and previously fell through to Limited — it's sealed product,
+    // never decklist-required:
+    expect(requireDecklistsDefault("Closed Deck - 2 Player")).toBe(false);
+  });
+  it("off for Teams/Type A despite resolving to Limited, and all non-constructed", () => {
+    for (const c of ["Paragon", "Teams", "Type A", "Booster Draft", "Sealed Deck", "Unofficial", null]) {
+      expect(requireDecklistsDefault(c)).toBe(false);
+    }
+  });
+});
+
+describe("Unofficial category", () => {
+  it("is offered and maps to Other", () => {
+    expect(STANDARD_CATEGORIES).toContain("Unofficial");
+    expect(categoryDefaults("Unofficial").deck_format).toBe("Other");
+  });
+});

--- a/utils/tournament/categoryDefaults.ts
+++ b/utils/tournament/categoryDefaults.ts
@@ -21,6 +21,7 @@ export const STANDARD_CATEGORIES = [
   "Teams",
   "Type A",
   "Paragon",
+  "Unofficial",
 ] as const;
 
 // Maps a category/format string (from a listing or the standard list) to its
@@ -38,11 +39,28 @@ export function categoryDefaults(category: string): CategoryDefaults {
     return { deck_format: "T2", max_score: 7, round_length: 75 };
   if (c.includes("draft"))
     return { deck_format: "Other", max_score: 5, round_length: 45 };
-  if (c.includes("sealed"))
+  // "Closed Deck - 2 Player" is the official listing term for sealed-product
+  // events (46 prod listing entries) — sealed product, never Limited.
+  if (c.includes("sealed") || c.includes("closed"))
     return { deck_format: "Other", max_score: 5, round_length: 45 };
   if (c.includes("unlimited"))
     return { deck_format: "Unlimited", max_score: 5, round_length: 45 };
+  if (c.includes("unofficial"))
+    return { deck_format: "Other", max_score: 5, round_length: 45 };
   // Type 1 (Limited) and Type A (a Type 1 variant) and anything else default
   // to Limited.
   return { deck_format: "Limited", max_score: 5, round_length: 45 };
+}
+
+/** Whether a decklist is required to QR-join, by category. Derives from the
+ * category's RESOLVED format (so listing strings like "Type 1" count), with
+ * explicit carve-outs: Type A and Teams also resolve to Limited but default
+ * off (Type A construction rules would hard-block at the door; Teams pending
+ * elder details). Hosts can flip per event. */
+export function requireDecklistsDefault(category: string | null): boolean {
+  if (!category) return false;
+  const c = category.toLowerCase();
+  if (c.includes("type a") || c.includes("teams") || c.includes("unofficial")) return false;
+  const fmt = categoryDefaults(category).deck_format;
+  return fmt === "Limited" || fmt === "Unlimited" || fmt === "T2";
 }

--- a/utils/tournament/naming.ts
+++ b/utils/tournament/naming.ts
@@ -1,0 +1,18 @@
+/** One formula everywhere: frozen generated names make events sort/group
+ * predictably in the public dataset. */
+export function buildTournamentName(
+  category: string,
+  opts?: { date?: Date; city?: string }
+): string {
+  const date = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(opts?.date ?? new Date());
+  const base = `${date} ${category} Tournament`;
+  return opts?.city ? `${base} — ${opts.city}` : base;
+}
+
+export function isNameFrozen(category: string | null): boolean {
+  return !!category && category !== "Unofficial";
+}


### PR DESCRIPTION
Players join tournaments by scanning a QR code (or typing a 6-char code); constructed events require a server-validated, immutably-snapshotted decklist to join; ending a tournament auto-publishes results + decklists to a new public results page.

Spec: `docs/superpowers/specs/2026-07-27-qr-join-decklist-submission-design.md` (rev 4, on main). Implemented task-by-task from the reviewed 13-task plan with per-task adversarial review; a final whole-branch review (which caught and fixed a cross-tournament authority-scoping hole in `attachDeckToParticipantAction`) is folded in.

## What's in here

- **Migration `084_qr_join_and_deck_submissions.sql`** — renumbered from the plan's 083 because PR #248 claimed 083 on main after the plan was written; content is otherwise exactly as planned:
  - `tournament_deck_submissions` (JSONB snapshots, default-deny: RLS + no policies + revoked from anon/authenticated, service-role only) and `tournament_join_blocks` (same posture)
  - `participants.user_id` (+ partial unique per tournament), `tournaments.require_decklists`, `tournaments.results_published`
  - `tournament_qr_join(...)` — SECURITY DEFINER, `FOR UPDATE` row lock so joins serialize against the host's Start; execute revoked from public/anon/authenticated
  - **`tournament_decklists.deck_id`: now nullable, FK changed CASCADE → SET NULL** — deleting a live deck no longer destroys the event record (the "CASCADE submission rot" P0 from the design)
- **Snapshot pipeline** — one read validates (`checkDeck`) and snapshots the same in-memory rows; maybeboard excluded at the query; requester must own the deck or it must be non-private. Public results loaders never read `deck_snapshot` (the "public-policy snapshot leak" P0 from the design), enforced by an adversarial regression test with hostile fixtures.
- **Player surface** — `/join` + `/join/[code]` (mobile-first), deck picker (my decks / community / paste-a-link), resubmit-until-start, verbatim consent line; join codes are Crockford base32 via `crypto.randomBytes` with hand-typing normalization.
- **Host surface** — QR dialog (format + require-decklists knobs, live joined/submitted counter), participant table with linked-account badges, submission modal (grouped by card type), remove & block, re-check all decklists.
- **End-of-tournament** — both end paths (manual end dialog with default-checked opt-out; auto-end on final round, which publishes unconditionally — the host's opt-out for auto-ended events is unpublishing afterward from the Publish section) route through one `publishOnEnd`; new public results index + per-event standings pages gated on `results_published`.
- **Tests** — 40+ new vitest cases (join codes, submission builder, join/host/results actions incl. security regression tests) + `e2e/qr-join.spec.ts` (written, statically verified, **not yet executed** — see below).

## Plan deviations worth knowing

- Migration is **084**, not 083 (collision with #248). All plan references to "083" mean this file.
- The plan's cited auto-end branch in `page.tsx` turned out to be unreachable; the real auto-end lives in `TournamentRounds.tsx` and is hooked via `onTournamentAutoPublish` (reviewer-verified both paths fire).
- The e2e spec uses UI password sign-in (matching every existing e2e spec) rather than cookie minting — the flow under test IS the sign-in redirect.

## Manual prod steps (in this order — order matters)

1. **Pre-check the FK constraint name** (migration drops it by name):
   `select conname from pg_constraint where conrelid = 'tournament_decklists'::regclass;` — expect `tournament_decklists_deck_id_fkey`.
2. **Apply migration 084 to prod — BEFORE deploying this branch.** Tournament creation now writes `require_decklists` on every categorized create; deploying first breaks tournament creation. (Supabase branch validation is broken repo-wide — fresh branches replay tracked migrations against an untracked baseline schema — so 084 was validated with read-only prod schema checks; a disposable-branch dry run isn't currently possible.)
3. **Post-apply default-deny probe**: with an authenticated user token (PostgREST), `select * from tournament_deck_submissions` must return a permission error / zero rows.
4. **Run the deferred e2e**: `npm run test:e2e -- qr-join` against a dev server. Live-run checklist: both playwright projects (desktop + mobile), `pickMainDeck()` pool sufficiency, post-join refresh timing, deck-picker load race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
