### PR TITLE
fix(results): mobile-usable public standings + honor decklistsPublished

### DIFF
--- a/app/decklist/community/client.tsx
+++ b/app/decklist/community/client.tsx
@@ -12,6 +12,7 @@ import { Deck } from "../card-search/types/deck";
 import { Card } from "../card-search/utils";
 import { getCardImageUrlOrNull as getCardImageUrl } from '../../shared/utils/cardImageUrl';
 import { normalizeFormat, getFormatDef } from "@/lib/formats";
+import { TrophyIcon } from "@/components/trophy-icon";
 
 interface DeckTag { id: string; name: string; color: string; }
 
@@ -88,35 +89,6 @@ function getPlacementLabel(place: number): string {
   if (place === 2) return "2nd Place";
   if (place === 3) return "3rd Place";
   return `${place}th Place`;
-}
-
-function TrophyIcon({ place, className }: { place: number; className?: string }) {
-  const colors = place === 1
-    ? { fill: "#FFD700", stroke: "#B8860B" }
-    : place === 2
-      ? { fill: "#C0C0C0", stroke: "#808080" }
-      : place === 3
-        ? { fill: "#CD7F32", stroke: "#8B5A2B" }
-        : null;
-
-  if (!colors) return null;
-
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-      {/* Cup bowl */}
-      <path d="M7 3h10v5c0 2.76-2.24 5-5 5s-5-2.24-5-5V3z" fill={colors.fill} stroke={colors.stroke} strokeWidth="1.2"/>
-      {/* Left handle */}
-      <path d="M7 5H5.5C4.12 5 3 6.12 3 7.5S4.12 10 5.5 10H7" stroke={colors.stroke} strokeWidth="1.2" fill="none"/>
-      {/* Right handle */}
-      <path d="M17 5h1.5C19.88 5 21 6.12 21 7.5S19.88 10 18.5 10H17" stroke={colors.stroke} strokeWidth="1.2" fill="none"/>
-      {/* Stem */}
-      <path d="M11 13h2v4h-2z" fill={colors.stroke}/>
-      {/* Base */}
-      <path d="M8 17h8v1.5a1 1 0 01-1 1H9a1 1 0 01-1-1V17z" fill={colors.fill} stroke={colors.stroke} strokeWidth="1"/>
-      {/* Base plate */}
-      <rect x="7" y="20" width="10" height="1.5" rx="0.5" fill={colors.stroke}/>
-    </svg>
-  );
 }
 
 const PAGE_SIZE = 24;

--- a/app/tournaments/__tests__/resultsLoaders.test.ts
+++ b/app/tournaments/__tests__/resultsLoaders.test.ts
@@ -138,6 +138,9 @@ describe("loadPublicResultsAction", () => {
     expect(r.success).toBe(true);
     if (r.success === true) {
       expect(r.standings[0].publishedDeckId).toBeNull();
+      // The results page drops the whole Decklist column off this flag, so it
+      // has to reach the UI rather than being inferred from all-null rows.
+      expect(r.decklistsPublished).toBe(false);
     }
     expect(calls.decklists).toBe(0); // gated on decklists_published, never queried
   });

--- a/app/tournaments/results/[id]/page.tsx
+++ b/app/tournaments/results/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import TopNav from "@/components/top-nav";
 import SponsorFooter from "@/components/sponsor-footer";
+import { TrophyIcon } from "@/components/trophy-icon";
 import { loadPublicResultsAction } from "../../actions";
 
 interface PageProps {
@@ -36,6 +37,21 @@ function formatEndedAt(endedAt: string | null): string | null {
   });
 }
 
