### PR TITLE
fix(e2e): stop leaking seeded test accounts

### DIFF
--- a/e2e/deleteUser.ts
+++ b/e2e/deleteUser.ts
@@ -1,0 +1,58 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Delete a seeded test user for real.
+ *
+ * `auth.admin.deleteUser` alone does NOT work on this project. Several public
+ * tables reference `auth.users` with `ON DELETE NO ACTION`, so the delete fails
+ * with a 500 ("Database error deleting user") and — because every call site
+ * wrapped it in a try/catch or ignored the error — the account silently stayed.
+ *
+ * That leak reached 300 orphaned `@e2e.test` users before anyone noticed, and
+ * it was not inert: leftover `profiles` rows hold the usernames a fresh seed
+ * wants, which is what made `spectator/lobby-lifecycle` fail with
+ * `duplicate key value violates unique constraint "profiles_username_key"`.
+ *
+ * The blocking children, confirmed against the live schema:
+ *   profiles.id          NO ACTION   ← auto-created by the signup trigger
+ *   decks.user_id        NO ACTION
+ *   deck_folders.user_id NO ACTION
+ * Everything else that matters (tournaments, playtest_members, forge_*,
+ * collection_cards, api_keys) is ON DELETE CASCADE and needs no help.
+ *
+ * Returns true when the user is gone, false otherwise — callers should surface
+ * a false rather than swallow it, or the leak simply comes back quietly.
+ */
+export async function deleteTestUser(
+  admin: SupabaseClient,
+  userId: string,
+): Promise<boolean> {
+  // Order matters: these block the auth.users delete.
+  await admin.from("decks").delete().eq("user_id", userId);
+  await admin.from("deck_folders").delete().eq("user_id", userId);
+  await admin.from("profiles").delete().eq("id", userId);
+
+  const { error } = await admin.auth.admin.deleteUser(userId);
+  if (error) {
+    console.error(`e2e cleanup: user ${userId} survived deletion: ${error.message}`);
+    return false;
+  }
+  return true;
+}
+
+/** Same, addressed by email — for callers that never captured the id. */
+export async function deleteTestUserByEmail(
+  admin: SupabaseClient,
+  email: string,
+): Promise<boolean> {
+  const { data, error } = await admin.auth.admin.listUsers();
+  if (error) {
+    console.error(`e2e cleanup: could not list users: ${error.message}`);
+    return false;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const users = (data as any).users as Array<{ id: string; email?: string }>;
+  const user = users.find((u) => u.email === email);
+  if (!user) return true; // already gone
+  return deleteTestUser(admin, user.id);
+}

--- a/e2e/forge/forgeSeed.ts
+++ b/e2e/forge/forgeSeed.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
+import { deleteTestUser } from "../deleteUser";
 
 const URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
 const SERVICE = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
@@ -58,8 +59,7 @@ export async function cleanupForgeMember(seed: SeededForgeMember) {
   await admin.from("forge_set_grants").delete().eq("user_id", seed.userId);
   await admin.from("forge_audit").delete().eq("actor", seed.userId);
   await admin.from("playtest_members").delete().eq("user_id", seed.userId);
-  // The live profiles FK to auth.users is NO ACTION (signup trigger auto-creates
-  // the row), so it must go first or deleteUser 500s and users accumulate.
-  await admin.from("profiles").delete().eq("id", seed.userId);
-  try { await admin.auth.admin.deleteUser(seed.userId); } catch { /* best-effort */ }
+  // This file already knew about the profiles FK; deleteTestUser is that same
+  // knowledge, shared, so the other seeds stop leaking users.
+  await deleteTestUser(admin, seed.userId);
 }

--- a/e2e/globalTeardown.ts
+++ b/e2e/globalTeardown.ts
@@ -1,0 +1,47 @@
+import { createClient } from "@supabase/supabase-js";
+import { deleteTestUser } from "./deleteUser";
+
+/**
+ * Sweep any `@e2e.test` accounts still standing after the run.
+ *
+ * Per-test cleanup handles the normal path, but it cannot handle the abnormal
+ * one: when a test exceeds its timeout Playwright tears the worker down and the
+ * cleanup hook never runs. The spectator specs talk to a REMOTE SpacetimeDB, so
+ * they time out on latency often enough for that to matter — and every timeout
+ * used to leave two accounts behind permanently.
+ *
+ * That is how 300 orphaned users accumulated between May and July 2026, which
+ * was not cosmetic: leftover `profiles` rows hold the usernames a later run
+ * wants, and `spectator/lobby-lifecycle` started failing with
+ * `duplicate key value violates unique constraint "profiles_username_key"`.
+ *
+ * Scoped strictly to the `.test` TLD, which is IANA-reserved and can never be a
+ * real address, so this cannot touch a live account.
+ */
+export default async function globalTeardown(): Promise<void> {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+  const service = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
+  if (!url || !service) return;
+
+  const admin = createClient(url, service, { auth: { persistSession: false } });
+
+  const { data, error } = await admin.auth.admin.listUsers({ perPage: 1000 });
+  if (error) {
+    console.warn(`e2e teardown: could not list users: ${error.message}`);
+    return;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const users = (data as any).users as Array<{ id: string; email?: string }>;
+  const leftovers = users.filter((u) => u.email?.endsWith("@e2e.test"));
+  if (leftovers.length === 0) return;
+
+  // Their tournaments cascade from auth.users; decks and profiles do not, which
+  // deleteTestUser handles.
+  let removed = 0;
+  for (const u of leftovers) {
+    if (await deleteTestUser(admin, u.id)) removed++;
+  }
+  console.log(
+    `e2e teardown: swept ${removed}/${leftovers.length} leftover @e2e.test accounts`,
+  );
+}

--- a/e2e/qr-join.spec.ts
+++ b/e2e/qr-join.spec.ts
@@ -4,6 +4,7 @@ import { CARDS, type CardData } from "@/lib/cards/lookup";
 import { FORMATS } from "@/lib/formats";
 import { matchesBanListEntry } from "@/utils/deckcheck/rules";
 import { generateJoinCode } from "@/lib/tournament/joinCodes";
+import { deleteTestUser } from "./deleteUser";
 
 // This spec exercises migration 084 (tournament_deck_submissions,
 // participants.user_id, tournaments.require_decklists) end-to-end. It is
@@ -235,12 +236,11 @@ async function cleanup(state: Seeded) {
     ["player", state.playerId],
   ] as const) {
     if (!userId) continue;
-    try {
-      const { error } = await admin.auth.admin.deleteUser(userId);
-      if (error) console.warn(`qr-join e2e cleanup: failed to delete ${label} user ${userId}:`, error.message);
-    } catch (err) {
-      console.warn(`qr-join e2e cleanup: failed to delete ${label} user ${userId}:`, err);
-    }
+    // Was a bare deleteUser, which always 500s on the profiles FK — this spec
+    // logged "Database error deleting user" on every single run and leaked both
+    // accounts each time.
+    const ok = await deleteTestUser(admin, userId);
+    if (!ok) console.warn(`qr-join e2e cleanup: ${label} user ${userId} survived`);
   }
 }
 

