### PR TITLE
feat(deckbuilder): hover preview for searched cards

### DIFF
--- a/app/decklist/card-search/client.tsx
+++ b/app/decklist/card-search/client.tsx
@@ -30,6 +30,7 @@ import type { User } from "@supabase/supabase-js";
 import { deleteDeckAction } from "../actions";
 import { MobileBottomNav } from "./components/MobileBottomNav";
 import { useCardPrices } from "./hooks/useCardPrices";
+import { useHoverPreview } from "./hooks/useHoverPreview";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 const supabase = createClient();
@@ -304,6 +305,12 @@ export default function CardSearchClient({
   // Drag-to-deck is disabled on mobile — touch drag doesn't work reliably and
   // the tap/stepper controls cover adding cards.
   const isMobile = useMediaQuery("(max-width: 767px)");
+
+  // Card hover preview. Owned here rather than in DeckBuilderPanel (which
+  // renders the toggle) so the search grid on the left honors the same
+  // preference as the deck panel on the right.
+  const [hoverPreviewEnabled, setHoverPreviewEnabled] = useState(true);
+  const searchHoverPreview = useHoverPreview(hoverPreviewEnabled && !isMobile);
   const [player1Name, setPlayer1Name] = useState(() => {
     if (typeof window === 'undefined') return "Player 1";
     return localStorage.getItem('spotlight-p1-name') ?? "Player 1";
@@ -2364,9 +2371,13 @@ export default function CardSearchClient({
               return (
                 <div
                   key={c.dataLine}
+                  {...searchHoverPreview.hoverProps(c)}
                   draggable={!isSpotlight && !isMobile}
                   onDragStart={(e) => {
                     if (isSpotlight || isMobile) return;
+                    // The tile keeps mouse-over while dragging, so the preview
+                    // would otherwise hang next to the cursor for the whole drag.
+                    searchHoverPreview.clear();
                     // Native HTML5 drag — picked up by `useExternalDropTarget`
                     // on the deck-panel zones. No @dnd-kit dependency, so this
                     // works across the search↔deck context boundary without
@@ -2612,6 +2623,8 @@ export default function CardSearchClient({
               );
             })}
           </div>
+          {/* Card preview on hover — follows the deck panel's toggle */}
+          {searchHoverPreview.overlay}
           <div className="py-3 text-center text-xs sm:text-sm text-muted-foreground">
             Showing {Math.min(visibleCount, filtered.length)} of {filtered.length}
           </div>
@@ -2748,6 +2761,8 @@ export default function CardSearchClient({
             hasUnsavedChanges={hasUnsavedChanges}
             isAuthenticated={!!user}
             isExpanded={!showSearch}
+            hoverPreviewEnabled={hoverPreviewEnabled}
+            onHoverPreviewEnabledChange={setHoverPreviewEnabled}
             deckCheckResult={deckCheckResult}
             isDeckChecking={isDeckChecking}
             allCards={cards}
@@ -2854,6 +2869,8 @@ export default function CardSearchClient({
               isAuthenticated={!!user}
               isExpanded={false}
               forceDisableHoverPreview
+              hoverPreviewEnabled={hoverPreviewEnabled}
+              onHoverPreviewEnabledChange={setHoverPreviewEnabled}
               deckCheckResult={deckCheckResult}
               isDeckChecking={isDeckChecking}
               allCards={cards}

--- a/app/decklist/card-search/components/DeckBuilderPanel.tsx
+++ b/app/decklist/card-search/components/DeckBuilderPanel.tsx
@@ -179,6 +179,10 @@ interface DeckBuilderPanelProps {
   onDescriptionChange?: (description: string) => void;
   /** Force-disable hover previews (e.g. on mobile) */
   forceDisableHoverPreview?: boolean;
+  /** Hover-preview preference. Owned by the parent so the search grid shares it. */
+  hoverPreviewEnabled: boolean;
+  /** Called when the user flips the hover-preview toggle in this panel. */
+  onHoverPreviewEnabledChange: (enabled: boolean) => void;
   /** Default tab to show when panel mounts (persists across mobile drawer open/close) */
   defaultTab?: TabType;
   /** Server-side deck check result */
@@ -237,6 +241,8 @@ export default function DeckBuilderPanel({
   onPreviewCardsChange,
   onDescriptionChange,
   forceDisableHoverPreview = false,
+  hoverPreviewEnabled,
+  onHoverPreviewEnabledChange,
   defaultTab,
   deckCheckResult,
   isDeckChecking,
@@ -573,7 +579,10 @@ export default function DeckBuilderPanel({
   // Expanded (FullDeckView) view options
   const [expandedViewMode, setExpandedViewMode] = useState<'normal' | 'stacked'>('stacked');
   const [expandedGroupBy, setExpandedGroupBy] = useState<'none' | 'alignment' | 'type'>('type');
-  const [disableHoverPreview, setDisableHoverPreview] = useState(forceDisableHoverPreview);
+  // The preference lives in the parent (shared with the search grid); this panel
+  // only renders the toggle and can force previews off regardless (mobile).
+  const disableHoverPreview = forceDisableHoverPreview || !hoverPreviewEnabled;
+  const toggleHoverPreview = () => onHoverPreviewEnabledChange(!hoverPreviewEnabled);
   
   // Initialize deck type based on deck.format
   const [deckType, setDeckType] = useState<FormatId>(() => normalizeFormat(deck.format));
@@ -2301,7 +2310,7 @@ export default function DeckBuilderPanel({
                   <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Card Hover Preview</span>
                   <Switch
                     checked={!disableHoverPreview}
-                    onChange={() => setDisableHoverPreview((v) => !v)}
+                    onChange={toggleHoverPreview}
                     className={`${!disableHoverPreview ? 'bg-primary' : 'bg-muted'} relative inline-flex h-5 w-10 items-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`}
                   >
                     <span
@@ -2514,7 +2523,7 @@ export default function DeckBuilderPanel({
               {/* Preview sidebar toggle */}
               <div className="hidden lg:block ml-auto">
                 <button
-                  onClick={() => setDisableHoverPreview((v) => !v)}
+                  onClick={toggleHoverPreview}
                   className={`flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md transition-colors ${
                     !disableHoverPreview
                       ? 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300'

--- a/app/decklist/card-search/hooks/useHoverPreview.tsx
+++ b/app/decklist/card-search/hooks/useHoverPreview.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import React from "react";
+import type { Card } from "../utils";
+import { CardThumb } from "../components/CardThumb";
+
+const PREVIEW_WIDTH = 300;
+const PREVIEW_HEIGHT = 400;
+const PADDING = 10;
+
+/** Position the preview beside the hovered element, flipping/clamping so it
+ *  never runs off screen. Mirrors `calculatePreviewPosition` in DeckCardList. */
+function calculatePreviewPosition(element: HTMLElement) {
+  const rect = element.getBoundingClientRect();
+
+  let x = rect.right + PADDING;
+  let y = rect.top;
+
+  // Would overflow the right edge → put it on the other side instead
+  if (x + PREVIEW_WIDTH > window.innerWidth) {
+    x = rect.left - PREVIEW_WIDTH - PADDING;
+  }
+  if (y + PREVIEW_HEIGHT > window.innerHeight) {
+    y = window.innerHeight - PREVIEW_HEIGHT - PADDING;
+  }
+  if (y < PADDING) {
+    y = PADDING;
+  }
+
+  return { x, y };
+}
+
+/**
+ * Floating card preview on hover, anchored to whatever element the pointer is
+ * over. Used by the search-results grid; the deck panel has its own inlined
+ * copy of the same behavior in `DeckCardList`.
+ *
+ * Usage:
+ *   const { hoverProps, clear, overlay } = useHoverPreview(enabled);
+ *   <div {...hoverProps(card)}> … </div>
+ *   {overlay}
+ */
+export function useHoverPreview(enabled: boolean) {
+  const [preview, setPreview] = React.useState<{ card: Card; x: number; y: number } | null>(null);
+  const clear = React.useCallback(() => setPreview(null), []);
+
+  // Drop a live preview the moment previews are switched off
+  React.useEffect(() => {
+    if (!enabled) setPreview(null);
+  }, [enabled]);
+
+  // Safety net: dismiss on any interaction that can hide or unmount the hovered
+  // element without dispatching its onMouseLeave (clicking opens a modal over
+  // the cursor, the tile re-renders, scrolling, switching tabs). Without this
+  // the preview can get stuck on screen until a refresh.
+  React.useEffect(() => {
+    if (!preview) return;
+    const dismiss = () => setPreview(null);
+    // pointerdown fires before any modal mounts or the tile unmounts
+    window.addEventListener("pointerdown", dismiss);
+    // capture: true so inner scroll containers are caught, not just window
+    window.addEventListener("scroll", dismiss, true);
+    window.addEventListener("blur", dismiss);
+    document.addEventListener("visibilitychange", dismiss);
+    return () => {
+      window.removeEventListener("pointerdown", dismiss);
+      window.removeEventListener("scroll", dismiss, true);
+      window.removeEventListener("blur", dismiss);
+      document.removeEventListener("visibilitychange", dismiss);
+    };
+  }, [preview]);
+
+  const hoverProps = React.useCallback(
+    (card: Card) =>
+      enabled
+        ? {
+            onMouseEnter: (e: React.MouseEvent<HTMLElement>) => {
+              setPreview({ card, ...calculatePreviewPosition(e.currentTarget) });
+            },
+            onMouseLeave: () => setPreview(null),
+          }
+        : {},
+    [enabled],
+  );
+
+  const overlay =
+    enabled && preview ? (
+      <div
+        className="fixed z-50 pointer-events-none"
+        style={{
+          left: `${preview.x}px`,
+          top: `${preview.y}px`,
+          maxWidth: `${PREVIEW_WIDTH}px`,
+        }}
+      >
+        <CardThumb
+          card={preview.card}
+          alt={preview.card.name}
+          className="rounded-lg shadow-2xl border-2 border-border"
+          style={{ maxHeight: `${PREVIEW_HEIGHT}px`, width: "auto" }}
+        />
+      </div>
+    ) : null;
+
+  return { hoverProps, clear, overlay };
+}


### PR DESCRIPTION
## What

The **Card Hover Preview** toggle now also previews cards in the search results on the left, not just cards in the deck panel on the right.

## Why it didn't already

The toggle's state lived inside `DeckBuilderPanel` (`useState` at what was line 576). The search grid is rendered inline by `client.tsx`, which is the *parent* of that panel — so it had no way to read the flag. This lifts the preference to `client.tsx` and passes it down as a controlled prop; the panel still owns the toggle UI and still force-disables previews for its mobile drawer instance.

## How

- New `useHoverPreview(enabled)` hook returning `{ hoverProps, clear, overlay }` — the anchored floating preview, with edge flip/clamp positioning and the safety net that dismisses on `pointerdown` / capture-phase `scroll` / `blur` / `visibilitychange` (without it the preview sticks on screen when a tile unmounts under the cursor or a modal opens over it).
- Search tiles spread `hoverProps(card)`; the overlay renders after the grid.
- Uses `CardThumb`, so Forge cards resolve through the builder-config seam instead of a 404'ing `<img src>`.
- Gated on `!isMobile` — hover is meaningless on touch.
- Cleared on `onDragStart`: the tile keeps mouse-over for the whole HTML5 drag, so the preview would otherwise trail the cursor to the deck panel.
- No new network cost — the hidden preloader already warms the raw blob URL for every visible search card, so the preview paints immediately instead of flashing a placeholder.

`DeckCardList` keeps its own inlined copy of this logic. Refactoring it onto the hook is a safe follow-up; left out to keep this diff to the feature.

## Verification

`tsc --noEmit` clean for the touched files (7 pre-existing errors remain, all in unrelated `__tests__` files).

Driven in a browser against the dev server at 1500×950:

1. Toggle on (default) → hovering a search tile shows the anchored preview; the tile's own `+`/`−`/menu buttons stay clickable through it (`pointer-events-none`).
2. Toggle off in the deck panel's **View options** → hovering a search tile shows nothing.
3. Toggle back on → deck-panel previews still work, confirming no regression from making that panel's state controlled.
4. Opening the View menu dismissed a live preview, exercising the `pointerdown` safety net.
5. Console clean throughout — only a pre-existing LCP image warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)