+// Podium tints mirror the placement badge in app/decklist/community/client.tsx.
+// Background shifts only — the design system forbids 1px sectioning lines.
+function podiumSurface(place: number | null): string {
+  if (place === 1) return "bg-yellow-50 dark:bg-yellow-900/20";
+  if (place === 2) return "bg-muted/60 dark:bg-muted/30";
+  if (place === 3) return "bg-orange-50 dark:bg-orange-900/15";
+  return "";
+}
+
+function podiumText(place: number | null): string {
+  if (place === 1) return "text-yellow-700 dark:text-yellow-300";
+  if (place === 3) return "text-orange-700 dark:text-orange-300";
+  return "text-foreground";
+}
+
 export default async function TournamentResultsPage({ params }: PageProps) {
   const { id } = await params;
   const result = await loadPublicResultsAction(id);
@@ -45,22 +61,35 @@ export default async function TournamentResultsPage({ params }: PageProps) {
   }
 
   const dateLabel = formatEndedAt(result.endedAt);
+  // When the host published standings but not decklists, dropping the column
+  // beats a full column of dashes that reads as "nobody submitted a deck".
+  const showDecklists = result.decklistsPublished;
 
   return (
     <div className="flex flex-col min-h-screen">
       <TopNav />
       <main className="flex-1 max-w-3xl mx-auto px-4 pt-8 pb-16 w-full">
+        <Link
+          href="/tournaments/results"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors mb-5"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+          All results
+        </Link>
+
         <div className="mb-6">
           <h1 className="font-cinzel text-2xl font-bold text-foreground">{result.name}</h1>
           <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
             {dateLabel && <span>{dateLabel}</span>}
             {result.category && (
-              <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-semibold tracking-wide text-muted-foreground">
+              <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-semibold tracking-wide text-muted-foreground">
                 {result.category}
               </span>
             )}
             {result.deckFormat && (
-              <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-semibold tracking-wide text-muted-foreground">
+              <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-semibold tracking-wide text-muted-foreground">
                 {result.deckFormat}
               </span>
             )}
@@ -70,57 +99,107 @@ export default async function TournamentResultsPage({ params }: PageProps) {
         {result.standings.length === 0 ? (
           <p className="text-sm text-muted-foreground">No standings recorded.</p>
         ) : (
-          <div className="rounded-lg border border-border bg-card overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-border bg-muted/50">
-                  <th className="text-left px-4 py-2.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                    Place
-                  </th>
-                  <th className="text-left px-4 py-2.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                    Player
-                  </th>
-                  <th className="text-left px-4 py-2.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                    Points
-                  </th>
-                  <th className="text-left px-4 py-2.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                    Diff
-                  </th>
-                  <th className="text-left px-4 py-2.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                    Decklist
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {result.standings.map((row, i) => (
-                  <tr key={i} className="border-b border-border last:border-0 odd:bg-muted/40">
-                    <td className="px-4 py-2.5 font-medium text-foreground">
+          <>
+            {/* Phone: stacked cards. The table's five padded columns overflow
+                below sm, which hid the decklist link off-screen entirely. */}
+            <ul className="space-y-2 sm:hidden">
+              {result.standings.map((row, i) => (
+                <li key={i} className={`rounded-lg overflow-hidden bg-card ${podiumSurface(row.place)}`}>
+                  <div className="flex items-center gap-2 px-4 pt-3">
+                    {row.place !== null && row.place <= 3 && (
+                      <TrophyIcon place={row.place} className="w-4 h-4 flex-shrink-0" />
+                    )}
+                    <span className={`text-sm font-semibold ${podiumText(row.place)}`}>
                       {row.place !== null ? ordinal(row.place) : "—"}
-                    </td>
-                    <td className="px-4 py-2.5 text-foreground">{row.name ?? "—"}</td>
-                    <td className="px-4 py-2.5 text-muted-foreground">
-                      {row.matchPoints ?? "—"}
-                    </td>
-                    <td className="px-4 py-2.5 text-muted-foreground">
-                      {row.differential ?? "—"}
-                    </td>
-                    <td className="px-4 py-2.5">
-                      {row.publishedDeckId ? (
-                        <Link
-                          href={`/decklist/${row.publishedDeckId}`}
-                          className="text-foreground underline underline-offset-2 hover:text-primary transition-colors"
-                        >
-                          View
-                        </Link>
-                      ) : (
-                        <span className="text-muted-foreground">—</span>
-                      )}
-                    </td>
+                    </span>
+                    <span className="text-sm text-foreground truncate">{row.name ?? "—"}</span>
+                  </div>
+                  <div className="px-4 pb-3 pt-1 text-xs text-muted-foreground">
+                    {row.matchPoints ?? "—"} pts · {row.differential ?? "—"} diff
+                    {showDecklists && !row.publishedDeckId && " · no decklist"}
+                  </div>
+                  {/* Full-width tap target. The tonal step (rather than a divider)
+                      keeps it legible over any podium tint, in either theme. */}
+                  {showDecklists && row.publishedDeckId && (
+                    <Link
+                      href={`/decklist/${row.publishedDeckId}`}
+                      className="flex min-h-[44px] items-center justify-between gap-2 bg-foreground/[0.06] px-4 text-sm font-medium text-foreground active:bg-foreground/[0.12] transition-colors"
+                    >
+                      View decklist
+                      <span aria-hidden className="text-muted-foreground">›</span>
+                    </Link>
+                  )}
+                </li>
+              ))}
+            </ul>
+
+            <div className="hidden sm:block rounded-lg bg-card overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-muted/50">
+                    <th className="text-left px-4 py-2.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                      Place
+                    </th>
+                    <th className="text-left px-4 py-2.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                      Player
+                    </th>
+                    <th className="text-left px-4 py-2.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                      Points
+                    </th>
+                    <th className="text-left px-4 py-2.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                      Diff
+                    </th>
+                    {showDecklists && (
+                      <th className="text-left px-4 py-2.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                        Decklist
+                      </th>
+                    )}
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                </thead>
+                <tbody>
+                  {result.standings.map((row, i) => (
+                    <tr key={i} className={podiumSurface(row.place)}>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex items-center gap-1.5 font-semibold ${podiumText(row.place)}`}>
+                          {row.place !== null && row.place <= 3 && (
+                            <TrophyIcon place={row.place} className="w-4 h-4 flex-shrink-0" />
+                          )}
+                          {row.place !== null ? ordinal(row.place) : "—"}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-foreground">{row.name ?? "—"}</td>
+                      <td className="px-4 py-3 text-muted-foreground">
+                        {row.matchPoints ?? "—"}
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">
+                        {row.differential ?? "—"}
+                      </td>
+                      {showDecklists && (
+                        <td className="px-4 py-3">
+                          {row.publishedDeckId ? (
+                            <Link
+                              href={`/decklist/${row.publishedDeckId}`}
+                              className="text-foreground underline underline-offset-2 hover:text-primary transition-colors"
+                            >
+                              View
+                            </Link>
+                          ) : (
+                            <span className="text-muted-foreground">—</span>
+                          )}
+                        </td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {!showDecklists && (
+              <p className="mt-4 text-xs text-muted-foreground">
+                The host has not published decklists for this event.
+              </p>
+            )}
+          </>
         )}
       </main>
       <SponsorFooter />

--- a/app/tournaments/results/page.tsx
+++ b/app/tournaments/results/page.tsx
@@ -8,9 +8,58 @@ export const metadata = {
   description: "Browse published standings and decklists from past Redemption CCG tournaments.",
 };
 
+function formatEndedAt(endedAt: string | null): string | null {
+  if (!endedAt) return null;
+  return new Date(endedAt).toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
 export default async function TournamentResultsIndexPage() {
   const result = await loadPublicResultsIndexAction();
   const events = result.success ? result.events : [];
+
+  if (events.length === 0) {
+    return (
+      <div className="flex flex-col min-h-screen">
+        <TopNav />
+        <main className="flex-1 flex items-center justify-center px-4 py-16 w-full">
+          <div className="max-w-sm text-center">
+            <svg
+              className="mx-auto w-12 h-12 text-muted-foreground/50"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M16.5 18.75h-9m9 0a3 3 0 013 3h-15a3 3 0 013-3m9 0v-3.375c0-.621-.503-1.125-1.125-1.125h-.871M7.5 18.75v-3.375c0-.621.504-1.125 1.125-1.125h.872m5.007 0H9.497m5.007 0a7.454 7.454 0 01-.982-3.172M9.497 14.25a7.454 7.454 0 00.981-3.172M5.25 4.236c-.982.143-1.954.317-2.916.52A6.003 6.003 0 007.73 9.728M5.25 4.236V4.5c0 2.108.966 3.99 2.48 5.228M5.25 4.236V2.721C7.456 2.41 9.71 2.25 12 2.25c2.291 0 4.545.16 6.75.47v1.516M7.73 9.728a6.726 6.726 0 002.748 1.35m8.272-6.842V4.5c0 2.108-.966 3.99-2.48 5.228M18.75 4.236c.982.143 1.954.317 2.916.52A6.003 6.003 0 0116.27 9.728m0 0a6.726 6.726 0 01-2.748 1.35m0 0a7.026 7.026 0 01-3.044 0"
+              />
+            </svg>
+            <h1 className="mt-4 text-lg font-medium text-foreground">
+              No published results yet
+            </h1>
+            <p className="mt-2 text-sm text-muted-foreground">
+              When a host publishes the standings from a completed tournament, the results
+              and decklists show up here.
+            </p>
+            <Link
+              href="/tournaments"
+              className="mt-6 inline-flex px-6 py-3 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 font-medium transition-colors"
+            >
+              Browse upcoming tournaments
+            </Link>
+          </div>
+        </main>
+        <SponsorFooter />
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -24,23 +73,37 @@ export default async function TournamentResultsIndexPage() {
         </p>
 
         <div className="mt-6 space-y-2">
-          {events.length === 0 ? (
-            <p className="text-sm text-muted-foreground">No published results yet.</p>
-          ) : (
-            events.map((e) => (
+          {events.map((e) => {
+            const dateLabel = formatEndedAt(e.endedAt);
+            return (
               <Link
                 key={e.id}
                 href={`/tournaments/results/${e.id}`}
-                className="block border border-border rounded-lg bg-card/80 backdrop-blur-sm hover:bg-card/90 transition-colors px-4 py-3"
+                className="block rounded-lg bg-card/80 backdrop-blur-sm hover:bg-card transition-colors px-4 py-3"
               >
                 <span className="text-sm font-medium text-foreground">{e.name}</span>
-                <span className="text-sm text-muted-foreground">
-                  {" "}
-                  — {e.playerCount} player{e.playerCount !== 1 ? "s" : ""}
-                </span>
+                {/* Name alone is not unique — the date, category and format are
+                    what tell two same-day events apart. */}
+                <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+                  <span>{dateLabel ?? "Date not recorded"}</span>
+                  <span aria-hidden>·</span>
+                  <span>
+                    {e.playerCount} player{e.playerCount !== 1 ? "s" : ""}
+                  </span>
+                  {e.category && (
+                    <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 font-semibold tracking-wide">
+                      {e.category}
+                    </span>
+                  )}
+                  {e.deckFormat && (
+                    <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 font-semibold tracking-wide">
+                      {e.deckFormat}
+                    </span>
+                  )}
+                </div>
               </Link>
-            ))
-          )}
+            );
+          })}
         </div>
       </main>
       <SponsorFooter />

--- a/components/trophy-icon.tsx
+++ b/components/trophy-icon.tsx
@@ -1,0 +1,33 @@
+/**
+ * Podium trophy — gold / silver / bronze. Renders nothing outside the top 3.
+ * Shared by the community deck grid and the public tournament standings so the
+ * two surfaces stay visually identical.
+ */
+export function TrophyIcon({ place, className }: { place: number; className?: string }) {
+  const colors = place === 1
+    ? { fill: "#FFD700", stroke: "#B8860B" }
+    : place === 2
+      ? { fill: "#C0C0C0", stroke: "#808080" }
+      : place === 3
+        ? { fill: "#CD7F32", stroke: "#8B5A2B" }
+        : null;
+
+  if (!colors) return null;
+
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      {/* Cup bowl */}
+      <path d="M7 3h10v5c0 2.76-2.24 5-5 5s-5-2.24-5-5V3z" fill={colors.fill} stroke={colors.stroke} strokeWidth="1.2"/>
+      {/* Left handle */}
+      <path d="M7 5H5.5C4.12 5 3 6.12 3 7.5S4.12 10 5.5 10H7" stroke={colors.stroke} strokeWidth="1.2" fill="none"/>
+      {/* Right handle */}
+      <path d="M17 5h1.5C19.88 5 21 6.12 21 7.5S19.88 10 18.5 10H17" stroke={colors.stroke} strokeWidth="1.2" fill="none"/>
+      {/* Stem */}
+      <path d="M11 13h2v4h-2z" fill={colors.stroke}/>
+      {/* Base */}
+      <path d="M8 17h8v1.5a1 1 0 01-1 1H9a1 1 0 01-1-1V17z" fill={colors.fill} stroke={colors.stroke} strokeWidth="1"/>
+      {/* Base plate */}
+      <rect x="7" y="20" width="10" height="1.5" rx="0.5" fill={colors.stroke}/>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Why

`/tournaments/results` and `/tournaments/results/[id]` are what a player pulls up on their phone at the table. Both were failing at that.

## Standings page (`app/tournaments/results/[id]/page.tsx`)

- **Mobile was broken.** Five `px-4` columns inside a `max-w-3xl px-4` wrapper overflowed at 390px. The wrapper had `overflow-x-auto` but rendered no affordance — no fade, no shadow, no visible scrollbar — so *View decklist*, the single action the page exists to offer, was clipped off-screen with no hint it was there. The link was also far below a 44x44 tap target. Below `sm` the table is now a **stacked card per player**: place badge + name, then the record, then a full-width **44px-tall "View decklist ›" row** as the tap target. The table is unchanged at `sm:` and up.
- **`decklistsPublished` was dead.** Computed in `app/tournaments/actions.ts` and never read, so an event with published standings but unpublished decklists rendered a column of `—` under a "Decklist" header — indistinguishable from "nobody submitted a deck". The column is now **dropped entirely** in that case, replaced by one explanatory line.
- **No-Line Rule violations.** Per-row `border-b` and `odd:bg-muted/40` zebra striping are gone; rows are separated by padding with a single tonal header band. **Top 3 get the trophy + tint treatment** already used in the community deck grid — extracted to `components/trophy-icon.tsx` so the two surfaces can't drift. Added a back link to the results index.

## Index (`app/tournaments/results/page.tsx`)

- `endedAt`, `category` and `deckFormat` were already fetched per event and thrown away — the list was sorted by an invisible date, and since tournament names have no unique constraint, two same-day events rendered as identical rows. All three now render.
- The empty state (one muted sentence at the top of a centered column, footer stranded) is now a centered block: glyph, headline, one explanatory line, and a primary action into `/tournaments`.

## Verification

- `npx tsc --noEmit` — clean apart from the pre-existing `__tests__/forge-anon-leak.test.ts` and `app/forge/lib/__tests__/playDecksAuthorize.test.ts` failures.
- `npx vitest run` — 1686 passed; the single failure is the pre-existing `__tests__/forge-lackey.test.ts` one. Added an assertion to `resultsLoaders.test.ts` that `decklistsPublished` reaches the UI, since the page now branches on it.
- **Screenshotted at 390px and 1400px, light and dark**, with a temporary local fixture (removed before commit — `grep` confirms no harness code remains). Measured: horizontal overflow is **0px** at 390px on every page/theme, and the mobile decklist links measure **358x44**.
- Empty state verified **live** against the real (read-only) data — there are currently zero tournaments with `results_published = true`.

## What could not be verified

There is no published tournament in production, so the **populated** standings table and index list were never rendered from real data — only from local fixtures shaped like `PublicResultsStandingRow` / `PublicResultsIndexEvent`. Nothing was published to create one. For the same reason, the moved `TrophyIcon` could not be seen on the community deck grid (the tournament-decks filter returns 0 decks); it was confirmed rendering correctly on the fixture standings page, and the community page still loads clean with 358 decks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)