### PR TITLE
fix(e2e): resurrect the repair suite — it has never passed

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -16,8 +16,26 @@ export const test = base.extend<Fixtures>({
     await page.getByLabel(/email/i).fill(seed.hostEmail);
     await page.getByLabel(/password/i).fill(seed.hostPassword);
     await page.getByRole("button", { name: /sign in/i }).click();
-    // Wait for redirect.
-    await page.waitForURL(/.*\/tracker.*|.*\/$/, { timeout: 10_000 });
+    // Wait for the redirect OFF the sign-in page rather than for a specific
+    // landing route. signInAction's destination has moved twice already
+    // (/tracker/tournaments -> /decklist/community, #82), and pinning it here
+    // silently broke every repair spec at the fixture. Each spec navigates to
+    // the page it actually needs, so all this has to prove is that auth stuck.
+    await page.waitForURL((url) => !url.pathname.startsWith("/sign-in"), {
+      timeout: 15_000,
+    });
+    // …then let that redirect finish landing. signInAction's redirect is a
+    // server-action redirect, so the URL flips as soon as the router accepts it
+    // while the document navigation is still in flight — and under load (a cold
+    // compile of the landing route) a spec's own goto() fired in that window
+    // dies with "Navigation ... is interrupted by another navigation".
+    // Sample until the location holds still, then wait for the load event.
+    for (let i = 0; i < 40; i++) {
+      const before = page.url();
+      await page.waitForTimeout(250);
+      if (page.url() === before) break;
+    }
+    await page.waitForLoadState("load");
     await use(seed);
     await cleanupTournament(seed);
   },

--- a/e2e/repair/dark-mode.spec.ts
+++ b/e2e/repair/dark-mode.spec.ts
@@ -1,29 +1,78 @@
 import { test, expect } from "../fixtures";
+import {
+  dialog,
+  dialogBox,
+  EDIT_DIALOG_HEADING,
+  editPastResult,
+  editResultPencil,
+  gotoRounds,
+  PAGE_READY_TIMEOUT,
+} from "./helpers";
 
-test("repair golden path works in dark mode", async ({ page, seeded }) => {
+/** "rgb(r, g, b)" / "rgba(...)" -> perceived luminance 0..255. */
+function luminance(color: string): number {
+  const [r, g, b] = (color.match(/[\d.]+/g) ?? []).slice(0, 3).map(Number);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+// NOTE: this spec used to end in `toHaveScreenshot("repair-dark-mode-standings.png")`
+// with no committed baseline, so the first run on any machine silently minted
+// a baseline from that machine's font rendering, GPU and scrollbars — after
+// which it would fail for everyone else and for CI. A snapshot nobody can
+// reproduce isn't a regression test, it's a tripwire. The dark-mode properties
+// that actually matter here are asserted directly instead: the theme applied,
+// the surfaces the edit flow renders on are genuinely dark, and the flow still
+// completes with legible contrast.
+// Reads the desktop match/standings tables — see golden-path.spec.ts.
+test.use({ viewport: { width: 1280, height: 800 } });
+
+test("the past-result edit flow works, and stays dark, in dark mode", async ({
+  page,
+  seeded,
+}) => {
   await page.emulateMedia({ colorScheme: "dark" });
-  await page.goto(`/tracker/tournaments/${seeded.tournamentId}`);
+  await gotoRounds(page, seeded.tournamentId, 1);
 
-  // Body background should not be pure white (sanity check that dark theme applied).
-  const bg = await page.evaluate(() => getComputedStyle(document.body).backgroundColor);
-  expect(bg).not.toBe("rgb(255, 255, 255)");
+  // next-themes runs with attribute="class" + defaultTheme="system".
+  await expect(page.locator("html")).toHaveClass(/dark/);
 
-  // Repair golden path.
-  const pencil = page.getByRole("button", { name: /repair result for alice vs bob/i });
-  await pencil.click();
-  const dialog = page.getByRole("dialog");
-  await expect(dialog).toBeVisible();
-  await dialog.getByRole("button", { name: /^3$/ }).nth(1).click();
-  await dialog.getByRole("button", { name: /^repair$/i }).click();
-  await expect(dialog).toBeHidden({ timeout: 5_000 });
+  const bodyBg = await page.evaluate(
+    () => getComputedStyle(document.body).backgroundColor,
+  );
+  expect(luminance(bodyBg)).toBeLessThan(96);
 
-  // Switch to participants tab for the standings visual-regression snapshot.
-  await page.getByRole("tab", { name: /participants/i }).click();
+  // The dialog has its own --dialog-bg token, so check the modal surface too
+  // rather than trusting the page background to speak for it.
+  await editResultPencil(page, "Alice", "Bob").click();
+  const d = dialog(page);
+  await expect(d.getByRole("heading", { name: EDIT_DIALOG_HEADING })).toBeVisible();
 
-  // Visual-regression snapshot for the standings view in dark mode.
-  // First run will produce the baseline; subsequent runs compare.
-  await expect(page).toHaveScreenshot("repair-dark-mode-standings.png", {
-    fullPage: true,
-    maxDiffPixelRatio: 0.02,
+  const modal = dialogBox(page);
+  const modalStyle = await modal.evaluate((el) => {
+    const s = getComputedStyle(el);
+    return { bg: s.backgroundColor, fg: s.color };
   });
+  expect(luminance(modalStyle.bg)).toBeLessThan(96);
+  // Dark surface, light text — catches the "dark class applied but tokens
+  // didn't follow" failure mode that a pure background check would miss.
+  expect(luminance(modalStyle.fg)).toBeGreaterThan(luminance(modalStyle.bg) + 64);
+
+  await page.keyboard.press("Escape");
+  await expect(d).toBeHidden();
+
+  // The flow itself still works end to end under the dark theme.
+  await editPastResult(page, {
+    p1: "Alice", p2: "Bob", p2Score: 3, reason: "dark mode",
+  });
+  await expect(page.getByRole("row").filter({ hasText: "Alice" })).toContainText("5–3");
+
+  // Standings render dark too — the tab this spec used to screenshot.
+  await page.getByRole("tablist").getByText("Standings", { exact: true }).click();
+  const standingsRow = page.getByRole("row").filter({ hasText: "Alice" });
+  await expect(standingsRow).toBeVisible({ timeout: PAGE_READY_TIMEOUT });
+  const rowStyle = await standingsRow.evaluate((el) => {
+    const s = getComputedStyle(el);
+    return { fg: s.color };
+  });
+  expect(luminance(rowStyle.fg)).toBeGreaterThan(128);
 });

--- a/e2e/repair/discoverability-picker.spec.ts
+++ b/e2e/repair/discoverability-picker.spec.ts
@@ -1,26 +1,77 @@
 import { test, expect } from "../fixtures";
+import { admin } from "../seed";
+import {
+  adminMenuItem,
+  dialog,
+  dialogTitled,
+  EDIT_DIALOG_HEADING,
+  gotoRounds,
+  MENU_EDIT_PAST_RESULT,
+  openAdminMenu,
+  PICKER_HEADING,
+  PICKER_SEARCH_PLACEHOLDER,
+  REASON_PLACEHOLDER,
+  saveEdit,
+  setScore,
+} from "./helpers";
 
-test("picker lets host jump to a specific past match's repair dialog", async ({ page, seeded }) => {
-  await page.goto(`/tracker/tournaments/${seeded.tournamentId}`);
+test("picker lets host jump straight to a past match's edit dialog", async ({
+  page,
+  seeded,
+}) => {
+  // The picker reaches any completed round from wherever the host is standing,
+  // so stay on the default (current) round — that's the point of this route.
+  await gotoRounds(page, seeded.tournamentId);
 
-  // Open the picker via the host overflow menu.
-  await page.getByRole("button", { name: /more host actions/i }).click();
-  await page.getByRole("menuitem", { name: /repair past result/i }).click();
+  await openAdminMenu(page);
+  await adminMenuItem(page, MENU_EDIT_PAST_RESULT).click();
 
-  const picker = page.getByRole("dialog").filter({ hasText: /repair past result/i });
+  const picker = dialogTitled(page, PICKER_HEADING);
   await expect(picker).toBeVisible();
 
-  // Round dropdown defaults to most-recently-completed round (1 in this seed).
-  // Type a player name into the search.
-  await picker.getByPlaceholder(/player name/i).fill("Alice");
+  // The round select defaults to current_round − 1 — the round just finished.
+  await expect(picker.getByRole("combobox")).toHaveValue("1");
 
-  // The Alice vs Bob list item should appear.
-  const aliceItem = picker.getByRole("button", { name: /alice vs bob/i });
+  // Round 1 has both of its matches listed up front…
+  const aliceItem = picker.getByRole("button", { name: "Alice vs Bob" });
+  await expect(aliceItem).toBeVisible();
+  await expect(picker.getByRole("button", { name: "Carol vs Dave" })).toBeVisible();
+
+  // …and searching by player name narrows it to one.
+  await picker.getByPlaceholder(PICKER_SEARCH_PLACEHOLDER).fill("Alice");
+  await expect(picker.getByRole("button", { name: "Carol vs Dave" })).toHaveCount(0);
   await expect(aliceItem).toBeVisible();
   await aliceItem.click();
 
-  // The picker closes and the repair dialog opens for that match.
+  // The picker closes and the edit dialog opens on the match it picked.
   await expect(picker).toBeHidden();
-  const repairDialog = page.getByRole("dialog").filter({ hasText: /repair result/i });
-  await expect(repairDialog).toBeVisible();
+  const editDialog = dialog(page);
+  await expect(
+    editDialog.getByRole("heading", { name: EDIT_DIALOG_HEADING }),
+  ).toBeVisible();
+  await expect(editDialog).toContainText("Alice Lost Souls (score):");
+  await expect(editDialog).toContainText("Bob Lost Souls (score):");
+  // Round 1 ≠ current_round, so this is a past-round correction and must ask why.
+  await expect(editDialog.getByPlaceholder(REASON_PLACEHOLDER)).toBeVisible();
+
+  // It's a working editor, not just a shell — the picker route has its own
+  // onRepairSuccess wiring (no toast, unlike the in-table pencil), so verify
+  // the write landed rather than the notification.
+  await setScore(editDialog, 2, 4);
+  await editDialog.getByPlaceholder(REASON_PLACEHOLDER).fill("picker route");
+  await saveEdit(editDialog);
+  await expect(editDialog).toBeHidden();
+
+  await expect
+    .poll(async () => {
+      const { data } = await admin!
+        .from("matches")
+        .select("player1_score, player2_score")
+        .eq("tournament_id", seeded.tournamentId)
+        .eq("round", 1)
+        .eq("player1_id", seeded.participantIds[0])
+        .single();
+      return data;
+    })
+    .toEqual({ player1_score: 5, player2_score: 4 });
 });

--- a/e2e/repair/golden-path.spec.ts
+++ b/e2e/repair/golden-path.spec.ts
@@ -1,39 +1,67 @@
 import { test, expect } from "../fixtures";
+import {
+  dialog,
+  editHistory,
+  editPastResult,
+  editResultPencil,
+  gotoRounds,
+  openRound,
+  PAGE_READY_TIMEOUT,
+} from "./helpers";
 
-test("host repairs a past-round score and standings reflect the change", async ({ page, seeded }) => {
-  await page.goto(`/tracker/tournaments/${seeded.tournamentId}`);
+// This spec reads the desktop match table (`hidden md:table`) and the standings
+// table, so pin a ≥md viewport rather than inheriting it from the project —
+// `npm run test:e2e` also runs the iPhone project, where those are display:none.
+test.use({ viewport: { width: 1280, height: 800 } });
 
-  // The repair pencil button is labeled "Repair result for {p1} vs {p2}" per Task 10.
-  const repairBtn = page.getByRole("button", { name: /repair result for alice vs bob/i });
-  await repairBtn.click();
+test("host edits a past-round score and standings reflect the change", async ({
+  page,
+  seeded,
+}) => {
+  // The pencil only renders for the host on a COMPLETED round, and the Rounds
+  // panel opens on current_round (2). Round 1 is the completed one in the seed.
+  await gotoRounds(page, seeded.tournamentId, 1);
 
-  // Repair dialog opens (mode="repair", title "Repair result").
-  const dialog = page.getByRole("dialog");
-  await expect(dialog).toBeVisible();
-  await expect(dialog.getByText(/repair result/i)).toBeVisible();
+  const row = page.getByRole("row").filter({ hasText: "Alice" });
+  await expect(row).toContainText("5–0");
 
-  // The dialog uses a ScoreSelector that renders buttons 0..max_score per player.
-  // To set player2 to 3 (was 0), click the "3" option in the second selector group.
-  // The ScoreSelector groups don't have stable role-based selectors, so fall back to
-  // clicking the visible button labeled "3" inside the dialog scope. There are two
-  // sets of 0-5 buttons; pick the second column by .nth(...).
-  //
-  // This selector is best-effort and may need adjustment when the test is first run.
-  // The dialog body has the player2 row second; the "3" button in that row should be:
-  await dialog.getByRole("button", { name: /^3$/ }).nth(1).click();
+  await editPastResult(page, {
+    p1: "Alice",
+    p2: "Bob",
+    p2Score: 3,
+    reason: "scorer mistake",
+  });
 
-  // Fill the optional reason field.
-  await dialog.getByPlaceholder(/why are you repairing/i).fill("scorer mistake");
+  // The round table re-renders with the corrected result and the per-round
+  // differential recomputed from it (Alice +2 / Bob −2, was +5 / −5).
+  await expect(row).toContainText("5–3");
+  await expect(row).toContainText("2 / -2");
 
-  // Submit the repair.
-  await dialog.getByRole("button", { name: /^repair$/i }).click();
+  // Host-only audit trail: one entry, old → new, carrying the reason.
+  const history = editHistory(page);
+  await expect(history).toBeVisible();
+  await history.locator("summary").click();
+  const entry = history.locator("li").first();
+  await expect(entry).toBeVisible();
+  await expect(entry).toContainText("5-0 → 5-3");
+  await expect(entry).toContainText("scorer mistake");
 
-  // Dialog closes after success.
-  await expect(dialog).toBeHidden({ timeout: 5_000 });
+  // Standings pick up the corrected differential. Alice still took the max
+  // score so her MP is unchanged at 3; only Diff moves, 5 → 2.
+  await page.getByRole("tablist").getByText("Standings", { exact: true }).click();
+  const aliceStanding = page.getByRole("row").filter({ hasText: "Alice" });
+  await expect(aliceStanding).toBeVisible({ timeout: PAGE_READY_TIMEOUT });
+  await expect(aliceStanding.getByRole("cell").nth(3)).toHaveText("3");
+  await expect(aliceStanding.getByRole("cell").nth(4)).toHaveText("2");
 
-  // Success toast shows.
-  await expect(page.getByText(/result repaired/i)).toBeVisible({ timeout: 5_000 });
-
-  // Audit log panel (host-only) should reflect the new entry with the reason.
-  await expect(page.getByText(/scorer mistake/i)).toBeVisible({ timeout: 5_000 });
+  // Reopening the dialog preselects the SAVED score, not the pre-edit one —
+  // guards match-edit's "seed both scores from the match on open" behaviour.
+  // (Leaving and re-entering the Rounds tab remounts the panel — TournamentRounds
+  // is keyed on activeTab — so it lands back on current_round and needs the hop.)
+  await page.getByRole("tablist").getByText("Rounds", { exact: true }).click();
+  await openRound(page, 1);
+  await editResultPencil(page, "Alice", "Bob").click();
+  await expect(
+    dialog(page).getByRole("button", { name: /^3$/ }).nth(1),
+  ).toHaveClass(/bg-primary/);
 });

--- a/e2e/repair/helpers.ts
+++ b/e2e/repair/helpers.ts
@@ -1,0 +1,237 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+// Selectors for the host result-editing flow, in one place.
+//
+// These specs were committed in #106 — the same PR that renamed the whole
+// feature from "Repair" to "Edit" — so they shipped pointing at copy that had
+// already changed and have never passed. Centralizing the selectors here means
+// the next rename is a one-file fix instead of eight.
+//
+// Current copy (components/ui/match-edit.tsx,
+// components/ui/RepairPastResultPicker.tsx,
+// components/ui/RegeneratePairingsButton.tsx,
+// components/ui/UnlockAndRepairDialog.tsx,
+// app/tracker/tournaments/[id]/page.tsx):
+//
+//   pencil aria-label ......... "Edit result for {p1} vs {p2}"  (repair mode)
+//                               "Edit score: {p1} vs {p2}"      (live round)
+//   dialog heading ............ "Edit result" / "Edit Match"
+//   reason placeholder ........ "Why are you editing this?"
+//   submit .................... "Save" / "Update"
+//   success toast ............. "Match updated."
+//   host menu trigger ......... aria-label "Admin actions" (wrench)
+//   host menu items ........... "Regenerate pairings", "Unlock & regenerate…",
+//                               "Edit a past result", "End tournament"
+//   picker heading ............ "Edit a past result", search "Player name"
+//   regenerate confirm ........ "Regenerate pairings for Round {n}?" / "Regenerate"
+//   unlock confirm ............ "Unlock & regenerate?" / "Unlock and regenerate"
+
+/* ------------------------------------------------------------------ copy */
+
+export const ADMIN_MENU_TRIGGER = /^admin actions$/i;
+export const MENU_REGENERATE_PAIRINGS = /^regenerate pairings$/i;
+export const MENU_UNLOCK_AND_REGENERATE = /^unlock & regenerate/i;
+export const MENU_EDIT_PAST_RESULT = /^edit a past result$/i;
+
+export const EDIT_DIALOG_HEADING = /^edit result$/i;
+export const EDIT_SUCCESS_TOAST = "Match updated.";
+export const REASON_PLACEHOLDER = /why are you editing this/i;
+export const EDIT_HISTORY = /edit history/i;
+
+export const PICKER_HEADING = /^edit a past result$/i;
+export const PICKER_SEARCH_PLACEHOLDER = /player name/i;
+
+export const REGENERATE_CONFIRM_CHECKBOX = /i confirm no players have started/i;
+export const REGENERATE_CONFIRM_BUTTON = /^regenerate$/i;
+
+export const UNLOCK_DIALOG_HEADING = /^unlock & regenerate\?$/i;
+export const UNLOCK_CONFIRM_CHECKBOX =
+  /i confirm these results will be permanently deleted/i;
+export const UNLOCK_CONFIRM_BUTTON = /^unlock and regenerate$/i;
+
+/**
+ * A cold `next dev` route compile plus the tournament page's chain of
+ * client-side fetches routinely runs past the 10s default expect timeout on the
+ * first assertion of a spec. Everything that waits for the page to *arrive*
+ * uses this; assertions about behaviour keep the default so a real regression
+ * still fails fast.
+ */
+export const PAGE_READY_TIMEOUT = 60_000;
+
+/* -------------------------------------------------------------- navigation */
+
+/**
+ * `page.goto` that survives the Next App Router.
+ *
+ * A client-side navigation that is still landing — the sign-in server-action
+ * redirect, or a `router.refresh()` after a mutation — aborts an overlapping
+ * `goto` with "interrupted by another navigation". That is an artefact of
+ * driving an SPA router from outside, not a product failure and not something
+ * the page can be asked about, so wait for the interloper and try again.
+ */
+export async function navigate(page: Page, url: string): Promise<void> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await page.goto(url);
+      return;
+    } catch (err) {
+      const interrupted = /interrupted by another navigation/i.test(String(err));
+      if (!interrupted || attempt >= 3) throw err;
+      await page.waitForLoadState("load").catch(() => undefined);
+    }
+  }
+}
+
+/** The "Round {n} of {total}" panel heading — the Rounds tab's readiness signal. */
+export function roundHeading(page: Page, round?: number): Locator {
+  return page.getByRole("heading", {
+    name:
+      round === undefined
+        ? /^round \d+ of \d+$/i
+        : new RegExp(`^round ${round} of \\d+$`, "i"),
+  });
+}
+
+/**
+ * Activate the Rounds tab. The default tab is Participants, and the Rounds
+ * tab's flowbite title is a JSX element rather than a plain string, so its
+ * computed accessible name isn't reliably "Rounds" — `getByRole("tab", …)`
+ * does not find it. Address it by its text within the tablist instead.
+ */
+export async function openRoundsTab(page: Page): Promise<void> {
+  await page.getByRole("tablist").getByText("Rounds", { exact: true }).click();
+  await expect(roundHeading(page)).toBeVisible({ timeout: PAGE_READY_TIMEOUT });
+}
+
+/**
+ * Page the Rounds panel to a specific round via the flowbite Pagination.
+ *
+ * The panel opens on `tournament.current_round`, so a completed past round —
+ * the only place the edit pencil renders — always needs an explicit hop.
+ */
+export async function openRound(page: Page, round: number): Promise<void> {
+  const pagination = page
+    .locator("nav")
+    .filter({ has: page.getByRole("button", { name: "Previous" }) });
+  await pagination
+    .getByRole("button", { name: String(round), exact: true })
+    .click();
+  await expect(roundHeading(page, round)).toBeVisible({
+    timeout: PAGE_READY_TIMEOUT,
+  });
+}
+
+/** goto the tournament, activate Rounds, and optionally hop to a round. */
+export async function gotoRounds(
+  page: Page,
+  tournamentId: string,
+  round?: number,
+): Promise<void> {
+  await navigate(page, `/tracker/tournaments/${tournamentId}`);
+  await openRoundsTab(page);
+  if (round !== undefined) await openRound(page, round);
+}
+
+/* ------------------------------------------------------------ edit dialog */
+
+/**
+ * The per-row pencil that opens the edit dialog for a completed round.
+ * Only rendered for the host on a completed round (`isHost && isRoundCompleted`).
+ *
+ * The desktop table (`hidden md:table`) and the mobile cards (`md:hidden`) both
+ * sit in the DOM; `getByRole` ignores `display: none` subtrees, so exactly one
+ * matches at any given viewport.
+ */
+export function editResultPencil(page: Page, p1: string, p2: string): Locator {
+  return page.getByRole("button", { name: `Edit result for ${p1} vs ${p2}` });
+}
+
+/**
+ * The open modal. This is the `fixed inset-0` overlay — components/ui/dialog.tsx
+ * puts role="dialog" on the backdrop, not on the box — so never measure it.
+ * Use {@link dialogBox} for geometry.
+ */
+export function dialog(page: Page): Locator {
+  return page.getByRole("dialog");
+}
+
+/** The modal box inside the overlay — the element that is actually laid out. */
+export function dialogBox(page: Page): Locator {
+  return dialog(page).locator("> div");
+}
+
+/**
+ * The open modal whose `<h2>` matches `heading`.
+ *
+ * Filtering by `hasText` would compare against the dialog's ENTIRE text, so an
+ * anchored heading regex never matches — address the heading element instead.
+ */
+export function dialogTitled(page: Page, heading: RegExp): Locator {
+  return dialog(page).filter({ has: page.getByRole("heading", { name: heading }) });
+}
+
+/**
+ * Set a player's score in the edit dialog. The two ScoreSelector rows each
+ * render buttons 0..max_score with no group role, so the row is addressed
+ * positionally: player 1 is the first block of digit buttons, player 2 the
+ * second.
+ */
+export async function setScore(
+  scope: Locator,
+  player: 1 | 2,
+  score: number,
+): Promise<void> {
+  await scope
+    .getByRole("button", { name: new RegExp(`^${score}$`) })
+    .nth(player - 1)
+    .click();
+}
+
+/** Submit the edit dialog ("Save" in repair mode, "Update" in live-round mode). */
+export async function saveEdit(scope: Locator): Promise<void> {
+  await scope.getByRole("button", { name: /^save$/i }).click();
+}
+
+/**
+ * Run a whole past-result edit: open the pencil, set player 2's score,
+ * optionally give a reason, save, and wait for the success toast.
+ */
+export async function editPastResult(
+  page: Page,
+  opts: { p1: string; p2: string; p2Score: number; reason?: string },
+): Promise<void> {
+  await editResultPencil(page, opts.p1, opts.p2).click();
+  const d = dialog(page);
+  await expect(d.getByRole("heading", { name: EDIT_DIALOG_HEADING })).toBeVisible();
+  await setScore(d, 2, opts.p2Score);
+  if (opts.reason !== undefined) {
+    await d.getByPlaceholder(REASON_PLACEHOLDER).fill(opts.reason);
+  }
+  await saveEdit(d);
+  await expect(d).toBeHidden();
+  await expect(page.getByText(EDIT_SUCCESS_TOAST, { exact: true })).toBeVisible();
+}
+
+/**
+ * The host-only per-match `<details>` audit trail rendered under an edited row.
+ * `:visible` picks whichever layout (table row vs. mobile card) the current
+ * viewport is showing.
+ */
+export function editHistory(page: Page): Locator {
+  return page.locator("details:visible").filter({ hasText: EDIT_HISTORY });
+}
+
+/* -------------------------------------------------------------- host menu */
+
+/**
+ * Open the wrench menu holding the host-only pairing and result actions. It
+ * lives in the Rounds panel header, so the Rounds tab must already be open.
+ */
+export async function openAdminMenu(page: Page): Promise<void> {
+  await page.getByRole("button", { name: ADMIN_MENU_TRIGGER }).click();
+  await expect(page.getByRole("menu")).toBeVisible();
+}
+
+export function adminMenuItem(page: Page, name: RegExp): Locator {
+  return page.getByRole("menuitem", { name });
+}

--- a/e2e/repair/inline-re-pair.spec.ts
+++ b/e2e/repair/inline-re-pair.spec.ts
@@ -1,8 +1,22 @@
 import { test, expect } from "../fixtures";
 import { admin } from "../seed";
+import {
+  adminMenuItem,
+  dialog,
+  editPastResult,
+  gotoRounds,
+  MENU_REGENERATE_PAIRINGS,
+  openAdminMenu,
+  REGENERATE_CONFIRM_BUTTON,
+  REGENERATE_CONFIRM_CHECKBOX,
+} from "./helpers";
 
-test("repair followed by re-pair button regenerates current round pairings", async ({ page, seeded }) => {
-  // Ensure round 2 has been paired but unscored.
+test("editing a past result then regenerating replaces the current round's pairings", async ({
+  page,
+  seeded,
+}) => {
+  // Round 2 is paired but unscored — the state in which "Regenerate pairings"
+  // is allowed without unlocking.
   await admin!.from("matches").insert([
     { tournament_id: seeded.tournamentId, round: 2, match_order: 1,
       player1_id: seeded.participantIds[0], player2_id: seeded.participantIds[2],
@@ -15,36 +29,47 @@ test("repair followed by re-pair button regenerates current round pairings", asy
     tournament_id: seeded.tournamentId, round_number: 2, is_completed: false,
   });
 
-  await page.goto(`/tracker/tournaments/${seeded.tournamentId}`);
-
-  // Step 1: repair Alice vs Bob in round 1 (change 5-0 to 5-3).
-  const repairBtn = page.getByRole("button", { name: /repair result for alice vs bob/i });
-  await repairBtn.click();
-  const dialog = page.getByRole("dialog");
-  await expect(dialog).toBeVisible();
-  await dialog.getByRole("button", { name: /^3$/ }).nth(1).click();
-  await dialog.getByRole("button", { name: /^repair$/i }).click();
-  await expect(dialog).toBeHidden({ timeout: 5_000 });
-  await expect(page.getByText(/result repaired/i)).toBeVisible({ timeout: 5_000 });
-
-  // Step 2: open the host overflow menu, then choose Re-pair current round.
-  // (Project toast has no inline action button per Task 18; the destructive
-  // actions live behind the ⋯ overflow menu post-WS4.)
-  await page.getByRole("button", { name: /more host actions/i }).click();
-  await page.getByRole("menuitem", { name: /re-pair current round/i }).click();
-
-  // Confirm dialog with checkbox.
-  const confirmDialog = page.getByRole("dialog").filter({ hasText: /re-pair round 2/i });
-  await expect(confirmDialog).toBeVisible();
-  await confirmDialog.getByLabel(/i confirm no players have started/i).check();
-  await confirmDialog.getByRole("button", { name: /^re-pair$/i }).click();
-
-  // Verify success: matches table for round 2 still has 2 rows (pairings replaced, not deleted).
-  // We re-fetch via admin (back-channel verify) to avoid flaky UI assertions.
-  await page.waitForTimeout(500); // give the action time to commit and revalidate
-  const { data: round2Matches } = await admin!.from("matches")
-    .select("id, player1_id, player2_id")
+  const before = await admin!.from("matches")
+    .select("id")
     .eq("tournament_id", seeded.tournamentId)
     .eq("round", 2);
-  expect(round2Matches?.length).toBeGreaterThan(0);
+  const beforeIds = (before.data ?? []).map((m) => m.id);
+  expect(beforeIds).toHaveLength(2);
+
+  // Step 1: correct Alice vs Bob in round 1 (5-0 → 5-3).
+  await gotoRounds(page, seeded.tournamentId, 1);
+  await editPastResult(page, { p1: "Alice", p2: "Bob", p2Score: 3, reason: "misheard" });
+
+  // Step 2: regenerate round 2's pairings off the corrected standings.
+  await openAdminMenu(page);
+  const regenerate = adminMenuItem(page, MENU_REGENERATE_PAIRINGS);
+  await expect(regenerate).toBeEnabled();
+  await regenerate.click();
+
+  const confirm = dialog(page).filter({ hasText: /regenerate pairings for round 2\?/i });
+  await expect(confirm).toBeVisible();
+
+  // The confirm button is gated on the checkbox.
+  const submit = confirm.getByRole("button", { name: REGENERATE_CONFIRM_BUTTON });
+  await expect(submit).toBeDisabled();
+  await confirm.getByLabel(REGENERATE_CONFIRM_CHECKBOX).check();
+  await expect(submit).toBeEnabled();
+  await submit.click();
+  await expect(confirm).toBeHidden();
+
+  // The RPC deletes and re-inserts, so round 2 keeps 2 unscored pairings but
+  // none of the original rows survive.
+  await expect
+    .poll(async () => {
+      const { data } = await admin!.from("matches")
+        .select("id, player1_score")
+        .eq("tournament_id", seeded.tournamentId)
+        .eq("round", 2);
+      return {
+        count: data?.length ?? 0,
+        reused: (data ?? []).filter((m) => beforeIds.includes(m.id)).length,
+        scored: (data ?? []).filter((m) => m.player1_score !== null).length,
+      };
+    })
+    .toEqual({ count: 2, reused: 0, scored: 0 });
 });

--- a/e2e/repair/just-ended-round.spec.ts
+++ b/e2e/repair/just-ended-round.spec.ts
@@ -1,8 +1,13 @@
 import { test, expect } from "../fixtures";
 import { admin } from "../seed";
+import { editResultPencil, gotoRounds, openRound, PAGE_READY_TIMEOUT } from "./helpers";
 
-test("just-ended round immediately shows repair pencil on its matches", async ({ page, seeded }) => {
-  // Add round 2 matches WITH scores so we can end the round.
+test("a round ended in-session is immediately editable without a reload", async ({
+  page,
+  seeded,
+}) => {
+  // Round 2 live (started, not completed) with both results already in, so
+  // End Round has everything it needs.
   await admin!.from("matches").insert([
     { tournament_id: seeded.tournamentId, round: 2, match_order: 1,
       player1_id: seeded.participantIds[0], player2_id: seeded.participantIds[2],
@@ -12,16 +17,33 @@ test("just-ended round immediately shows repair pencil on its matches", async ({
       player1_score: 5, player2_score: 2, winner_id: seeded.participantIds[1], is_tie: false },
   ]);
   await admin!.from("rounds").insert({
-    tournament_id: seeded.tournamentId, round_number: 2, is_completed: false,
+    tournament_id: seeded.tournamentId, round_number: 2,
+    is_completed: false, started_at: new Date().toISOString(),
   });
 
-  await page.goto(`/tracker/tournaments/${seeded.tournamentId}`);
+  await gotoRounds(page, seeded.tournamentId);
 
-  // End the active round (this triggers handleEndRound in page.tsx).
-  // Button label varies; try common forms.
-  const endRoundBtn = page.getByRole("button", { name: /end round/i }).first();
-  await endRoundBtn.click();
+  // While the round is live there is no edit-a-past-result pencil — only the
+  // live-score pencil ("Edit score: …"). This is the before-state the rest of
+  // the test is contrasted against.
+  await expect(editResultPencil(page, "Alice", "Carol")).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Edit score: Alice vs Carol" }),
+  ).toBeVisible();
 
-  // Wait for the round to be marked completed (handleEndRound updates state).
-  await expect(page.getByRole("button", { name: /repair result for alice vs carol/i })).toBeVisible({ timeout: 5_000 });
+  await page.getByRole("button", { name: "End Round" }).click();
+  const confirm = page.getByRole("dialog").filter({ hasText: /end round 2\?/i });
+  await expect(confirm).toBeVisible();
+  await confirm.getByRole("button", { name: /^end round$/i }).click();
+
+  // Ending a round advances the panel to the next round's (empty) pairings.
+  await expect(
+    page.getByRole("heading", { name: /^round 3 of 3$/i }),
+  ).toBeVisible({ timeout: PAGE_READY_TIMEOUT });
+
+  // Page back to the round that just ended: its results are editable right
+  // away, with no reload — the pencil comes from live state, not a fresh load.
+  await openRound(page, 2);
+  await expect(editResultPencil(page, "Alice", "Carol")).toBeVisible();
+  await expect(editResultPencil(page, "Bob", "Dave")).toBeVisible();
 });

--- a/e2e/repair/mobile-viewport.spec.ts
+++ b/e2e/repair/mobile-viewport.spec.ts
@@ -1,15 +1,29 @@
 import { test, expect } from "../fixtures";
+import {
+  dialog,
+  dialogBox,
+  EDIT_DIALOG_HEADING,
+  EDIT_SUCCESS_TOAST,
+  editResultPencil,
+  gotoRounds,
+  REASON_PLACEHOLDER,
+  saveEdit,
+  setScore,
+} from "./helpers";
 
-test.use({ viewport: { width: 375, height: 667 } });
+const VIEWPORT = { width: 375, height: 667 }; // iPhone SE
+test.use({ viewport: VIEWPORT });
 
-test("repair golden path works on mobile viewport (iPhone SE)", async ({ page, seeded }) => {
-  await page.goto(`/tracker/tournaments/${seeded.tournamentId}`);
+test("past-result edit is usable on a phone-sized viewport", async ({ page, seeded }) => {
+  await gotoRounds(page, seeded.tournamentId, 1);
 
-  // Find the repair pencil for Alice vs Bob.
-  const pencil = page.getByRole("button", { name: /repair result for alice vs bob/i });
+  // Below md the table is display:none and the card list takes over, so this
+  // resolves to the mobile pencil.
+  const pencil = editResultPencil(page, "Alice", "Bob");
   await expect(pencil).toBeVisible();
 
-  // Verify the hit area is at least 44x44.
+  // Touch target: match-edit renders the trigger w-11 h-11 and the mobile card
+  // wraps it in a matching w-11 h-11 box, so 44×44 is the contract.
   const box = await pencil.boundingBox();
   expect(box).not.toBeNull();
   expect(box!.width).toBeGreaterThanOrEqual(44);
@@ -17,23 +31,50 @@ test("repair golden path works on mobile viewport (iPhone SE)", async ({ page, s
 
   await pencil.click();
 
-  // The dialog renders bottom-sheet on mobile — anchored to the bottom half.
-  const dialog = page.getByRole("dialog");
-  await expect(dialog).toBeVisible();
-  const dialogBox = await dialog.boundingBox();
-  expect(dialogBox).not.toBeNull();
-  // Bottom-anchored: the dialog's bottom edge should be close to the viewport bottom (667).
-  expect(dialogBox!.y + dialogBox!.height).toBeGreaterThan(400);
+  const d = dialog(page);
+  await expect(d.getByRole("heading", { name: EDIT_DIALOG_HEADING })).toBeVisible();
 
-  // Set player2 score to 3 (was 0). Brittle selector — first run will tune.
-  await dialog.getByRole("button", { name: /^3$/ }).nth(1).click();
+  // The overlay carries role="dialog" and is fixed inset-0, so measure the box
+  // inside it. It is centred (not a bottom sheet) and capped at
+  // max-h-[calc(100dvh-2rem)], so what matters on a phone is that it fits:
+  // no horizontal overflow and no vertical clipping.
+  const modal = dialogBox(page);
+  const modalBox = await modal.boundingBox();
+  expect(modalBox).not.toBeNull();
+  expect(modalBox!.x).toBeGreaterThanOrEqual(0);
+  expect(modalBox!.x + modalBox!.width).toBeLessThanOrEqual(VIEWPORT.width);
+  expect(modalBox!.y).toBeGreaterThanOrEqual(0);
+  expect(modalBox!.y + modalBox!.height).toBeLessThanOrEqual(VIEWPORT.height);
 
-  // The primary submit "Repair" should be reachable in the bottom half.
-  const submit = dialog.getByRole("button", { name: /^repair$/i });
+  // Every score option in both rows has to be tappable without scrolling
+  // sideways — six 40px buttons plus gaps is the tightest row in the app.
+  for (const row of [0, 1]) {
+    for (const score of [0, 5]) {
+      const b = d.getByRole("button", { name: new RegExp(`^${score}$`) }).nth(row);
+      const bb = await b.boundingBox();
+      expect(bb).not.toBeNull();
+      expect(bb!.x).toBeGreaterThanOrEqual(0);
+      expect(bb!.x + bb!.width).toBeLessThanOrEqual(VIEWPORT.width);
+    }
+  }
+
+  await setScore(d, 2, 3);
+  await d.getByPlaceholder(REASON_PLACEHOLDER).fill("phone edit");
+
+  // Submit must be on-screen, not pushed below the fold by the score rows.
+  const submit = d.getByRole("button", { name: /^save$/i });
   const submitBox = await submit.boundingBox();
   expect(submitBox).not.toBeNull();
-  expect(submitBox!.y).toBeGreaterThan(333); // lower half of 667
+  expect(submitBox!.y + submitBox!.height).toBeLessThanOrEqual(VIEWPORT.height);
 
-  await submit.click();
-  await expect(dialog).toBeHidden({ timeout: 5_000 });
+  await saveEdit(d);
+  await expect(d).toBeHidden();
+  await expect(page.getByText(EDIT_SUCCESS_TOAST, { exact: true })).toBeVisible();
+
+  // The mobile card reflects the corrected result. The card layout shows no
+  // raw score — only the derived per-round line — so assert on that: Alice's
+  // differential moves +5 → +2 and Bob's −5 → −2.
+  const card = page.locator("div.md\\:hidden > div").filter({ hasText: "Alice" }).first();
+  await expect(card).toContainText("Match Pts 3 · Diff 2");
+  await expect(card).toContainText("Match Pts 0 · Diff -2");
 });

--- a/e2e/repair/non-host-view.spec.ts
+++ b/e2e/repair/non-host-view.spec.ts
@@ -1,33 +1,109 @@
 import { test, expect } from "../fixtures";
 import { admin, adminAvailable } from "../seed";
+import type { Page } from "@playwright/test";
+import {
+  ADMIN_MENU_TRIGGER,
+  EDIT_HISTORY,
+  editHistory,
+  editPastResult,
+  editResultPencil,
+  gotoRounds,
+  MENU_EDIT_PAST_RESULT,
+  navigate,
+} from "./helpers";
 
-test("non-host player sees no host affordances", async ({ page, seeded }) => {
-  if (!adminAvailable) test.skip();
+// NOTE ON PREMISE. The original spec assumed a signed-in non-host could browse
+// the tournament page and simply be shown fewer controls. That isn't what the
+// product does: RLS on `tournaments` (and on matches / participants / rounds /
+// match_edits) is `auth.uid() = host_id`, with no participant or public read
+// policy, so /tracker/tournaments/[id] renders "Tournament not found" for
+// anyone who isn't the host. The assertions below test THAT — which is the
+// stronger guarantee anyway — rather than pretending the page loads.
 
-  // Create a non-host user.
-  const otherEmail = `other-${Date.now()}@e2e.test`;
-  const otherPassword = "Testpass12345";
-  await admin!.auth.admin.createUser({ email: otherEmail, password: otherPassword, email_confirm: true });
+const PASSWORD = "Testpass12345";
 
-  // Log out the host fixture, log in as the non-host.
-  await page.goto("/sign-in");
-  await page.getByLabel(/email/i).fill(otherEmail);
-  await page.getByLabel(/password/i).fill(otherPassword);
-  await page.getByRole("button", { name: /sign in/i }).click();
-  await page.waitForURL(/.*/);
+async function createNonHost(): Promise<string> {
+  const email = `other-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@e2e.test`;
+  await admin!.auth.admin.createUser({ email, password: PASSWORD, email_confirm: true });
+  return email;
+}
 
-  await page.goto(`/tracker/tournaments/${seeded.tournamentId}`);
-
-  // No host affordances visible.
-  await expect(page.getByRole("button", { name: /repair past result/i })).toHaveCount(0);
-  await expect(page.getByRole("button", { name: /repair result for/i })).toHaveCount(0);
-  await expect(page.getByRole("button", { name: /^re-pair current round$/i })).toHaveCount(0);
-  await expect(page.getByText(/audit log/i)).toHaveCount(0);
-
-  // Cleanup other user.
+async function deleteUser(email: string): Promise<void> {
   const usersResult = await admin!.auth.admin.listUsers();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const allUsers = (usersResult.data as any).users as Array<{ id: string; email?: string }>;
-  const other = allUsers.find(u => u.email === otherEmail);
-  if (other) await admin!.auth.admin.deleteUser(other.id);
+  const user = allUsers.find((u) => u.email === email);
+  if (user) await admin!.auth.admin.deleteUser(user.id);
+}
+
+/** Replace the host session in this browser with a signed-in non-host. */
+async function signInAs(page: Page, email: string): Promise<void> {
+  await navigate(page, "/sign-in");
+  await page.getByLabel(/email/i).fill(email);
+  await page.getByLabel(/password/i).fill(PASSWORD);
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await page.waitForURL((url) => !url.pathname.startsWith("/sign-in"), {
+    timeout: 15_000,
+  });
+}
+
+test("a non-host gets none of the host's result-editing surface", async ({
+  page,
+  seeded,
+}) => {
+  test.skip(!adminAvailable, "requires SUPABASE_SERVICE_ROLE_KEY");
+  const otherEmail = await createNonHost();
+
+  try {
+    // Establish the affordances FIRST, as the host. Without this the absence
+    // assertions below pass just as happily against stale selectors — which is
+    // exactly how this spec "passed" for the whole time it tested nothing.
+    await gotoRounds(page, seeded.tournamentId, 1);
+    await expect(editResultPencil(page, "Alice", "Bob")).toBeVisible();
+    await expect(page.getByRole("button", { name: ADMIN_MENU_TRIGGER })).toBeVisible();
+
+    // Leave an audit trail too, so the non-host checks below are about
+    // permission rather than about there being nothing to hide.
+    await editPastResult(page, {
+      p1: "Alice", p2: "Bob", p2Score: 3, reason: "host eyes only",
+    });
+    await expect(editHistory(page)).toBeVisible();
+
+    await signInAs(page, otherEmail);
+    await navigate(page, `/tracker/tournaments/${seeded.tournamentId}`);
+
+    // The tournament itself is unreachable, so the whole host surface is too.
+    await expect(
+      page.getByRole("heading", { name: /tournament not found/i }),
+    ).toBeVisible();
+    await expect(page.getByRole("tablist")).toHaveCount(0);
+
+    await expect(editResultPencil(page, "Alice", "Bob")).toHaveCount(0);
+    await expect(editResultPencil(page, "Carol", "Dave")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /^edit score:/i })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: ADMIN_MENU_TRIGGER })).toHaveCount(0);
+    await expect(page.getByRole("menuitem", { name: MENU_EDIT_PAST_RESULT })).toHaveCount(0);
+    await expect(page.getByRole("menu")).toHaveCount(0);
+
+    // Neither the audit trail nor the reason the host typed leaks.
+    await expect(page.getByText(EDIT_HISTORY)).toHaveCount(0);
+    await expect(page.getByText("host eyes only")).toHaveCount(0);
+  } finally {
+    await deleteUser(otherEmail);
+  }
+});
+
+test("a signed-out visitor never reaches the page at all", async ({ page, seeded }) => {
+  test.skip(!adminAvailable, "requires SUPABASE_SERVICE_ROLE_KEY");
+
+  // The `seeded` fixture signs the host in; drop that session.
+  await page.context().clearCookies();
+  await navigate(page, `/tracker/tournaments/${seeded.tournamentId}`);
+
+  // /tracker is a protected prefix, so this bounces to sign-in before the
+  // tournament page (and its host controls) is ever rendered.
+  await expect(page).toHaveURL(/\/sign-in\?/);
+  await expect(editResultPencil(page, "Alice", "Bob")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: ADMIN_MENU_TRIGGER })).toHaveCount(0);
+  await expect(page.getByText(EDIT_HISTORY)).toHaveCount(0);
 });

--- a/e2e/repair/unlock-and-re-pair.spec.ts
+++ b/e2e/repair/unlock-and-re-pair.spec.ts
@@ -1,8 +1,23 @@
 import { test, expect } from "../fixtures";
 import { admin } from "../seed";
+import {
+  adminMenuItem,
+  dialogTitled,
+  gotoRounds,
+  MENU_REGENERATE_PAIRINGS,
+  MENU_UNLOCK_AND_REGENERATE,
+  openAdminMenu,
+  UNLOCK_CONFIRM_BUTTON,
+  UNLOCK_CONFIRM_CHECKBOX,
+  UNLOCK_DIALOG_HEADING,
+} from "./helpers";
 
-test("host unlocks and re-pairs when current round has scored matches", async ({ page, seeded }) => {
-  // Seed round 2 paired with ONE scored match.
+test("host unlocks and regenerates when the current round already has a score", async ({
+  page,
+  seeded,
+}) => {
+  // Round 2 paired with ONE scored match — the state that blocks a plain
+  // regenerate and surfaces the unlock escape hatch.
   await admin!.from("matches").insert([
     { tournament_id: seeded.tournamentId, round: 2, match_order: 1,
       player1_id: seeded.participantIds[0], player2_id: seeded.participantIds[2],
@@ -16,30 +31,40 @@ test("host unlocks and re-pairs when current round has scored matches", async ({
     tournament_id: seeded.tournamentId, round_number: 2, is_completed: false,
   });
 
-  await page.goto(`/tracker/tournaments/${seeded.tournamentId}`);
+  await gotoRounds(page, seeded.tournamentId);
+  await openAdminMenu(page);
 
-  // Open the host overflow menu.
-  await page.getByRole("button", { name: /more host actions/i }).click();
+  // Plain regenerate is disabled because a result already exists…
+  await expect(adminMenuItem(page, MENU_REGENERATE_PAIRINGS)).toBeDisabled();
+  // …and the unlock entry only exists in that same state.
+  const unlock = adminMenuItem(page, MENU_UNLOCK_AND_REGENERATE);
+  await expect(unlock).toBeVisible();
+  await unlock.click();
 
-  // Re-pair menu item should be disabled because scores exist.
-  const rePair = page.getByRole("menuitem", { name: /^re-pair current round$/i });
-  await expect(rePair).toBeDisabled();
+  const confirm = dialogTitled(page, UNLOCK_DIALOG_HEADING);
+  await expect(confirm).toBeVisible();
+  // It must name exactly what is about to be destroyed.
+  await expect(confirm).toContainText("discard the following 1 result");
+  await expect(confirm).toContainText("Alice vs Carol: 5-0");
 
-  // Unlock entry is rendered in the same menu when scores exist.
-  await page.getByRole("menuitem", { name: /unlock and re-pair/i }).click();
+  const submit = confirm.getByRole("button", { name: UNLOCK_CONFIRM_BUTTON });
+  await expect(submit).toBeDisabled();
+  await confirm.getByLabel(UNLOCK_CONFIRM_CHECKBOX).check();
+  await expect(submit).toBeEnabled();
+  await submit.click();
+  await expect(confirm).toBeHidden();
 
-  const dialog = page.getByRole("dialog").filter({ hasText: /unlock and re-pair/i });
-  await expect(dialog).toBeVisible();
-  await expect(dialog.getByText(/alice/i)).toBeVisible(); // Alice was in the scored round 2 match
-  await dialog.getByLabel(/i confirm these results will be permanently deleted/i).check();
-  await dialog.getByRole("button", { name: /unlock and regenerate/i }).click();
-
-  // Confirm new pairings exist; the prior scored row is gone.
-  await page.waitForTimeout(500);
-  const { data: scored } = await admin!.from("matches")
-    .select("id, player1_score")
-    .eq("tournament_id", seeded.tournamentId)
-    .eq("round", 2)
-    .not("player1_score", "is", null);
-  expect(scored?.length ?? 0).toBe(0);
+  // Round 2 is re-paired from scratch: two matches, no surviving score.
+  await expect
+    .poll(async () => {
+      const { data } = await admin!.from("matches")
+        .select("id, player1_score")
+        .eq("tournament_id", seeded.tournamentId)
+        .eq("round", 2);
+      return {
+        count: data?.length ?? 0,
+        scored: (data ?? []).filter((m) => m.player1_score !== null).length,
+      };
+    })
+    .toEqual({ count: 2, scored: 0 });
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   reporter: "list",
+  // The default 30s doesn't cover a cold `next dev` route compile. The tracker
+  // tournament page alone takes ~10s the first time it's hit, and a spec that
+  // visits two uncompiled routes blows the budget before it asserts anything.
+  timeout: 90_000,
+  expect: { timeout: 10_000 },
   use: {
     baseURL: process.env.E2E_BASE_URL ?? "http://localhost:3000",
     trace: "on-first-retry",


### PR DESCRIPTION
The eight specs under `e2e/repair/` have **never** gone green. This makes them pass, honestly.

## Two independent root causes

**1. The login fixture pinned a redirect that moved (#82).**
`e2e/fixtures.ts` waited for a specific landing route after sign-in. `signInAction`'s destination changed in #82 (`/tracker/tournaments` → `/decklist/community`), so every spec timed out *in the fixture*, before asserting anything. It now waits to leave `/sign-in` — that's all the fixture needs to prove — and then waits for that redirect to finish landing, because the server-action redirect flips the URL while the navigation is still in flight and a spec's own `goto()` fired in that window dies with "interrupted by another navigation".

**2. The specs were born stale (#106).**
#106 added these specs in the same commit that renamed the whole feature from "Repair" to "Edit". They shipped pointing at copy that had already changed — `more host actions`, `Repair result`, `Repair`, `Result repaired`, `Re-pair round 2` — none of which has ever existed in shipped code.

## What changed

- **`e2e/repair/helpers.ts` (new)** — every selector for this flow in one place, so the next rename is a one-file fix instead of eight. Also holds the two navigation facts the specs kept getting wrong: the Rounds tab's flowbite title is a JSX element so `getByRole("tab", { name: /rounds/i })` doesn't find it, and the Rounds panel opens on `current_round`, so a completed past round — the only place the edit pencil renders — always needs an explicit pagination hop.
- **All 8 specs rewritten** against the real UI (`Admin actions` wrench, `Edit a past result`, `Regenerate pairings`, `Unlock & regenerate…`, `Edit result`, `Save`, `Match updated.`).
- **`playwright.config.ts`** — `timeout: 90_000`, `expect.timeout: 10_000`. A cold `next dev` compile of the tournament route alone eats most of the 30s default.
- Assertions were strengthened, not loosened, wherever the old ones were weak: back-channel DB checks now assert the regenerate RPC actually replaced the rows (count + no reused ids + no surviving scores) rather than `length > 0`, and `page.waitForTimeout(500)` was replaced with `expect.poll`.

## Two premises that did not match the product

Both were rewritten rather than papered over:

- **`dark-mode.spec.ts`** ended in `toHaveScreenshot()` with no committed baseline. The first run on any machine would silently mint a baseline from that machine's font rendering, GPU and scrollbars, after which it fails for everyone else. A snapshot nobody can reproduce is a tripwire, not a regression test. Replaced with concrete assertions: `html.dark` applied, page *and dialog* surfaces measurably dark, dialog contrast (light text on dark surface — catches "dark class applied but tokens didn't follow", which a background-only check misses), and the full edit flow completing under the dark theme.
- **`non-host-view.spec.ts`** assumed a signed-in non-host could browse the tournament page and simply see fewer controls. They can't: RLS on `tournaments` (and `matches` / `participants` / `rounds` / `match_edits`) is `auth.uid() = host_id` with no participant or public read policy, so `/tracker/tournaments/[id]` renders "Tournament not found" for anyone else. This spec previously "passed" only because its selectors matched nothing. It now (a) proves the affordances exist for the host first, so the absence assertions can't pass against stale selectors again, (b) has the host leave a real audit trail, then (c) asserts the non-host gets none of it. A second case covers the signed-out visitor, who is bounced to `/sign-in` by middleware.

## Deliberately not fixed

- **`mobile-viewport.spec.ts`'s bottom-sheet assertion was wrong about the product.** `components/ui/dialog.tsx` puts `role="dialog"` on the `fixed inset-0` overlay, so the old `boundingBox()` measured the viewport and the "anchored to the bottom half" check passed on 667 > 400 no matter what. The dialog is in fact centred (`items-center`), not a bottom sheet. Rather than assert a layout the product doesn't have, the spec now measures the modal box and asserts what actually matters on a phone: it fits horizontally and vertically, every score button is reachable without sideways scroll, and Save is above the fold. **The 44×44 touch-target assertion is correct and was kept** — `match-edit.tsx` renders the trigger `w-11 h-11` and the mobile card wraps the repair pencil in a matching `w-11 h-11`. (The `w-10 h-10` wrapper belongs to the live-score pencil, which is never rendered for a host on a completed round.)
- **No product code was touched.** No product bugs were found — every failure traced to a stale selector, a stale premise, or the fixture.

## Verification

`npx playwright test e2e/repair --project=chromium-desktop` — **9/9 passing**, three consecutive runs. Also green across both configured projects (`chromium-desktop` + `chromium-mobile`, 18/18), and `tsc --noEmit` is clean for `e2e/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)