### PR TITLE
fix(e2e): make the qr-join host assertions actually reachable

### DIFF
--- a/e2e/qr-join.spec.ts
+++ b/e2e/qr-join.spec.ts
@@ -252,6 +252,25 @@ async function signIn(page: Page, email: string, password: string) {
   await page.getByRole("button", { name: /sign in/i }).click();
 }
 
+/**
+ * Sign in and wait for the session to actually be established.
+ *
+ * signInAction is a server-action redirect, so the click resolves long before
+ * the browser has left /sign-in. Navigating during that window lands on a page
+ * rendered without the session — which then bounces straight back to /sign-in.
+ * Callers that need a *specific* destination (the redirectTo flow below) wait
+ * on that URL instead; this is for callers that just need to be logged in.
+ *
+ * Mirrors the pattern the forge specs already use.
+ */
+async function signInAndSettle(page: Page, email: string, password: string) {
+  await signIn(page, email, password);
+  await page.waitForURL((u) => !u.pathname.startsWith("/sign-in"), {
+    timeout: 30_000,
+  });
+  await page.waitForLoadState("load");
+}
+
 test.describe("QR join + decklist submission", () => {
   test.skip(!adminAvailable, "requires SUPABASE_SERVICE_ROLE_KEY + NEXT_PUBLIC_SUPABASE_URL");
 
@@ -327,13 +346,30 @@ test.describe("QR join + decklist submission", () => {
     const hostContext = await browser.newContext();
     const hostPage = await hostContext.newPage();
     await hostPage.goto("/sign-in");
-    await signIn(hostPage, seeded.hostEmail, seeded.hostPassword);
-    await hostPage.waitForURL(/.*/);
+    // NOT waitForURL(/.*/) — that regex matches the CURRENT url, so it resolved
+    // instantly against /sign-in and the goto below raced the pending sign-in
+    // redirect. The host arrived unauthenticated and was bounced back to
+    // /sign-in, where "1 of 1" naturally doesn't exist.
+    await signInAndSettle(hostPage, seeded.hostEmail, seeded.hostPassword);
 
     await hostPage.goto(`/tracker/tournaments/${seeded.tournamentId}`);
-    await expect(hostPage.getByText("1 of 1")).toBeVisible();
+    // The summary renders after the participants + decklists fetches resolve,
+    // which on a cold dev-server route compile is well past the 5s default.
+    await expect(hostPage.getByText("1 of 1")).toBeVisible({ timeout: 30_000 });
     await expect(hostPage.getByText(/participants have decklists/i)).toBeVisible();
-    await expect(hostPage.getByTitle(`${seeded.deckName} — view submission`)).toBeVisible();
+
+    // ParticipantTable renders a desktop table AND a mobile card list, both
+    // always in the DOM and toggled by CSS — so an unfiltered getByTitle matches
+    // two elements and trips strict mode before it ever checks visibility.
+    // Assert on whichever layout this viewport is actually showing.
+    const submissionButton = hostPage
+      .getByTitle(`${seeded.deckName} — view submission`)
+      .filter({ visible: true });
+    await expect(submissionButton).toBeVisible();
+
+    // It opens the submission, which is the point of the link.
+    await submissionButton.click();
+    await expect(hostPage.getByRole("dialog")).toBeVisible();
 
     await hostContext.close();
   });


### PR DESCRIPTION
`qr-join.spec.ts` now passes. Two test bugs, **no product bug** — the QR join, decklist submission and DB assertions were already passing; only the host-view tail failed.

## 1. The host sign-in never completed

```js
await hostPage.waitForURL(/.*/);
```

That regex matches the URL the page is *already on*, so it resolved instantly against `/sign-in`. The `goto` that followed raced the still-in-flight server-action redirect, the host arrived without a session, and `/tracker` bounced it back to sign-in — where `"1 of 1"` understandably doesn't exist.

The saved failure snapshot confirms it; the page under assertion is the **Sign in** page:

```yaml
- heading "Sign in" [level=1]
- link "Sign in": /url: /sign-in
- link "Sign up": /url: /sign-up
```

Replaced with a `signInAndSettle` helper that waits to leave `/sign-in` and for the load to settle. This is the pattern the **forge specs already use** — it just never propagated here. The same no-op wait also existed in `repair/non-host-view.spec.ts`, fixed in #265.

## 2. The submission link tripped strict mode

`ParticipantTable` renders a desktop table **and** a mobile card list, both always in the DOM and toggled by CSS, so `getByTitle` matched two elements and threw before it ever checked visibility:

```
strict mode violation: getByTitle('… — view submission') resolved to 2 elements
```

Filtered to the layout the viewport is actually showing. I also followed the click through to the submission dialog, so the assertion covers what the link is *for* rather than just that it exists.

Plus: raised the `"1 of 1"` wait, which renders only after the participants and decklists fetches resolve — past the 5s default on a cold route compile.

## Verification

Passes on two consecutive runs against a live dev server (~40s each).

## Noticed, not fixed

Cleanup logs `Database error deleting user` for both seeded accounts — the `profiles` FK blocks `auth.admin.deleteUser`. It's non-fatal (the spec logs and continues) and pre-existing, so test users accumulate in the project. Worth a follow-up.

## Context

This is the second of two e2e repairs. #265 resurrects the `repair/` suite, which had **never passed**. Both traced to the same root cause: **nothing runs tests in CI** — `.github/workflows/` contains only `deploy-spacetimedb.yml`, no vitest, no Playwright, no typecheck. That's how the same `waitForURL(/.*/)` bug ended up in three places with the fix applied to only one.

Worth knowing how close a gate is: on clean `main`, `tsc --noEmit` has 10 errors — **all in two test files**, product code is clean — and `vitest` has 1 failure (`forge-lackey`). A `tsc && vitest` check needs no secrets and is about that much work away from green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)