--- a/e2e/seed.ts
+++ b/e2e/seed.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
+import { deleteTestUserByEmail } from "./deleteUser";
 
 const URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
 const SERVICE = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
@@ -64,19 +65,9 @@ export async function seedTournamentWithCompletedRound1(): Promise<SeededTournam
 
 export async function cleanupTournament(seed: SeededTournament) {
   if (!admin) return;
-  const client = admin;
-  await client.from("tournaments").delete().eq("id", seed.tournamentId);
-  // Best-effort user cleanup. The admin.auth.admin API doesn't expose getUserByEmail
-  // on all SDK versions; if it's missing, the test users accumulate harmlessly.
-  try {
-    const result = await client.auth.admin.listUsers();
-    if (!result.error) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const users = (result.data as any).users as Array<{ id: string; email?: string }>;
-      const user = users.find(u => u.email === seed.hostEmail);
-      if (user) await client.auth.admin.deleteUser(user.id);
-    }
-  } catch {
-    // ignore
-  }
+  await admin.from("tournaments").delete().eq("id", seed.tournamentId);
+  // This used to swallow every failure on the theory that "test users accumulate
+  // harmlessly". They don't — the real failure mode was the profiles FK, and
+  // 146 host-* accounts piled up from this one call site alone.
+  await deleteTestUserByEmail(admin, seed.hostEmail);
 }

--- a/e2e/spectatorSeed.ts
+++ b/e2e/spectatorSeed.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
+import { deleteTestUser } from "./deleteUser";
 
 const URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
 const SERVICE = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
