### PR TITLE
feat(tracker): keyboard score entry for the round table

### DIFF
--- a/components/ui/ScoreCell.tsx
+++ b/components/ui/ScoreCell.tsx
@@ -22,12 +22,12 @@ export const ScoreCell = forwardRef<
     isCursor: boolean;
     isRejected: boolean;
     saveState: RowSaveState;
-    disabled?: boolean;
     onKeyDown: (e: React.KeyboardEvent) => void;
     onFocus: () => void;
+    onBlur: (e: React.FocusEvent) => void;
   }
 >(function ScoreCell(
-  { value, playerName, isCursor, isRejected, saveState, disabled, onKeyDown, onFocus },
+  { value, playerName, isCursor, isRejected, saveState, onKeyDown, onFocus, onBlur },
   ref,
 ) {
   return (
@@ -37,12 +37,12 @@ export const ScoreCell = forwardRef<
       inputMode="numeric"
       maxLength={1}
       readOnly
-      disabled={disabled}
       value={value === null ? "" : String(value)}
       placeholder="–"
       aria-label={`Score for ${playerName}`}
       onKeyDown={onKeyDown}
       onFocus={onFocus}
+      onBlur={onBlur}
       // Every mutation goes through the key handler, which owns validation and
       // cursor movement. readOnly keeps the browser from inserting characters
       // behind its back (paste, IME, autofill) while still allowing focus.
@@ -55,22 +55,27 @@ export const ScoreCell = forwardRef<
         // underline rather than an outlined box.
         "border-0 border-b-2 outline-none",
         "placeholder:text-muted-foreground/50",
-        disabled
-          ? "bg-transparent border-transparent text-muted-foreground cursor-not-allowed"
-          : isRejected
-            ? "bg-destructive/15 border-destructive text-foreground"
-            : isCursor
-              ? "bg-muted border-primary text-foreground"
-              : saveState === "error"
-                ? "bg-destructive/10 border-destructive/50 text-foreground"
-                : "bg-muted/40 border-transparent text-foreground hover:bg-muted",
+        isRejected
+          ? "bg-destructive/15 border-destructive text-foreground"
+          : isCursor
+            ? "bg-muted border-primary text-foreground"
+            : saveState === "error"
+              ? "bg-destructive/10 border-destructive/50 text-foreground"
+              : "bg-muted/40 border-transparent text-foreground hover:bg-muted",
       ].join(" ")}
     />
   );
 });
 
 /** Per-row save indicator, sized to never shift the row's layout. */
