### PR TITLE
fix(decks): stop card rows overlapping, size tiles from the grid

### DIFF
--- a/app/decklist/[deckId]/client.tsx
+++ b/app/decklist/[deckId]/client.tsx
@@ -1541,7 +1541,7 @@ export default function PublicDeckClient({ deck, isOwner, isLoggedIn }: Props) {
                       <span className="ml-1.5 font-normal">({groupCount})</span>
                     </h3>
                   )}
-                  <div className="flex flex-wrap gap-x-1.5">
+                  <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-6 xl:grid-cols-7">
                     {cards.map((card, index) => (
                       <CardTile
                         key={`main-${card.card_name}-${card.card_set}-${index}`}
@@ -1568,7 +1568,7 @@ export default function PublicDeckClient({ deck, isOwner, isLoggedIn }: Props) {
               ({reserveCount} cards)
             </span>
           </h2>
-          <div className="flex flex-wrap gap-x-1.5">
+          <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-6 xl:grid-cols-7">
             {sortedReserveCards.map((card, index) => (
               <CardTile
                 key={`reserve-${card.card_name}-${card.card_set}-${index}`}
@@ -1597,7 +1597,7 @@ export default function PublicDeckClient({ deck, isOwner, isLoggedIn }: Props) {
               ?
             </span>
           </h2>
-          <div className="flex flex-wrap gap-x-1.5">
+          <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-6 xl:grid-cols-7">
             {sortedMaybeboardCards.map((card, index) => (
               <CardTile
                 key={`maybeboard-${card.card_name}-${card.card_set}-${index}`}

--- a/app/forge/play/decks/[deckId]/view/DeckViewClient.tsx
+++ b/app/forge/play/decks/[deckId]/view/DeckViewClient.tsx
@@ -6,10 +6,10 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   Link2, Check, Pencil, Copy, Loader2,
-  ChevronLeft, ChevronRight, X, LayoutGrid, GalleryVerticalEnd,
+  LayoutGrid, GalleryVerticalEnd,
 } from "lucide-react";
 import type { GrantedForgeCard } from "@/app/forge/lib/deckPool";
 import type { ForgeDeckView } from "@/app/forge/lib/deckTypes";
@@ -28,6 +28,7 @@ import {
 import { getPublicImageUrl } from "@/app/decklist/card-search/hooks/useCardImageUrl";
 import ForgeCardPreview from "@/app/forge/components/ForgeCardPreview";
 import ForgeShareDeckModal from "@/app/forge/components/ForgeShareDeckModal";
+import CardEnlargeModal from "@/components/ui/CardEnlargeModal";
 import { getFormatDef } from "@/lib/formats";
 
 function formatDeckType(format: string): string {
@@ -204,19 +205,6 @@ export default function DeckViewClient({ deck, granted }: { deck: ForgeDeckView;
     [navItems],
   );
 
-  useEffect(() => {
-    if (enlarged === null) return;
-    function onKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") setEnlarged(null);
-      else if (e.key === "ArrowLeft") navigate(-1);
-      else if (e.key === "ArrowRight") navigate(1);
-    }
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [enlarged, navigate]);
-
-  const touchStartX = useRef<number | null>(null);
-
   async function copyLink() {
     await navigator.clipboard.writeText(`${window.location.origin}/forge/play/decks/${deck.id}/view`);
     setLinkCopied(true);
@@ -244,77 +232,26 @@ export default function DeckViewClient({ deck, granted }: { deck: ForgeDeckView;
   return (
     <div className="mt-4">
       {/* Enlarged card modal — arrows/keyboard/swipe cycle through the deck */}
-      {enlarged !== null && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4 backdrop-blur-sm"
-          onClick={() => setEnlarged(null)}
+      {enlarged === "paragon" ? (
+        <CardEnlargeModal onClose={() => setEnlarged(null)}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={`/paragons/Paragon ${deck.paragon}.png`}
+            alt={deck.paragon ?? "Paragon"}
+            className="w-full rounded-lg shadow-2xl"
+          />
+        </CardEnlargeModal>
+      ) : enlarged !== null ? (
+        <CardEnlargeModal
+          onClose={() => setEnlarged(null)}
+          name={enlarged.name}
+          qty={enlarged.qty}
+          subtitle={enlarged.type ? prettifyTypeName(enlarged.type) : undefined}
+          nav={hasNav ? { index: enlargedIndex, total: navItems.length, onNavigate: navigate } : undefined}
         >
-          <button
-            onClick={() => setEnlarged(null)}
-            className="absolute right-4 top-4 rounded-full p-2 text-white/70 transition-colors hover:bg-white/10 hover:text-white"
-            aria-label="Close"
-          >
-            <X className="h-6 w-6" />
-          </button>
-          <div
-            className="flex w-full max-w-lg items-center justify-center gap-2 sm:gap-4"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {hasNav && (
-              <button
-                onClick={() => navigate(-1)}
-                className="hidden flex-shrink-0 rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/25 sm:block"
-                aria-label="Previous card"
-              >
-                <ChevronLeft className="h-6 w-6" />
-              </button>
-            )}
-            <div
-              className="w-full max-w-sm"
-              onTouchStart={(e) => { touchStartX.current = e.touches[0].clientX; }}
-              onTouchEnd={(e) => {
-                const start = touchStartX.current;
-                touchStartX.current = null;
-                if (start === null) return;
-                const dx = e.changedTouches[0].clientX - start;
-                if (Math.abs(dx) > 48) navigate(dx > 0 ? -1 : 1);
-              }}
-            >
-              {enlarged === "paragon" ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                  src={`/paragons/Paragon ${deck.paragon}.png`}
-                  alt={deck.paragon ?? "Paragon"}
-                  className="w-full rounded-lg shadow-2xl"
-                />
-              ) : (
-                <>
-                  <CardFace item={enlarged} />
-                  <div className="mt-3 text-center">
-                    <p className="text-sm font-semibold text-white">
-                      {enlarged.name}
-                      {enlarged.qty > 1 && <span className="font-normal text-white/70"> ×{enlarged.qty}</span>}
-                    </p>
-                    <p className="text-xs text-white/70">
-                      {enlarged.type && `${prettifyTypeName(enlarged.type)}`}
-                      {hasNav && `${enlarged.type ? " · " : ""}${enlargedIndex + 1} of ${navItems.length}`}
-                    </p>
-                  </div>
-                </>
-              )}
-            </div>
-            {hasNav && (
-              <button
-                onClick={() => navigate(1)}
-                className="hidden flex-shrink-0 rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/25 sm:block"
-                aria-label="Next card"
-              >
-                <ChevronRight className="h-6 w-6" />
-              </button>
-            )}
-          </div>
-        </div>
-      )}
+          <CardFace item={enlarged} />
+        </CardEnlargeModal>
+      ) : null}
 
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">

--- a/components/ui/CardEnlargeModal.tsx
+++ b/components/ui/CardEnlargeModal.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useEffect, useRef, type ReactNode } from "react";
+import { ChevronLeft, ChevronRight, X } from "lucide-react";
+
+/** Prev/next wiring. Omit when there is no list to cycle through — the arrows,
+ * arrow keys, swipe and the "N of M" counter all disappear with it. */
+export interface CardEnlargeNav {
+  /** 0-based position of the card on screen, for the counter. */
+  index: number;
+  total: number;
+  onNavigate: (delta: number) => void;
+}
+
+/**
+ * Full-screen enlarged card: arrows / arrow keys / swipe cycle through the
+ * deck, Escape or a backdrop click closes.
+ *
+ * Extracted from the Forge deck view so the host's submission modal can enlarge
+ * a card the same way — its grid tiles are too small to read a card name on.
+ */
+export default function CardEnlargeModal({
+  children,
+  onClose,
+  name,
+  qty,
+  subtitle,
+  nav,
+}: {
+  /** The enlarged card face. */
+  children: ReactNode;
+  onClose: () => void;
+  /** Caption under the card. Omit `name` for a bare image (the Paragon case). */
+  name?: string;
+  qty?: number;
+  subtitle?: string;
+  nav?: CardEnlargeNav;
+}) {
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      } else if (e.key === "ArrowLeft") {
+        e.stopPropagation();
+        nav?.onNavigate(-1);
+      } else if (e.key === "ArrowRight") {
+        e.stopPropagation();
+        nav?.onNavigate(1);
+      }
+    }
+    // Capture phase + stopPropagation so that when this sits inside another
+    // dialog (the host's submission modal), Escape closes the enlarged card
+    // instead of tearing down the dialog underneath it.
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => document.removeEventListener("keydown", onKeyDown, true);
+  }, [onClose, nav]);
+
+  const touchStartX = useRef<number | null>(null);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <button
+        onClick={onClose}
+        className="absolute right-4 top-4 rounded-full p-2 text-white/70 transition-colors hover:bg-white/10 hover:text-white"
+        aria-label="Close"
+      >
+        <X className="h-6 w-6" />
+      </button>
+      <div
+        className="flex w-full max-w-lg items-center justify-center gap-2 sm:gap-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {nav && (
+          <button
+            onClick={() => nav.onNavigate(-1)}
+            className="hidden flex-shrink-0 rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/25 sm:block"
+            aria-label="Previous card"
+          >
+            <ChevronLeft className="h-6 w-6" />
+          </button>
+        )}
+        <div
+          className="w-full max-w-sm"
+          onTouchStart={(e) => { touchStartX.current = e.touches[0].clientX; }}
+          onTouchEnd={(e) => {
+            const start = touchStartX.current;
+            touchStartX.current = null;
+            if (start === null) return;
+            const dx = e.changedTouches[0].clientX - start;
+            if (Math.abs(dx) > 48) nav?.onNavigate(dx > 0 ? -1 : 1);
+          }}
+        >
+          {children}
+          {name !== undefined && (
+            <div className="mt-3 text-center">
+              <p className="text-sm font-semibold text-white">
+                {name}
+                {qty !== undefined && qty > 1 && (
+                  <span className="font-normal text-white/70"> ×{qty}</span>
+                )}
+              </p>
+              <p className="text-xs text-white/70">
+                {subtitle}
+                {nav && `${subtitle ? " · " : ""}${nav.index + 1} of ${nav.total}`}
+              </p>
+            </div>
+          )}
+        </div>
+        {nav && (
+          <button
+            onClick={() => nav.onNavigate(1)}
+            className="hidden flex-shrink-0 rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/25 sm:block"
+            aria-label="Next card"
+          >
+            <ChevronRight className="h-6 w-6" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/ui/CardTile.tsx
+++ b/components/ui/CardTile.tsx
@@ -41,7 +41,10 @@ export default function CardTile({
 
   return (
     <div
-      className={`relative group ${interactive ? "cursor-pointer" : ""} ${compact ? "w-[calc(100%/12-4px)] min-w-[70px] -mb-6 last:mb-0" : ""}`}
+      // Sizing is the caller's grid's job. This used to hardcode a 12-column
+      // track plus a negative bottom margin, which pinned every tile to ~70px
+      // at every breakpoint and overlapped each row onto the next.
+      className={`relative group ${interactive ? "cursor-pointer" : ""}`}
       onClick={onClick}
       onMouseEnter={
         onHover
@@ -71,7 +74,7 @@ export default function CardTile({
             className="object-contain"
             sizes={
               compact
-                ? "(max-width: 640px) 25vw, (max-width: 1024px) 12.5vw, 8vw"
+                ? "(max-width: 640px) 33vw, (max-width: 1024px) 17vw, 12vw"
                 : "(max-width: 640px) 33vw, (max-width: 768px) 25vw, 16vw"
             }
             loading="lazy"

--- a/components/ui/SubmissionModal.tsx
+++ b/components/ui/SubmissionModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Image from "next/image";
 import {
   Dialog,
   DialogContent,
@@ -11,7 +12,9 @@ import {
 } from "./dialog";
 import { getSubmissionAction } from "@/app/tracker/tournaments/actions";
 import { findCard } from "@/lib/cards/lookup";
+import { getCardImageUrl } from "@/app/shared/utils/cardImageUrl";
 import CardTile from "./CardTile";
+import CardEnlargeModal from "./CardEnlargeModal";
 import type { DeckSnapshot, DeckSnapshotCard } from "@/lib/tournament/deckSubmission";
 import type { DeckCheckIssue } from "@/utils/deckcheck";
 
@@ -104,7 +107,15 @@ function ZoneSection({ title, cards }: { title: string; cards: DeckSnapshotCard[
  * public deck page's CardTile so a host sees decks exactly as players do, and
  * keeps the list view's type headings — without them the grid is strictly less
  * information than the list it replaces. */
-function ZoneImages({ title, cards }: { title: string; cards: DeckSnapshotCard[] }) {
+function ZoneImages({
+  title,
+  cards,
+  onSelect,
+}: {
+  title: string;
+  cards: DeckSnapshotCard[];
+  onSelect: (card: DeckSnapshotCard) => void;
+}) {
   if (cards.length === 0) return null;
   const total = cards.reduce((n, c) => n + c.quantity, 0);
   const groups = groupByType(cards);
@@ -119,7 +130,9 @@ function ZoneImages({ title, cards }: { title: string; cards: DeckSnapshotCard[]
             <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
               {g.type}
             </p>
-            <div className="mt-1.5 grid grid-cols-4 gap-2 sm:grid-cols-6 md:grid-cols-8">
+            {/* ~97px on a phone up to ~163px on a desktop: enough to recognise
+                the art, never enough to read the card, so tiles enlarge. */}
+            <div className="mt-1.5 grid grid-cols-3 gap-2 sm:grid-cols-4 lg:grid-cols-5 2xl:grid-cols-6">
               {g.cards.map((c, i) => (
                 <CardTile
                   key={`${c.name}-${c.set}-${i}`}
@@ -129,6 +142,7 @@ function ZoneImages({ title, cards }: { title: string; cards: DeckSnapshotCard[]
                     card_img_file: c.imgFile,
                     quantity: c.quantity,
                   }}
+                  onClick={() => onSelect(c)}
                 />
               ))}
             </div>
@@ -136,6 +150,28 @@ function ZoneImages({ title, cards }: { title: string; cards: DeckSnapshotCard[]
         ))}
       </div>
     </div>
+  );
+}
+
+/** The enlarged face for one snapshot card — name-only when the art is missing,
+ * mirroring CardTile's fallback. */
+function EnlargedFace({ card }: { card: DeckSnapshotCard }) {
+  const src = getCardImageUrl(card.imgFile || "");
+  if (!src) {
+    return (
+      <div className="flex aspect-[2.5/3.5] w-full items-center justify-center rounded-lg bg-muted p-4 text-center text-sm font-medium text-muted-foreground">
+        {card.name}
+      </div>
+    );
+  }
+  return (
+    <Image
+      src={src}
+      alt={card.name}
+      width={500}
+      height={700}
+      className="h-auto w-full rounded-lg shadow-2xl"
+    />
   );
 }
 
@@ -160,6 +196,7 @@ export default function SubmissionModal({
   // name. The choice sticks across opens so a host checking a row of decks
   // picks a view once.
   const [view, setView] = useState<"list" | "images">("list");
+  const [enlarged, setEnlarged] = useState<DeckSnapshotCard | null>(null);
 
   useEffect(() => {
     if (!open || !participantId) return;
@@ -199,11 +236,21 @@ export default function SubmissionModal({
     if (!open) {
       setSubmission(null);
       setError(null);
+      setEnlarged(null);
     }
   }, [open]);
 
   const mainCards = submission?.snapshot.cards.filter((c) => c.zone === "main") ?? [];
   const reserveCards = submission?.snapshot.cards.filter((c) => c.zone === "reserve") ?? [];
+
+  // Flat display order (main groups → reserve groups) for the enlarged card's
+  // prev/next. `groupByType` hands back the very snapshot objects ZoneImages
+  // renders, so identity is enough to locate the clicked card.
+  const navCards = [...groupByType(mainCards), ...groupByType(reserveCards)].flatMap(
+    (g) => g.cards,
+  );
+  const enlargedIndex = enlarged ? navCards.indexOf(enlarged) : -1;
+  const hasNav = enlargedIndex !== -1 && navCards.length > 1;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -270,8 +317,8 @@ export default function SubmissionModal({
                 </>
               ) : (
                 <>
-                  <ZoneImages title="Main deck" cards={mainCards} />
-                  <ZoneImages title="Reserve" cards={reserveCards} />
+                  <ZoneImages title="Main deck" cards={mainCards} onSelect={setEnlarged} />
+                  <ZoneImages title="Reserve" cards={reserveCards} onSelect={setEnlarged} />
                 </>
               )}
             </>
@@ -285,6 +332,30 @@ export default function SubmissionModal({
             Close
           </button>
         </DialogFooter>
+        {/* Inside DialogContent so its backdrop click can't bubble out to the
+            Dialog root and close the whole submission modal. */}
+        {enlarged && (
+          <CardEnlargeModal
+            onClose={() => setEnlarged(null)}
+            name={enlarged.name}
+            qty={enlarged.quantity}
+            subtitle={enlarged.set}
+            nav={
+              hasNav
+                ? {
+                    index: enlargedIndex,
+                    total: navCards.length,
+                    onNavigate: (delta) =>
+                      setEnlarged(
+                        navCards[(enlargedIndex + delta + navCards.length) % navCards.length],
+                      ),
+                  }
+                : undefined
+            }
+          >
+            <EnlargedFace card={enlarged} />
+          </CardEnlargeModal>
+        )}
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Why

`CardTile`'s compact mode carried its own layout — `w-[calc(100%/12-4px)] min-w-[70px] -mb-6 last:mb-0`. Two things fell out of that:

1. **The negative bottom margin overlapped every row onto the next by 24px** on a ~98px card. The bottom strip of each card (set / rarity) was hidden, and on a phone cards covered the following group heading. It isn't a designed fan effect — no horizontal offset, no shadow separation, no z-order intent — it just read as broken CSS. (The deck page's *stacked* view overlaps deliberately via `-mb-32` on its own wrapper; that's a separate code path and is untouched.)
2. **The hardcoded 12-column track applied at every breakpoint**, so tiles measured ~74px at 1400px and ~70px at 390px — they got *smaller* as the viewport grew past the min-width. There was no responsive sizing at all.

Separately, the host's `SubmissionModal` rendered a grid of `CardTile`s with **no click handler**, so a host could never enlarge a card to read it. At ~99px desktop / ~63px mobile that defeats the view's stated purpose ("recognising cards the host doesn't know by name").

## What changed

- **`components/ui/CardTile.tsx`** — dropped the width/min-width/negative-margin hardcode. Sizing is the caller's grid's job now. Bumped the compact `sizes` hint so the CDN still serves sharp art at the larger tile size.
- **`app/decklist/[deckId]/client.tsx`** — the three CardTile call sites (main deck, reserve, considering) swap `flex flex-wrap gap-x-1.5` for `grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-6 xl:grid-cols-7`. Diff is deliberately limited to the one class string per site.
- **`components/ui/CardEnlargeModal.tsx`** (new) — the Forge deck view's enlarge modal (prev/next, arrow keys, swipe, "N of M" counter, backdrop/Escape close), extracted verbatim behind a small props API. One deliberate change: the key handler now listens in the capture phase and stops propagation, so Escape over an enlarged card closes the card instead of also tearing down the dialog underneath it. Without that, nesting it inside `SubmissionModal` would close both.
- **`app/forge/play/decks/[deckId]/view/DeckViewClient.tsx`** — imports the extracted modal; ~70 lines of inline overlay JSX and its keydown effect removed. Nav list / index / `hasNav` logic stays put (it's deck-specific).
- **`components/ui/SubmissionModal.tsx`** — the Images grid becomes `grid-cols-3 sm:grid-cols-4 lg:grid-cols-5 2xl:grid-cols-6` and every tile is clickable, enlarging into `CardEnlargeModal` with prev/next cycling the whole deck in display order (main groups → reserve groups). `CardTile`'s `interactive = !!onClick` contract is unchanged — the pointer cursor and hover ring now appear because there *is* something to click.

## Measured (public deck page, `/decklist/78c09d65…`)

| | before | after |
|---|---|---|
| tile width @ 1400px | 74px | **127px** |
| tile width @ 390px | 70px | **114px** |
| row gap | **-24px** (overlap) | **+8px** |
| tile width @ 640 / 768 / 1024 / 1920 | ~70–74px everywhere | 146 / 116 / 107 / 127px |

`SubmissionModal` tiles: ~99px → **163px** desktop, ~63px → ~97px mobile (and now enlargeable to a full-width 358px card on a phone).

## Verified

- `npx tsc --noEmit` clean apart from the two pre-existing test-file failures (`__tests__/forge-anon-leak.test.ts`, `app/forge/lib/__tests__/playDecksAuthorize.test.ts`).
- `npx vitest run` — 1686 pass, 1 pre-existing failure (`__tests__/forge-lackey.test.ts` brigade parsing).
- Deck page driven with Playwright at 1400px and 390px, light and dark: no overlap, no horizontal overflow, group headings clear. Stacked view still overlaps at its intended -120px.
- Forge deck view (`/forge/play/decks/…/view`) with a real session: enlarge modal opens with prev/next/close, caption reads `King's Sword [RR2] · Dominant · 1 of 5`, ArrowRight advances to `2 of 5`, Escape closes — identical to before the extraction.
- `SubmissionModal`'s wiring was exercised through a throwaway harness page (deleted before commit) that reproduces its exact nesting — `Dialog > DialogContent > CardTile grid + CardEnlargeModal` — with real components: the overlay renders above the dialog and is the topmost hit-test target, arrow keys cycle, Escape closes the enlarged card while the dialog stays open, a second Escape closes the dialog.

## Not verified

There are currently zero deck submissions in the database, so the real `SubmissionModal` can't be reached through the UI — its enlarge wiring is covered by the structural harness above plus code review, not by a live host flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)