@@ -43,7 +44,16 @@ export async function seedPlayer(label: string): Promise<SeededPlayer> {
 
   const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
   const email = `spec-${label}-${stamp}@e2e.test`;
-  const username = `spec_${label}_${stamp}`.slice(0, 24);
+  // profiles.username is UNIQUE and capped at 24 chars, so the uniquifier has
+  // to survive the cap — `spec_${label}_${stamp}`.slice(0, 24) truncated from
+  // the RIGHT, cutting the random suffix off entirely and leaving only coarse
+  // timestamp precision. Playwright parallelises across files (6 workers), and
+  // board.spec and lobby-lifecycle both seed the label "host", so two runs
+  // could land on the same name and fail with a profiles_username_key
+  // violation. Build it right-to-left instead: the random part is never lost,
+  // and only the human-readable label gets squeezed.
+  const suffix = Math.random().toString(36).slice(2, 8); // 6 chars, always kept
+  const username = `s_${label}`.slice(0, 24 - suffix.length - 1) + `_${suffix}`;
 
   const { data: created, error: uErr } = await admin.auth.admin.createUser({
     email,
@@ -89,11 +99,9 @@ export async function seedPlayer(label: string): Promise<SeededPlayer> {
 
 export async function cleanupPlayer(p: SeededPlayer) {
   if (!admin) return;
-  // deck_cards cascade on deck delete in most schemas; delete decks explicitly.
-  await admin.from("decks").delete().eq("user_id", p.userId);
-  try {
-    await admin.auth.admin.deleteUser(p.userId);
-  } catch {
-    // ignore — leftover e2e users are harmless
-  }
+  // The old comment here said "leftover e2e users are harmless". They are not:
+  // their profiles rows keep the usernames a later run needs, which is exactly
+  // how this file's own lobby-lifecycle spec started failing on
+  // profiles_username_key. deleteTestUser removes the blocking rows first.
+  await deleteTestUser(admin, p.userId);
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,9 @@ loadEnv({ path: ".env.local", quiet: true });
 
 export default defineConfig({
   testDir: "./e2e",
+  // Belt-and-braces for seeded accounts: per-test cleanup handles the normal
+  // path, this catches whatever a timed-out or crashed worker left behind.
+  globalTeardown: "./e2e/globalTeardown.ts",
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,


### PR DESCRIPTION
**300 orphaned `@e2e.test` users** had accumulated since 2026-05-28, plus 300 `profiles` rows and 28 tournaments. I've purged them; this PR stops it recurring.

They weren't inert. A leftover `profiles` row keeps the username a later run wants, so `spectator/lobby-lifecycle` had started failing with `duplicate key value violates unique constraint "profiles_username_key"` — and taking three other tests in the file down with it. After the purge, that file went from 1 failed / 3 never-ran to **4 passed**.

## Why deletion silently failed

`auth.admin.deleteUser` **cannot** delete these users. Three tables reference `auth.users` with `ON DELETE NO ACTION`:

| child | column |
|---|---|
| `profiles` | `id` — auto-created by the signup trigger |
| `decks` | `user_id` |
| `deck_folders` | `user_id` |

So the call 500s with "Database error deleting user". Every call site either wrapped it in a bare `try/catch` or logged and moved on — one of them under the comment *"leftover e2e users are harmless"*.

`forge/forgeSeed.ts` had already diagnosed this and deleted `profiles` first. `e2e/deleteUser.ts` is that knowledge shared across the other seeds, and it **returns a boolean** so a failure gets surfaced instead of swallowed.

## The username collision

`spectatorSeed.ts` also generated colliding usernames. `profiles.username` is UNIQUE and capped at 24 chars, and this truncated from the **right**:

```js
const username = `spec_${label}_${stamp}`.slice(0, 24);
```

That cut the random suffix off entirely, leaving only coarse timestamp precision. The leftovers prove it — every stored username is exactly 24 chars ending in a dash:

```
spec_host_1785335682640-
spec_join_1785335683130-
spec_viewer_178533568373
```

Playwright parallelises across files (6 workers), and `board.spec` and `lobby-lifecycle` both seed the label `"host"`, so two files could land on the same name. Rebuilt right-to-left so the random part is never what gets dropped: `s_host_wdxfol`.

## Safety net

Per-test cleanup can't run at all when a test exceeds its timeout — Playwright tears the worker down and the hook never fires. The spectator specs talk to a **remote** SpacetimeDB, so they time out on latency often enough for that to matter; I watched exactly this leak 3 more accounts mid-verification.

Added a `globalTeardown` that sweeps any survivor. Scoped strictly to the `.test` TLD, which is IANA-reserved and can never be a real address.

## Verification

Live run reported:

```
e2e teardown: swept 14/14 leftover @e2e.test accounts
```

Database now:

| | before | after |
|---|---|---|
| `@e2e.test` users | 300 | **0** |
| orphaned profiles | 300 | **0** |
| orphaned tournaments | 28 | **0** |
| real users | 336 | 336 |
| tournaments | 296 | 268 |
| decks | 1891 | 1879 |

Before deleting anything I confirmed full isolation: 0 e2e users in real tournaments, 0 real users in e2e tournaments, 0 e2e decks referenced by real decklists or submissions, 0 public e2e decks.

## Not fixed here

The spectator suite is **flaky against the remote SpacetimeDB** — one file took 18 minutes and blew a 240s test timeout on a run where it had passed in ~3 minutes earlier. That's pre-existing and unrelated to these changes (which only touch cleanup and a username string), but it's the reason the safety net is worth having.

🤖 Generated with [Claude Code](https://claude.com/claude-code)