### PR TITLE
fix(join): center the join screen + lock QR format for official events

### DIFF
--- a/app/join/[code]/JoinClient.tsx
+++ b/app/join/[code]/JoinClient.tsx
@@ -11,7 +11,6 @@ import {
   type JoinInfo,
   type JoinResult,
 } from "../actions";
-import { FORMATS } from "@/lib/formats";
 
 type JoinedState = Extract<JoinInfo, { success: true }>;
 type FailedResult = Extract<JoinResult, { success: false }>;
@@ -30,7 +29,6 @@ function Shell({ children }: { children: React.ReactNode }) {
 }
 
 function EventHeader({ info }: { info: JoinedState }) {
-  const badge = info.deckFormat ? FORMATS[info.deckFormat]?.badge : undefined;
   return (
     <div className="mb-6 text-center">
       <h1 className="font-cinzel text-2xl font-bold text-foreground sm:text-3xl">
@@ -38,11 +36,6 @@ function EventHeader({ info }: { info: JoinedState }) {
       </h1>
       <div className="mt-2 flex flex-wrap items-center justify-center gap-2 text-sm text-muted-foreground">
         {info.category && <span>{info.category}</span>}
-        {badge && (
-          <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium text-foreground">
-            {badge}
-          </span>
-        )}
         {info.hostName && <span>Hosted by {info.hostName}</span>}
       </div>
     </div>

--- a/app/join/[code]/JoinClient.tsx
+++ b/app/join/[code]/JoinClient.tsx
@@ -17,7 +17,16 @@ type JoinedState = Extract<JoinInfo, { success: true }>;
 type FailedResult = Extract<JoinResult, { success: false }>;
 
 function Shell({ children }: { children: React.ReactNode }) {
-  return <main className="mx-auto max-w-md px-4 py-8">{children}</main>;
+  // Centered card over the full-screen hero background: without the vertical
+  // centering the content clings to the top of an otherwise-empty immersive
+  // backdrop, and without the panel it reads as bare text floating on art.
+  return (
+    <div className="flex min-h-[100dvh] items-center justify-center px-4 py-10">
+      <div className="w-full max-w-md rounded-2xl border border-border bg-card/80 p-6 shadow-xl backdrop-blur-md sm:p-8">
+        {children}
+      </div>
+    </div>
+  );
 }
 
 function EventHeader({ info }: { info: JoinedState }) {
@@ -237,7 +246,7 @@ export default function JoinClient({
     return (
       <Shell>
         <EventHeader info={info} />
-        <div className="rounded-lg border border-border bg-card p-4">
+        <div className="rounded-lg border border-border bg-background/40 p-4">
           <p className="text-sm text-muted-foreground">Registered as</p>
           <p className="text-lg font-medium text-foreground">{joined.displayName}</p>
 

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -21,8 +21,8 @@ export default function JoinLandingPage() {
   }
 
   return (
-    <main className="mx-auto max-w-sm px-4 py-16">
-      <div className="rounded-lg border border-border bg-card p-6">
+    <main className="flex min-h-[100dvh] items-center justify-center px-4 py-10">
+      <div className="w-full max-w-sm rounded-2xl border border-border bg-card/80 p-6 shadow-xl backdrop-blur-md">
         <h1 className="text-2xl font-semibold text-foreground">Join a tournament</h1>
         <p className="mt-2 text-sm text-muted-foreground">
           Enter the code your host gave you.

--- a/components/ui/QRJoinDialog.tsx
+++ b/components/ui/QRJoinDialog.tsx
@@ -18,7 +18,8 @@ import {
   getJoinStatsAction,
 } from "../../app/tracker/tournaments/actions";
 import { FORMAT_IDS, normalizeTournamentFormat, type FormatId } from "../../lib/formats";
-import { requireDecklistsDefault } from "../../utils/tournament/categoryDefaults";
+import { categoryDefaults, requireDecklistsDefault } from "../../utils/tournament/categoryDefaults";
+import { isNameFrozen } from "../../utils/tournament/naming";
 
 // Only the columns this dialog reads/writes — callers pass the full
 // tournament row (typed `any` at the page level), which satisfies this shape.
@@ -55,6 +56,15 @@ function friendlyError(code: string): string {
 }
 
 function initialFormat(tournament: QRJoinTournament): FormatId | "Other" {
+  // Official categories freeze the event name (e.g. "… Type 1 Unlimited
+  // Tournament"), so the format is implied by the category itself. Derive it
+  // from the category — not the stored deck_format, which an earlier edit
+  // could have drifted from the name — so what the host sees and what the
+  // deck-check enforces always agree with the name. Only free-form
+  // "Unofficial" events keep a stored, host-chosen format.
+  if (isNameFrozen(tournament.category)) {
+    return categoryDefaults(tournament.category as string).deck_format;
+  }
   return normalizeTournamentFormat(tournament.deck_format) ?? "Other";
 }
 
@@ -75,6 +85,9 @@ export default function QRJoinDialog({
   onTournamentUpdated,
 }: QRJoinDialogProps) {
   const enabled = !!tournament.code;
+  // Official events derive their format from the category (which also freezes
+  // the name), so the host can't edit it into a name/format contradiction.
+  const formatLocked = isNameFrozen(tournament.category);
 
   const [deckFormat, setDeckFormat] = useState<FormatId | "Other">(() => initialFormat(tournament));
   const [requireDecklists, setRequireDecklists] = useState<boolean>(() =>
@@ -287,22 +300,32 @@ export default function QRJoinDialog({
           )}
 
           <div className="space-y-4">
-            <label className="block">
-              <span className="text-sm font-medium text-foreground mb-1.5 block">Format</span>
-              <select
-                value={deckFormat}
-                onChange={(e) => handleFormatChange(e.target.value as FormatId | "Other")}
-                disabled={saving}
-                className={selectClasses}
-              >
-                {FORMAT_IDS.map((id) => (
-                  <option key={id} value={id}>
-                    {id}
-                  </option>
-                ))}
-                <option value="Other">Other</option>
-              </select>
-            </label>
+            {formatLocked ? (
+              <div>
+                <span className="text-sm font-medium text-foreground mb-1.5 block">Format</span>
+                <div className="w-full flex items-center justify-between gap-3 rounded-lg border border-border bg-muted/40 p-2.5">
+                  <span className="font-medium text-foreground">{deckFormat}</span>
+                  <span className="text-xs text-muted-foreground">Set by the event category</span>
+                </div>
+              </div>
+            ) : (
+              <label className="block">
+                <span className="text-sm font-medium text-foreground mb-1.5 block">Format</span>
+                <select
+                  value={deckFormat}
+                  onChange={(e) => handleFormatChange(e.target.value as FormatId | "Other")}
+                  disabled={saving}
+                  className={selectClasses}
+                >
+                  {FORMAT_IDS.map((id) => (
+                    <option key={id} value={id}>
+                      {id}
+                    </option>
+                  ))}
+                  <option value="Other">Other</option>
+                </select>
+              </label>
+            )}
 
             <label
               className={`flex items-start gap-3 rounded-lg border border-border bg-background p-3 transition-colors ${

--- a/components/ui/background.tsx
+++ b/components/ui/background.tsx
@@ -25,6 +25,12 @@ const Background: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
 
   const skipBackground = SKIP_BACKGROUND_PREFIXES.some(prefix => pathname.startsWith(prefix));
 
+  // Most pages render the app nav in the top 56px, so the hero starts at
+  // top-14 to sit below it. The public /join pages have no nav, so that
+  // offset leaves an empty dark band at the top — let the hero go full-bleed
+  // there instead.
+  const heroTop = pathname.startsWith("/join") ? "top-0" : "top-14";
+
   if (skipBackground) {
     return (
       <div className="min-h-screen w-full bg-background">
@@ -41,7 +47,7 @@ const Background: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
         <div className={`absolute inset-0 bg-background`}></div>
 
       {/* Hero image container */}
-      <div className="fixed inset-x-0 top-14 bottom-0 overflow-hidden">
+      <div className={`fixed inset-x-0 ${heroTop} bottom-0 overflow-hidden`}>
         {/* Base background color */}
         <div className="absolute inset-0 bg-background" />
 


### PR DESCRIPTION
Two follow-up fixes to the QR-join feature (#253), both flagged from real screenshots.

## 1. Join screen was pinned to the top of the hero

The signed-out / join states rendered as bare text at the very top of the full-screen hero background — a tiny block of content in a sea of empty art, looking unfinished on desktop. Now the content sits in a centered, elevated card (with `backdrop-blur` for legibility over the art), vertically centered in the viewport, on both the `/join` code-entry landing and the `/join/[code]` states. Mobile keeps the full-width single column.

Verified locally (dev server → prod data) at desktop + mobile, light + dark:

- Card is centered horizontally and vertically (`[box=496,317,448,266]` at 1440×900; `[box=16,303,358,238]` at 390×844).
- Dark mode: glassy card reads cleanly over the immersive hero art.

## 2. QR-join format was editable on events whose name already fixes the format

Official categories freeze the tournament name (e.g. "Jul 28, 2026 **Type 1 Unlimited** Tournament"), so the format is determined by the category at creation. But the QR dialog still offered an editable **Format** `<select>`, and changing it wrote `tournaments.deck_format` — so a host could set an "Unlimited"-named event to validate decks as **Limited**. Name and format could silently disagree.

Now, for name-frozen (official) categories the format is derived from the category and shown **read-only** ("Set by the event category"); only the free-form **Unofficial** category keeps the editable selector. This also fixes the field showing the wrong format, since it's now sourced from the same category that names the event.

Verified as host (`baboonytim`) on the live "Type 1 Unlimited" event: the dialog now shows a read-only **Unlimited · Set by the event category** field instead of an editable dropdown; the require-decklist toggle is unchanged.

**Note:** the lock is client-side (host-only action, so low abuse risk — this is a data-consistency fix, not a security boundary). Server-side enforcement in `updateJoinSettingsAction` could be a later hardening if wanted.

Type gate clean (only the pre-existing forge-anon-leak / playDecksAuthorize errors remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 3. Empty dark band at the top of /join

The shared `Background` starts the hero image at `top-14` to clear the app nav, but `/join` renders no nav — leaving an empty dark strip (with a visible seam) above the art. The hero is now full-bleed (`top-0`) on `/join` routes, so it fills the viewport.

## 4. Removed the redundant format-letter badge

The boxed format letter (e.g. "U") sat right next to the category text ("Type 1 Unlimited"), which already names the format — redundant and visually odd. Removed; the category line carries the format.
