### PR TITLE
chore(history): remove the Results tab from the history nav

### DIFF
--- a/app/tournaments/history/NavTabs.tsx
+++ b/app/tournaments/history/NavTabs.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import Link from "next/link";
-
 export type ViewId =
   | "tournaments"
   | "champions"
@@ -45,15 +43,6 @@ export default function NavTabs({ view, setView }: NavTabsProps) {
           {tab.label}
         </button>
       ))}
-      {/* Pattern-break: this is a real navigation link (to /tournaments/results),
-          not a view-state switch like the buttons above — Results is its own
-          page, not a HistoryClient view. Styled to match the other tabs. */}
-      <Link
-        href="/tournaments/results"
-        className="shrink-0 px-4 py-3 text-sm font-medium text-muted-foreground hover:text-foreground border-b-2 border-transparent"
-      >
-        Results
-      </Link>
     </div>
   );
 }


### PR DESCRIPTION
Removes the **Results** tab from the tournament history page's nav bar.

It was the one entry in that tab bar that wasn't a view switch — the other tabs flip `HistoryClient` state, while Results was a plain `<Link>` out to `/tournaments/results`. Removing it also made the `next/link` import unused, so that's dropped too.

`/tournaments/results` itself is untouched and still reachable — it's linked from the top nav and the tournaments list, so the page isn't orphaned.

## Verification
- `npx tsc --noEmit` — no errors in `NavTabs.tsx` (the remaining errors are pre-existing ones in test files on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)