### PR TITLE
feat(tournaments): tier + editable event type in Settings

### DIFF
--- a/app/tournaments/tournaments-client.tsx
+++ b/app/tournaments/tournaments-client.tsx
@@ -325,7 +325,7 @@ function ListingCard({
 
           <div className="mt-4 flex items-center gap-3">
             <Link
-              href={`/tracker/tournaments?from_listing=${listing.id}&city=${encodeURIComponent(listing.city)}${listing.formats.length > 0 ? `&formats=${encodeURIComponent(listing.formats.map((f) => f.format).join("|"))}` : ""}`}
+              href={`/tracker/tournaments?from_listing=${listing.id}&city=${encodeURIComponent(listing.city)}${listing.formats.length > 0 ? `&formats=${encodeURIComponent(listing.formats.map((f) => f.format).join("|"))}` : ""}${listing.tournament_type ? `&type=${encodeURIComponent(listing.tournament_type)}` : ""}`}
               className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
             >
               <FaTrophy className="w-3 h-3" />

--- a/app/tracker/tournaments/[id]/page.tsx
+++ b/app/tracker/tournaments/[id]/page.tsx
@@ -1026,6 +1026,7 @@ export default function TournamentPage({
             onDecklistsChange={fetchDecklists}
             usernames={usernames}
             onOpenQrJoin={() => setQrJoinDialogOpen(true)}
+            onTournamentUpdated={fetchTournamentDetails}
             decklistSummary={decklistSummary}
             onRepairCompleted={() => {
               fetchParticipants();

--- a/app/tracker/tournaments/__tests__/joinHostActions.test.ts
+++ b/app/tracker/tournaments/__tests__/joinHostActions.test.ts
@@ -137,49 +137,82 @@ describe("setQrJoinEnabledAction", () => {
 
 // ─── updateJoinSettingsAction ───────────────────────────────────────────
 
+// The format itself is no longer an input here — Tournament Settings owns it.
+// What this action still has to guarantee is the invariant that gate protected:
+// require_decklists=true must never persist on an event with no specific
+// format, because every player would then be bounced with `decklist_required`.
+// It now enforces that against the PERSISTED deck_format instead of a caller-
+// supplied one, which also closes the old bypass (passing "Sealed" instead of
+// the literal "Other") by construction.
 describe("updateJoinSettingsAction", () => {
-  it("rejects require_decklists=true with deckFormat='Other', never touches the DB", async () => {
-    const r = await updateJoinSettingsAction("t1", { deckFormat: "Other", requireDecklists: true });
+  it("rejects require_decklists=true when the persisted format is 'Other'", async () => {
+    const tournaments = makeNode();
+    tournaments._resp = { data: { deck_format: "Other" }, error: null };
+    userClientImpl = makeClient({ tournaments });
+
+    const r = await updateJoinSettingsAction("t1", { requireDecklists: true });
 
     expect(r).toEqual({ success: false, error: "format_required" });
-    expect(createClient).not.toHaveBeenCalled();
+    expect(tournaments.update).not.toHaveBeenCalled();
   });
 
-  it("accepts require_decklists=true with a real format", async () => {
+  it("rejects require_decklists=true when no format is set at all", async () => {
+    const tournaments = makeNode();
+    tournaments._resp = { data: { deck_format: null }, error: null };
+    userClientImpl = makeClient({ tournaments });
+
+    const r = await updateJoinSettingsAction("t1", { requireDecklists: true });
+
+    expect(r).toEqual({ success: false, error: "format_required" });
+    expect(tournaments.update).not.toHaveBeenCalled();
+  });
+
+  // The old bypass: "Sealed" isn't the literal "Other" but normalizes to it.
+  // Reading the persisted value through normalizeTournamentFormat catches it.
+  it("rejects a stored format that only normalizes to 'Other' (e.g. 'Sealed')", async () => {
+    const tournaments = makeNode();
+    tournaments._resp = { data: { deck_format: "Sealed" }, error: null };
+    userClientImpl = makeClient({ tournaments });
+
+    const r = await updateJoinSettingsAction("t1", { requireDecklists: true });
+
+    expect(r).toEqual({ success: false, error: "format_required" });
+    expect(tournaments.update).not.toHaveBeenCalled();
+  });
+
+  it("accepts require_decklists=true when a real format is persisted", async () => {
+    const tournaments = makeNode();
+    tournaments._resp = { data: { deck_format: "Limited" }, error: null };
+    userClientImpl = makeClient({ tournaments });
+
+    const r = await updateJoinSettingsAction("t1", { requireDecklists: true });
+
+    expect(r).toEqual({ success: true });
+    expect(tournaments.update).toHaveBeenCalledWith({ require_decklists: true });
+  });
+
+  it("turning decklists OFF never needs a format and skips the lookup", async () => {
     const tournaments = makeNode();
     tournaments._resp = { data: null, error: null };
     userClientImpl = makeClient({ tournaments });
 
-    const r = await updateJoinSettingsAction("t1", { deckFormat: "Limited", requireDecklists: true });
+    const r = await updateJoinSettingsAction("t1", { requireDecklists: false });
 
     expect(r).toEqual({ success: true });
-    expect(tournaments.update).toHaveBeenCalledWith({ deck_format: "Limited", require_decklists: true });
+    expect(tournaments.select).not.toHaveBeenCalled();
+    expect(tournaments.update).toHaveBeenCalledWith({ require_decklists: false });
   });
 
-  // Regression: "Sealed"/"Draft" normalize to 'Other' via normalizeTournamentFormat,
-  // so comparing raw input against the literal "Other" alone let a caller
-  // bypass the format_required gate by passing "Sealed" instead of "Other" —
-  // persisting exactly the state (require_decklists=true, no real format)
-  // the gate exists to prevent. The whitelist must reject it outright,
-  // regardless of requireDecklists.
-  it("'Sealed' (not the literal 'Other', but normalizes to it) is rejected outright", async () => {
-    const r = await updateJoinSettingsAction("t1", {
-      deckFormat: "Sealed" as any,
-      requireDecklists: true,
-    });
+  it("never writes deck_format — that's Tournament Settings' column now", async () => {
+    const tournaments = makeNode();
+    tournaments._resp = { data: { deck_format: "T2" }, error: null };
+    userClientImpl = makeClient({ tournaments });
 
-    expect(r).toEqual({ success: false, error: "invalid_format" });
-    expect(createClient).not.toHaveBeenCalled();
-  });
+    await updateJoinSettingsAction("t1", { requireDecklists: true });
 
-  it("junk format string is rejected outright, even with requireDecklists=false", async () => {
-    const r = await updateJoinSettingsAction("t1", {
-      deckFormat: "asdf" as any,
-      requireDecklists: false,
-    });
-
-    expect(r).toEqual({ success: false, error: "invalid_format" });
-    expect(createClient).not.toHaveBeenCalled();
+    for (const call of tournaments.update.mock.calls) {
+      expect(call[0]).not.toHaveProperty("deck_format");
+    }
   });
 });
 

--- a/app/tracker/tournaments/actions.ts
+++ b/app/tracker/tournaments/actions.ts
@@ -6,7 +6,7 @@ import { computeFinalStandings } from "@/lib/tournament/standings";
 import { buildStateFromSupabase } from "@/utils/tournament/stateAdapter";
 import { generateJoinCode } from "@/lib/tournament/joinCodes";
 import { buildDeckSubmission, type DeckSnapshot } from "@/lib/tournament/deckSubmission";
-import { normalizeTournamentFormat, FORMAT_IDS, type FormatId } from "@/lib/formats";
+import { normalizeTournamentFormat, type FormatId } from "@/lib/formats";
 import { checkDeck, type DeckCheckCard, type DeckCheckIssue } from "@/utils/deckcheck";
 
 // System user that owns published tournament deck copies
@@ -436,25 +436,29 @@ export async function setQrJoinEnabledAction(
 
 export async function updateJoinSettingsAction(
   tournamentId: string,
-  s: { deckFormat: FormatId | "Other"; requireDecklists: boolean }
+  s: { requireDecklists: boolean }
 ): Promise<{ success: boolean; error?: string }> {
-  // The declared type is FormatId | "Other", but nothing stops a caller from
-  // bypassing TS and passing an arbitrary string. normalizeTournamentFormat
-  // maps things like "Sealed"/"Draft" to 'Other' and unrecognized junk to
-  // 'Limited', so comparing the raw input against the literal "Other" below
-  // is only safe once we've confirmed it's actually one of the real ids.
-  const isValidFormat = s.deckFormat === "Other" || (FORMAT_IDS as readonly string[]).includes(s.deckFormat);
-  if (!isValidFormat) {
-    return { success: false, error: "invalid_format" };
-  }
-  if (s.requireDecklists === true && s.deckFormat === "Other") {
-    return { success: false, error: "format_required" };
+  const supabase = await createClient();
+
+  // The format is Tournament Settings' to set, not this dialog's — but the
+  // invariant it protects still has to hold here: requiring a decklist on an
+  // event with no specific format makes it unjoinable (every player is bounced
+  // with `decklist_required`). Read the persisted format and refuse.
+  if (s.requireDecklists === true) {
+    const { data } = await supabase
+      .from("tournaments")
+      .select("deck_format")
+      .eq("id", tournamentId)
+      .maybeSingle();
+    const format = normalizeTournamentFormat(data?.deck_format);
+    if (format === null || format === "Other") {
+      return { success: false, error: "format_required" };
+    }
   }
 
-  const supabase = await createClient();
   const { error } = await supabase
     .from("tournaments")
-    .update({ deck_format: s.deckFormat, require_decklists: s.requireDecklists })
+    .update({ require_decklists: s.requireDecklists })
     .eq("id", tournamentId);
 
   if (error) return { success: false, error: error.message };

--- a/app/tracker/tournaments/page.tsx
+++ b/app/tracker/tournaments/page.tsx
@@ -10,6 +10,7 @@ import { HiPencil, HiTrash, HiPlus, HiOutlineDesktopComputer } from "react-icons
 import { useRouter, useSearchParams } from "next/navigation";
 import TournamentFormModal from "../../../components/ui/tournament-form-modal";
 import { categoryDefaults, requireDecklistsDefault } from "../../../utils/tournament/categoryDefaults";
+import { normalizeTier } from "../../../utils/tournament/tiers";
 import { getFormatDef } from "@/lib/formats";
 
 const supabase = createClient();
@@ -27,6 +28,7 @@ function TournamentsPageInner() {
   const [listingCity, setListingCity] = useState("");
   const [fromListingId, setFromListingId] = useState<string | null>(null);
   const [listingFormats, setListingFormats] = useState<string[]>([]);
+  const [listingTier, setListingTier] = useState<string | null>(null);
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -39,10 +41,15 @@ function TournamentsPageInner() {
     const listingId = searchParams.get("from_listing");
     const city = searchParams.get("city");
     const formats = searchParams.get("formats");
+    // The listing's advertised tournament_type is free text ("South Central
+    // Regional"); normalizeTier collapses it onto a canonical tier, or null if
+    // it's something we don't recognize.
+    const type = searchParams.get("type");
     if (listingId) {
       setListingCity(city ?? "");
       setFromListingId(listingId);
       setListingFormats(formats ? formats.split("|").filter(Boolean) : []);
+      setListingTier(normalizeTier(type));
       setisAddTournamentModalOpen(true);
     }
   }, [searchParams]);
@@ -67,7 +74,7 @@ function TournamentsPageInner() {
   // creates one per checked type in a single insert; when hosting from a listing
   // they share its listing_id and group under one event card.
   const handleAddTournament = async (
-    items: { name: string; category: string | null }[]
+    items: { name: string; category: string | null; tier: string | null }[]
   ) => {
     if (items.length === 0) return;
     try {
@@ -87,9 +94,10 @@ function TournamentsPageInner() {
         return;
       }
 
-      const rows = items.map(({ name, category }) => {
+      const rows = items.map(({ name, category, tier }) => {
         const row: Record<string, unknown> = { name, host_id: user.id };
         if (fromListingId) row.listing_id = fromListingId;
+        if (tier) row.tier = tier;
         // A chosen category records the format and pre-fills sensible settings the
         // host can still change later in Tournament Settings.
         if (category) {
@@ -120,6 +128,7 @@ function TournamentsPageInner() {
           setFromListingId(null);
           setListingCity("");
           setListingFormats([]);
+          setListingTier(null);
           // Clean up URL params
           router.replace("/tracker/tournaments", { scroll: false });
         }
@@ -146,6 +155,9 @@ function TournamentsPageInner() {
     const city = group.map((t) => t.name?.split(" — ")[1]).find(Boolean) ?? "";
     setListingCity(city);
     setListingFormats([]);
+    // Same reasoning as the city: inherit the tier its siblings carry so the
+    // late-added category's generated name matches the rest of the event.
+    setListingTier(group.map((t) => t.tier).find(Boolean) ?? null);
     setisAddTournamentModalOpen(true);
   };
 
@@ -339,12 +351,14 @@ function TournamentsPageInner() {
                 setFromListingId(null);
                 setListingCity("");
                 setListingFormats([]);
+                setListingTier(null);
                 router.replace("/tracker/tournaments", { scroll: false });
               }
             }}
             onSubmit={handleAddTournament}
             listingCity={listingCity}
             categoryOptions={listingFormats.length > 0 ? listingFormats : undefined}
+            defaultTier={listingTier}
           />
         </div>
         {loading ? (

--- a/components/ui/QRJoinDialog.tsx
+++ b/components/ui/QRJoinDialog.tsx
@@ -17,7 +17,7 @@ import {
   updateJoinSettingsAction,
   getJoinStatsAction,
 } from "../../app/tracker/tournaments/actions";
-import { FORMAT_IDS, normalizeTournamentFormat, type FormatId } from "../../lib/formats";
+import { normalizeTournamentFormat, type FormatId } from "../../lib/formats";
 import { categoryDefaults, requireDecklistsDefault } from "../../utils/tournament/categoryDefaults";
 import { isNameFrozen } from "../../utils/tournament/naming";
 
@@ -42,7 +42,7 @@ const ERROR_MESSAGES: Record<string, string> = {
   not_found: "You don't have access to this tournament.",
   code_generation_failed: "Couldn't generate a join code — please try again.",
   invalid_format: "That format isn't valid.",
-  format_required: "Choose a specific format before requiring decklists.",
+  format_required: "Set a format in the Settings tab before requiring decklists.",
 };
 
 // Shown when a server action throws outright (network drop, expired
@@ -85,10 +85,9 @@ export default function QRJoinDialog({
   onTournamentUpdated,
 }: QRJoinDialogProps) {
   const enabled = !!tournament.code;
-  // Official events derive their format from the category (which also freezes
-  // the name), so the host can't edit it into a name/format contradiction.
-  const formatLocked = isNameFrozen(tournament.category);
 
+  // Read-only here: Tournament Settings owns the event's category and format.
+  // This dialog owns the join knobs (code, require-decklist) and nothing else.
   const [deckFormat, setDeckFormat] = useState<FormatId | "Other">(() => initialFormat(tournament));
   const [requireDecklists, setRequireDecklists] = useState<boolean>(() =>
     initialRequireDecklists(tournament)
@@ -144,7 +143,6 @@ export default function QRJoinDialog({
     setError(null);
     try {
       const settingsRes = await updateJoinSettingsAction(tournament.id, {
-        deckFormat,
         requireDecklists,
       });
       if (settingsRes.success === false) {
@@ -187,47 +185,31 @@ export default function QRJoinDialog({
 
   // Auto-save knob edits once QR Join is already live — there's no separate
   // "save" step once a code has been handed out. `previous` is the
-  // pre-optimistic-update {deckFormat, requireDecklists} pair so a failed or
-  // thrown save can roll the local (already-changed) state back to the
-  // last-known-persisted values instead of leaving the UI showing something
-  // the server never saved.
-  async function persistSettings(
-    next: { deckFormat: FormatId | "Other"; requireDecklists: boolean },
-    previous: { deckFormat: FormatId | "Other"; requireDecklists: boolean }
-  ) {
+  // pre-optimistic-update value so a failed or thrown save can roll the local
+  // (already-changed) state back to the last-known-persisted one instead of
+  // leaving the UI showing something the server never saved.
+  async function handleRequireChange(checked: boolean) {
+    const previous = requireDecklists;
+    setRequireDecklists(checked);
     if (!enabled) return;
     setSaving(true);
     setError(null);
     try {
-      const res = await updateJoinSettingsAction(tournament.id, next);
+      const res = await updateJoinSettingsAction(tournament.id, {
+        requireDecklists: checked,
+      });
       if (res.success === false) {
         setError(friendlyError(res.error ?? ""));
-        setDeckFormat(previous.deckFormat);
-        setRequireDecklists(previous.requireDecklists);
+        setRequireDecklists(previous);
         return;
       }
       onTournamentUpdated();
     } catch {
       setError(GENERIC_ERROR_MESSAGE);
-      setDeckFormat(previous.deckFormat);
-      setRequireDecklists(previous.requireDecklists);
+      setRequireDecklists(previous);
     } finally {
       setSaving(false);
     }
-  }
-
-  function handleFormatChange(next: FormatId | "Other") {
-    const previous = { deckFormat, requireDecklists };
-    const nextRequire = next === "Other" ? false : requireDecklists;
-    setDeckFormat(next);
-    setRequireDecklists(nextRequire);
-    if (enabled) persistSettings({ deckFormat: next, requireDecklists: nextRequire }, previous);
-  }
-
-  function handleRequireChange(checked: boolean) {
-    const previous = { deckFormat, requireDecklists };
-    setRequireDecklists(checked);
-    if (enabled) persistSettings({ deckFormat, requireDecklists: checked }, previous);
   }
 
   function copyUrl() {
@@ -240,9 +222,6 @@ export default function QRJoinDialog({
       })
       .catch(() => {});
   }
-
-  const selectClasses =
-    "w-full bg-background border border-border text-foreground rounded-lg p-2.5 focus:outline-none focus:border-primary/60 transition-colors disabled:opacity-60 disabled:cursor-not-allowed";
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
@@ -300,32 +279,13 @@ export default function QRJoinDialog({
           )}
 
           <div className="space-y-4">
-            {formatLocked ? (
-              <div>
-                <span className="text-sm font-medium text-foreground mb-1.5 block">Format</span>
-                <div className="w-full flex items-center justify-between gap-3 rounded-lg border border-border bg-muted/40 p-2.5">
-                  <span className="font-medium text-foreground">{deckFormat}</span>
-                  <span className="text-xs text-muted-foreground">Set by the event category</span>
-                </div>
+            <div>
+              <span className="text-sm font-medium text-foreground mb-1.5 block">Format</span>
+              <div className="w-full flex items-center justify-between gap-3 rounded-lg border border-border bg-muted/40 p-2.5">
+                <span className="font-medium text-foreground">{deckFormat}</span>
+                <span className="text-xs text-muted-foreground">Set in the Settings tab</span>
               </div>
-            ) : (
-              <label className="block">
-                <span className="text-sm font-medium text-foreground mb-1.5 block">Format</span>
-                <select
-                  value={deckFormat}
-                  onChange={(e) => handleFormatChange(e.target.value as FormatId | "Other")}
-                  disabled={saving}
-                  className={selectClasses}
-                >
-                  {FORMAT_IDS.map((id) => (
-                    <option key={id} value={id}>
-                      {id}
-                    </option>
-                  ))}
-                  <option value="Other">Other</option>
-                </select>
-              </label>
-            )}
+            </div>
 
             <label
               className={`flex items-start gap-3 rounded-lg border border-border bg-background p-3 transition-colors ${

--- a/components/ui/TournamentSettings.tsx
+++ b/components/ui/TournamentSettings.tsx
@@ -216,7 +216,13 @@ export default function TournamentSettings({
     }
     // The event-type cascade wins over a same-field scalar edit: re-seeded
     // values are computed from the pending edits, so they're already current.
-    if (plan) Object.assign(patch, plan);
+    if (plan) {
+      Object.assign(patch, plan as Partial<TournamentInfo>);
+    } else if (eventTypeDirty) {
+      // Tier changed on a tournament that has no category. There's nothing to
+      // cascade from and no frozen name to regenerate — just write the tier.
+      patch.tier = tier || null;
+    }
     if (Object.keys(patch).length === 0) return;
 
     const snapshot = { ...tournamentInfo, ...patch };
@@ -366,7 +372,10 @@ export default function TournamentSettings({
                   disabled={editingDisabled}
                   className={inputClasses}
                 >
-                  <option value="">Not specified</option>
+                  {/* Only offered while the event genuinely has no category
+                      (pre-dates the field). Once one is set, clearing it would
+                      strand the frozen name with a category it no longer has. */}
+                  {!savedCategory && <option value="">Not specified</option>}
                   {categoryOptions.map((c) => (
                     <option key={c} value={c}>
                       {c}

--- a/components/ui/TournamentSettings.tsx
+++ b/components/ui/TournamentSettings.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
-import { Check, Loader2, Lock } from "lucide-react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { AlertTriangle, Check, Loader2, Lock } from "lucide-react";
 import { suggestNumberOfRounds } from "../../utils/tournamentUtils";
 import { createClient } from "../../utils/supabase/client";
+import { FORMAT_IDS, normalizeTournamentFormat, type FormatId } from "../../lib/formats";
+import { STANDARD_CATEGORIES } from "../../utils/tournament/categoryDefaults";
+import { TOURNAMENT_TIERS } from "../../utils/tournament/tiers";
+import { planEventTypeChange, type EventTypePlan } from "../../utils/tournament/eventType";
+import { getJoinStatsAction } from "../../app/tracker/tournaments/actions";
 
 interface TournamentInfo {
   n_rounds: number | null;
@@ -17,11 +22,21 @@ interface TournamentInfo {
   numbering_mode: string | null;
   has_started: boolean | null;
   has_ended: boolean | null;
+  // Event type. Edited through the dedicated tier/category state below rather
+  // than in place, so these always hold the persisted values.
+  name: string;
+  tier: string | null;
+  category: string | null;
+  deck_format: string | null;
+  require_decklists: boolean | null;
+  created_at: string;
 }
 
 interface TournamentSettingsProps {
   tournamentId: string;
   participantCount: number;
+  // Called after a successful save so the page header picks up a rename.
+  onTournamentUpdated?: () => void;
 }
 
 type SaveStatus = "idle" | "saving" | "saved" | "error";
@@ -38,6 +53,12 @@ const EMPTY_INFO: TournamentInfo = {
   numbering_mode: "tables",
   has_started: null,
   has_ended: null,
+  name: "",
+  tier: null,
+  category: null,
+  deck_format: null,
+  require_decklists: null,
+  created_at: new Date(0).toISOString(),
 };
 
 // Fields the user can edit and that get written on Save.
@@ -55,14 +76,23 @@ const EDITABLE_KEYS = [
 export default function TournamentSettings({
   tournamentId,
   participantCount,
+  onTournamentUpdated,
 }: TournamentSettingsProps) {
   const [tournamentInfo, setTournamentInfo] = useState<TournamentInfo>(EMPTY_INFO);
   // Baseline reflecting what's persisted in the DB, used for dirty tracking.
   const [savedInfo, setSavedInfo] = useState<TournamentInfo>(EMPTY_INFO);
   const [round1Started, setRound1Started] = useState(false);
   const [pinnedCount, setPinnedCount] = useState(0);
+  const [submittedCount, setSubmittedCount] = useState(0);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
+  const [saveError, setSaveError] = useState<string | null>(null);
   const savedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Event type lives outside tournamentInfo: "" means unspecified, and the
+  // cascade into name/format/derived settings is computed rather than typed.
+  const [tier, setTier] = useState<string>("");
+  const [category, setCategory] = useState<string>("");
+  const [unofficialFormat, setUnofficialFormat] = useState<FormatId | "Other">("Other");
 
   const suggestedRounds = suggestNumberOfRounds(participantCount);
 
@@ -74,7 +104,7 @@ export default function TournamentSettings({
       const { data, error } = await client
         .from("tournaments")
         .select(
-          "n_rounds, current_round, round_length, max_score, bye_points, bye_differential, starting_table_number, sound_notifications, has_started, has_ended, numbering_mode",
+          "n_rounds, current_round, round_length, max_score, bye_points, bye_differential, starting_table_number, sound_notifications, has_started, has_ended, numbering_mode, name, tier, category, deck_format, require_decklists, created_at",
         )
         .eq("id", tournamentId)
         .single();
@@ -86,6 +116,14 @@ export default function TournamentSettings({
 
       setTournamentInfo(data);
       setSavedInfo(data);
+      setTier(data.tier ?? "");
+      setCategory(data.category ?? "");
+      setUnofficialFormat(normalizeTournamentFormat(data.deck_format) ?? "Other");
+
+      // Only used to warn that changing the format leaves existing deck-check
+      // verdicts stale. Host-gated server action; a non-host gets 0 and no warning.
+      const stats = await getJoinStatsAction(tournamentId);
+      setSubmittedCount(stats.success === true ? stats.submitted : 0);
 
       const { data: round1 } = await client
         .from("rounds")
@@ -109,12 +147,65 @@ export default function TournamentSettings({
   const flashSaved = useCallback(() => {
     setSaveStatus("saved");
     if (savedTimer.current) clearTimeout(savedTimer.current);
-    savedTimer.current = setTimeout(() => setSaveStatus("idle"), 1500);
+    savedTimer.current = setTimeout(() => setSaveStatus("idle"), 3000);
   }, []);
 
-  const isDirty = EDITABLE_KEYS.some(
+  const editingDisabled = !!tournamentInfo.has_ended;
+  const maxScoreLocked = round1Started || editingDisabled;
+
+  const savedTier = savedInfo.tier ?? "";
+  const savedCategory = savedInfo.category ?? "";
+  const savedUnofficialFormat = normalizeTournamentFormat(savedInfo.deck_format) ?? "Other";
+  const eventTypeDirty =
+    tier !== savedTier ||
+    category !== savedCategory ||
+    (category === "Unofficial" && unofficialFormat !== savedUnofficialFormat);
+
+  // The same plan drives the preview and the persisted patch, so what the host
+  // is shown and what gets written can't drift apart. Only computed once a
+  // category is picked — there's nothing to cascade from "unspecified".
+  const plan: EventTypePlan | null = useMemo(() => {
+    if (!category || !eventTypeDirty) return null;
+    return planEventTypeChange(
+      {
+        name: savedInfo.name,
+        tier: savedInfo.tier,
+        category: savedInfo.category,
+        deck_format: savedInfo.deck_format,
+        // Pending edits count as host overrides: a round length just changed by
+        // hand shouldn't be re-seeded out from under them.
+        max_score: tournamentInfo.max_score,
+        round_length: tournamentInfo.round_length,
+        require_decklists: savedInfo.require_decklists,
+        created_at: savedInfo.created_at,
+      },
+      {
+        tier: tier || null,
+        category,
+        unofficialFormat: category === "Unofficial" ? unofficialFormat : undefined,
+      },
+      { maxScoreLocked },
+    );
+  }, [
+    category,
+    eventTypeDirty,
+    savedInfo,
+    tournamentInfo.max_score,
+    tournamentInfo.round_length,
+    tier,
+    unofficialFormat,
+    maxScoreLocked,
+  ]);
+
+  const scalarDirty = EDITABLE_KEYS.some(
     (key) => tournamentInfo[key] !== savedInfo[key],
   );
+  const isDirty = scalarDirty || eventTypeDirty;
+
+  // Changing the format leaves already-stored deck-check verdicts stale — they
+  // were computed against the old one and are not re-run.
+  const formatChanging =
+    !!plan && normalizeTournamentFormat(savedInfo.deck_format) !== plan.deck_format;
 
   const handleSave = useCallback(async () => {
     const patch: Partial<TournamentInfo> = {};
@@ -123,10 +214,14 @@ export default function TournamentSettings({
         patch[key] = tournamentInfo[key] as never;
       }
     }
+    // The event-type cascade wins over a same-field scalar edit: re-seeded
+    // values are computed from the pending edits, so they're already current.
+    if (plan) Object.assign(patch, plan);
     if (Object.keys(patch).length === 0) return;
 
-    const snapshot = tournamentInfo;
+    const snapshot = { ...tournamentInfo, ...patch };
     setSaveStatus("saving");
+    setSaveError(null);
     try {
       const client = createClient();
       const { error } = await client
@@ -135,12 +230,17 @@ export default function TournamentSettings({
         .eq("id", tournamentId);
       if (error) throw error;
       setSavedInfo(snapshot);
+      // Re-seeded settings and the regenerated name have to show up in the form
+      // too, not just in the baseline.
+      setTournamentInfo(snapshot);
       flashSaved();
+      onTournamentUpdated?.();
     } catch (err) {
       console.error("Error updating tournament:", err);
+      setSaveError(err instanceof Error ? err.message : String(err));
       setSaveStatus("error");
     }
-  }, [tournamentId, tournamentInfo, savedInfo, flashSaved]);
+  }, [tournamentId, tournamentInfo, savedInfo, plan, flashSaved, onTournamentUpdated]);
 
   useEffect(() => {
     return () => {
@@ -148,13 +248,19 @@ export default function TournamentSettings({
     };
   }, []);
 
-  const editingDisabled = !!tournamentInfo.has_ended;
-  const maxScoreLocked = round1Started || editingDisabled;
   const numberingModeLocked = !!tournamentInfo.has_started || editingDisabled;
   const minRounds = Math.max(1, tournamentInfo.current_round || 1);
 
   const inputClasses =
     "w-full bg-background border border-border text-foreground rounded-lg p-2.5 focus:outline-none focus:border-primary/60 transition-colors disabled:opacity-60 disabled:cursor-not-allowed";
+
+  // Events hosted from an official listing carry that listing's own category
+  // string ("Type 1 - 2P", "Type 1 - Teams"), which isn't in the standard list.
+  // Prepend it so opening Settings never silently coerces the category.
+  const categoryOptions =
+    savedCategory && !STANDARD_CATEGORIES.includes(savedCategory as never)
+      ? [savedCategory, ...STANDARD_CATEGORIES]
+      : [...STANDARD_CATEGORIES];
 
   return (
     <div className="w-full max-w-[800px] mx-auto">
@@ -181,26 +287,9 @@ export default function TournamentSettings({
           </svg>
           Tournament Settings
         </h2>
-        <div className="text-xs text-muted-foreground h-5 flex items-center gap-1.5" aria-live="polite">
-          {saveStatus === "saving" && (
-            <>
-              <Loader2 className="w-3.5 h-3.5 animate-spin" />
-              Saving…
-            </>
-          )}
-          {saveStatus === "saved" && (
-            <>
-              <Check className="w-3.5 h-3.5 text-primary" />
-              Saved
-            </>
-          )}
-          {saveStatus === "error" && (
-            <span className="text-destructive">Failed to save</span>
-          )}
-          {saveStatus === "idle" && isDirty && (
-            <span className="text-amber-600 dark:text-amber-500">Unsaved changes</span>
-          )}
-        </div>
+        {/* Save status lives in the sticky footer next to the button, where the
+            host is actually looking when they click it — this card is tall
+            enough that a header-only confirmation flashes off-screen. */}
       </div>
 
       <div className="bg-card jayden-gradient-bg shadow-md dark:shadow-none border border-border rounded-xl overflow-hidden">
@@ -237,6 +326,143 @@ export default function TournamentSettings({
         </div>
 
         <div className="p-4 sm:p-6 space-y-6">
+          {/* Event type — the single owner of category/format. The QR Join
+              dialog reads these; it no longer writes them. */}
+          <div className="rounded-lg border border-border bg-muted/20 p-4 space-y-4">
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">Event Type</h3>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Sets the deck format players are checked against, and the event name.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <label className="block">
+                <span className="text-sm font-medium text-foreground mb-1.5 block">
+                  Tier
+                </span>
+                <select
+                  value={tier}
+                  onChange={(e) => setTier(e.target.value)}
+                  disabled={editingDisabled}
+                  className={inputClasses}
+                >
+                  <option value="">Not specified</option>
+                  {TOURNAMENT_TIERS.map((t) => (
+                    <option key={t} value={t}>
+                      {t}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="block">
+                <span className="text-sm font-medium text-foreground mb-1.5 block">
+                  Category
+                </span>
+                <select
+                  value={category}
+                  onChange={(e) => setCategory(e.target.value)}
+                  disabled={editingDisabled}
+                  className={inputClasses}
+                >
+                  <option value="">Not specified</option>
+                  {categoryOptions.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+
+            {category === "Unofficial" ? (
+              <label className="block">
+                <span className="text-sm font-medium text-foreground mb-1.5 block">
+                  Format
+                </span>
+                <select
+                  value={unofficialFormat}
+                  onChange={(e) =>
+                    setUnofficialFormat(e.target.value as FormatId | "Other")
+                  }
+                  disabled={editingDisabled}
+                  className={inputClasses}
+                >
+                  {FORMAT_IDS.map((id) => (
+                    <option key={id} value={id}>
+                      {id}
+                    </option>
+                  ))}
+                  <option value="Other">Other</option>
+                </select>
+              </label>
+            ) : (
+              <div>
+                <span className="text-sm font-medium text-foreground mb-1.5 block">
+                  Format
+                </span>
+                <div className="w-full flex items-center justify-between gap-3 rounded-lg border border-border bg-muted/40 p-2.5">
+                  <span className="font-medium text-foreground">
+                    {plan
+                      ? plan.deck_format
+                      : normalizeTournamentFormat(savedInfo.deck_format) ?? "—"}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {category ? "Set by the category" : "Pick a category to set this"}
+                  </span>
+                </div>
+              </div>
+            )}
+
+            {plan && (
+              <div className="rounded-lg border border-primary/40 bg-primary/5 p-3 space-y-1">
+                <p className="text-xs font-medium text-foreground">On save:</p>
+                <ul className="text-xs text-muted-foreground space-y-0.5">
+                  {plan.name && (
+                    <li>
+                      Renames to <span className="text-foreground">{plan.name}</span>
+                    </li>
+                  )}
+                  {plan.max_score !== undefined && (
+                    <li>
+                      Lost Souls {tournamentInfo.max_score} → {plan.max_score}
+                    </li>
+                  )}
+                  {plan.round_length !== undefined && (
+                    <li>
+                      Round length {tournamentInfo.round_length} → {plan.round_length} min
+                    </li>
+                  )}
+                  {plan.require_decklists !== undefined && (
+                    <li>
+                      Decklists {plan.require_decklists ? "required" : "no longer required"}
+                    </li>
+                  )}
+                  {!plan.name &&
+                    plan.max_score === undefined &&
+                    plan.round_length === undefined &&
+                    plan.require_decklists === undefined && (
+                      <li>No other settings change.</li>
+                    )}
+                </ul>
+              </div>
+            )}
+
+            {formatChanging && submittedCount > 0 && (
+              <div className="flex items-start gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3">
+                <AlertTriangle className="w-4 h-4 text-amber-500 mt-0.5 flex-shrink-0" />
+                <p className="text-xs text-amber-700 dark:text-amber-400">
+                  {submittedCount} submitted decklist{submittedCount === 1 ? " was" : "s were"}{" "}
+                  checked against{" "}
+                  {normalizeTournamentFormat(savedInfo.deck_format) ?? "no format"}. Changing
+                  the format won&apos;t re-check {submittedCount === 1 ? "it" : "them"} — the
+                  legality badges will be stale.
+                </p>
+              </div>
+            )}
+          </div>
+
           {/* Status row (always read-only) */}
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
             <div className="rounded-lg bg-muted/40 border border-border p-3">
@@ -474,12 +700,40 @@ export default function TournamentSettings({
           )}
 
           {!editingDisabled && (
-            <div className="flex items-center justify-end gap-3 pt-2 border-t border-border">
-              {isDirty && saveStatus !== "saving" && (
-                <span className="text-xs text-muted-foreground">
-                  You have unsaved changes
-                </span>
-              )}
+            // Sticky so the button and its status stay on screen while the host
+            // scrolls this (very tall) form. -mx/-mb pull it out of the card's
+            // padding so the backdrop spans the full width.
+            <div className="sticky bottom-0 -mx-4 sm:-mx-6 -mb-4 sm:-mb-6 mt-2 px-4 sm:px-6 py-3 border-t border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 flex items-center justify-end gap-3 flex-wrap">
+              <div
+                className="text-xs flex items-center gap-1.5 mr-auto"
+                aria-live="polite"
+              >
+                {saveStatus === "saving" && (
+                  <span className="text-muted-foreground flex items-center gap-1.5">
+                    <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                    Saving…
+                  </span>
+                )}
+                {saveStatus === "saved" && (
+                  <span className="text-primary flex items-center gap-1.5">
+                    <Check className="w-3.5 h-3.5" />
+                    Saved
+                  </span>
+                )}
+                {saveStatus === "error" && (
+                  <span className="text-destructive">
+                    Failed to save{saveError ? `: ${saveError}` : ""}
+                  </span>
+                )}
+                {saveStatus === "idle" &&
+                  (isDirty ? (
+                    <span className="text-amber-600 dark:text-amber-500">
+                      Unsaved changes
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground">No changes to save</span>
+                  ))}
+              </div>
               <button
                 type="button"
                 onClick={handleSave}

--- a/components/ui/TournamentTabs.tsx
+++ b/components/ui/TournamentTabs.tsx
@@ -61,6 +61,9 @@ interface TournamentTabsProps {
   usernames?: Map<string, string>;
   /** Opens the QR Join dialog (mounted at the page level). */
   onOpenQrJoin?: () => void;
+  /** Fired after Tournament Settings persists a change, so the page header
+   * picks up a rename from the Event Type section. */
+  onTournamentUpdated?: () => void;
   /** "N of M participants have decklists" — only meaningful pre-start when
    * the tournament requires decklists; null hides the line entirely. */
   decklistSummary?: { submitted: number; total: number } | null;
@@ -106,6 +109,7 @@ export default function TournamentTabs({
   isHost = false,
   usernames,
   onOpenQrJoin,
+  onTournamentUpdated,
   decklistSummary,
   numberingMode,
   onRepairCompleted,
@@ -371,6 +375,7 @@ export default function TournamentTabs({
           <TournamentSettings
             tournamentId={tournamentId}
             participantCount={participants.length}
+            onTournamentUpdated={onTournamentUpdated}
             key={activeTab} // Force re-render when tab becomes active
           />
         </div>

--- a/components/ui/tournament-form-modal.tsx
+++ b/components/ui/tournament-form-modal.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { Button } from "./button";
 import { STANDARD_CATEGORIES } from "../../utils/tournament/categoryDefaults";
 import { buildTournamentName, isNameFrozen } from "../../utils/tournament/naming";
+import { TOURNAMENT_TIERS } from "../../utils/tournament/tiers";
 import {
   Dialog,
   DialogContent,
@@ -16,12 +17,16 @@ interface TournamentFormModalProps {
   onClose: () => void;
   // Create one tournament per item. With 0/1 category selected this is a single
   // item carrying the (editable) name; with 2+ it's one auto-named item per type.
-  onSubmit: (items: { name: string; category: string | null }[]) => void;
+  onSubmit: (
+    items: { name: string; category: string | null; tier: string | null }[]
+  ) => void;
   // City to append to generated names for events hosted from a public listing.
   listingCity?: string;
   // Categories to offer. Defaults to the standard list when omitted (e.g. an
   // official listing passes its own formats here).
   categoryOptions?: string[];
+  // Tier the source listing advertised, pre-selected when hosting from one.
+  defaultTier?: string | null;
 }
 
 // Drop a trailing "- 2P" / "2P" player-count suffix; it reads as clutter.
@@ -33,11 +38,15 @@ const TournamentFormModal: React.FC<TournamentFormModalProps> = ({
   onSubmit,
   listingCity,
   categoryOptions,
+  defaultTier,
 }) => {
   const firstCheckboxRef = useRef<HTMLInputElement>(null);
   const [name, setName] = useState("");
   // The set of checked categories. Each checked type becomes its own tournament.
   const [selected, setSelected] = useState<string[]>([]);
+  // Sanctioning tier, shared by every tournament this modal creates — one event
+  // is one tier even when it runs several categories. "" means unspecified.
+  const [tier, setTier] = useState<string>("");
   // Once the host edits the name, we stop auto-building it from the category.
   const [nameTouched, setNameTouched] = useState(false);
 
@@ -55,14 +64,18 @@ const TournamentFormModal: React.FC<TournamentFormModalProps> = ({
     // Pre-check the first type so the modal opens ready to add one tournament,
     // matching the previous single-select default. The host can check more.
     const initial = options[0] ? [options[0]] : [];
+    const initialTier = defaultTier ?? "";
     setSelected(initial);
+    setTier(initialTier);
     setNameTouched(false);
-    setName(buildTournamentName(cleanCategory(initial[0] ?? "")));
+    setName(
+      buildTournamentName(cleanCategory(initial[0] ?? ""), { tier: initialTier || null })
+    );
     requestAnimationFrame(() => {
       firstCheckboxRef.current?.focus();
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen]);
+  }, [isOpen, defaultTier]);
 
   // Creating multiple tournaments at once: each gets an auto-built name, so the
   // single editable name field is replaced by a preview list.
@@ -80,18 +93,35 @@ const TournamentFormModal: React.FC<TournamentFormModalProps> = ({
     // host hasn't taken over the name. Going to 0 or 2+ leaves the field for the
     // host / preview to drive.
     if (!nameTouched) {
-      if (next.length === 1) setName(buildTournamentName(cleanCategory(next[0])));
+      if (next.length === 1)
+        setName(buildTournamentName(cleanCategory(next[0]), { tier: tier || null }));
       else if (next.length === 0) setName("");
     }
   };
 
+  const handleTierChange = (value: string) => {
+    setTier(value);
+    if (!nameTouched && selected.length === 1) {
+      setName(buildTournamentName(cleanCategory(selected[0]), { tier: value || null }));
+    }
+  };
+
+  // The name every generated (frozen or multi) tournament gets.
+  const generatedName = (category: string) =>
+    buildTournamentName(cleanCategory(category), {
+      city: listingCity,
+      tier: tier || null,
+    });
+
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    const chosenTier = tier || null;
     if (isMulti) {
       onSubmit(
         selected.map((c) => ({
-          name: buildTournamentName(cleanCategory(c), { city: listingCity }),
+          name: generatedName(c),
           category: c,
+          tier: chosenTier,
         }))
       );
       return;
@@ -99,15 +129,16 @@ const TournamentFormModal: React.FC<TournamentFormModalProps> = ({
     if (frozen) {
       onSubmit([
         {
-          name: buildTournamentName(cleanCategory(selected[0]), { city: listingCity }),
+          name: generatedName(selected[0]),
           category: selected[0],
+          tier: chosenTier,
         },
       ]);
       return;
     }
     const trimmed = name.trim();
     if (!trimmed) return;
-    onSubmit([{ name: trimmed, category: selected[0] ?? null }]);
+    onSubmit([{ name: trimmed, category: selected[0] ?? null, tier: chosenTier }]);
   };
 
   const fieldClasses =
@@ -124,6 +155,30 @@ const TournamentFormModal: React.FC<TournamentFormModalProps> = ({
         </DialogHeader>
         <form onSubmit={handleSubmit}>
           <DialogBody className="space-y-3">
+            <div>
+              <label
+                htmlFor="tier"
+                className="block text-xs font-medium text-muted-foreground mb-1"
+              >
+                Tier
+              </label>
+              <select
+                id="tier"
+                value={tier}
+                onChange={(e) => handleTierChange(e.target.value)}
+                className={fieldClasses}
+              >
+                <option value="">Not specified</option>
+                {TOURNAMENT_TIERS.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
+              </select>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Appears in the event name. Applies to every category you check.
+              </p>
+            </div>
             <div
               role="group"
               aria-labelledby="category-group-label"
@@ -173,9 +228,9 @@ const TournamentFormModal: React.FC<TournamentFormModalProps> = ({
                     <li
                       key={c}
                       className="text-sm text-foreground truncate"
-                      title={buildTournamentName(cleanCategory(c), { city: listingCity })}
+                      title={generatedName(c)}
                     >
-                      {buildTournamentName(cleanCategory(c), { city: listingCity })}
+                      {generatedName(c)}
                     </li>
                   ))}
                 </ul>
@@ -189,7 +244,7 @@ const TournamentFormModal: React.FC<TournamentFormModalProps> = ({
                   Tournament name
                 </span>
                 <div className="rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm text-foreground truncate">
-                  {buildTournamentName(cleanCategory(selected[0]), { city: listingCity })}
+                  {generatedName(selected[0])}
                 </div>
                 <p className="mt-1 text-xs text-muted-foreground">
                   Official events use standardized names.

--- a/docs/superpowers/specs/2026-07-28-tournament-event-type-settings-design.md
+++ b/docs/superpowers/specs/2026-07-28-tournament-event-type-settings-design.md
@@ -1,0 +1,237 @@
+# Tournament event type in Settings — design
+
+**Date:** 2026-07-28
+**Status:** Approved, ready for implementation plan
+**Branch:** `feat/event-type-settings`
+
+## 1. Problem
+
+A tournament's format lives in `tournaments.deck_format`, set once at creation from the
+category the host checks in **Add Tournament** ([`app/tracker/tournaments/page.tsx:90-100`](../../../app/tracker/tournaments/page.tsx)).
+After that:
+
+- **No screen shows it.** The only UI that surfaces `deck_format` is the QR Join dialog,
+  which put a `<select>` there because QR Join was the first feature that needed a format
+  (to run deck check on submission) and there was nowhere else to edit it. Tournament-level
+  config leaked into a feature-level dialog.
+- **`category` is immutable.** It is written once at insert and updated nowhere in the
+  codebase. A host who picks the wrong category has no recourse but to delete the event.
+- PR #256 already locked the QR dialog's format field read-only for name-frozen categories,
+  because editing it could desync `deck_format` from the frozen name (an event named
+  "… Type 1 Unlimited Tournament" validating decks as Limited). That closed the symptom
+  and left the cause: no tournament-level owner for event type.
+
+Separately, **Tournament Settings' save feedback is misplaced.** The status indicator
+(`Saving…` / `✓ Saved` / `Failed to save` / `Unsaved changes`) renders in the card header
+at [`TournamentSettings.tsx:180-200`](../../../components/ui/TournamentSettings.tsx) while
+the Save button sits at the bottom of a ~1300px-tall card. The host clicks Save at the
+bottom and the confirmation flashes for 1.5s off-screen at the top.
+
+## 2. Goals
+
+1. Tournament Settings becomes the single owner of event type (category → format).
+2. The QR Join dialog stops writing `deck_format` and becomes read-only about it.
+3. Changing category cascades to the frozen name and category-derived settings under one
+   predictable rule, previewed before save.
+4. Save feedback lands where the host is looking.
+
+**Non-goals:** re-running deck check on format change (ruled out — warn only); versioning
+deck submissions; exposing format anywhere outside Settings and the QR dialog.
+
+## 3. Locked decisions
+
+| Question | Ruling |
+|---|---|
+| Name when category changes | **Regenerate automatically** when the new category is official. |
+| Editable after decklists / start | **Allow, warn only** — stale legality verdicts are surfaced, not prevented. |
+| Format select | Editable **only** for `Unofficial`; derived and read-only otherwise. |
+| Save-row placement | Sticky footer inside the settings card. |
+
+## 4. The cascade rule
+
+One principle: **derived values the host has not overridden follow the category; anything
+the host changed stays put.**
+
+Concretely, given a category change from `old` → `next`:
+
+| Field | Behavior |
+|---|---|
+| `category` | Set to `next`. |
+| `deck_format` | `categoryDefaults(next).deck_format`, unless `next === "Unofficial"`, where it is the host's explicit select value. |
+| `name` | Regenerated when `isNameFrozen(next)`. Left untouched when `next === "Unofficial"` (no frozen form exists). |
+| `max_score` | Re-seeded to `categoryDefaults(next).max_score` **only if** it currently equals `categoryDefaults(old).max_score`. Skipped entirely when locked (round 1 started). |
+| `round_length` | Same rule against `categoryDefaults(old).round_length`. |
+| `require_decklists` | Same rule against `requireDecklistsDefault(old)`. |
+
+**Hard invariant, overriding the rule above:** when the resolved `deck_format` is `"Other"`
+or `null`, `require_decklists` is forced to `false`. A tournament with `require_decklists =
+true` and no specific format is unjoinable — [`app/join/actions.ts`](../../../app/join/actions.ts)
+returns `decklist_required` for every player. The re-seed rule alone does not prevent this
+(host turns the toggle on for Type A, then switches to Booster Draft), so it is enforced
+unconditionally.
+
+### 4.1 Name regeneration
+
+Applies only when `isNameFrozen(next)` — switching *to* `Unofficial` never touches the name.
+
+Do **not** reformat from `created_at` — that is a UTC timestamp, while the stored name was
+generated client-side in the host's timezone (`created_at = 2026-07-29 01:15Z` on an event
+named "Jul 28, 2026 …"). Server- or UTC-side regeneration would shift the date.
+
+Instead, swap the category token in place:
+
+```
+/^(.+?, \d{4}) (.+) Tournament(?: — (.+))?$/
+      ^date       ^category            ^city
+```
+
+On match, keep group 1 (date) and group 3 (city) verbatim and substitute the new category.
+On no match — the name is free-form, e.g. coming from `Unofficial` — fall back to
+`buildTournamentName(next, { date: new Date(created_at) })`, preserving any ` — City`
+suffix found in the current name.
+
+**Accepted trade-off:** a host who renamed an official event by hand loses that name. The
+post-creation rename paths ([`page.tsx:185`](../../../app/tracker/tournaments/page.tsx),
+[`[id]/page.tsx:902`](../../../app/tracker/tournaments/[id]/page.tsx)) do not check
+`isNameFrozen`, so hand-edited official names exist. The inline preview makes the
+replacement visible rather than silent.
+
+### 4.2 One pure function
+
+```ts
+// utils/tournament/categoryChange.ts
+export interface CategoryChangePlan {
+  category: string;
+  deck_format: FormatId | "Other";
+  name?: string;
+  max_score?: number;
+  round_length?: number;
+  require_decklists?: boolean;
+}
+
+export function planCategoryChange(
+  current: {
+    name: string;
+    category: string | null;
+    deck_format: string | null;
+    max_score: number | null;
+    round_length: number | null;
+    require_decklists: boolean | null;
+    created_at: string;
+  },
+  next: { category: string; unofficialFormat?: FormatId | "Other" },
+  opts: { maxScoreLocked: boolean }
+): CategoryChangePlan;
+```
+
+`unofficialFormat` is read only when `next.category === "Unofficial"`. Omitted there, the
+plan keeps `normalizeTournamentFormat(current.deck_format) ?? "Other"` — switching to
+Unofficial preserves whatever format was already in force rather than resetting to `Other`
+and silently disabling decklist requirements.
+
+The same function drives both the preview and the persisted patch, so the two cannot
+disagree. It is pure and unit-testable — no Supabase, no clock. Tests cover: official →
+official re-seed, overridden field preserved, `maxScoreLocked` skip, the `Other` +
+`require_decklists` invariant, city-suffix preservation, and the free-form-name fallback.
+
+## 5. UI: Event Type section
+
+A new section at the top of the Tournament Settings card, above the status row.
+
+- **Category** — a `<select>` over `STANDARD_CATEGORIES`.
+  **Legacy categories must not be silently coerced.** Prod holds category values that came
+  from official listings and are absent from `STANDARD_CATEGORIES`: `Type 1`,
+  `Type 1 - 2P`, `Type 1 - 2 Player`, `Type 1 - Teams`, `Type 2 - 2P`, `Type 2 - 2 Player`
+  (12 rows). When the tournament's current category is not in the list, prepend it as an
+  option so opening Settings never changes what is displayed.
+- **Format** — read-only display (`Unlimited · set by category`) for every category except
+  `Unofficial`, which gets an editable select over `FORMAT_IDS` + `Other`.
+- **Change preview** — while the category select differs from the persisted value, render
+  the diff produced by `planCategoryChange`:
+  > Will rename to *Jul 28, 2026 Type 2 Tournament* · Lost Souls 5 → 7 · Round length 45 → 75
+- **Stale-verdict warning** — when `deck_format` would change and submissions exist, amber:
+  > 3 submitted decklists were checked against Unlimited. Changing the format won't re-check
+  > them — their legality badges will be stale.
+
+  The count comes from `getJoinStatsAction(tournamentId).submitted`, which is already
+  host-gated and reads the default-deny `tournament_deck_submissions` table via the admin
+  client. Reuse it rather than adding a query.
+- **Locking** — the whole section respects the existing `editingDisabled` (tournament
+  ended). It is *not* locked by `has_started`, per the warn-only ruling.
+
+### 5.1 No data backfill
+
+Legacy rows store `deck_format = 'T1'` (12 rows) where `categoryDefaults` now yields
+`Limited`. No migration is needed: every consumer reads through
+`normalizeTournamentFormat`, and `normalizeFormat('T1')` already falls through to
+`'Limited'`. Settings writes canonical `FormatId`s going forward; old values keep
+normalizing correctly.
+
+## 6. QR Join dialog
+
+- Format renders read-only for **all** categories, not just name-frozen ones. Hint text:
+  "Set in the Settings tab." No link — cross-tab navigation from a dialog is plumbing this
+  does not need.
+- `formatLocked` and the editable `<select>` branch are deleted;
+  [`initialFormat()`](../../../components/ui/QRJoinDialog.tsx) is kept as-is (it derives
+  from category for name-frozen events, which stays correct and covers legacy drift).
+- `updateJoinSettingsAction` drops `deckFormat` from its payload and writes only
+  `require_decklists`. `handleFormatChange` is deleted.
+- The `format_required` error message changes to point at Settings:
+  "Set a format in the Settings tab before requiring decklists."
+
+Resulting boundary: **Settings owns event identity** (category → format); **the QR dialog
+owns join knobs** (code, require-decklist, live counters).
+
+## 7. Save feedback
+
+1. The footer row (`isDirty` text + Save button) becomes `sticky bottom-0` inside the card,
+   so the button and its status stay visible while editing a tall form.
+2. The live status moves next to the button: `Unsaved changes` → `Saving…` → `✓ Saved`
+   (flash extended 1.5s → 3s) / `Failed to save: <reason>`. The header keeps no duplicate.
+3. Real errors surface. `handleSave` currently `console.error`s and renders a bare
+   "Failed to save", making an RLS denial and a network drop indistinguishable. Render
+   `error.message`.
+4. When clean, the footer reads "No changes to save" so the dim button is explained.
+
+## 8. Data flow
+
+`TournamentSettings` already writes with the browser Supabase client; the
+`host_can_access_tournaments` RLS policy is `ALL` on `auth.uid() = host_id`, so `name`,
+`category`, and `deck_format` are all writable from the client exactly like the existing
+fields. No new server action is needed for the save itself.
+
+Changes required around it:
+
+- Extend the settings `SELECT` to include `name`, `category`, `deck_format`,
+  `require_decklists`, `created_at`.
+- Category is tracked outside `EDITABLE_KEYS`; on save, when it changed, merge
+  `planCategoryChange(...)` into the patch. The scalar-field diff is unchanged.
+- Add an `onTournamentUpdated?: () => void` prop to `TournamentSettings`, threaded through
+  [`TournamentTabs.tsx:371`](../../../components/ui/TournamentTabs.tsx) to
+  `fetchTournamentDetails` in [`[id]/page.tsx`](../../../app/tracker/tournaments/[id]/page.tsx),
+  so a rename refreshes the page header. `key={activeTab}` already remounts the component
+  per tab visit, so no other staleness handling is needed.
+
+## 9. Testing
+
+**Unit** (`utils/tournament/__tests__/categoryChange.test.ts`) — the cascade cases in §4.2,
+plus the name regex against every prod-observed name shape.
+
+**Component/manual** — change category on a fresh event and confirm rename + re-seed;
+change it on an event with a submitted decklist and confirm the amber warning and that
+verdicts are left alone; change it after round 1 and confirm `max_score` is untouched;
+open Settings on a legacy `Type 1 - 2P` event and confirm the category is not coerced;
+confirm the QR dialog shows format read-only and can still toggle require-decklist.
+
+**Regression** — `updateJoinSettingsAction` no longer accepting `deckFormat` must not break
+`app/join/__tests__/actions.test.ts` or the QR dialog's enable path, which calls it before
+`setQrJoinEnabledAction`.
+
+## 10. Out of scope
+
+- Re-running deck check on format change (explicitly ruled out).
+- Deck-submission history — resubmission overwrites via `onConflict: "participant_id"`.
+- Showing format on the tournament detail header or the public results page.
+- Server-side enforcement that `deck_format` matches `category`; Settings and the create
+  modal are the only writers, and both derive it.

--- a/docs/superpowers/specs/2026-07-28-tournament-event-type-settings-design.md
+++ b/docs/superpowers/specs/2026-07-28-tournament-event-type-settings-design.md
@@ -1,12 +1,25 @@
 # Tournament event type in Settings — design
 
 **Date:** 2026-07-28
-**Status:** Approved, ready for implementation plan
+**Status:** Implemented
 **Branch:** `feat/event-type-settings`
 
 ## 1. Problem
 
-A tournament's format lives in `tournaments.deck_format`, set once at creation from the
+An event's "type" is two orthogonal things — its **tier** (Regional, State, National…) and
+its **category/format** (Type 2, Paragon…). Neither was owned by Tournament Settings.
+
+**Tier didn't exist at all.** The public listings page already carries one
+(`tournament_listings.tournament_type`) and renders it as a badge, but hosting an event
+from a listing dropped it on the floor: no column, no field at creation, nothing in the
+generated name. Prod listings use `Local (Open)` (23), `State` (17), `District` (9),
+`Regional` (8, plus 8 named variants like "South Central Regional"), `Local (Closed)` (7),
+and `National` (1, plus "Redemption National Tournament").
+
+**Category/format was set once and never shown again.** The format lives in
+`tournaments.deck_format`, written at creation from the category the host checks in
+**Add Tournament** ([`app/tracker/tournaments/page.tsx:90-100`](../../../app/tracker/tournaments/page.tsx)).
+After that:
 category the host checks in **Add Tournament** ([`app/tracker/tournaments/page.tsx:90-100`](../../../app/tracker/tournaments/page.tsx)).
 After that:
 
@@ -29,34 +42,66 @@ bottom and the confirmation flashes for 1.5s off-screen at the top.
 
 ## 2. Goals
 
-1. Tournament Settings becomes the single owner of event type (category → format).
-2. The QR Join dialog stops writing `deck_format` and becomes read-only about it.
-3. Changing category cascades to the frozen name and category-derived settings under one
-   predictable rule, previewed before save.
-4. Save feedback lands where the host is looking.
+1. A tier can be set when creating a tournament, inherited from the listing when hosting
+   from one, and it shows up in the event name.
+2. Tournament Settings becomes the single owner of event type (tier + category → format).
+3. The QR Join dialog stops writing `deck_format` and becomes read-only about it.
+4. Changing tier or category cascades to the frozen name — and, for category, to the
+   category-derived settings — under one predictable rule, previewed before save.
+5. Save feedback lands where the host is looking.
 
 **Non-goals:** re-running deck check on format change (ruled out — warn only); versioning
-deck submissions; exposing format anywhere outside Settings and the QR dialog.
+deck submissions; backfilling tiers onto existing tournaments; exposing tier or format
+anywhere outside Settings, the create modal, and the QR dialog.
 
 ## 3. Locked decisions
 
 | Question | Ruling |
 |---|---|
-| Name when category changes | **Regenerate automatically** when the new category is official. |
+| Name when tier/category changes | **Regenerate automatically** when the category is official. |
 | Editable after decklists / start | **Allow, warn only** — stale legality verdicts are surfaced, not prevented. |
 | Format select | Editable **only** for `Unofficial`; derived and read-only otherwise. |
 | Save-row placement | Sticky footer inside the settings card. |
+| Tier vocabulary | The six canonical tiers, normalized from listing free text. |
+
+## 3.1 Tier model
+
+`tournaments.tier` (migration `085_add_tournament_tier.sql`) — nullable `text`, no default,
+no backfill. Free text rather than an enum for the same reason `category` is: the
+vocabulary originates in scraped listing text, and a new tier appearing in a listing must
+not require a migration.
+
+The canonical list and normalizer live in [`utils/tournament/tiers.ts`](../../../utils/tournament/tiers.ts):
+`Local (Open)`, `Local (Closed)`, `District`, `State`, `Regional`, `National`.
+`normalizeTier()` collapses listing variants — "South Central Regional" → `Regional`,
+"Redemption National Tournament" → `National` — and returns `null` for anything
+unrecognized rather than guessing.
+
+The name formula gains a tier slot: `{Mon D, YYYY} [{Tier} ]{Category} Tournament[ — {City}]`,
+so "Aug 2, 2026 Regional Type 2 Tournament — Wichita". With no tier the formula is
+byte-identical to today's, which is what keeps every existing name valid.
+
+Where a tier comes from at creation:
+- **Hosting from a listing** — `/tournaments` passes `&type=` on the Host This Event link;
+  the tracker normalizes it and pre-selects it.
+- **Adding a category to an existing event** — inherited from a sibling tournament, the
+  same way the city already is.
+- **Otherwise** — the host picks from the select, defaulting to "Not specified".
+
+One tier applies to every tournament the modal creates in a batch: an event is one tier
+even when it runs several categories.
 
 ## 4. The cascade rule
 
 One principle: **derived values the host has not overridden follow the category; anything
 the host changed stays put.**
 
-Concretely, given a category change from `old` → `next`:
+Concretely, given a change from `old` → `next`:
 
 | Field | Behavior |
 |---|---|
-| `category` | Set to `next`. |
+| `tier` | Set to `next.tier` (or `null`). Cascades into `name` only — a tier carries no settings. |
+| `category` | Set to `next.category`. |
 | `deck_format` | `categoryDefaults(next).deck_format`, unless `next === "Unofficial"`, where it is the host's explicit select value. |
 | `name` | Regenerated when `isNameFrozen(next)`. Left untouched when `next === "Unofficial"` (no frozen form exists). |
 | `max_score` | Re-seeded to `categoryDefaults(next).max_score` **only if** it currently equals `categoryDefaults(old).max_score`. Skipped entirely when locked (round 1 started). |
@@ -72,23 +117,29 @@ unconditionally.
 
 ### 4.1 Name regeneration
 
-Applies only when `isNameFrozen(next)` — switching *to* `Unofficial` never touches the name.
+Applies only when `isNameFrozen(next.category)` — switching *to* `Unofficial` never touches
+the name, tier change or not.
 
 Do **not** reformat from `created_at` — that is a UTC timestamp, while the stored name was
 generated client-side in the host's timezone (`created_at = 2026-07-29 01:15Z` on an event
 named "Jul 28, 2026 …"). Server- or UTC-side regeneration would shift the date.
 
-Instead, swap the category token in place:
+Instead, swap the subject in place:
 
 ```
 /^(.+?, \d{4}) (.+) Tournament(?: — (.+))?$/
-      ^date       ^category            ^city
+      ^date      ^subject             ^city
 ```
 
-On match, keep group 1 (date) and group 3 (city) verbatim and substitute the new category.
-On no match — the name is free-form, e.g. coming from `Unofficial` — fall back to
-`buildTournamentName(next, { date: new Date(created_at) })`, preserving any ` — City`
-suffix found in the current name.
+Only the date and city are read back out; tier and category come from columns, so the
+subject never has to be disambiguated. On match, keep group 1 (date) and group 3 (city)
+verbatim and rebuild the subject as `[tier, category].filter(Boolean).join(" ")`. On no
+match — the name is free-form, e.g. an `Unofficial` event being promoted — fall back to
+`buildTournamentName(next.category, { date: new Date(created_at), tier, city })`,
+preserving any ` — City` suffix found in the current name.
+
+This also means a tier that is *set*, *changed*, or *cleared* rewrites the name correctly
+without stacking or stranding tokens.
 
 **Accepted trade-off:** a host who renamed an official event by hand loses that name. The
 post-creation rename paths ([`page.tsx:185`](../../../app/tracker/tournaments/page.tsx),
@@ -99,8 +150,9 @@ replacement visible rather than silent.
 ### 4.2 One pure function
 
 ```ts
-// utils/tournament/categoryChange.ts
-export interface CategoryChangePlan {
+// utils/tournament/eventType.ts
+export interface EventTypePlan {
+  tier: string | null;
   category: string;
   deck_format: FormatId | "Other";
   name?: string;
@@ -109,9 +161,10 @@ export interface CategoryChangePlan {
   require_decklists?: boolean;
 }
 
-export function planCategoryChange(
+export function planEventTypeChange(
   current: {
     name: string;
+    tier: string | null;
     category: string | null;
     deck_format: string | null;
     max_score: number | null;
@@ -119,9 +172,9 @@ export function planCategoryChange(
     require_decklists: boolean | null;
     created_at: string;
   },
-  next: { category: string; unofficialFormat?: FormatId | "Other" },
+  next: { tier: string | null; category: string; unofficialFormat?: FormatId | "Other" },
   opts: { maxScoreLocked: boolean }
-): CategoryChangePlan;
+): EventTypePlan;
 ```
 
 `unofficialFormat` is read only when `next.category === "Unofficial"`. Omitted there, the
@@ -130,25 +183,31 @@ Unofficial preserves whatever format was already in force rather than resetting 
 and silently disabling decklist requirements.
 
 The same function drives both the preview and the persisted patch, so the two cannot
-disagree. It is pure and unit-testable — no Supabase, no clock. Tests cover: official →
-official re-seed, overridden field preserved, `maxScoreLocked` skip, the `Other` +
-`require_decklists` invariant, city-suffix preservation, and the free-form-name fallback.
+disagree. It is pure and unit-testable — no Supabase, no clock.
+[`utils/tournament/__tests__/eventType.test.ts`](../../../utils/tournament/__tests__/eventType.test.ts)
+(24 tests) covers: tier normalization and round-tripping, tier set/change/clear in the
+name, official → official re-seed, tier-only change touching nothing but the name,
+overridden field preserved, `maxScoreLocked` skip, the `Other` + `require_decklists`
+invariant (including the hand-toggled Type A → Sealed case), city-suffix preservation, the
+free-form-name fallback, the UTC date-shift guard, and the null-category legacy row.
 
 ## 5. UI: Event Type section
 
 A new section at the top of the Tournament Settings card, above the status row.
 
-- **Category** — a `<select>` over `STANDARD_CATEGORIES`.
+- **Tier** — a `<select>` over `TOURNAMENT_TIERS` plus "Not specified".
+- **Category** — a `<select>` over `STANDARD_CATEGORIES` plus "Not specified".
   **Legacy categories must not be silently coerced.** Prod holds category values that came
   from official listings and are absent from `STANDARD_CATEGORIES`: `Type 1`,
   `Type 1 - 2P`, `Type 1 - 2 Player`, `Type 1 - Teams`, `Type 2 - 2P`, `Type 2 - 2 Player`
   (12 rows). When the tournament's current category is not in the list, prepend it as an
   option so opening Settings never changes what is displayed.
-- **Format** — read-only display (`Unlimited · set by category`) for every category except
-  `Unofficial`, which gets an editable select over `FORMAT_IDS` + `Other`.
-- **Change preview** — while the category select differs from the persisted value, render
-  the diff produced by `planCategoryChange`:
-  > Will rename to *Jul 28, 2026 Type 2 Tournament* · Lost Souls 5 → 7 · Round length 45 → 75
+- **Format** — read-only display (`Unlimited · Set by the category`) for every category
+  except `Unofficial`, which gets an editable select over `FORMAT_IDS` + `Other`.
+- **Change preview** — while tier/category/format differ from the persisted values, render
+  the diff produced by `planEventTypeChange`:
+  > On save: Renames to *Jul 28, 2026 Regional Type 2 Tournament* · Lost Souls 5 → 7 ·
+  > Round length 45 → 75
 - **Stale-verdict warning** — when `deck_format` would change and submissions exist, amber:
   > 3 submitted decklists were checked against Unlimited. Changing the format won't re-check
   > them — their legality badges will be stale.
@@ -177,11 +236,18 @@ normalizing correctly.
   from category for name-frozen events, which stays correct and covers legacy drift).
 - `updateJoinSettingsAction` drops `deckFormat` from its payload and writes only
   `require_decklists`. `handleFormatChange` is deleted.
+- **The invariant it used to enforce still has to hold.** The old action refused
+  `requireDecklists=true` with `deckFormat="Other"`; with the format no longer an input, it
+  now reads the *persisted* `deck_format` and refuses on `null`/`Other`. This also closes
+  the old bypass by construction — a caller could previously pass `"Sealed"` (not the
+  literal `"Other"`, but normalizing to it) and was caught only by a separate whitelist;
+  reading the stored value through `normalizeTournamentFormat` catches every such variant.
+  Turning decklists *off* skips the lookup entirely.
 - The `format_required` error message changes to point at Settings:
   "Set a format in the Settings tab before requiring decklists."
 
-Resulting boundary: **Settings owns event identity** (category → format); **the QR dialog
-owns join knobs** (code, require-decklist, live counters).
+Resulting boundary: **Settings owns event identity** (tier + category → format); **the QR
+dialog owns join knobs** (code, require-decklist, live counters).
 
 ## 7. Save feedback
 
@@ -198,40 +264,54 @@ owns join knobs** (code, require-decklist, live counters).
 
 `TournamentSettings` already writes with the browser Supabase client; the
 `host_can_access_tournaments` RLS policy is `ALL` on `auth.uid() = host_id`, so `name`,
-`category`, and `deck_format` are all writable from the client exactly like the existing
-fields. No new server action is needed for the save itself.
+`tier`, `category`, and `deck_format` are all writable from the client exactly like the
+existing fields. No new server action is needed for the save itself.
 
 Changes required around it:
 
-- Extend the settings `SELECT` to include `name`, `category`, `deck_format`,
+- Extend the settings `SELECT` to include `name`, `tier`, `category`, `deck_format`,
   `require_decklists`, `created_at`.
-- Category is tracked outside `EDITABLE_KEYS`; on save, when it changed, merge
-  `planCategoryChange(...)` into the patch. The scalar-field diff is unchanged.
+- Tier and category are tracked outside `EDITABLE_KEYS`, in their own state ( `""` means
+  unspecified). On save, when either changed, merge `planEventTypeChange(...)` into the
+  patch. The scalar-field diff is unchanged, and the plan wins on any overlapping field
+  because its re-seeds are computed *from* the pending edits.
+- On success, both `savedInfo` and `tournamentInfo` are set to the merged snapshot, so
+  re-seeded settings and the regenerated name show up in the form and not just the
+  dirty-tracking baseline.
 - Add an `onTournamentUpdated?: () => void` prop to `TournamentSettings`, threaded through
-  [`TournamentTabs.tsx:371`](../../../components/ui/TournamentTabs.tsx) to
+  [`TournamentTabs.tsx`](../../../components/ui/TournamentTabs.tsx) to
   `fetchTournamentDetails` in [`[id]/page.tsx`](../../../app/tracker/tournaments/[id]/page.tsx),
   so a rename refreshes the page header. `key={activeTab}` already remounts the component
   per tab visit, so no other staleness handling is needed.
 
 ## 9. Testing
 
-**Unit** (`utils/tournament/__tests__/categoryChange.test.ts`) — the cascade cases in §4.2,
-plus the name regex against every prod-observed name shape.
+**Unit** — [`utils/tournament/__tests__/eventType.test.ts`](../../../utils/tournament/__tests__/eventType.test.ts)
+(24 tests, §4.2) and the rewritten `updateJoinSettingsAction` block in
+[`app/tracker/tournaments/__tests__/joinHostActions.test.ts`](../../../app/tracker/tournaments/__tests__/joinHostActions.test.ts)
+(26 tests), which now asserts the invariant against the persisted format, the `"Sealed"`
+bypass, the skip-lookup-when-off path, and that `deck_format` is never written.
 
-**Component/manual** — change category on a fresh event and confirm rename + re-seed;
+Full suite: 1673 passing. Three files fail identically with these changes stashed —
+`forge-anon-leak` and `superuser-anon-leak` (env-gated, run via `npm run test:security`)
+and one `forge-lackey` brigade assertion. All pre-existing and unrelated.
+
+**Manual, still to do** — change category on a fresh event and confirm rename + re-seed;
 change it on an event with a submitted decklist and confirm the amber warning and that
 verdicts are left alone; change it after round 1 and confirm `max_score` is untouched;
 open Settings on a legacy `Type 1 - 2P` event and confirm the category is not coerced;
-confirm the QR dialog shows format read-only and can still toggle require-decklist.
-
-**Regression** — `updateJoinSettingsAction` no longer accepting `deckFormat` must not break
-`app/join/__tests__/actions.test.ts` or the QR dialog's enable path, which calls it before
-`setQrJoinEnabledAction`.
+set a tier and confirm the name gains it and the sticky footer confirmation is visible
+without scrolling; confirm the QR dialog shows format read-only and can still toggle
+require-decklist.
 
 ## 10. Out of scope
 
 - Re-running deck check on format change (explicitly ruled out).
 - Deck-submission history — resubmission overwrites via `onConflict: "participant_id"`.
+- Backfilling `tier` onto existing tournaments, or onto tournaments already linked to a
+  listing that advertises one.
+- Rendering the tier as a badge on the tracker list or the public results page — it only
+  reaches those surfaces through the event name for now.
 - Showing format on the tournament detail header or the public results page.
 - Server-side enforcement that `deck_format` matches `category`; Settings and the create
   modal are the only writers, and both derive it.

--- a/supabase/migrations/085_add_tournament_tier.sql
+++ b/supabase/migrations/085_add_tournament_tier.sql
@@ -1,0 +1,16 @@
+-- Sanctioning tier for a tournament (Regional, State, National, …), orthogonal
+-- to its category/format: a Regional and a Local can both be Type 1 Unlimited.
+--
+-- Free text rather than an enum, mirroring `category`: the vocabulary comes
+-- from tournament_listings.tournament_type, which is scraped free text, and a
+-- new tier showing up in a listing must not require a migration. The canonical
+-- list and the normalizer live in utils/tournament/tiers.ts.
+--
+-- Nullable with no default and no backfill — existing tournaments simply have
+-- no tier, and their frozen names (which never carried one) stay valid.
+
+alter table public.tournaments
+  add column if not exists tier text;
+
+comment on column public.tournaments.tier is
+  'Sanctioning tier: Local (Open) | Local (Closed) | District | State | Regional | National. Null = unspecified. Canonical list in utils/tournament/tiers.ts.';

--- a/utils/tournament/__tests__/eventType.test.ts
+++ b/utils/tournament/__tests__/eventType.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+import { planEventTypeChange, renameForEventType } from "../eventType";
+import { normalizeTier, TOURNAMENT_TIERS } from "../tiers";
+
+// A Type 1 Unlimited event sitting entirely at its category defaults
+// (Unlimited / 5 souls / 45 min / decklists required), with no tier.
+const UNLIMITED = {
+  name: "Jul 28, 2026 Type 1 Unlimited Tournament",
+  tier: null,
+  category: "Type 1 Unlimited",
+  deck_format: "Unlimited",
+  max_score: 5,
+  round_length: 45,
+  require_decklists: true,
+  created_at: "2026-07-29T01:15:57.307Z",
+};
+
+const UNLOCKED = { maxScoreLocked: false };
+
+describe("normalizeTier", () => {
+  it("collapses named regionals and nationals onto their base tier", () => {
+    expect(normalizeTier("South Central Regional")).toBe("Regional");
+    expect(normalizeTier("Midwest Regional")).toBe("Regional");
+    expect(normalizeTier("Redemption National Tournament")).toBe("National");
+    expect(normalizeTier("Redemption National")).toBe("National");
+  });
+
+  it("keeps the open/closed distinction on Local", () => {
+    expect(normalizeTier("Local (Open)")).toBe("Local (Open)");
+    expect(normalizeTier("Local (Closed)")).toBe("Local (Closed)");
+    expect(normalizeTier("local")).toBe("Local (Open)");
+  });
+
+  it("passes through the plain tiers", () => {
+    expect(normalizeTier("State")).toBe("State");
+    expect(normalizeTier("District")).toBe("District");
+  });
+
+  it("returns null rather than guessing on unknown or empty input", () => {
+    expect(normalizeTier("Casual Meetup")).toBeNull();
+    expect(normalizeTier("")).toBeNull();
+    expect(normalizeTier(null)).toBeNull();
+  });
+
+  it("round-trips every canonical tier", () => {
+    for (const tier of TOURNAMENT_TIERS) expect(normalizeTier(tier)).toBe(tier);
+  });
+});
+
+describe("renameForEventType", () => {
+  it("swaps the category token and keeps the date verbatim", () => {
+    expect(
+      renameForEventType(UNLIMITED.name, { tier: null, category: "Type 2" }, UNLIMITED.created_at)
+    ).toBe("Jul 28, 2026 Type 2 Tournament");
+  });
+
+  it("inserts the tier between date and category", () => {
+    expect(
+      renameForEventType(
+        UNLIMITED.name,
+        { tier: "Regional", category: "Type 2" },
+        UNLIMITED.created_at
+      )
+    ).toBe("Jul 28, 2026 Regional Type 2 Tournament");
+  });
+
+  it("drops the tier again when it is cleared", () => {
+    expect(
+      renameForEventType(
+        "Jul 28, 2026 Regional Type 2 Tournament",
+        { tier: null, category: "Type 2" },
+        UNLIMITED.created_at
+      )
+    ).toBe("Jul 28, 2026 Type 2 Tournament");
+  });
+
+  it("replaces an existing tier rather than stacking one", () => {
+    expect(
+      renameForEventType(
+        "Jul 28, 2026 Regional Type 2 Tournament",
+        { tier: "National", category: "Type 2" },
+        UNLIMITED.created_at
+      )
+    ).toBe("Jul 28, 2026 National Type 2 Tournament");
+  });
+
+  it("preserves a city suffix", () => {
+    expect(
+      renameForEventType(
+        "Jul 28, 2026 Type 1 Unlimited Tournament — Dallas",
+        { tier: "State", category: "Type 2" },
+        UNLIMITED.created_at
+      )
+    ).toBe("Jul 28, 2026 State Type 2 Tournament — Dallas");
+  });
+
+  it("does not reformat the date from created_at (UTC would shift it a day)", () => {
+    // created_at is Jul 29 in UTC; the stored name says Jul 28 because it was
+    // generated in the host's timezone. The rename must not "correct" it.
+    expect(
+      renameForEventType(UNLIMITED.name, { tier: null, category: "Type 2" }, UNLIMITED.created_at)
+    ).toContain("Jul 28, 2026");
+  });
+
+  it("rebuilds from created_at when the name is free-form", () => {
+    const out = renameForEventType(
+      "Friday Night Redemption",
+      { tier: "Local (Open)", category: "Type 2" },
+      UNLIMITED.created_at
+    );
+    expect(out).toMatch(/^\w{3} \d{1,2}, \d{4} Local \(Open\) Type 2 Tournament$/);
+  });
+
+  it("keeps a city suffix when falling back on a free-form name", () => {
+    expect(
+      renameForEventType("Game Night — Dallas", { tier: null, category: "Type 2" }, UNLIMITED.created_at)
+    ).toMatch(/ Type 2 Tournament — Dallas$/);
+  });
+});
+
+describe("planEventTypeChange", () => {
+  it("re-seeds every derived field the host left alone", () => {
+    const plan = planEventTypeChange(UNLIMITED, { tier: null, category: "Type 2" }, UNLOCKED);
+    expect(plan).toEqual({
+      tier: null,
+      category: "Type 2",
+      deck_format: "T2",
+      name: "Jul 28, 2026 Type 2 Tournament",
+      max_score: 7,
+      round_length: 75,
+    });
+    // Type 2 also defaults decklists on, so the flag doesn't change.
+    expect(plan.require_decklists).toBeUndefined();
+  });
+
+  it("renames on a tier-only change and touches nothing else", () => {
+    const plan = planEventTypeChange(
+      UNLIMITED,
+      { tier: "Regional", category: "Type 1 Unlimited" },
+      UNLOCKED
+    );
+    expect(plan.name).toBe("Jul 28, 2026 Regional Type 1 Unlimited Tournament");
+    expect(plan.max_score).toBeUndefined();
+    expect(plan.round_length).toBeUndefined();
+    expect(plan.deck_format).toBe("Unlimited");
+  });
+
+  it("preserves a setting the host overrode", () => {
+    const plan = planEventTypeChange(
+      { ...UNLIMITED, round_length: 60 },
+      { tier: null, category: "Type 2" },
+      UNLOCKED
+    );
+    expect(plan.round_length).toBeUndefined();
+    expect(plan.max_score).toBe(7);
+  });
+
+  it("skips max_score when it is locked by round 1", () => {
+    const plan = planEventTypeChange(
+      UNLIMITED,
+      { tier: null, category: "Type 2" },
+      { maxScoreLocked: true }
+    );
+    expect(plan.max_score).toBeUndefined();
+    expect(plan.round_length).toBe(75);
+  });
+
+  it("forces require_decklists off when the format becomes Other", () => {
+    const plan = planEventTypeChange(UNLIMITED, { tier: null, category: "Booster Draft" }, UNLOCKED);
+    expect(plan.deck_format).toBe("Other");
+    expect(plan.require_decklists).toBe(false);
+  });
+
+  it("forces require_decklists off even when the host turned it on by hand", () => {
+    // Type A defaults decklists OFF, so `true` here is a host override the
+    // re-seed rule would otherwise preserve straight into a format-less event.
+    const typeA = {
+      ...UNLIMITED,
+      name: "Jul 28, 2026 Type A Tournament",
+      category: "Type A",
+      deck_format: "Limited",
+      require_decklists: true,
+    };
+    const plan = planEventTypeChange(typeA, { tier: null, category: "Sealed Deck" }, UNLOCKED);
+    expect(plan.deck_format).toBe("Other");
+    expect(plan.require_decklists).toBe(false);
+  });
+
+  it("leaves the name alone when switching to Unofficial, tier or not", () => {
+    const plan = planEventTypeChange(
+      UNLIMITED,
+      { tier: "Regional", category: "Unofficial" },
+      UNLOCKED
+    );
+    expect(plan.name).toBeUndefined();
+    expect(plan.tier).toBe("Regional");
+  });
+
+  it("keeps the current format when switching to Unofficial without an explicit one", () => {
+    const plan = planEventTypeChange(UNLIMITED, { tier: null, category: "Unofficial" }, UNLOCKED);
+    expect(plan.deck_format).toBe("Unlimited");
+  });
+
+  it("takes the host's format when switching to Unofficial with one", () => {
+    const plan = planEventTypeChange(
+      UNLIMITED,
+      { tier: null, category: "Unofficial", unofficialFormat: "T2" },
+      UNLOCKED
+    );
+    expect(plan.deck_format).toBe("T2");
+  });
+
+  it("re-seeds nothing for a tournament that predates categories", () => {
+    const legacy = {
+      ...UNLIMITED,
+      name: "Some Old Event",
+      category: null,
+      max_score: 5,
+      round_length: 45,
+      require_decklists: false,
+    };
+    const plan = planEventTypeChange(legacy, { tier: null, category: "Type 2" }, UNLOCKED);
+    expect(plan.max_score).toBeUndefined();
+    expect(plan.round_length).toBeUndefined();
+    expect(plan.require_decklists).toBeUndefined();
+    expect(plan.deck_format).toBe("T2");
+  });
+
+  it("normalizes a legacy T1 deck_format when moving to Unofficial", () => {
+    const legacy = { ...UNLIMITED, category: "Type 1", deck_format: "T1" };
+    const plan = planEventTypeChange(legacy, { tier: null, category: "Unofficial" }, UNLOCKED);
+    expect(plan.deck_format).toBe("Limited");
+  });
+});

--- a/utils/tournament/eventType.ts
+++ b/utils/tournament/eventType.ts
@@ -1,0 +1,138 @@
+import { FormatId, normalizeTournamentFormat } from "../../lib/formats";
+import { categoryDefaults, requireDecklistsDefault } from "./categoryDefaults";
+import { buildTournamentName, isNameFrozen } from "./naming";
+
+// An event's "type" is two orthogonal things: its sanctioning tier (Regional,
+// State, …) and its category/format (Type 2, Paragon, …). Changing either
+// cascades into the frozen name; changing the category also cascades into the
+// settings derived from it. One rule governs that cascade: derived values the
+// host never overrode follow the new category; anything the host changed stays
+// put. Kept pure so the Settings preview and the persisted patch are computed
+// by the same code and can't disagree.
+
+export interface EventTypeCurrent {
+  name: string;
+  tier: string | null;
+  category: string | null;
+  deck_format: string | null;
+  max_score: number | null;
+  round_length: number | null;
+  require_decklists: boolean | null;
+  created_at: string;
+}
+
+export interface EventTypeNext {
+  tier: string | null;
+  category: string;
+  /** Read only when category is "Unofficial" — the one case with no category to derive a format from. */
+  unofficialFormat?: FormatId | "Other";
+}
+
+export interface EventTypePlan {
+  tier: string | null;
+  category: string;
+  deck_format: FormatId | "Other";
+  name?: string;
+  max_score?: number;
+  round_length?: number;
+  require_decklists?: boolean;
+}
+
+// "{Mon D, YYYY} {subject} Tournament[ — {City}]" — the frozen form from
+// buildTournamentName, where subject is the tier and category together. Only
+// the date and city are read back out; tier and category come from columns, so
+// there's no need to disambiguate them inside the subject.
+//
+// Capturing the date rather than reformatting it matters: created_at is UTC
+// while the stored name was generated in the host's timezone (created_at
+// 2026-07-29T01:15Z on an event named "Jul 28, 2026 …"), so reformatting would
+// shift the date by a day.
+const FROZEN_NAME_RE = /^(.+?, \d{4}) (.+) Tournament(?: — (.+))?$/;
+
+export function renameForEventType(
+  currentName: string,
+  next: { tier: string | null; category: string },
+  createdAt: string
+): string {
+  const subject = [next.tier, next.category].filter(Boolean).join(" ");
+  const m = currentName.match(FROZEN_NAME_RE);
+  if (m) {
+    const [, date, , city] = m;
+    return `${date} ${subject} Tournament${city ? ` — ${city}` : ""}`;
+  }
+  // Free-form name (an Unofficial event being promoted to an official
+  // category). Rebuild from the creation date, keeping any city suffix.
+  const city = currentName.includes(" — ")
+    ? currentName.split(" — ").slice(1).join(" — ")
+    : undefined;
+  return buildTournamentName(next.category, {
+    date: new Date(createdAt),
+    city,
+    tier: next.tier,
+  });
+}
+
+export function planEventTypeChange(
+  current: EventTypeCurrent,
+  next: EventTypeNext,
+  opts: { maxScoreLocked: boolean }
+): EventTypePlan {
+  const nextDefaults = categoryDefaults(next.category);
+  // A tournament created before categories existed has no old defaults to
+  // compare against, so nothing counts as "still at the default" and no
+  // derived field gets re-seeded.
+  const oldDefaults = current.category ? categoryDefaults(current.category) : null;
+
+  // Format is derived from the category everywhere except Unofficial. Omitting
+  // the format there keeps whatever was already in force rather than resetting
+  // to "Other" and silently disabling the decklist requirement.
+  const deckFormat: FormatId | "Other" =
+    next.category === "Unofficial"
+      ? next.unofficialFormat ?? normalizeTournamentFormat(current.deck_format) ?? "Other"
+      : nextDefaults.deck_format;
+
+  const plan: EventTypePlan = {
+    tier: next.tier,
+    category: next.category,
+    deck_format: deckFormat,
+  };
+
+  // Only official categories have a frozen name to regenerate — an Unofficial
+  // event's name is the host's own, tier change or not.
+  if (isNameFrozen(next.category)) {
+    const name = renameForEventType(current.name, next, current.created_at);
+    if (name !== current.name) plan.name = name;
+  }
+
+  if (
+    oldDefaults &&
+    !opts.maxScoreLocked &&
+    current.max_score === oldDefaults.max_score &&
+    nextDefaults.max_score !== current.max_score
+  ) {
+    plan.max_score = nextDefaults.max_score;
+  }
+
+  if (
+    oldDefaults &&
+    current.round_length === oldDefaults.round_length &&
+    nextDefaults.round_length !== current.round_length
+  ) {
+    plan.round_length = nextDefaults.round_length;
+  }
+
+  const wasRequired = current.require_decklists === true;
+  let requireDecklists = wasRequired;
+  if (oldDefaults && wasRequired === requireDecklistsDefault(current.category)) {
+    requireDecklists = requireDecklistsDefault(next.category);
+  }
+  // Hard invariant, overriding the re-seed rule: an event with no specific
+  // format cannot require decklists — every player would be bounced with
+  // `decklist_required` (app/join/actions.ts), making the event unjoinable.
+  // The rule alone doesn't prevent this: a host who turns the toggle on for
+  // Type A (default off) and then switches to Booster Draft keeps it on.
+  if (deckFormat === "Other") requireDecklists = false;
+  if (requireDecklists !== wasRequired) plan.require_decklists = requireDecklists;
+
+  return plan;
+}

--- a/utils/tournament/naming.ts
+++ b/utils/tournament/naming.ts
@@ -2,14 +2,17 @@
  * predictably in the public dataset. */
 export function buildTournamentName(
   category: string,
-  opts?: { date?: Date; city?: string }
+  opts?: { date?: Date; city?: string; tier?: string | null }
 ): string {
   const date = new Intl.DateTimeFormat("en-US", {
     month: "short",
     day: "numeric",
     year: "numeric",
   }).format(opts?.date ?? new Date());
-  const base = `${date} ${category} Tournament`;
+  // Tier sits between the date and the category ("Aug 2, 2026 Regional Type 2
+  // Tournament") and is simply absent when the event has none.
+  const subject = [opts?.tier, category].filter(Boolean).join(" ");
+  const base = `${date} ${subject} Tournament`;
   return opts?.city ? `${base} — ${opts.city}` : base;
 }
 

--- a/utils/tournament/tiers.ts
+++ b/utils/tournament/tiers.ts
@@ -1,0 +1,33 @@
+// A tournament's sanctioning tier, orthogonal to its category/format: a
+// Regional and a Local can both be Type 1 Unlimited. Mirrors the vocabulary the
+// public listings already use (tournament_listings.tournament_type), so an
+// event hosted from a listing inherits the tier the listing advertised.
+
+export const TOURNAMENT_TIERS = [
+  "Local (Open)",
+  "Local (Closed)",
+  "District",
+  "State",
+  "Regional",
+  "National",
+] as const;
+
+export type TournamentTier = (typeof TOURNAMENT_TIERS)[number];
+
+/**
+ * Map a listing's free-text tournament_type onto a canonical tier. Listings
+ * carry named variants — "South Central Regional", "Redemption National
+ * Tournament", "Midwest Regional" — that all collapse to their base tier.
+ * Returns null for anything unrecognized so an odd listing leaves the tier
+ * unset rather than guessing.
+ */
+export function normalizeTier(raw: string | null | undefined): TournamentTier | null {
+  const t = (raw ?? "").toLowerCase().trim();
+  if (!t) return null;
+  if (t.includes("national")) return "National";
+  if (t.includes("regional")) return "Regional";
+  if (t.includes("district")) return "District";
+  if (t.includes("state")) return "State";
+  if (t.includes("local")) return t.includes("closed") ? "Local (Closed)" : "Local (Open)";
+  return null;
+}


### PR DESCRIPTION
Tournament Settings now owns an event's *type*. The QR Join dialog stops writing `deck_format` — it only reads it — and a tournament's **tier** (Regional, State, National, …) becomes a first-class field for the first time.

Spec: `docs/superpowers/specs/2026-07-28-tournament-event-type-settings-design.md`

## Why

The Format dropdown lived in the QR Join dialog because QR Join was the first feature that needed a format (to deck-check submissions) and there was nowhere else to put it — tournament-level config leaking into a feature dialog. #256 locked that field read-only for official categories, which closed the symptom; this closes the cause. Separately, `category` was written once at insert and updated nowhere, so a wrong pick meant deleting the event.

Tier existed on the public listings page (`tournament_listings.tournament_type`, rendered as a badge) but hosting from a listing dropped it: no column, no field, nothing in the name.

## What changed

**Tier**
- Migration `085`: nullable `tournaments.tier`, no default, no backfill. **Already applied to prod** (288 rows, 0 with a tier; `authenticated` has a table-level UPDATE grant so the new column is covered).
- `utils/tournament/tiers.ts` — canonical list (`Local (Open)`, `Local (Closed)`, `District`, `State`, `Regional`, `National`) plus `normalizeTier()`, which collapses listing free text: "South Central Regional" → `Regional`, "Redemption National Tournament" → `National`, unknown → `null` rather than a guess.
- Name formula gains a tier slot: `{Mon D, YYYY} [{Tier} ]{Category} Tournament[ — {City}]`. With no tier it is byte-identical to today's, which is what keeps every existing name valid.
- Set at creation from the listing's type (passed through as `&type=` from `/tournaments`), inherited from a sibling when adding a category to an existing event, or picked by hand.

**Event type in Settings**
- New Event Type section: tier, category, and format, with a change preview and a stale-deck-check warning.
- `utils/tournament/eventType.ts` — one pure `planEventTypeChange()` drives both the preview and the persisted patch, so they cannot disagree. Rule: derived settings the host never overrode follow the new category; anything they changed stays.
- Legacy listing categories (`Type 1 - 2P`, `Type 1 - Teams`, … 12 rows in prod) are offered as options so opening Settings never silently coerces them.

**QR Join dialog**
- Format is read-only for all categories, pointing at the Settings tab.
- `updateJoinSettingsAction` drops `deckFormat` and now enforces the format invariant against the **persisted** value — which also closes the old bypass where `"Sealed"` (not the literal `"Other"`, but normalizing to it) slipped past.

**Save feedback**
- The footer is `sticky bottom-0` inside the card, with the status beside the button. Previously you clicked Save at the bottom of a ~1300px card and the confirmation flashed for 1.5s in the header, usually off-screen.
- Real error text instead of a bare "Failed to save"; "No changes to save" explains the disabled state.

## Decisions worth knowing

- **Auto-rename, no confirm step.** A host who hand-renamed an official event loses that name; the inline preview makes it visible rather than silent.
- **Format stays editable after decklists land — warn only.** Stored `is_legal` / `deckcheck_issues` were computed against the old format and are *not* re-run; the amber warning says so.
- **Hard invariant:** a `deck_format` of `Other`/null forces `require_decklists = false`. Otherwise the event is unjoinable — every player gets `decklist_required`. The re-seed rule alone doesn't catch the toggle-on-for-Type-A-then-switch-to-Booster-Draft path.
- **Never reformat a name's date from `created_at`.** It's UTC while the name was generated in the host's timezone (`created_at 2026-07-29T01:15Z` on "Jul 28, 2026 …"); reformatting shifts it a day. The rename captures the date substring instead.
- **No `deck_format` backfill.** 12 legacy rows store `'T1'`; `normalizeFormat('T1')` already returns `Limited` and every consumer reads through it.

## Testing

- `utils/tournament/__tests__/eventType.test.ts` — 24 new tests: tier normalization, tier set/change/clear in the name, re-seed vs. override, `maxScoreLocked` skip, the `Other` invariant, city-suffix preservation, the UTC date-shift guard, null-category legacy rows.
- `joinHostActions.test.ts` — `updateJoinSettingsAction` block rewritten (26 passing) to assert the invariant against the persisted format, the `"Sealed"` bypass, the skip-lookup-when-off path, and that `deck_format` is never written.
- Full suite: 1673 passing. Three files fail identically on untouched `origin/main` (`forge-anon-leak`, `superuser-anon-leak` — env-gated, run via `npm run test:security` — and one `forge-lackey` brigade assertion). Verified by stashing.

Manual verification of the UI flows has **not** been done yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)