-export function SaveIndicator({ state }: { state: RowSaveState }) {
+export function SaveIndicator({
+  state,
+  error,
+}: {
+  state: RowSaveState;
+  /** Why the save failed — surfaced verbatim rather than a generic string. */
+  error?: string;
+}) {
   return (
     <span className="inline-flex w-4 justify-center" aria-live="polite">
       {state === "saving" && (
@@ -83,10 +88,12 @@ export function SaveIndicator({ state }: { state: RowSaveState }) {
         <Check className="w-3 h-3 text-primary" aria-label="Saved" />
       )}
       {state === "error" && (
-        <TriangleAlert
-          className="w-3 h-3 text-destructive"
-          aria-label="Failed to save — check the score"
-        />
+        <span title={error ?? "Failed to save"} className="inline-flex">
+          <TriangleAlert
+            className="w-3 h-3 text-destructive"
+            aria-label={error ?? "Failed to save"}
+          />
+        </span>
       )}
     </span>
   );

--- a/components/ui/ScoreCell.tsx
+++ b/components/ui/ScoreCell.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { forwardRef } from "react";
+import { Check, Loader2, TriangleAlert } from "lucide-react";
+import type { RowSaveState } from "./useScoreGrid";
+
+/**
+ * One editable score cell in the desktop round table.
+ *
+ * A real <input> rather than a tabIndex'd div so it inherits caret, selection,
+ * and assistive-tech behavior for free. maxLength=1 is safe because
+ * tournaments.max_score is locked to 5 or 7, so a score is always one digit.
+ *
+ * Focus is shown with a surface shift plus a solid accent underline rather than
+ * a ring — consistent with the design system's tonal-layering rule.
+ */
+export const ScoreCell = forwardRef<
+  HTMLInputElement,
+  {
+    value: number | null;
+    playerName: string;
+    isCursor: boolean;
+    isRejected: boolean;
+    saveState: RowSaveState;
+    disabled?: boolean;
+    onKeyDown: (e: React.KeyboardEvent) => void;
+    onFocus: () => void;
+  }
+>(function ScoreCell(
+  { value, playerName, isCursor, isRejected, saveState, disabled, onKeyDown, onFocus },
+  ref,
+) {
+  return (
+    <input
+      ref={ref}
+      type="text"
+      inputMode="numeric"
+      maxLength={1}
+      readOnly
+      disabled={disabled}
+      value={value === null ? "" : String(value)}
+      placeholder="–"
+      aria-label={`Score for ${playerName}`}
+      onKeyDown={onKeyDown}
+      onFocus={onFocus}
+      // Every mutation goes through the key handler, which owns validation and
+      // cursor movement. readOnly keeps the browser from inserting characters
+      // behind its back (paste, IME, autofill) while still allowing focus.
+      onChange={() => {}}
+      className={[
+        "w-9 h-9 rounded-md text-center text-sm font-medium tabular-nums",
+        "transition-colors caret-transparent cursor-pointer",
+        // Bottom accent only — the design system forbids 1px boxes for
+        // structure, so the active cell reads as a surface shift plus an
+        // underline rather than an outlined box.
+        "border-0 border-b-2 outline-none",
+        "placeholder:text-muted-foreground/50",
+        disabled
+          ? "bg-transparent border-transparent text-muted-foreground cursor-not-allowed"
+          : isRejected
+            ? "bg-destructive/15 border-destructive text-foreground"
+            : isCursor
+              ? "bg-muted border-primary text-foreground"
+              : saveState === "error"
+                ? "bg-destructive/10 border-destructive/50 text-foreground"
+                : "bg-muted/40 border-transparent text-foreground hover:bg-muted",
+      ].join(" ")}
+    />
+  );
+});
+
+/** Per-row save indicator, sized to never shift the row's layout. */
+export function SaveIndicator({ state }: { state: RowSaveState }) {
+  return (
+    <span className="inline-flex w-4 justify-center" aria-live="polite">
+      {state === "saving" && (
+        <Loader2
+          className="w-3 h-3 animate-spin text-muted-foreground"
+          aria-label="Saving"
+        />
+      )}
+      {state === "saved" && (
+        <Check className="w-3 h-3 text-primary" aria-label="Saved" />
+      )}
+      {state === "error" && (
+        <TriangleAlert
+          className="w-3 h-3 text-destructive"
+          aria-label="Failed to save — check the score"
+        />
+      )}
+    </span>
+  );
+}

--- a/components/ui/ScoreShortcutsDialog.tsx
+++ b/components/ui/ScoreShortcutsDialog.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { Keyboard } from "lucide-react";
+import { Dialog, DialogContent } from "./dialog";
+
+/**
+ * Cheatsheet for the desktop keyboard score grid, plus the ⌨ trigger that
+ * opens it. Desktop-only — the mobile pairing cards keep the tap-the-pencil
+ * flow, so the trigger is hidden below `md`.
+ */
+
+interface ShortcutRow {
+  keys: string[];
+  /** Separator drawn between key chips — plain text, never itself a chip. */
+  joiner?: string;
+  label: string;
+}
+
+const NAV_SHORTCUTS: ShortcutRow[] = [
+  { keys: ["0", "5"], joiner: "–", label: "Type a score — fills the cell and jumps to the next" },
+  { keys: ["Enter"], label: "Next match (or the next unscored one from the bottom)" },
+  { keys: ["→", "←"], joiner: "/", label: "Move between the two players" },
+  { keys: ["↑", "↓"], joiner: "/", label: "Same player, previous / next match" },
+  { keys: ["Tab"], label: "Next cell (same as →)" },
+  { keys: ["Home", "End"], joiner: "/", label: "First / last cell" },
+];
+
+const EDIT_SHORTCUTS: ShortcutRow[] = [
+  { keys: ["Backspace"], label: "Clear this score" },
+  { keys: ["Esc"], label: "Undo the current cell, then leave the grid" },
+  { keys: ["?"], label: "Open this cheatsheet" },
+];
+
+function Kbd({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd className="inline-flex min-w-[1.75rem] items-center justify-center rounded-md bg-muted px-2 py-1 font-mono text-xs font-medium text-foreground">
+      {children}
+    </kbd>
+  );
+}
+
+function ShortcutList({ rows }: { rows: ShortcutRow[] }) {
+  return (
+    <ul className="space-y-2.5">
+      {rows.map((row) => (
+        <li key={row.label} className="flex items-baseline gap-3">
+          <span className="flex shrink-0 items-center gap-1">
+            {row.keys.map((key, i) => (
+              <span key={key} className="flex items-center gap-1">
+                {i > 0 && row.joiner && (
+                  <span className="text-xs text-muted-foreground">{row.joiner}</span>
+                )}
+                <Kbd>{key}</Kbd>
+              </span>
+            ))}
+          </span>
+          <span className="text-sm text-muted-foreground">{row.label}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function ScoreShortcutsButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="Keyboard shortcuts for score entry"
+      title="Keyboard shortcuts (?)"
+      className="hidden md:inline-flex items-center justify-center w-9 h-9 rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+    >
+      <Keyboard className="w-4 h-4" aria-hidden="true" />
+    </button>
+  );
+}
+
+export function ScoreShortcutsDialog({
+  open,
+  onOpenChange,
+  maxScore,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  maxScore: number;
+}) {
+  // The digit row is the one line that depends on the tournament's soul cap.
+  const navRows = NAV_SHORTCUTS.map((row) =>
+    row.keys[0] === "0" ? { ...row, keys: ["0", String(maxScore)] } : row,
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="md" className="bg-card border-2 border-border px-8 py-7">
+        <h2 className="text-xl font-bold text-foreground">Keyboard score entry</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Click any score cell in the round table to start. Most matches are two
+          keystrokes — type both scores and you land on the next match.
+        </p>
+
+        <div className="mt-6 space-y-6">
+          <section>
+            <h3 className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Moving around
+            </h3>
+            <ShortcutList rows={navRows} />
+          </section>
+          <section>
+            <h3 className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Fixing and leaving
+            </h3>
+            <ShortcutList rows={EDIT_SHORTCUTS} />
+          </section>
+        </div>
+
+        <p className="mt-6 text-xs text-muted-foreground">
+          Scores save on their own as you type. The pencil still works for
+          editing one match at a time.
+        </p>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/ui/ScoreShortcutsDialog.tsx
+++ b/components/ui/ScoreShortcutsDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { Keyboard } from "lucide-react";
 import { Dialog, DialogContent } from "./dialog";
 
@@ -89,10 +90,24 @@ export function ScoreShortcutsDialog({
     row.keys[0] === "0" ? { ...row, keys: ["0", String(maxScore)] } : row,
   );
 
+  // The Dialog primitive is hand-rolled and does not trap focus, so opening the
+  // cheatsheet from a score cell would leave that cell focused underneath —
+  // every keystroke spent reading this would land in the grid behind it.
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  useEffect(() => {
+    if (open) headingRef.current?.focus();
+  }, [open]);
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent size="md" className="bg-card border-2 border-border px-8 py-7">
-        <h2 className="text-xl font-bold text-foreground">Keyboard score entry</h2>
+        <h2
+          ref={headingRef}
+          tabIndex={-1}
+          className="text-xl font-bold text-foreground outline-none"
+        >
+          Keyboard score entry
+        </h2>
         <p className="mt-2 text-sm text-muted-foreground">
           Click any score cell in the round table to start. Most matches are two
           keystrokes — type both scores and you land on the next match.

--- a/components/ui/TournamentRounds.tsx
+++ b/components/ui/TournamentRounds.tsx
@@ -15,6 +15,9 @@ import { Button } from "./button";
 import ToastNotification from "./toast-notification";
 import ConfirmationDialog from "./confirmation-dialog";
 import InfoHint, { MP_ROUND_HINT, DIFF_ROUND_HINT } from "./InfoHint";
+import { ScoreCell, SaveIndicator } from "./ScoreCell";
+import { useScoreGrid } from "./useScoreGrid";
+import { ScoreShortcutsButton, ScoreShortcutsDialog } from "./ScoreShortcutsDialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -22,6 +25,9 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "./dropdown-menu";
+
+/** Set once the host dismisses the "type scores straight into the table" hint. */
+const KEYBOARD_HINT_DISMISSED_KEY = "rtt.scoreGrid.hintDismissed";
 
 const formatDateTime = (timestamp: string | null) => {
   if (!timestamp) return "";
@@ -910,6 +916,39 @@ export default function TournamentRounds({
 
   const isSeatsMode = tournamentInfo.numbering_mode === "seats";
 
+  // ---- Keyboard score grid (desktop, live round, host only) ---------------
+  // Inline score cells replace the read-only Result column so a host can enter
+  // a whole round without touching the mouse. Re-pair mode takes the table
+  // over for click-to-swap, so the grid stands down while it's active.
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const gridEnabled = isHost && isRoundActive && !repairMode;
+
+  // Read in an effect, not in the initializer — localStorage isn't available
+  // during SSR and reading it inline would hydrate-mismatch.
+  const [showKeyboardHint, setShowKeyboardHint] = useState(false);
+  useEffect(() => {
+    setShowKeyboardHint(
+      window.localStorage.getItem(KEYBOARD_HINT_DISMISSED_KEY) !== "1",
+    );
+  }, []);
+  const dismissKeyboardHint = () => {
+    window.localStorage.setItem(KEYBOARD_HINT_DISMISSED_KEY, "1");
+    setShowKeyboardHint(false);
+  };
+
+  const scoreGrid = useScoreGrid({
+    matches,
+    maxScore: tournamentInfo.max_score ?? 5,
+    enabled: gridEnabled,
+    onSaved: () => {
+      // Clear the "missing score" highlight End Round paints, and let the page
+      // re-evaluate its re-pair gating.
+      setMatchErrorIndex([]);
+      onMatchesChanged?.();
+    },
+    onOpenHelp: () => setShortcutsOpen(true),
+  });
+
   /** Persisted table with legacy fallback to positional numbering. */
   const displayTable = (match: any, index: number): number =>
     match.table_number ?? index + (tournamentInfo.starting_table_number || 1);
@@ -968,6 +1007,9 @@ export default function TournamentRounds({
                       <h2 className="text-lg font-semibold text-foreground whitespace-nowrap">
                         Round {currentPage} of {tournamentInfo.n_rounds}
                       </h2>
+                      {gridEnabled && (
+                        <ScoreShortcutsButton onClick={() => setShortcutsOpen(true)} />
+                      )}
                     </div>
                     {/* Status line — always one row so the panel header height
                         stays consistent across upcoming / live / completed
@@ -986,6 +1028,29 @@ export default function TournamentRounds({
                         <span className="italic">Awaiting start</span>
                       )}
                     </p>
+                    {/* One-time discovery hint. The grid is invisible until you
+                        click a cell, so first-time hosts need a nudge; after
+                        that it's noise, hence the localStorage dismissal. */}
+                    {gridEnabled && showKeyboardHint && (
+                      <p className="hidden md:flex items-center gap-2 text-xs text-muted-foreground whitespace-nowrap">
+                        <span>Type scores straight into the table</span>
+                        <button
+                          type="button"
+                          onClick={() => setShortcutsOpen(true)}
+                          className="text-foreground underline underline-offset-2 hover:text-primary"
+                        >
+                          See shortcuts
+                        </button>
+                        <span aria-hidden="true">·</span>
+                        <button
+                          type="button"
+                          onClick={dismissKeyboardHint}
+                          className="hover:text-foreground"
+                        >
+                          Dismiss
+                        </button>
+                      </p>
+                    )}
                   </div>
                   {currentPage === tournamentInfo.current_round && (
                       // Round-control tiering: prints are outline (secondary),
@@ -1151,7 +1216,31 @@ export default function TournamentRounds({
                                   </span>
                                 </td>
                                 <td className={`px-4 py-2 text-center border-r tabular-nums ${matchErrorIndex.includes(index) ? "border-red-400" : "border-border"}`}>
-                                  {hasResult ? (
+                                  {gridEnabled ? (
+                                    <div className="flex items-center justify-center gap-1.5">
+                                      <ScoreCell
+                                        ref={(el) => scoreGrid.registerInput(index, 0, el)}
+                                        value={scoreGrid.valueAt(index, 0)}
+                                        playerName={match.player1_id.name}
+                                        isCursor={scoreGrid.isCursor(index, 0)}
+                                        isRejected={scoreGrid.isRejected(index, 0)}
+                                        saveState={scoreGrid.saveState[match.id] ?? "idle"}
+                                        onKeyDown={(e) => scoreGrid.onKeyDown(e, { row: index, col: 0 })}
+                                        onFocus={() => scoreGrid.focusCell({ row: index, col: 0 })}
+                                      />
+                                      <ScoreCell
+                                        ref={(el) => scoreGrid.registerInput(index, 1, el)}
+                                        value={scoreGrid.valueAt(index, 1)}
+                                        playerName={match.player2_id.name}
+                                        isCursor={scoreGrid.isCursor(index, 1)}
+                                        isRejected={scoreGrid.isRejected(index, 1)}
+                                        saveState={scoreGrid.saveState[match.id] ?? "idle"}
+                                        onKeyDown={(e) => scoreGrid.onKeyDown(e, { row: index, col: 1 })}
+                                        onFocus={() => scoreGrid.focusCell({ row: index, col: 1 })}
+                                      />
+                                      <SaveIndicator state={scoreGrid.saveState[match.id] ?? "idle"} />
+                                    </div>
+                                  ) : hasResult ? (
                                     <span className="font-medium text-foreground">
                                       {match.player1_score}&ndash;{match.player2_score}
                                     </span>
@@ -1680,6 +1769,11 @@ export default function TournamentRounds({
         }
         confirmLabel="End round"
         cancelLabel="Cancel"
+      />
+      <ScoreShortcutsDialog
+        open={shortcutsOpen}
+        onOpenChange={setShortcutsOpen}
+        maxScore={tournamentInfo.max_score ?? 5}
       />
     </div >
     </>

--- a/components/ui/TournamentRounds.tsx
+++ b/components/ui/TournamentRounds.tsx
@@ -174,6 +174,8 @@ export default function TournamentRounds({
   // on the current round's view, surfacing the repair UI on a round that was
   // never completed. Only the latest request applies its results.
   const latestRoundFetch = useRef(0);
+  /** Same guard for the matches/byes fetch — see fetchCurrentRoundData. */
+  const latestMatchesFetch = useRef(0);
   const [roundInfo, setRoundInfo] = useState<RoundInfo>({
     started_at: null,
     ended_at: null,
@@ -408,6 +410,13 @@ export default function TournamentRounds({
   };
 
   const fetchCurrentRoundData = async () => {
+    // Sequence guard, mirroring fetchTournamentAndRoundInfo's. Entering a round
+    // from the keyboard fires one refetch per saved match, so a dozen of these
+    // can be in flight at once; without this the last RESPONSE wins rather than
+    // the last REQUEST, and an early, mostly-unscored snapshot can clobber the
+    // current one — which then makes End Round reject a fully-scored round.
+    const seq = ++latestMatchesFetch.current;
+
     const { data, error } = await client
       .from("matches")
       .select(
@@ -417,17 +426,19 @@ export default function TournamentRounds({
       .eq("round", currentPage)
       .order("table_number", { ascending: true, nullsFirst: true })
       .order("match_order", { ascending: true });
-    
+
+    if (seq !== latestMatchesFetch.current) return;
     if (error) console.log(error);
     setMatches(data || []);
-  
+
     const { data: byeData, error: byeError } = await client
       .from("byes")
       .select("id, participant_id:participants(id, name), match_points, differential")
       .eq("tournament_id", tournamentId)
       .eq("round_number", currentPage)
       .order("id", { ascending: true });
-    
+
+    if (seq !== latestMatchesFetch.current) return;
     if (byeError) console.log(byeError);
     setByes(byeData);
   };
@@ -939,11 +950,17 @@ export default function TournamentRounds({
   const scoreGrid = useScoreGrid({
     matches,
     maxScore: tournamentInfo.max_score ?? 5,
-    enabled: gridEnabled,
-    onSaved: () => {
-      // Clear the "missing score" highlight End Round paints, and let the page
-      // re-evaluate its re-pair gating.
-      setMatchErrorIndex([]);
+    // Stand down while the cheatsheet is up, so keys read as "I'm reading the
+    // shortcuts" rather than being typed into the row behind the modal.
+    enabled: gridEnabled && !shortcutsOpen,
+    onSaved: (matchId) => {
+      // Clear the "missing score" highlight for THIS row only. Clearing the
+      // whole set would wipe the other rows End Round flagged, losing the
+      // "which ones are still missing" affordance the highlight exists for.
+      setMatchErrorIndex((prev) => {
+        const row = matches.findIndex((m) => m.id === matchId);
+        return row === -1 ? prev : prev.filter((i) => i !== row);
+      });
       onMatchesChanged?.();
     },
     onOpenHelp: () => setShortcutsOpen(true),
@@ -1218,27 +1235,34 @@ export default function TournamentRounds({
                                 <td className={`px-4 py-2 text-center border-r tabular-nums ${matchErrorIndex.includes(index) ? "border-red-400" : "border-border"}`}>
                                   {gridEnabled ? (
                                     <div className="flex items-center justify-center gap-1.5">
-                                      <ScoreCell
-                                        ref={(el) => scoreGrid.registerInput(index, 0, el)}
-                                        value={scoreGrid.valueAt(index, 0)}
-                                        playerName={match.player1_id.name}
-                                        isCursor={scoreGrid.isCursor(index, 0)}
-                                        isRejected={scoreGrid.isRejected(index, 0)}
-                                        saveState={scoreGrid.saveState[match.id] ?? "idle"}
-                                        onKeyDown={(e) => scoreGrid.onKeyDown(e, { row: index, col: 0 })}
-                                        onFocus={() => scoreGrid.focusCell({ row: index, col: 0 })}
+                                      {([0, 1] as const).map((col) => (
+                                        <ScoreCell
+                                          key={col}
+                                          ref={(el) => scoreGrid.registerInput(index, col, el)}
+                                          value={scoreGrid.valueAt(index, col)}
+                                          playerName={
+                                            col === 0
+                                              ? match.player1_id.name
+                                              : match.player2_id.name
+                                          }
+                                          isCursor={scoreGrid.isCursor(index, col)}
+                                          isRejected={scoreGrid.isRejected(index, col)}
+                                          saveState={scoreGrid.saveState[match.id] ?? "idle"}
+                                          onKeyDown={(e) =>
+                                            scoreGrid.onKeyDown(e, { row: index, col })
+                                          }
+                                          onFocus={() =>
+                                            scoreGrid.focusCell({ row: index, col })
+                                          }
+                                          // Clicking away mid-correction must not
+                                          // strand the edit locally.
+                                          onBlur={(e) => scoreGrid.onBlurCell(e, index)}
+                                        />
+                                      ))}
+                                      <SaveIndicator
+                                        state={scoreGrid.saveState[match.id] ?? "idle"}
+                                        error={scoreGrid.saveError[match.id]}
                                       />
-                                      <ScoreCell
-                                        ref={(el) => scoreGrid.registerInput(index, 1, el)}
-                                        value={scoreGrid.valueAt(index, 1)}
-                                        playerName={match.player2_id.name}
-                                        isCursor={scoreGrid.isCursor(index, 1)}
-                                        isRejected={scoreGrid.isRejected(index, 1)}
-                                        saveState={scoreGrid.saveState[match.id] ?? "idle"}
-                                        onKeyDown={(e) => scoreGrid.onKeyDown(e, { row: index, col: 1 })}
-                                        onFocus={() => scoreGrid.focusCell({ row: index, col: 1 })}
-                                      />
-                                      <SaveIndicator state={scoreGrid.saveState[match.id] ?? "idle"} />
                                     </div>
                                   ) : hasResult ? (
                                     <span className="font-medium text-foreground">

--- a/components/ui/match-edit.tsx
+++ b/components/ui/match-edit.tsx
@@ -4,7 +4,7 @@ import { Button } from "./button";
 import { Pencil } from "lucide-react";
 import { Dispatch, FormEvent, SetStateAction, useEffect, useRef, useState } from "react";
 import { createClient } from "../../utils/supabase/client";
-import { getUserSafe } from "../../utils/supabase/getUserSafe";
+import { saveMatchScore, validateScorePair } from "../../utils/tournament/saveMatchScore";
 import { Dialog, DialogContent } from "./dialog";
 
 export default function MatchEditModal({
@@ -108,27 +108,17 @@ export default function MatchEditModal({
     e.preventDefault();
     setError(null);
 
-    // Require an explicit choice — null sentinel guard. Without this, the
-    // < / > comparisons below would treat null as 0 and silently submit a
-    // 0–0 result the user never selected.
-    if (player1Score === null || player2Score === null) {
-      setError("Select a score for both players before submitting.");
+    // Covers the null sentinel ("no choice yet" — never conflate with 0), the
+    // 0..max_score range, and the unreachable max–max pair.
+    const invalid = validateScorePair(player1Score, player2Score, tournament.max_score);
+    if (invalid) {
+      setError(invalid);
       return;
     }
+    // Past the guard both scores are numbers; TS can't narrow through the helper.
+    if (player1Score === null || player2Score === null) return;
 
     if (mode === "repair") {
-      if (
-        player1Score < 0 || player2Score < 0 ||
-        player1Score > tournament.max_score ||
-        player2Score > tournament.max_score
-      ) {
-        setError(`Invalid scores. Scores must be between 0 and ${tournament.max_score}, inclusive.`);
-        return;
-      }
-      if (player1Score === tournament.max_score && player2Score === tournament.max_score) {
-        setError(`Score cannot be ${tournament.max_score}-${tournament.max_score}.`);
-        return;
-      }
       const { repairMatchScoreAction } = await import("@/app/tracker/tournaments/repair-actions");
       const result = await repairMatchScoreAction({
         matchId: match.id,
@@ -150,114 +140,23 @@ export default function MatchEditModal({
       return;
     }
 
-    if (
-      isNaN(player2Score) ||
-      player1Score < 0 ||
-      player2Score < 0 ||
-      player1Score > tournament.max_score ||
-      player2Score > tournament.max_score
-    ) {
-      setError(`Invalid scores. Scores must be between 0 and ${tournament.max_score}, inclusive.`);
-      return;
-    }
-    if (player1Score === tournament.max_score && player2Score === tournament.max_score) {
-      setError(`Score cannot be ${tournament.max_score}-${tournament.max_score}.`);
-      return;
-    }
-    const client = createClient();
-
-    // A read/write failure mid-round is most often a dead/expired session (the
-    // owner-scoped RLS query returns no row). getUserSafe distinguishes that
-    // (returns null) from a transient network blip (keeps the session), so flaky
-    // venue wifi shows a generic retry message rather than a false "session
-    // expired"; it also refreshes the token if it still can, enabling recovery
-    // on retry.
-    const sessionExpiredMessage =
-      "Your session expired — reload the page to sign back in, then re-enter the score.";
-    const hasValidSession = async () => !!(await getUserSafe(client));
-
-    const player1 = await client
-      .from("participants")
-      .select("differential, match_points, id")
-      .eq("id", match.player1_id.id)
-      .single();
-    const player2 = await client
-      .from("participants")
-      .select("differential, match_points, id")
-      .eq("id", match.player2_id.id)
-      .single();
-
-    if (player1.error || player2.error) {
-      console.log(player1.error, player2.error);
-      setError(
-        (await hasValidSession())
-          ? "Couldn't load player data. Please try again."
-          : sessionExpiredMessage,
-      );
-      return;
-    }
-
-    let player1_match_points, player2_match_points;
-    let isTie = false;
-    let winnerId: string | null = null;
-
-    if (player2Score === player1Score) {
-      player1_match_points = 1.5;
-      player2_match_points = 1.5;
-      isTie = true;
-      winnerId = null;
-    } else if (player1Score === tournament.max_score) {
-      player1_match_points = 3;
-      player2_match_points = 0;
-      winnerId = match.player1_id.id;
-    } else if (player2Score === tournament.max_score) {
-      player1_match_points = 0;
-      player2_match_points = 3;
-      winnerId = match.player2_id.id;
-    } else if (player1Score > player2Score) {
-      player1_match_points = 2;
-      player2_match_points = 1;
-      winnerId = match.player1_id.id;
-    } else if (player2Score > player1Score) {
-      player1_match_points = 1;
-      player2_match_points = 2;
-      winnerId = match.player2_id.id;
-    }
-
-    // Update the match without modifying match_order
-    const { data, error } = await client
-      .from("matches")
-      .update({
-        player1_score: player1Score,
-        player2_score: player2Score,
-        differential:
-          (player1.data.differential ?? 0) + (player1Score - player2Score),
-        differential2:
-          (player2.data.differential ?? 0) + (player2Score - player1Score),
-        player1_match_points:
-          (player1.data.match_points || 0) + player1_match_points,
-        player2_match_points:
-          (player2.data.match_points || 0) + player2_match_points,
-        is_tie: isTie,
-        winner_id: winnerId,
-        updated_at: new Date(),
-      })
-      .eq("id", match.id);
+    const result = await saveMatchScore(createClient(), {
+      matchId: match.id,
+      player1Id: match.player1_id.id,
+      player2Id: match.player2_id.id,
+      player1Score,
+      player2Score,
+      maxScore: tournament.max_score,
+    });
 
     setMatchErrorIndex((prev) => prev.filter((i) => i !== index));
 
-    if (!error) {
-      setOpen(false);
-    } else {
-      console.log(error);
-      setError(
-        (await hasValidSession())
-          ? "Failed to save match scores. Please try again."
-          : sessionExpiredMessage,
-      );
+    if (result.ok === false) {
+      setError(result.error);
       return;
     }
 
+    setOpen(false);
     fetchCurrentRoundData?.();
   };
 

--- a/components/ui/useScoreGrid.ts
+++ b/components/ui/useScoreGrid.ts
@@ -1,0 +1,242 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import { createClient } from "../../utils/supabase/client";
+import { saveMatchScore, validateScorePair } from "../../utils/tournament/saveMatchScore";
+import {
+  handleGridKey,
+  type CellRef,
+  type ScoreColumn,
+} from "../../lib/tournament/scoreGridNav";
+
+/**
+ * Cursor, optimistic draft state, and background persistence for the desktop
+ * keyboard score grid.
+ *
+ * Saving is deliberately decoupled from typing: a digit updates local state and
+ * moves the cursor immediately, and the write fires in the background once a
+ * row holds both scores. The host never waits on a round-trip, so the three
+ * queries saveMatchScore issues are invisible at typing speed.
+ */
+
+export type RowSaveState = "idle" | "saving" | "saved" | "error";
+
+/** Local, not-yet-confirmed scores, keyed by match id. */
+type Draft = Record<string, { p1: number | null; p2: number | null }>;
+
+export interface ScoreGridMatch {
+  id: string;
+  player1_id: { id: string; name: string };
+  player2_id: { id: string; name: string };
+  player1_score: number | null;
+  player2_score: number | null;
+}
+
+export function useScoreGrid({
+  matches,
+  maxScore,
+  enabled,
+  onSaved,
+  onOpenHelp,
+}: {
+  matches: ScoreGridMatch[];
+  maxScore: number;
+  enabled: boolean;
+  /** Called after a successful write so the parent can refetch / clear errors. */
+  onSaved?: (matchId: string) => void;
+  onOpenHelp?: () => void;
+}) {
+  const [cursor, setCursor] = useState<CellRef | null>(null);
+  const [draft, setDraft] = useState<Draft>({});
+  const [saveState, setSaveState] = useState<Record<string, RowSaveState>>({});
+  const [rejected, setRejected] = useState<string | null>(null);
+  const inputRefs = useRef<Map<string, HTMLInputElement>>(new Map());
+
+  const cellKey = (row: number, col: ScoreColumn) => `${row}:${col}`;
+
+  const registerInput = useCallback(
+    (row: number, col: ScoreColumn, el: HTMLInputElement | null) => {
+      const key = cellKey(row, col);
+      if (el) inputRefs.current.set(key, el);
+      else inputRefs.current.delete(key);
+    },
+    [],
+  );
+
+  /** Effective value for a cell: the local draft if present, else the DB value. */
+  const valueAt = useCallback(
+    (row: number, col: ScoreColumn): number | null => {
+      const match = matches[row];
+      if (!match) return null;
+      const d = draft[match.id];
+      if (d) return col === 0 ? d.p1 : d.p2;
+      return col === 0 ? match.player1_score : match.player2_score;
+    },
+    [matches, draft],
+  );
+
+  const isRowComplete = useCallback(
+    (row: number) => valueAt(row, 0) !== null && valueAt(row, 1) !== null,
+    [valueAt],
+  );
+
+  const focusCell = useCallback((to: CellRef) => {
+    setCursor(to);
+    // Focus after paint so a cell that just mounted (or re-ordered) exists.
+    requestAnimationFrame(() => {
+      const el = inputRefs.current.get(cellKey(to.row, to.col));
+      el?.focus();
+      el?.select();
+    });
+  }, []);
+
+  /**
+   * Persist a row once both its cells hold a value. Illegal pairs (max–max)
+   * are left in the draft and flagged rather than written, so the host sees the
+   * bad row instead of silently losing the entry.
+   */
+  const commitRow = useCallback(
+    async (row: number, next: { p1: number | null; p2: number | null }) => {
+      const match = matches[row];
+      if (!match) return;
+      if (next.p1 === null || next.p2 === null) return;
+      if (validateScorePair(next.p1, next.p2, maxScore)) {
+        setSaveState((s) => ({ ...s, [match.id]: "error" }));
+        return;
+      }
+
+      setSaveState((s) => ({ ...s, [match.id]: "saving" }));
+      const result = await saveMatchScore(createClient(), {
+        matchId: match.id,
+        player1Id: match.player1_id.id,
+        player2Id: match.player2_id.id,
+        player1Score: next.p1,
+        player2Score: next.p2,
+        maxScore,
+      });
+
+      if (result.ok === false) {
+        setSaveState((s) => ({ ...s, [match.id]: "error" }));
+        return;
+      }
+
+      setSaveState((s) => ({ ...s, [match.id]: "saved" }));
+      onSaved?.(match.id);
+      // Drop the draft only after the parent has been told to refetch; until
+      // its data lands the draft is still what the cell should show.
+      setDraft((d) => {
+        const { [match.id]: _drop, ...rest } = d;
+        return rest;
+      });
+    },
+    [matches, maxScore, onSaved],
+  );
+
+  const writeCell = useCallback(
+    (at: CellRef, value: number | null) => {
+      const match = matches[at.row];
+      if (!match) return;
+      const current = draft[match.id] ?? {
+        p1: match.player1_score,
+        p2: match.player2_score,
+      };
+      const next =
+        at.col === 0 ? { ...current, p1: value } : { ...current, p2: value };
+      setDraft((d) => ({ ...d, [match.id]: next }));
+      setSaveState((s) => ({ ...s, [match.id]: "idle" }));
+      if (value !== null) void commitRow(at.row, next);
+    },
+    [matches, draft, commitRow],
+  );
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent, at: CellRef) => {
+      if (!enabled) return;
+
+      const action = handleGridKey(e.key, {
+        cursor: at,
+        rowCount: matches.length,
+        maxScore,
+        isRowComplete,
+        isDirty: draft[matches[at.row]?.id] !== undefined,
+      });
+
+      if (action.kind === "passthrough") return;
+      e.preventDefault();
+
+      switch (action.kind) {
+        case "move":
+          focusCell(action.to);
+          break;
+        case "write":
+          writeCell(action.at, action.value);
+          focusCell(action.then);
+          break;
+        case "revert": {
+          const match = matches[action.at.row];
+          if (match) {
+            setDraft((d) => {
+              const { [match.id]: _drop, ...rest } = d;
+              return rest;
+            });
+            setSaveState((s) => ({ ...s, [match.id]: "idle" }));
+          }
+          break;
+        }
+        case "exit":
+          inputRefs.current.get(cellKey(at.row, at.col))?.blur();
+          setCursor(null);
+          break;
+        case "reject": {
+          // Brief flash on the offending cell — the digit is above the cap.
+          const key = cellKey(action.at.row, action.at.col);
+          setRejected(key);
+          setTimeout(() => setRejected((r) => (r === key ? null : r)), 400);
+          break;
+        }
+        case "help":
+          onOpenHelp?.();
+          break;
+      }
+    },
+    [
+      enabled,
+      matches,
+      maxScore,
+      isRowComplete,
+      draft,
+      focusCell,
+      writeCell,
+      onOpenHelp,
+    ],
+  );
+
+  const isCursor = useCallback(
+    (row: number, col: ScoreColumn) =>
+      cursor?.row === row && cursor?.col === col,
+    [cursor],
+  );
+
+  const isRejected = useCallback(
+    (row: number, col: ScoreColumn) => rejected === cellKey(row, col),
+    [rejected],
+  );
+
+  /** How many matches still need a result — drives the grid's footer hint. */
+  const unscoredCount = useMemo(
+    () => matches.reduce((n, _m, i) => (isRowComplete(i) ? n : n + 1), 0),
+    [matches, isRowComplete],
+  );
+
+  return {
+    cursor,
+    valueAt,
+    saveState,
+    unscoredCount,
+    registerInput,
+    focusCell,
+    onKeyDown,
+    isCursor,
+    isRejected,
+  };
+}

--- a/components/ui/useScoreGrid.ts
+++ b/components/ui/useScoreGrid.ts
@@ -1,10 +1,12 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { createClient } from "../../utils/supabase/client";
 import { saveMatchScore, validateScorePair } from "../../utils/tournament/saveMatchScore";
 import {
   handleGridKey,
+  commitDecision,
+  needsFlush,
   type CellRef,
   type ScoreColumn,
 } from "../../lib/tournament/scoreGridNav";
@@ -15,8 +17,7 @@ import {
  *
  * Saving is deliberately decoupled from typing: a digit updates local state and
  * moves the cursor immediately, and the write fires in the background once a
- * row holds both scores. The host never waits on a round-trip, so the three
- * queries saveMatchScore issues are invisible at typing speed.
+ * row holds both scores. The host never waits on a round-trip.
  */
 
 export type RowSaveState = "idle" | "saving" | "saved" | "error";
@@ -32,6 +33,9 @@ export interface ScoreGridMatch {
   player2_score: number | null;
 }
 
+/** How long a green "saved" tick stays up before the row goes quiet again. */
+const SAVED_INDICATOR_MS = 2000;
+
 export function useScoreGrid({
   matches,
   maxScore,
@@ -42,15 +46,32 @@ export function useScoreGrid({
   matches: ScoreGridMatch[];
   maxScore: number;
   enabled: boolean;
-  /** Called after a successful write so the parent can refetch / clear errors. */
+  /** Called after a successful write so the parent can refetch. */
   onSaved?: (matchId: string) => void;
   onOpenHelp?: () => void;
 }) {
   const [cursor, setCursor] = useState<CellRef | null>(null);
   const [draft, setDraft] = useState<Draft>({});
   const [saveState, setSaveState] = useState<Record<string, RowSaveState>>({});
+  const [saveError, setSaveError] = useState<Record<string, string>>({});
   const [rejected, setRejected] = useState<string | null>(null);
   const inputRefs = useRef<Map<string, HTMLInputElement>>(new Map());
+
+  // Latest draft, readable from async callbacks without going stale. `draft`
+  // state drives rendering; this mirror is what commit logic reads.
+  const draftRef = useRef<Draft>({});
+  useEffect(() => { draftRef.current = draft; }, [draft]);
+
+  // Monotonic per-match write counter. A response only gets to touch state if
+  // it belongs to the newest write for that row, so two commits racing on the
+  // same match can't resolve out of order and leave the earlier value showing.
+  const writeSeq = useRef<Map<string, number>>(new Map());
+  const savedTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  useEffect(() => {
+    const timers = savedTimers.current;
+    return () => { timers.forEach(clearTimeout); };
+  }, []);
 
   const cellKey = (row: number, col: ScoreColumn) => `${row}:${col}`;
 
@@ -80,32 +101,58 @@ export function useScoreGrid({
     [valueAt],
   );
 
+  /**
+   * Move the cursor and focus synchronously.
+   *
+   * Focusing on a later frame is not safe here: the cell a keystroke targets is
+   * derived from the focused element, so if a re-render (every save triggers
+   * one) delays the focus move past the next keypress, that keypress lands on
+   * the cell we just left and overwrites the score just entered. Every row is
+   * already mounted, so the ref is always populated and this can be immediate.
+   */
   const focusCell = useCallback((to: CellRef) => {
     setCursor(to);
-    // Focus after paint so a cell that just mounted (or re-ordered) exists.
-    requestAnimationFrame(() => {
-      const el = inputRefs.current.get(cellKey(to.row, to.col));
-      el?.focus();
-      el?.select();
-    });
+    const el = inputRefs.current.get(cellKey(to.row, to.col));
+    el?.focus();
+    el?.select();
+  }, []);
+
+  const markSaved = useCallback((matchId: string) => {
+    setSaveState((s) => ({ ...s, [matchId]: "saved" }));
+    const existing = savedTimers.current.get(matchId);
+    if (existing) clearTimeout(existing);
+    savedTimers.current.set(
+      matchId,
+      setTimeout(() => {
+        setSaveState((s) => (s[matchId] === "saved" ? { ...s, [matchId]: "idle" } : s));
+        savedTimers.current.delete(matchId);
+      }, SAVED_INDICATOR_MS),
+    );
   }, []);
 
   /**
-   * Persist a row once both its cells hold a value. Illegal pairs (max–max)
-   * are left in the draft and flagged rather than written, so the host sees the
-   * bad row instead of silently losing the entry.
+   * Persist a row. Only ever called with a complete, legal pair — partial rows
+   * and illegal pairs are filtered by the callers so a half-typed correction
+   * never reaches the database.
    */
   const commitRow = useCallback(
-    async (row: number, next: { p1: number | null; p2: number | null }) => {
+    async (row: number, next: { p1: number; p2: number }) => {
       const match = matches[row];
       if (!match) return;
-      if (next.p1 === null || next.p2 === null) return;
-      if (validateScorePair(next.p1, next.p2, maxScore)) {
+
+      const invalid = validateScorePair(next.p1, next.p2, maxScore);
+      if (invalid) {
         setSaveState((s) => ({ ...s, [match.id]: "error" }));
+        setSaveError((e) => ({ ...e, [match.id]: invalid }));
         return;
       }
 
+      const seq = (writeSeq.current.get(match.id) ?? 0) + 1;
+      writeSeq.current.set(match.id, seq);
+
       setSaveState((s) => ({ ...s, [match.id]: "saving" }));
+      setSaveError((e) => { const { [match.id]: _drop, ...rest } = e; return rest; });
+
       const result = await saveMatchScore(createClient(), {
         matchId: match.id,
         player1Id: match.player1_id.id,
@@ -115,56 +162,200 @@ export function useScoreGrid({
         maxScore,
       });
 
+      // A newer write for this row superseded us — discard this response.
+      if (writeSeq.current.get(match.id) !== seq) return;
+
       if (result.ok === false) {
         setSaveState((s) => ({ ...s, [match.id]: "error" }));
+        setSaveError((e) => ({ ...e, [match.id]: result.error }));
         return;
       }
 
-      setSaveState((s) => ({ ...s, [match.id]: "saved" }));
+      markSaved(match.id);
+      // The draft is deliberately NOT dropped here. onSaved only *schedules* a
+      // refetch; dropping now would blank the cells for a full round-trip. The
+      // effect below retires each draft when the refetched row matches it.
       onSaved?.(match.id);
-      // Drop the draft only after the parent has been told to refetch; until
-      // its data lands the draft is still what the cell should show.
-      setDraft((d) => {
-        const { [match.id]: _drop, ...rest } = d;
-        return rest;
-      });
     },
-    [matches, maxScore, onSaved],
+    [matches, maxScore, onSaved, markSaved],
+  );
+
+  /**
+   * Retire drafts once the refetched `matches` agree with them. This is what
+   * makes the optimistic value survive the gap between save and refetch, and
+   * it self-heals: a draft the server never accepted stays visible.
+   */
+  useEffect(() => {
+    setDraft((d) => {
+      if (Object.keys(d).length === 0) return d;
+      let changed = false;
+      const next: Draft = {};
+      for (const [matchId, value] of Object.entries(d)) {
+        const row = matches.find((m) => m.id === matchId);
+        const settled =
+          row &&
+          row.player1_score === value.p1 &&
+          row.player2_score === value.p2;
+        if (settled) changed = true;
+        else next[matchId] = value;
+      }
+      return changed ? next : d;
+    });
+  }, [matches]);
+
+  const draftFor = useCallback(
+    (match: ScoreGridMatch) =>
+      draftRef.current[match.id] ?? {
+        p1: match.player1_score,
+        p2: match.player2_score,
+      },
+    [],
   );
 
   const writeCell = useCallback(
-    (at: CellRef, value: number | null) => {
+    (at: CellRef, value: number) => {
       const match = matches[at.row];
       if (!match) return;
-      const current = draft[match.id] ?? {
-        p1: match.player1_score,
-        p2: match.player2_score,
-      };
+      const current = draftFor(match);
       const next =
         at.col === 0 ? { ...current, p1: value } : { ...current, p2: value };
+
+      draftRef.current = { ...draftRef.current, [match.id]: next };
       setDraft((d) => ({ ...d, [match.id]: next }));
-      setSaveState((s) => ({ ...s, [match.id]: "idle" }));
-      if (value !== null) void commitRow(at.row, next);
+
+      switch (commitDecision(current, next)) {
+        case "commit":
+          void commitRow(at.row, { p1: next.p1 as number, p2: next.p2 as number });
+          break;
+        case "defer":
+          // Correction in progress — flushRow persists it when the cursor
+          // leaves, so two digits produce one save rather than an intermediate.
+          setSaveState((s) => ({ ...s, [match.id]: "idle" }));
+          break;
+        case "none":
+          break;
+      }
     },
-    [matches, draft, commitRow],
+    [matches, draftFor, commitRow],
+  );
+
+  /**
+   * Flush a pending correction when the cursor leaves its row. Pairs with
+   * writeCell's deferral so re-typing both scores is a single write.
+   */
+  const flushRow = useCallback(
+    (row: number) => {
+      const match = matches[row];
+      if (!match) return;
+      const d = draftRef.current[match.id];
+      const saved = { p1: match.player1_score, p2: match.player2_score };
+      if (!needsFlush(d, saved)) return;
+      void commitRow(row, { p1: d!.p1 as number, p2: d!.p2 as number });
+    },
+    [matches, commitRow],
+  );
+
+  /**
+   * Blur handler for a cell. Flushes only when focus is genuinely LEAVING the
+   * row — moving P1 → P2 within a row must not flush, or a correction commits
+   * its half-typed intermediate (retyping 3-1 as 1-3 would save 1-1 the moment
+   * the cursor crossed to P2, exactly the write the deferral exists to avoid).
+   *
+   * This is the single flush point: focusCell is synchronous, so every cursor
+   * move — keyboard, click, or exit — produces a blur here.
+   */
+  const onBlurCell = useCallback(
+    (e: React.FocusEvent, row: number) => {
+      const next = e.relatedTarget as Node | null;
+      if (next) {
+        const p1 = inputRefs.current.get(cellKey(row, 0));
+        const p2 = inputRefs.current.get(cellKey(row, 1));
+        if (next === p1 || next === p2) return; // still inside this row
+      }
+      flushRow(row);
+    },
+    [flushRow],
+  );
+
+  /** Clear a cell locally AND in the database, so the two can't disagree. */
+  const clearCell = useCallback(
+    async (at: CellRef) => {
+      const match = matches[at.row];
+      if (!match) return;
+      const current = draftFor(match);
+      const next =
+        at.col === 0 ? { ...current, p1: null } : { ...current, p2: null };
+
+      draftRef.current = { ...draftRef.current, [match.id]: next };
+      setDraft((d) => ({ ...d, [match.id]: next }));
+
+      // Nothing recorded yet — the local clear is the whole job.
+      if (match.player1_score === null && match.player2_score === null) {
+        setSaveState((s) => ({ ...s, [match.id]: "idle" }));
+        return;
+      }
+
+      const seq = (writeSeq.current.get(match.id) ?? 0) + 1;
+      writeSeq.current.set(match.id, seq);
+      setSaveState((s) => ({ ...s, [match.id]: "saving" }));
+
+      const client = createClient();
+      const { error } = await client
+        .from("matches")
+        .update({
+          player1_score: null,
+          player2_score: null,
+          is_tie: null,
+          winner_id: null,
+          updated_at: new Date(),
+        })
+        .eq("id", match.id);
+
+      if (writeSeq.current.get(match.id) !== seq) return;
+
+      if (error) {
+        setSaveState((s) => ({ ...s, [match.id]: "error" }));
+        setSaveError((e) => ({
+          ...e,
+          [match.id]: "Couldn't clear this result. Please try again.",
+        }));
+        return;
+      }
+
+      markSaved(match.id);
+      onSaved?.(match.id);
+    },
+    [matches, draftFor, onSaved, markSaved],
   );
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent, at: CellRef) => {
       if (!enabled) return;
 
-      const action = handleGridKey(e.key, {
-        cursor: at,
-        rowCount: matches.length,
-        maxScore,
-        isRowComplete,
-        isDirty: draft[matches[at.row]?.id] !== undefined,
-      });
+      const match = matches[at.row];
+      const action = handleGridKey(
+        e.key,
+        {
+          cursor: at,
+          rowCount: matches.length,
+          maxScore,
+          isRowComplete,
+          valueAt,
+          isDirty: match ? draftRef.current[match.id] !== undefined : false,
+        },
+        { ctrlKey: e.ctrlKey, metaKey: e.metaKey, altKey: e.altKey },
+      );
 
       if (action.kind === "passthrough") return;
       e.preventDefault();
+      // The cheatsheet's Dialog listens for Escape on document; without this the
+      // same press would both close it and discard the cell underneath.
+      e.stopPropagation();
 
       switch (action.kind) {
+        // No explicit flush on either of these: focusCell moves focus
+        // synchronously, so onBlurCell fires and decides whether the row is
+        // actually being left. Flushing here too would double-post the write.
         case "move":
           focusCell(action.to);
           break;
@@ -172,13 +363,14 @@ export function useScoreGrid({
           writeCell(action.at, action.value);
           focusCell(action.then);
           break;
+        case "clear":
+          void clearCell(action.at);
+          break;
         case "revert": {
-          const match = matches[action.at.row];
           if (match) {
-            setDraft((d) => {
-              const { [match.id]: _drop, ...rest } = d;
-              return rest;
-            });
+            const { [match.id]: _drop, ...rest } = draftRef.current;
+            draftRef.current = rest;
+            setDraft(rest);
             setSaveState((s) => ({ ...s, [match.id]: "idle" }));
           }
           break;
@@ -188,7 +380,6 @@ export function useScoreGrid({
           setCursor(null);
           break;
         case "reject": {
-          // Brief flash on the offending cell — the digit is above the cap.
           const key = cellKey(action.at.row, action.at.col);
           setRejected(key);
           setTimeout(() => setRejected((r) => (r === key ? null : r)), 400);
@@ -204,9 +395,11 @@ export function useScoreGrid({
       matches,
       maxScore,
       isRowComplete,
-      draft,
+      valueAt,
       focusCell,
       writeCell,
+      clearCell,
+      flushRow,
       onOpenHelp,
     ],
   );
@@ -222,19 +415,14 @@ export function useScoreGrid({
     [rejected],
   );
 
-  /** How many matches still need a result — drives the grid's footer hint. */
-  const unscoredCount = useMemo(
-    () => matches.reduce((n, _m, i) => (isRowComplete(i) ? n : n + 1), 0),
-    [matches, isRowComplete],
-  );
-
   return {
     cursor,
     valueAt,
     saveState,
-    unscoredCount,
+    saveError,
     registerInput,
     focusCell,
+    onBlurCell,
     onKeyDown,
     isCursor,
     isRejected,

--- a/lib/tournament/__tests__/scoreGridNav.test.ts
+++ b/lib/tournament/__tests__/scoreGridNav.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect } from "vitest";
+import {
+  handleGridKey,
+  stepLeft,
+  stepRight,
+  nextUnscored,
+  type GridContext,
+  type CellRef,
+} from "../scoreGridNav";
+
+const cell = (row: number, col: 0 | 1): CellRef => ({ row, col });
+
+/** 4 rows, max 5, nothing scored yet, cursor at 0/P1. */
+const ctx = (over: Partial<GridContext> = {}): GridContext => ({
+  cursor: cell(0, 0),
+  rowCount: 4,
+  maxScore: 5,
+  isRowComplete: () => false,
+  ...over,
+});
+
+describe("stepRight / stepLeft", () => {
+  it("moves P1 -> P2 within a row", () => {
+    expect(stepRight(cell(1, 0), 4)).toEqual(cell(1, 1));
+  });
+  it("wraps P2 -> next row's P1", () => {
+    expect(stepRight(cell(1, 1), 4)).toEqual(cell(2, 0));
+  });
+  it("returns null off the last cell", () => {
+    expect(stepRight(cell(3, 1), 4)).toBeNull();
+  });
+  it("wraps P1 -> previous row's P2", () => {
+    expect(stepLeft(cell(2, 0), 4)).toEqual(cell(1, 1));
+  });
+  it("returns null off the first cell", () => {
+    expect(stepLeft(cell(0, 0), 4)).toBeNull();
+  });
+});
+
+describe("nextUnscored", () => {
+  it("finds the first incomplete row at or after the start", () => {
+    const complete = (r: number) => r < 2;
+    expect(nextUnscored(0, 4, complete)).toEqual(cell(2, 0));
+  });
+  it("wraps around to find an earlier gap", () => {
+    const complete = (r: number) => r !== 1;
+    expect(nextUnscored(2, 4, complete)).toEqual(cell(1, 0));
+  });
+  it("returns null when every row is scored", () => {
+    expect(nextUnscored(0, 4, () => true)).toBeNull();
+  });
+});
+
+describe("digit entry", () => {
+  it("writes the digit and advances P1 -> P2", () => {
+    expect(handleGridKey("3", ctx())).toEqual({
+      kind: "write",
+      at: cell(0, 0),
+      value: 3,
+      then: cell(0, 1),
+    });
+  });
+
+  it("writes on P2 and advances to the next row's P1", () => {
+    expect(handleGridKey("1", ctx({ cursor: cell(0, 1) }))).toEqual({
+      kind: "write",
+      at: cell(0, 1),
+      value: 1,
+      then: cell(1, 0),
+    });
+  });
+
+  it("two keystrokes record a whole match and land on the next", () => {
+    const first = handleGridKey("3", ctx());
+    expect(first.kind).toBe("write");
+    const afterFirst = first.kind === "write" ? first.then : cell(0, 0);
+    const second = handleGridKey("1", ctx({ cursor: afterFirst }));
+    expect(second).toEqual({
+      kind: "write",
+      at: cell(0, 1),
+      value: 1,
+      then: cell(1, 0),
+    });
+  });
+
+  it("accepts a digit equal to max_score", () => {
+    expect(handleGridKey("5", ctx()).kind).toBe("write");
+  });
+
+  it("rejects a digit above max_score without writing", () => {
+    expect(handleGridKey("6", ctx())).toEqual({ kind: "reject", at: cell(0, 0) });
+  });
+
+  it("accepts 7 only when max_score is 7", () => {
+    expect(handleGridKey("7", ctx({ maxScore: 5 })).kind).toBe("reject");
+    expect(handleGridKey("7", ctx({ maxScore: 7 })).kind).toBe("write");
+  });
+
+  it("accepts 0", () => {
+    expect(handleGridKey("0", ctx())).toMatchObject({ kind: "write", value: 0 });
+  });
+
+  it("parks on the first unscored row after filling the last cell", () => {
+    // Rows 0 and 2 already done; we're finishing row 3, so row 1 is the gap.
+    const action = handleGridKey(
+      "2",
+      ctx({
+        cursor: cell(3, 1),
+        isRowComplete: (r) => r === 0 || r === 2,
+      }),
+    );
+    expect(action).toEqual({
+      kind: "write",
+      at: cell(3, 1),
+      value: 2,
+      then: cell(1, 0),
+    });
+  });
+
+  it("holds position when the last cell completes the round", () => {
+    const action = handleGridKey(
+      "2",
+      ctx({ cursor: cell(3, 1), isRowComplete: (r) => r !== 3 }),
+    );
+    expect(action).toEqual({
+      kind: "write",
+      at: cell(3, 1),
+      value: 2,
+      then: cell(3, 1),
+    });
+  });
+});
+
+describe("arrow navigation", () => {
+  it("ArrowDown moves to the next row, same column", () => {
+    expect(handleGridKey("ArrowDown", ctx({ cursor: cell(1, 1) }))).toEqual({
+      kind: "move",
+      to: cell(2, 1),
+    });
+  });
+
+  it("ArrowUp moves to the previous row, same column", () => {
+    expect(handleGridKey("ArrowUp", ctx({ cursor: cell(2, 0) }))).toEqual({
+      kind: "move",
+      to: cell(1, 0),
+    });
+  });
+
+  it("clamps at the top and bottom instead of wrapping", () => {
+    expect(handleGridKey("ArrowUp", ctx({ cursor: cell(0, 1) }))).toEqual({
+      kind: "move",
+      to: cell(0, 1),
+    });
+    expect(handleGridKey("ArrowDown", ctx({ cursor: cell(3, 0) }))).toEqual({
+      kind: "move",
+      to: cell(3, 0),
+    });
+  });
+
+  it("ArrowLeft/Right wrap across row boundaries", () => {
+    expect(handleGridKey("ArrowRight", ctx({ cursor: cell(1, 1) }))).toEqual({
+      kind: "move",
+      to: cell(2, 0),
+    });
+    expect(handleGridKey("ArrowLeft", ctx({ cursor: cell(2, 0) }))).toEqual({
+      kind: "move",
+      to: cell(1, 1),
+    });
+  });
+
+  it("holds at the grid edges", () => {
+    expect(handleGridKey("ArrowLeft", ctx({ cursor: cell(0, 0) }))).toEqual({
+      kind: "move",
+      to: cell(0, 0),
+    });
+    expect(handleGridKey("ArrowRight", ctx({ cursor: cell(3, 1) }))).toEqual({
+      kind: "move",
+      to: cell(3, 1),
+    });
+  });
+
+  it("Home and End jump to the grid extremes", () => {
+    expect(handleGridKey("Home", ctx({ cursor: cell(2, 1) }))).toEqual({
+      kind: "move",
+      to: cell(0, 0),
+    });
+    expect(handleGridKey("End", ctx({ cursor: cell(1, 0) }))).toEqual({
+      kind: "move",
+      to: cell(3, 1),
+    });
+  });
+});
+
+describe("Enter", () => {
+  it("advances to the next row's P1 from either column", () => {
+    expect(handleGridKey("Enter", ctx({ cursor: cell(1, 1) }))).toEqual({
+      kind: "move",
+      to: cell(2, 0),
+    });
+    expect(handleGridKey("Enter", ctx({ cursor: cell(1, 0) }))).toEqual({
+      kind: "move",
+      to: cell(2, 0),
+    });
+  });
+
+  it("on the last row, jumps back to the first unscored row", () => {
+    expect(
+      handleGridKey(
+        "Enter",
+        ctx({ cursor: cell(3, 1), isRowComplete: (r) => r !== 2 }),
+      ),
+    ).toEqual({ kind: "move", to: cell(2, 0) });
+  });
+
+  it("on the last row with everything scored, holds position", () => {
+    expect(
+      handleGridKey("Enter", ctx({ cursor: cell(3, 0), isRowComplete: () => true })),
+    ).toEqual({ kind: "move", to: cell(3, 0) });
+  });
+});
+
+describe("clearing and exiting", () => {
+  it("Backspace clears the cell without moving", () => {
+    expect(handleGridKey("Backspace", ctx({ cursor: cell(2, 1) }))).toEqual({
+      kind: "write",
+      at: cell(2, 1),
+      value: null,
+      then: cell(2, 1),
+    });
+  });
+
+  it("Delete behaves like Backspace", () => {
+    expect(handleGridKey("Delete", ctx()).kind).toBe("write");
+  });
+
+  it("Escape reverts a dirty cell, then exits on the second press", () => {
+    expect(handleGridKey("Escape", ctx({ isDirty: true }))).toEqual({
+      kind: "revert",
+      at: cell(0, 0),
+    });
+    expect(handleGridKey("Escape", ctx({ isDirty: false }))).toEqual({ kind: "exit" });
+  });
+});
+
+describe("passthrough", () => {
+  it("leaves Tab to the browser so native tab order still works", () => {
+    expect(handleGridKey("Tab", ctx()).kind).toBe("passthrough");
+  });
+
+  it("ignores letters", () => {
+    expect(handleGridKey("a", ctx()).kind).toBe("passthrough");
+  });
+
+  it("opens help on ?", () => {
+    expect(handleGridKey("?", ctx()).kind).toBe("help");
+  });
+
+  it("does nothing at all when the round has no matches", () => {
+    expect(handleGridKey("3", ctx({ rowCount: 0 })).kind).toBe("passthrough");
+  });
+});

--- a/lib/tournament/__tests__/scoreGridNav.test.ts
+++ b/lib/tournament/__tests__/scoreGridNav.test.ts
@@ -4,6 +4,8 @@ import {
   stepLeft,
   stepRight,
   nextUnscored,
+  commitDecision,
+  needsFlush,
   type GridContext,
   type CellRef,
 } from "../scoreGridNav";
@@ -16,8 +18,15 @@ const ctx = (over: Partial<GridContext> = {}): GridContext => ({
   rowCount: 4,
   maxScore: 5,
   isRowComplete: () => false,
+  valueAt: () => null,
   ...over,
 });
+
+/** Build a valueAt from a sparse {"row:col": value} map. */
+const valuesFrom =
+  (map: Record<string, number>) =>
+  (row: number, col: 0 | 1): number | null =>
+    map[`${row}:${col}`] ?? null;
 
 describe("stepRight / stepLeft", () => {
   it("moves P1 -> P2 within a row", () => {
@@ -84,7 +93,12 @@ describe("digit entry", () => {
   });
 
   it("accepts a digit equal to max_score", () => {
-    expect(handleGridKey("5", ctx()).kind).toBe("write");
+    expect(handleGridKey("5", ctx())).toEqual({
+      kind: "write",
+      at: cell(0, 0),
+      value: 5,
+      then: cell(0, 1),
+    });
   });
 
   it("rejects a digit above max_score without writing", () => {
@@ -92,8 +106,16 @@ describe("digit entry", () => {
   });
 
   it("accepts 7 only when max_score is 7", () => {
-    expect(handleGridKey("7", ctx({ maxScore: 5 })).kind).toBe("reject");
-    expect(handleGridKey("7", ctx({ maxScore: 7 })).kind).toBe("write");
+    expect(handleGridKey("7", ctx({ maxScore: 5 }))).toEqual({
+      kind: "reject",
+      at: cell(0, 0),
+    });
+    expect(handleGridKey("7", ctx({ maxScore: 7 }))).toEqual({
+      kind: "write",
+      at: cell(0, 0),
+      value: 7,
+      then: cell(0, 1),
+    });
   });
 
   it("accepts 0", () => {
@@ -107,6 +129,8 @@ describe("digit entry", () => {
       ctx({
         cursor: cell(3, 1),
         isRowComplete: (r) => r === 0 || r === 2,
+        // Row 3's P1 is filled, so this keystroke really does complete it.
+        valueAt: valuesFrom({ "3:0": 4 }),
       }),
     );
     expect(action).toEqual({
@@ -120,7 +144,11 @@ describe("digit entry", () => {
   it("holds position when the last cell completes the round", () => {
     const action = handleGridKey(
       "2",
-      ctx({ cursor: cell(3, 1), isRowComplete: (r) => r !== 3 }),
+      ctx({
+        cursor: cell(3, 1),
+        isRowComplete: (r) => r !== 3,
+        valueAt: valuesFrom({ "3:0": 4 }),
+      }),
     );
     expect(action).toEqual({
       kind: "write",
@@ -128,6 +156,51 @@ describe("digit entry", () => {
       value: 2,
       then: cell(3, 1),
     });
+  });
+
+  it("comes back to a half-filled last row instead of skipping past it", () => {
+    // Filling row 3's P2 while its P1 is still blank must NOT treat row 3 as
+    // done — otherwise the round ends with a silently half-scored match.
+    const action = handleGridKey(
+      "2",
+      ctx({
+        cursor: cell(3, 1),
+        isRowComplete: () => true,
+        valueAt: () => null, // row 3's P1 is empty
+      }),
+    );
+    expect(action).toEqual({
+      kind: "write",
+      at: cell(3, 1),
+      value: 2,
+      then: cell(3, 0),
+    });
+  });
+});
+
+describe("modifier keys are never scores", () => {
+  // Cmd+1..9 switches browser tabs, Cmd+0 resets zoom. Treating those as score
+  // input silently wrote a real result into the focused cell.
+  for (const mod of ["ctrlKey", "metaKey", "altKey"] as const) {
+    it(`ignores digits held with ${mod}`, () => {
+      expect(handleGridKey("1", ctx(), { [mod]: true }).kind).toBe("passthrough");
+      expect(handleGridKey("0", ctx(), { [mod]: true }).kind).toBe("passthrough");
+    });
+
+    it(`ignores navigation keys held with ${mod}`, () => {
+      expect(handleGridKey("ArrowDown", ctx(), { [mod]: true }).kind).toBe("passthrough");
+      expect(handleGridKey("Enter", ctx(), { [mod]: true }).kind).toBe("passthrough");
+      expect(handleGridKey("Backspace", ctx(), { [mod]: true }).kind).toBe("passthrough");
+    });
+  }
+
+  it("still writes a bare digit with no modifiers", () => {
+    expect(handleGridKey("3", ctx(), {}).kind).toBe("write");
+    expect(handleGridKey("3", ctx()).kind).toBe("write");
+  });
+
+  it("allows Shift, which is how '?' is typed on most layouts", () => {
+    expect(handleGridKey("?", ctx(), { ctrlKey: false }).kind).toBe("help");
   });
 });
 
@@ -220,17 +293,21 @@ describe("Enter", () => {
 });
 
 describe("clearing and exiting", () => {
-  it("Backspace clears the cell without moving", () => {
+  // `clear` is its own action, not a write-with-null: clearing has to reach the
+  // database. When it was a local-only write the cell went blank while the old
+  // score stayed recorded, and the cheatsheet promised otherwise.
+  it("Backspace emits a clear for the cursor cell", () => {
     expect(handleGridKey("Backspace", ctx({ cursor: cell(2, 1) }))).toEqual({
-      kind: "write",
+      kind: "clear",
       at: cell(2, 1),
-      value: null,
-      then: cell(2, 1),
     });
   });
 
   it("Delete behaves like Backspace", () => {
-    expect(handleGridKey("Delete", ctx()).kind).toBe("write");
+    expect(handleGridKey("Delete", ctx({ cursor: cell(1, 0) }))).toEqual({
+      kind: "clear",
+      at: cell(1, 0),
+    });
   });
 
   it("Escape reverts a dirty cell, then exits on the second press", () => {
@@ -239,6 +316,51 @@ describe("clearing and exiting", () => {
       at: cell(0, 0),
     });
     expect(handleGridKey("Escape", ctx({ isDirty: false }))).toEqual({ kind: "exit" });
+  });
+});
+
+describe("commitDecision", () => {
+  it("commits when a keystroke completes a previously blank row", () => {
+    expect(commitDecision({ p1: 3, p2: null }, { p1: 3, p2: 1 })).toBe("commit");
+  });
+
+  it("does nothing while the row is still half-filled", () => {
+    expect(commitDecision({ p1: null, p2: null }, { p1: 3, p2: null })).toBe("none");
+    expect(commitDecision({ p1: null, p2: null }, { p1: null, p2: 2 })).toBe("none");
+  });
+
+  // The bug this exists to prevent: correcting a recorded 3-1 to 1-3 used to
+  // write a 1-1 tie the moment the first digit landed, then race a second save.
+  it("defers when overwriting a row that was already complete", () => {
+    expect(commitDecision({ p1: 3, p2: 1 }, { p1: 1, p2: 1 })).toBe("defer");
+    expect(commitDecision({ p1: 1, p2: 1 }, { p1: 1, p2: 3 })).toBe("defer");
+  });
+
+  it("treats 0 as a real score, not as absent", () => {
+    expect(commitDecision({ p1: 0, p2: null }, { p1: 0, p2: 0 })).toBe("commit");
+    expect(commitDecision({ p1: 0, p2: 0 }, { p1: 5, p2: 0 })).toBe("defer");
+  });
+});
+
+describe("needsFlush", () => {
+  it("flushes a complete draft that differs from what's saved", () => {
+    expect(needsFlush({ p1: 1, p2: 3 }, { p1: 3, p2: 1 })).toBe(true);
+  });
+
+  it("skips a draft that already matches the saved scores", () => {
+    expect(needsFlush({ p1: 3, p2: 1 }, { p1: 3, p2: 1 })).toBe(false);
+  });
+
+  it("skips a half-filled draft — a partial row is never persisted", () => {
+    expect(needsFlush({ p1: 1, p2: null }, { p1: 3, p2: 1 })).toBe(false);
+  });
+
+  it("skips when there is no draft at all", () => {
+    expect(needsFlush(undefined, { p1: 3, p2: 1 })).toBe(false);
+  });
+
+  it("flushes a draft onto a row that had no score", () => {
+    expect(needsFlush({ p1: 2, p2: 0 }, { p1: null, p2: null })).toBe(true);
   });
 });
 

--- a/lib/tournament/scoreGridNav.ts
+++ b/lib/tournament/scoreGridNav.ts
@@ -26,8 +26,14 @@ export interface CellRef {
 export type GridAction =
   /** Move the cursor; write nothing. */
   | { kind: "move"; to: CellRef }
-  /** Write `value` (null = clear) into `at`, then move the cursor to `then`. */
-  | { kind: "write"; at: CellRef; value: number | null; then: CellRef }
+  /** Write `value` into `at`, then move the cursor to `then`. */
+  | { kind: "write"; at: CellRef; value: number; then: CellRef }
+  /**
+   * Clear `at` back to unscored. Distinct from `write` because clearing has to
+   * reach the database — a local-only clear leaves the host looking at a blank
+   * cell while the old score is still recorded.
+   */
+  | { kind: "clear"; at: CellRef }
   /** Discard the in-progress edit on `at` and restore its saved value. */
   | { kind: "revert"; at: CellRef }
   /** Leave the grid entirely (blur back to the page). */
@@ -51,12 +57,22 @@ export interface GridContext {
    * matches array; a row is "complete" once both its cells hold a value.
    */
   isRowComplete: (row: number) => boolean;
+  /**
+   * Current effective value of a cell (draft if any, else the saved score).
+   * Lets the handler tell "this keystroke completes the row" from "the row is
+   * still half-filled", which `isRowComplete` alone can't express.
+   */
+  valueAt: (row: number, col: ScoreColumn) => number | null;
   /** True when the in-progress edit on the cursor differs from what's saved. */
   isDirty?: boolean;
 }
 
 const clampRow = (row: number, rowCount: number) =>
   Math.max(0, Math.min(row, rowCount - 1));
+
+/** The value in the cursor row's OTHER column. */
+const valueAtOtherColumn = (ctx: GridContext): number | null =>
+  ctx.valueAt(ctx.cursor.row, ctx.cursor.col === 0 ? 1 : 0);
 
 /**
  * Step one cell to the right, wrapping P2 → next row's P1. Returns null when
@@ -94,16 +110,76 @@ export function nextUnscored(
   return null;
 }
 
+/** A row's two scores, either of which may still be unset. */
+export interface ScorePair {
+  p1: number | null;
+  p2: number | null;
+}
+
+/**
+ * Whether writing `next` over `current` should hit the database now.
+ *
+ * - `commit`  — this keystroke completed a previously incomplete row.
+ * - `defer`   — the row was already complete, so this is a correction in
+ *               progress. Holding the write until the cursor leaves the row
+ *               means re-typing 3-1 as 1-3 produces ONE save, not a spurious
+ *               1-1 tie followed by a race to overwrite it.
+ * - `none`    — still half-filled; nothing to persist.
+ *
+ * Pure and exported so the rule is testable without rendering the grid; the
+ * hook that owns draft state is where this used to live implicitly, and where
+ * the intermediate-write bug lived with it.
+ */
+export function commitDecision(
+  current: ScorePair,
+  next: ScorePair,
+): "commit" | "defer" | "none" {
+  const nowComplete = next.p1 !== null && next.p2 !== null;
+  if (!nowComplete) return "none";
+  const wasComplete = current.p1 !== null && current.p2 !== null;
+  return wasComplete ? "defer" : "commit";
+}
+
+/**
+ * Whether a deferred correction still needs flushing when the cursor leaves.
+ * Returns false when the draft matches what's already saved, so merely tabbing
+ * across an untouched row doesn't fire a pointless write.
+ */
+export function needsFlush(draft: ScorePair | undefined, saved: ScorePair): boolean {
+  if (!draft) return false;
+  if (draft.p1 === null || draft.p2 === null) return false;
+  return draft.p1 !== saved.p1 || draft.p2 !== saved.p2;
+}
+
+/** Modifier state of the keystroke. Absent fields are treated as false. */
+export interface KeyModifiers {
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+  altKey?: boolean;
+}
+
 /**
  * Interpret a keystroke. `key` is a raw KeyboardEvent.key.
  *
  * Enter is deliberately NOT a commit key — writes are committed by the
  * component when the cursor leaves a row, so a digit keystroke alone is enough.
  * Enter just advances to the next row, matching spreadsheet muscle memory.
+ *
+ * `mods` must be passed through from the event. Without it, Cmd+1 (switch to
+ * browser tab 1) and Cmd+0 (reset zoom) arrive here as a bare "1"/"0" and get
+ * written into the focused cell — a real score, silently saved.
  */
-export function handleGridKey(key: string, ctx: GridContext): GridAction {
+export function handleGridKey(
+  key: string,
+  ctx: GridContext,
+  mods: KeyModifiers = {},
+): GridAction {
   const { cursor, rowCount, maxScore, isRowComplete } = ctx;
   if (rowCount === 0) return { kind: "passthrough" };
+
+  // Any Ctrl/Cmd/Alt combination belongs to the browser or the OS, never to the
+  // grid. Bail before the digit branch so accelerators keep working untouched.
+  if (mods.ctrlKey || mods.metaKey || mods.altKey) return { kind: "passthrough" };
 
   // A digit writes and auto-advances. This is the hot path: "3" "1" fills a
   // whole match and lands on the next one.
@@ -116,9 +192,12 @@ export function handleGridKey(key: string, ctx: GridContext): GridAction {
     const then =
       forward ??
       nextUnscored(0, rowCount, (r) =>
-        // The cell we're about to write isn't in state yet, so treat the row
-        // we just completed as complete when scanning.
-        r === cursor.row ? true : isRowComplete(r),
+        // Treat the row we're completing as done, but only when this keystroke
+        // actually completes it — on a half-filled row the other cell is still
+        // blank and the host needs to be sent back to it.
+        r === cursor.row
+          ? valueAtOtherColumn(ctx) !== null
+          : isRowComplete(r),
       ) ??
       cursor;
     return { kind: "write", at: cursor, value, then };
@@ -155,7 +234,7 @@ export function handleGridKey(key: string, ctx: GridContext): GridAction {
 
     case "Backspace":
     case "Delete":
-      return { kind: "write", at: cursor, value: null, then: cursor };
+      return { kind: "clear", at: cursor };
 
     case "Home":
       return { kind: "move", to: { row: 0, col: 0 } };

--- a/lib/tournament/scoreGridNav.ts
+++ b/lib/tournament/scoreGridNav.ts
@@ -1,0 +1,179 @@
+// lib/tournament/scoreGridNav.ts
+//
+// Pure navigation + keystroke logic for the desktop score-entry grid.
+//
+// Kept free of React and DOM so the whole key map is unit-testable. The
+// component layer owns focus (a roving tabindex over real <input> cells) and
+// persistence; this module only answers "given the current cell and this key,
+// where do we go and what do we write?".
+//
+// Single-digit assumption: tournaments.max_score is a <select> locked to 5 or 7
+// (components/ui/TournamentSettings.tsx), so a score is always one character.
+// That's what lets a digit keystroke both write AND advance — two keystrokes
+// records a whole match.
+
+/** Which of a match row's two score cells the cursor is on. */
+export type ScoreColumn = 0 | 1;
+
+/** A cell address within the round's match list. */
+export interface CellRef {
+  /** Index into the round's `matches` array. */
+  row: number;
+  col: ScoreColumn;
+}
+
+/** Result of interpreting one keystroke against the grid. */
+export type GridAction =
+  /** Move the cursor; write nothing. */
+  | { kind: "move"; to: CellRef }
+  /** Write `value` (null = clear) into `at`, then move the cursor to `then`. */
+  | { kind: "write"; at: CellRef; value: number | null; then: CellRef }
+  /** Discard the in-progress edit on `at` and restore its saved value. */
+  | { kind: "revert"; at: CellRef }
+  /** Leave the grid entirely (blur back to the page). */
+  | { kind: "exit" }
+  /** Open the shortcuts cheatsheet. */
+  | { kind: "help" }
+  /** A digit outside 0..maxScore — reject it visibly, write nothing. */
+  | { kind: "reject"; at: CellRef }
+  /** Not a grid key; let the browser handle it. */
+  | { kind: "passthrough" };
+
+/** Everything the key handler needs to know about the grid's current state. */
+export interface GridContext {
+  cursor: CellRef;
+  /** Number of match rows in the current round. */
+  rowCount: number;
+  /** Tournament max_score (5 or 7). Upper bound for a legal digit. */
+  maxScore: number;
+  /**
+   * Per-row scored state, used by `nextUnscored`. Index-aligned with the
+   * matches array; a row is "complete" once both its cells hold a value.
+   */
+  isRowComplete: (row: number) => boolean;
+  /** True when the in-progress edit on the cursor differs from what's saved. */
+  isDirty?: boolean;
+}
+
+const clampRow = (row: number, rowCount: number) =>
+  Math.max(0, Math.min(row, rowCount - 1));
+
+/**
+ * Step one cell to the right, wrapping P2 → next row's P1. Returns null when
+ * already on the very last cell (caller decides whether that's a no-op or a
+ * jump to the first unscored row).
+ */
+export function stepRight(cell: CellRef, rowCount: number): CellRef | null {
+  if (cell.col === 0) return { row: cell.row, col: 1 };
+  if (cell.row + 1 < rowCount) return { row: cell.row + 1, col: 0 };
+  return null;
+}
+
+/** Step one cell to the left, wrapping P1 → previous row's P2. */
+export function stepLeft(cell: CellRef, rowCount: number): CellRef | null {
+  if (cell.col === 1) return { row: cell.row, col: 0 };
+  if (cell.row > 0) return { row: cell.row - 1, col: 1 };
+  return null;
+}
+
+/**
+ * First cell of the first incomplete row at or after `from`, wrapping once to
+ * the top. Returns null when every row is scored — that's the signal the round
+ * is ready to end. This is the Excel "jump to the next blank" behavior, and it
+ * targets exactly the rows End Round blocks on.
+ */
+export function nextUnscored(
+  from: number,
+  rowCount: number,
+  isRowComplete: (row: number) => boolean,
+): CellRef | null {
+  for (let i = 0; i < rowCount; i++) {
+    const row = (from + i) % rowCount;
+    if (!isRowComplete(row)) return { row, col: 0 };
+  }
+  return null;
+}
+
+/**
+ * Interpret a keystroke. `key` is a raw KeyboardEvent.key.
+ *
+ * Enter is deliberately NOT a commit key — writes are committed by the
+ * component when the cursor leaves a row, so a digit keystroke alone is enough.
+ * Enter just advances to the next row, matching spreadsheet muscle memory.
+ */
+export function handleGridKey(key: string, ctx: GridContext): GridAction {
+  const { cursor, rowCount, maxScore, isRowComplete } = ctx;
+  if (rowCount === 0) return { kind: "passthrough" };
+
+  // A digit writes and auto-advances. This is the hot path: "3" "1" fills a
+  // whole match and lands on the next one.
+  if (/^[0-9]$/.test(key)) {
+    const value = Number(key);
+    if (value > maxScore) return { kind: "reject", at: cursor };
+    const forward = stepRight(cursor, rowCount);
+    // Falling off the last cell parks on the first still-unscored row so the
+    // host is never left staring at a dead cursor with blanks above them.
+    const then =
+      forward ??
+      nextUnscored(0, rowCount, (r) =>
+        // The cell we're about to write isn't in state yet, so treat the row
+        // we just completed as complete when scanning.
+        r === cursor.row ? true : isRowComplete(r),
+      ) ??
+      cursor;
+    return { kind: "write", at: cursor, value, then };
+  }
+
+  switch (key) {
+    case "ArrowUp":
+      return {
+        kind: "move",
+        to: { row: clampRow(cursor.row - 1, rowCount), col: cursor.col },
+      };
+
+    case "ArrowDown":
+      return {
+        kind: "move",
+        to: { row: clampRow(cursor.row + 1, rowCount), col: cursor.col },
+      };
+
+    case "ArrowLeft":
+      return { kind: "move", to: stepLeft(cursor, rowCount) ?? cursor };
+
+    case "ArrowRight":
+      return { kind: "move", to: stepRight(cursor, rowCount) ?? cursor };
+
+    case "Enter": {
+      const target =
+        cursor.row + 1 < rowCount
+          ? { row: cursor.row + 1, col: 0 as ScoreColumn }
+          : nextUnscored(0, rowCount, isRowComplete);
+      // Every row scored and Enter pressed on the last one — hold position
+      // rather than wrapping the host back to the top unnecessarily.
+      return { kind: "move", to: target ?? cursor };
+    }
+
+    case "Backspace":
+    case "Delete":
+      return { kind: "write", at: cursor, value: null, then: cursor };
+
+    case "Home":
+      return { kind: "move", to: { row: 0, col: 0 } };
+
+    case "End":
+      return { kind: "move", to: { row: rowCount - 1, col: 1 } };
+
+    case "Escape":
+      // First Escape abandons the in-progress edit; a second one (nothing left
+      // to revert) releases focus back to the page.
+      return ctx.isDirty ? { kind: "revert", at: cursor } : { kind: "exit" };
+
+    case "?":
+      return { kind: "help" };
+
+    default:
+      // Tab/Shift+Tab included: DOM order already matches the grid order, so
+      // the browser's native tabbing is correct. Don't fight it.
+      return { kind: "passthrough" };
+  }
+}

--- a/utils/tournament/saveMatchScore.ts
+++ b/utils/tournament/saveMatchScore.ts
@@ -1,0 +1,146 @@
+// utils/tournament/saveMatchScore.ts
+//
+// The single live-round score write, shared by the score-entry modal
+// (components/ui/match-edit.tsx) and the keyboard score grid
+// (components/ui/ScoreGrid* in TournamentRounds.tsx).
+//
+// Extracted verbatim from match-edit.tsx so the two entry surfaces cannot
+// drift on validation or on what gets written. Behavior is deliberately
+// unchanged from the modal's original implementation, including the
+// denormalized player{1,2}_match_points / differential{,2} snapshot columns.
+//
+// Scope note: this is the LIVE-ROUND path only. Correcting a result on a
+// completed round still goes through repairMatchScoreAction ->
+// repair_match_score, which recomputes participant totals from history.
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { getUserSafe } from "../supabase/getUserSafe";
+
+export type SaveScoreResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+export const SESSION_EXPIRED_MESSAGE =
+  "Your session expired — reload the page to sign back in, then re-enter the score.";
+
+/**
+ * Validate a score pair against the tournament's cap. Pure — used by the grid
+ * to reject a keystroke before it ever reaches the network, and by the modal
+ * to gate submit.
+ *
+ * Returns null when the pair is legal, otherwise the message to show.
+ */
+export function validateScorePair(
+  p1: number | null,
+  p2: number | null,
+  maxScore: number,
+): string | null {
+  if (p1 === null || p2 === null) {
+    return "Select a score for both players before submitting.";
+  }
+  if (Number.isNaN(p1) || Number.isNaN(p2)) {
+    return `Invalid scores. Scores must be between 0 and ${maxScore}, inclusive.`;
+  }
+  if (p1 < 0 || p2 < 0 || p1 > maxScore || p2 > maxScore) {
+    return `Invalid scores. Scores must be between 0 and ${maxScore}, inclusive.`;
+  }
+  // Both players reaching the soul cap is not a reachable game state.
+  if (p1 === maxScore && p2 === maxScore) {
+    return `Score cannot be ${maxScore}-${maxScore}.`;
+  }
+  return null;
+}
+
+/** Match points each player earns, mirroring lib/tournament/standingsScoring. */
+export function matchPointsFor(
+  p1Score: number,
+  p2Score: number,
+  maxScore: number,
+): { p1: number; p2: number; isTie: boolean; p1Wins: boolean | null } {
+  if (p1Score === p2Score) return { p1: 1.5, p2: 1.5, isTie: true, p1Wins: null };
+  if (p1Score === maxScore) return { p1: 3, p2: 0, isTie: false, p1Wins: true };
+  if (p2Score === maxScore) return { p1: 0, p2: 3, isTie: false, p1Wins: false };
+  if (p1Score > p2Score) return { p1: 2, p2: 1, isTie: false, p1Wins: true };
+  return { p1: 1, p2: 2, isTie: false, p1Wins: false };
+}
+
+/**
+ * Write a live-round result. Reads both participants' running totals to build
+ * the per-match snapshot columns, exactly as the modal has always done.
+ */
+export async function saveMatchScore(
+  client: SupabaseClient,
+  args: {
+    matchId: string;
+    player1Id: string;
+    player2Id: string;
+    player1Score: number;
+    player2Score: number;
+    maxScore: number;
+  },
+): Promise<SaveScoreResult> {
+  const { matchId, player1Id, player2Id, player1Score, player2Score, maxScore } =
+    args;
+
+  const invalid = validateScorePair(player1Score, player2Score, maxScore);
+  if (invalid) return { ok: false, error: invalid };
+
+  // A read/write failure mid-round is most often a dead/expired session (the
+  // owner-scoped RLS query returns no row). getUserSafe distinguishes that
+  // (returns null) from a transient network blip, so flaky venue wifi shows a
+  // generic retry message rather than a false "session expired".
+  const hasValidSession = async () => !!(await getUserSafe(client));
+
+  const [player1, player2] = await Promise.all([
+    client
+      .from("participants")
+      .select("differential, match_points, id")
+      .eq("id", player1Id)
+      .single(),
+    client
+      .from("participants")
+      .select("differential, match_points, id")
+      .eq("id", player2Id)
+      .single(),
+  ]);
+
+  if (player1.error || player2.error) {
+    return {
+      ok: false,
+      error: (await hasValidSession())
+        ? "Couldn't load player data. Please try again."
+        : SESSION_EXPIRED_MESSAGE,
+    };
+  }
+
+  const pts = matchPointsFor(player1Score, player2Score, maxScore);
+  const winnerId = pts.isTie ? null : pts.p1Wins ? player1Id : player2Id;
+
+  const { error } = await client
+    .from("matches")
+    .update({
+      player1_score: player1Score,
+      player2_score: player2Score,
+      differential:
+        (player1.data.differential ?? 0) + (player1Score - player2Score),
+      differential2:
+        (player2.data.differential ?? 0) + (player2Score - player1Score),
+      player1_match_points: (player1.data.match_points || 0) + pts.p1,
+      player2_match_points: (player2.data.match_points || 0) + pts.p2,
+      is_tie: pts.isTie,
+      winner_id: winnerId,
+      updated_at: new Date(),
+    })
+    .eq("id", matchId);
+
+  if (error) {
+    return {
+      ok: false,
+      error: (await hasValidSession())
+        ? "Failed to save match scores. Please try again."
+        : SESSION_EXPIRED_MESSAGE,
+    };
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
Enter a whole round from the keyboard. Two keystrokes per match, no mouse.

## Why

Recording one result today is four clicks and a modal cycle: mouse to the pencil at the far right of a 7-column table, click, click P1's score, click P2's score, click **Update**. A 32-player five-round event is ~320 clicks.

There was no keyboard handling anywhere in the host flow. The only `onKeyDown` in the tournament area was the modal's Escape guard; the only `tabIndex` was on player-name cells in re-pair mode. Keyboard-only entry was technically reachable but took ~15 tabs per match through unlabeled score buttons.

## What makes it fast

`tournaments.max_score` is a `<select>` locked to 5 or 7, and it locks once round 1 starts — so **a score is always a single digit**. That means a keystroke can both write and advance. Type `3`, type `1`, and you're on the next match.

## Changes

- **Inline score cells** replace the read-only Result column for a host on a live round. Real `<input maxLength={1}>` so caret/selection/AT behavior comes free. Spectators, completed rounds, re-pair mode and the mobile card layout are untouched and still render the read-only `3–1` text.
- **`lib/tournament/scoreGridNav.ts`** holds the entire key map as pure functions — no React, no DOM — so the behavior is unit-testable. 33 tests.

  | Key | Action |
  |---|---|
  | `0`–`max` | write **and** auto-advance |
  | `Enter` | next match (from the last row, the first *unscored* one) |
  | `→` `←` / `Tab` | between the two players, wrapping across rows |
  | `↑` `↓` | same player, prev/next match |
  | `Home` `End` | first / last cell |
  | `Backspace` | clear |
  | `Esc` | revert the cell, then leave the grid |
  | `?` | cheatsheet |

- **Optimistic writes.** A digit updates local state and moves the cursor immediately; the save fires in the background once a row holds both scores, so the host never waits on a round-trip. Per-row saving/saved/error indicator.
- **Guardrails.** Digits above `max_score` flash and are not written. Illegal max–max pairs are flagged rather than saved. `Enter` from the bottom jumps to the first unscored match — exactly what End Round blocks on.
- **Discovery.** A ⌨ button in the round header (and `?`) opens a `<kbd>` cheatsheet, plus a dismissible one-line hint on first use (`localStorage`). Both desktop-only.

## Refactor

The live-round write moves out of `match-edit.tsx` into `utils/tournament/saveMatchScore.ts` so the modal and the grid can't drift on validation or on what gets written. **Behavior is unchanged**, including the denormalized `player{1,2}_match_points` / `differential{,2}` snapshot columns. Correcting a completed round still goes through `repair_match_score`.

Worth knowing: I initially assumed re-typing a score would double-count. It doesn't — the edit path never touches `participants.match_points`, the table's MP/Diff come from `perRoundScores` on the raw scores, and End Round recomputes from full history. So no SQL change was needed.

## Verification

Driven against the dev server with Playwright on a seeded live round:

- six keystrokes recorded three matches; DB confirmed correct `player1_score`/`player2_score`, `is_tie` and `winner_id`
- `9` rejected at `max_score=5`; `7` accepted at `max_score=7`, and the cheatsheet adapts
- `ArrowDown`/`ArrowRight`/`Backspace` land where expected
- `?` and the ⌨ icon both open the cheatsheet
- completed round: zero cells, zero keyboard icons, read-only `7–3` intact
- dark mode correct, no console errors

`vitest`: 1719 passed, +33 new. The one failure (`forge-lackey`) is pre-existing on `main`. `tsc --noEmit`: no new errors.

## Noticed but not touched

Both pre-existing and out of scope for this branch:

1. **The repair e2e suite is broken.** Six specs target `/repair result for alice vs bob/i` and a submit button `/^repair$/i`, but the component emits `"Edit result for …"` and `"Save"`. `non-host-view.spec.ts` still passes, but vacuously.
2. **The mobile pairing card shows no result at all** — only per-round MP/Diff, so on a phone you infer the score.
3. `player{1,2}_match_points` / `differential2` appear to be read by nothing; a grid-only save could drop two participant SELECTs per write. Left alone to keep this diff behavior-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)