### PR TITLE
fix(play): send opponent's cards to their own reserve/discard/banish

### DIFF
--- a/spacetimedb/__tests__/cardOwnership.test.ts
+++ b/spacetimedb/__tests__/cardOwnership.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+// Lives outside spacetimedb/src (the module's tsconfig `include`) so its vitest
+// import is never pulled into `spacetime publish`; root vitest still runs it via
+// the **/__tests__/** glob.
+import { resolveDestinationOwnerId, resolveHomeOwnerId } from '../src/cardOwnership';
+
+const ME = 1n;
+const OPP = 2n;
+/** originalOwnerId sentinel for "this card has never changed hands". */
+const UNSET = 0n;
+
+describe('resolveDestinationOwnerId', () => {
+  describe('graveyard piles belong to the card owner', () => {
+    // The reported bug: peeking the top 3 of the OPPONENT's deck and
+    // right-click → Reserve put their card in MY reserve. A card leaving its
+    // owner's deck goes to that owner's pile — the actor never gains it.
+    it("sends an opponent's deck card to the opponent's reserve, not mine", () => {
+      expect(
+        resolveDestinationOwnerId({
+          ownerId: OPP,
+          originalOwnerId: UNSET,
+          fromZone: 'deck',
+          toZone: 'reserve',
+          actorId: ME,
+          targetOwnerId: null,
+        }),
+      ).toBe(OPP);
+    });
+
+    it.each(['discard', 'banish'])(
+      "sends an opponent's deck card to the opponent's %s",
+      (toZone) => {
+        expect(
+          resolveDestinationOwnerId({
+            ownerId: OPP,
+            originalOwnerId: UNSET,
+            fromZone: 'deck',
+            toZone,
+            actorId: ME,
+            targetOwnerId: null,
+          }),
+        ).toBe(OPP);
+      },
+    );
+
+    // Dragging an opponent's card onto my own reserve pile is still their card
+    // leaving play, so it goes home rather than defecting to my pile.
+    it("keeps an opponent's card home even when dropped on my reserve", () => {
+      expect(
+        resolveDestinationOwnerId({
+          ownerId: OPP,
+          originalOwnerId: UNSET,
+          fromZone: 'deck',
+          toZone: 'reserve',
+          actorId: ME,
+          targetOwnerId: ME,
+        }),
+      ).toBe(OPP);
+    });
+
+    it('sends my own deck card to my reserve', () => {
+      expect(
+        resolveDestinationOwnerId({
+          ownerId: ME,
+          originalOwnerId: UNSET,
+          fromZone: 'deck',
+          toZone: 'reserve',
+          actorId: ME,
+          targetOwnerId: null,
+        }),
+      ).toBe(ME);
+    });
+
+    // A captured hero sitting in my territory still banishes to its real
+    // owner's pile.
+    it('returns a captured card to its original owner when it leaves play', () => {
+      expect(
+        resolveDestinationOwnerId({
+          ownerId: ME,
+          originalOwnerId: OPP,
+          fromZone: 'territory',
+          toZone: 'banish',
+          actorId: ME,
+          targetOwnerId: null,
+        }),
+      ).toBe(OPP);
+    });
+  });
+
+  describe('taking from an opponent hidden zone', () => {
+    // The "taking" exception survives for hand — that is what makes cards like
+    // "take the top card of the opponent's deck into your hand" work.
+    it("takes the opponent's top deck card into my hand", () => {
+      expect(
+        resolveDestinationOwnerId({
+          ownerId: OPP,
+          originalOwnerId: UNSET,
+          fromZone: 'deck',
+          toZone: 'hand',
+          actorId: ME,
+          targetOwnerId: null,
+        }),
+      ).toBe(ME);
+    });
+
+    it('honors an explicit drop on the opponent hand (giving a card away)', () => {
+      expect(
+        resolveDestinationOwnerId({
+          ownerId: ME,
+          originalOwnerId: UNSET,
+          fromZone: 'hand',
+          toZone: 'hand',
+          actorId: ME,
+          targetOwnerId: OPP,
+        }),
+      ).toBe(OPP);
+    });
+  });
+
+  describe('explicit drops and shared zones', () => {
+    it('honors an explicit Land of Bondage drop over home routing', () => {
+      expect(
+        resolveDestinationOwnerId({
+          ownerId: OPP,
+          originalOwnerId: UNSET,
+          fromZone: 'territory',
+          toZone: 'land-of-bondage',
+          actorId: ME,
+          targetOwnerId: ME,
+        }),
+      ).toBe(ME);
+    });
+
+    it('keeps the current owner when moving within shared table zones', () => {
+      expect(
+        resolveDestinationOwnerId({
+          ownerId: OPP,
+          originalOwnerId: UNSET,
+          fromZone: 'territory',
+          toZone: 'battle',
+          actorId: ME,
+          targetOwnerId: null,
+        }),
+      ).toBe(OPP);
+    });
+  });
+});
+
+describe('resolveHomeOwnerId', () => {
+  it('routes a card taken from an opponent hidden zone to the actor', () => {
+    expect(
+      resolveHomeOwnerId({
+        ownerId: OPP,
+        originalOwnerId: UNSET,
+        fromZone: 'deck',
+        toZone: 'hand',
+        actorId: ME,
+        targetOwnerId: null,
+      }),
+    ).toBe(ME);
+  });
+
+  it('routes a card leaving a public zone to its true owner', () => {
+    expect(
+      resolveHomeOwnerId({
+        ownerId: ME,
+        originalOwnerId: OPP,
+        fromZone: 'territory',
+        toZone: 'discard',
+        actorId: ME,
+        targetOwnerId: null,
+      }),
+    ).toBe(OPP);
+  });
+});

--- a/spacetimedb/src/cardOwnership.ts
+++ b/spacetimedb/src/cardOwnership.ts
@@ -1,0 +1,90 @@
+// Pure card-ownership routing. No SpacetimeDB runtime imports so this can be
+// unit tested in isolation (see __tests__/cardOwnership.test.ts) and shared by
+// move_card and move_cards_batch in index.ts, which previously carried two
+// hand-maintained copies of the same decision chain.
+
+// Home zones = private per-player piles. Every other zone (territory, battle,
+// land-of-redemption, soul-deck) is shared table space.
+export const HOME_ZONES: string[] = ['deck', 'discard', 'reserve', 'banish', 'hand', 'land-of-bondage'];
+
+// The subset of home zones whose contents the opponent cannot see.
+export const HIDDEN_HOME_ZONES: string[] = ['deck', 'discard', 'reserve', 'banish', 'hand'];
+
+// Piles a card falls into when it leaves play. These always belong to the
+// card's true owner — you can never send a card into someone else's pile.
+export const GRAVEYARD_PILE_ZONES: string[] = ['discard', 'reserve', 'banish'];
+
+export interface OwnerRouting {
+  /** Current owner of the card. 0n is the shared (Paragon soul) sentinel. */
+  ownerId: bigint;
+  /** Owner the card was dealt to; 0n when it has never changed hands. */
+  originalOwnerId: bigint;
+  /** Zone the card is leaving. */
+  fromZone: string;
+  /** Zone the card is entering. */
+  toZone: string;
+  /** Seat that invoked the reducer. */
+  actorId: bigint;
+  /** Seat whose zone the card was explicitly dropped on; null for a non-drop move. */
+  targetOwnerId: bigint | null;
+}
+
+/**
+ * The card's real owner — the seat its piles belong to. A captured card keeps
+ * originalOwnerId pointing at the seat that brought it to the table, so it
+ * finds its way home when it leaves play.
+ */
+export function resolveTrueHomeOwnerId(
+  card: Pick<OwnerRouting, 'ownerId' | 'originalOwnerId'>,
+): bigint {
+  return card.originalOwnerId !== 0n ? card.originalOwnerId : card.ownerId;
+}
+
+/**
+ * Owner for a card landing in a private pile.
+ *
+ * Normally the card's true owner. Narrow exception: when the actor pulls a card
+ * OUT of an opponent's hidden pile (their deck/hand/reserve/banish/discard)
+ * without naming a target seat, treat it as *taking* — route to the actor. That
+ * exception is what makes "take the top card of the opponent's deck into your
+ * hand" work. It deliberately does NOT apply to graveyard piles; see
+ * resolveDestinationOwnerId.
+ */
+export function resolveHomeOwnerId(card: OwnerRouting): bigint {
+  const trueHome = resolveTrueHomeOwnerId(card);
+  const isTakingFromOpponentHiddenZone =
+    HIDDEN_HOME_ZONES.includes(card.fromZone) && card.ownerId !== card.actorId;
+  return isTakingFromOpponentHiddenZone ? card.actorId : trueHome;
+}
+
+/**
+ * Which seat owns the card once it arrives in `toZone`.
+ *
+ * Rules, in priority order:
+ *  1. An explicit drop on a seat's Land of Bondage or hand is unambiguous user
+ *     intent ("take into my hand" / "give to the opponent") and always wins.
+ *  2. Graveyard piles (discard / reserve / banish) always belong to the card's
+ *     true owner, whoever moved it and wherever it came from.
+ *  3. Other home zones route home, honoring an explicit drop on the other seat.
+ *  4. Shared table zones keep the current owner unless a target seat is named.
+ */
+export function resolveDestinationOwnerId(card: OwnerRouting): bigint {
+  const { toZone, actorId, targetOwnerId } = card;
+  const trueHome = resolveTrueHomeOwnerId(card);
+
+  const isExplicitLobDrop = toZone === 'land-of-bondage' && targetOwnerId !== null;
+  const isExplicitHandDrop = toZone === 'hand' && targetOwnerId !== null;
+  if (isExplicitLobDrop || isExplicitHandDrop) return targetOwnerId as bigint;
+
+  // Unconditionally the true owner — deliberately NOT resolveHomeOwnerId. A
+  // card leaving play was never *taken*, so pulling the opponent's card out of
+  // their deck/hand and reserving, discarding, or banishing it fills THEIR pile.
+  if (GRAVEYARD_PILE_ZONES.includes(toZone)) return trueHome;
+
+  if (HOME_ZONES.includes(toZone)) {
+    const droppedOnOwnZone = targetOwnerId === null || targetOwnerId === actorId;
+    return droppedOnOwnZone ? resolveHomeOwnerId(card) : targetOwnerId;
+  }
+
+  return targetOwnerId !== null ? targetOwnerId : card.ownerId;
+}

--- a/spacetimedb/src/index.ts
+++ b/spacetimedb/src/index.ts
@@ -6,6 +6,7 @@ import { ScheduleAt, Timestamp } from 'spacetimedb';
 import { makeSeed, seededShuffle, seededDiceRoll, xorshift64, generateGameCode } from './utils';
 import { isLeavingPlayField } from './playField';
 import { makeFreeSpotAllocator } from './battlePlacement';
+import { resolveDestinationOwnerId, resolveHomeOwnerId, type OwnerRouting } from './cardOwnership';
 import {
   getAbilitiesForCard,
   getEffectiveAbilities,
@@ -3010,24 +3011,18 @@ export const move_card = spacetimedb.reducer(
       return;
     }
 
-    // Home zones = private per-player piles. The "home" owner is the card's
-    // true owner (originalOwnerId, falling back to current ownerId) — a
-    // captured opponent card (e.g. a captured hero) returns to the opponent's
-    // pile when banished/discarded, and an opponent's in-play card banished
-    // by the actor goes to the opponent's banish pile.
-    //
-    // Narrow exception: when the actor pulls a card OUT of an opponent's
-    // hidden home pile (their deck/hand/reserve/banish/discard) without an
-    // explicit targetOwnerId, treat it as *taking* — route to the actor's
-    // pile. Public in-play zones (territory / land-of-redemption /
-    // land-of-bondage) never trigger this, so banishing an opponent's
-    // territory card sends it to the opponent's banish pile.
-    const HOME_ZONES = ['deck', 'discard', 'reserve', 'banish', 'hand', 'land-of-bondage'];
-    const HIDDEN_HOME_ZONES = ['deck', 'discard', 'reserve', 'banish', 'hand'];
-    const trueHomeOwnerId = card.originalOwnerId !== 0n ? card.originalOwnerId : card.ownerId;
-    const isTakingFromOpponentHiddenZone =
-      HIDDEN_HOME_ZONES.includes(fromZone) && card.ownerId !== player.id;
-    const homeOwnerId = isTakingFromOpponentHiddenZone ? player.id : trueHomeOwnerId;
+    // Destination ownership — see cardOwnership.ts for the full rule set. In
+    // short: graveyard piles always belong to the card's true owner, other home
+    // zones route home (with an explicit drop on the other seat honored), and
+    // shared table zones keep the current owner.
+    const ownerRouting: OwnerRouting = {
+      ownerId: card.ownerId,
+      originalOwnerId: card.originalOwnerId,
+      fromZone,
+      toZone,
+      actorId: player.id,
+      targetOwnerId: targetOwnerId ? BigInt(targetOwnerId) : null,
+    };
 
     // Lost souls sent to discard or reserve go to land-of-bondage instead
     const isLostSoul = card.cardType === 'LS' || card.cardName.toLowerCase().includes('lost soul');
@@ -3072,47 +3067,7 @@ export const move_card = spacetimedb.reducer(
     // Moving to deck/soul-deck = face-down; leaving deck, reserve, or soul-deck = face-up; otherwise preserve
     const isFlipped = (toZone === 'deck' || toZone === 'soul-deck') ? true : (fromZone === 'deck' || fromZone === 'reserve' || fromZone === 'soul-deck') ? false : card.isFlipped;
     // Optionally transfer ownership (e.g. rescue lost soul, capture hero).
-    // For private home zones, route to the original owner so opponent-owned
-    // cards return to their real owner's piles even when the actor dropped
-    // them on their own zone (e.g. banishing a captured opponent card on my
-    // banish pile sends it to the opponent's banish). An explicit drop on
-    // someone else's zone (targetOwnerId ≠ actor) still wins, so "give to
-    // opponent's hand" works as intended.
-    // Explicit LoB drops are unambiguous user intent — the player dragged the
-    // card onto a specific seat's LoB. Honor targetOwnerId without applying
-    // home-routing, which would otherwise redirect opponent-owned cards back
-    // to the opponent's LoB even when the user dropped on their own.
-    // Hand is the same: a drag onto a specific seat's hand is "take into my
-    // hand" or "give to opponent's hand" — never "send the captured card back
-    // to its original owner's hand".
-    const isExplicitLobDrop =
-      toZone === 'land-of-bondage' && !!targetOwnerId;
-    const isExplicitHandDrop =
-      toZone === 'hand' && !!targetOwnerId;
-
-    // Graveyard-style piles (discard / reserve / banish) always belong to the
-    // card's true owner — you can't send a card you gave or lent to the
-    // opponent into *their* pile. An explicit drop on a specific seat's pile is
-    // honored only when that seat is the card's true owner (returning a captured
-    // card, or discarding the opponent's own deck card); otherwise the card
-    // returns home. The "taking from an opponent's hidden zone" case is
-    // preserved through homeOwnerId.
-    const GRAVEYARD_PILE_ZONES = ['discard', 'reserve', 'banish'];
-    let newOwnerId: bigint;
-    if (isExplicitLobDrop || isExplicitHandDrop) {
-      newOwnerId = BigInt(targetOwnerId);
-    } else if (GRAVEYARD_PILE_ZONES.includes(toZone)) {
-      newOwnerId = (targetOwnerId && BigInt(targetOwnerId) === trueHomeOwnerId)
-        ? trueHomeOwnerId
-        : homeOwnerId;
-    } else if (HOME_ZONES.includes(toZone)) {
-      const droppedOnOwnZone = !targetOwnerId || BigInt(targetOwnerId) === player.id;
-      newOwnerId = droppedOnOwnZone ? homeOwnerId : BigInt(targetOwnerId);
-    } else if (targetOwnerId) {
-      newOwnerId = BigInt(targetOwnerId);
-    } else {
-      newOwnerId = card.ownerId;
-    }
+    let newOwnerId: bigint = resolveDestinationOwnerId(ownerRouting);
     // Paragon: dropping a soul-origin card back into the shared LoB resets ownership to the shared sentinel.
     if (
       targetOwnerId === '0' &&
@@ -3541,22 +3496,16 @@ export const move_cards_batch = spacetimedb.reducer(
         }
       }
 
-      // Home zones = private per-player piles. The "home" owner is the card's
-      // true owner (originalOwnerId, falling back to current ownerId) — a
-      // captured opponent card returns to the opponent's pile when banished/
-      // discarded, and an opponent's in-play card banished by the actor goes
-      // to the opponent's banish pile.
-      //
-      // Narrow exception: when the actor pulls a card OUT of an opponent's
-      // hidden home pile (their deck/hand/reserve/banish/discard) without an
-      // explicit targetOwnerId, treat it as *taking* — route to the actor's
-      // pile. See parallel comment in move_card.
-      const HOME_ZONES = ['deck', 'discard', 'reserve', 'banish', 'hand', 'land-of-bondage'];
-      const HIDDEN_HOME_ZONES = ['deck', 'discard', 'reserve', 'banish', 'hand'];
-      const trueHomeOwnerId = card.originalOwnerId !== 0n ? card.originalOwnerId : card.ownerId;
-      const isTakingFromOpponentHiddenZone =
-        HIDDEN_HOME_ZONES.includes(card.zone) && card.ownerId !== player.id;
-      const homeOwnerId = isTakingFromOpponentHiddenZone ? player.id : trueHomeOwnerId;
+      // Destination ownership — shared with move_card, see cardOwnership.ts.
+      const ownerRouting: OwnerRouting = {
+        ownerId: card.ownerId,
+        originalOwnerId: card.originalOwnerId,
+        fromZone: card.zone,
+        toZone,
+        actorId: player.id,
+        targetOwnerId: newOwnerId,
+      };
+      const homeOwnerId = resolveHomeOwnerId(ownerRouting);
 
       // Lost souls sent to discard or reserve go to land-of-bondage instead.
       // Tokens are exempt — a token Lost Soul dragged to a removal zone is
@@ -3633,36 +3582,8 @@ export const move_cards_batch = spacetimedb.reducer(
       const rawPos = posMap[idStr] || { posX: '', posY: '' };
       // Ensure posX/posY are strings — client may send numbers via JSON positions map
       const pos = { posX: String(rawPos.posX ?? ''), posY: String(rawPos.posY ?? '') };
-      // Same home-zone routing rule as the single move_card reducer: a drop on
-      // the actor's own home pile sends captured cards to their original
-      // owner's pile. Explicit drops on someone else's zone (newOwnerId set
-      // and not the actor) still win.
-      // Explicit LoB drop: honor the target seat (mirror of move_card). The
-      // user dragged the card onto a specific player's LoB, so home-routing
-      // shouldn't override that choice. Hand follows the same rule — a drag
-      // onto a specific seat's hand is "take" or "give", never "return to
-      // original owner".
-      const isExplicitLobDrop =
-        toZone === 'land-of-bondage' && newOwnerId !== null;
-      const isExplicitHandDrop =
-        toZone === 'hand' && newOwnerId !== null;
-      // Graveyard-style piles (discard / reserve / banish) always return to the
-      // card's true owner — mirror of the move_card rule. An explicit drop on a
-      // seat's pile only wins when that seat is the card's true owner.
-      const GRAVEYARD_PILE_ZONES = ['discard', 'reserve', 'banish'];
-      let cardOwnerId: bigint;
-      if (isExplicitLobDrop || isExplicitHandDrop) {
-        cardOwnerId = newOwnerId!;
-      } else if (GRAVEYARD_PILE_ZONES.includes(toZone)) {
-        cardOwnerId = (newOwnerId !== null && newOwnerId === trueHomeOwnerId)
-          ? trueHomeOwnerId
-          : homeOwnerId;
-      } else if (HOME_ZONES.includes(toZone)) {
-        const droppedOnOwnZone = newOwnerId === null || newOwnerId === player.id;
-        cardOwnerId = droppedOnOwnZone ? homeOwnerId : newOwnerId;
-      } else {
-        cardOwnerId = newOwnerId ?? card.ownerId;
-      }
+      // Same routing rule as the single move_card reducer.
+      const cardOwnerId: bigint = resolveDestinationOwnerId(ownerRouting);
       const cardFinalZone = finalZoneById.get(idStr) ?? toZone;
       // Paragon: rescuing a shared soul transfers ownership. Default to the
       // acting seat, but honor an explicit targetOwnerId when the caller


### PR DESCRIPTION
## The bug

In online mode, looking at the top 3 cards of the **opponent's** deck and then right-click → **Reserve** sent the card to **my** reserve instead of theirs.

## Root cause

Two rules in `move_card` contradicted each other:

1. **The "taking" exception** — pulling a card out of an opponent's *hidden* zone (deck / hand / reserve / banish / discard) with no explicit target seat routes it to the actor. This is what makes *"take the top card of the opponent's deck into your hand"* work.
2. **"Graveyard piles belong to the true owner"** — discard / reserve / banish always go home.

Rule 2's implementation fell back to the taking-aware owner, so rule 1 silently won. Reserving an opponent's deck card matched the taking path exactly — hidden source zone, not your card, no target seat — and read as *taking* it.

The same file already showed the intended behavior: the Lost Soul redirect a few lines above deliberately opts out of the taking rule (*"a Lost Soul is never actually taken"*), and `move_card_to_top_of_deck` never applied it. Regular cards heading to a graveyard pile were the gap.

## The fix

Graveyard piles now route **unconditionally** to the card's true owner. A card leaving play was never taken, so it fills its owner's pile no matter who moved it or where they dropped it.

The rule lived in two hand-maintained copies in `move_card` and `move_cards_batch` — which is how they drifted apart — so it's extracted into `spacetimedb/src/cardOwnership.ts` and both reducers now share it. That also fixes the batch path (multi-select / drag), which carried the identical bug.

**Preserved unchanged**, each covered by a test:
- Taking an opponent's deck card into your hand
- Giving a card to the opponent's hand
- Explicit Land of Bondage drops
- Captured cards returning to their real owner when banished
- Paragon shared-soul ownership

## Verification

The rule was extracted **with the bug intact** first, then tested: the 4 graveyard cases failed (returning `1n`/me instead of `2n`/opponent) while the other 8 passed — pinning the defect to that one branch rather than to the extraction. After the fix, all 12 pass.

- `spacetimedb/__tests__/cardOwnership.test.ts` — 12 tests, all pass
- `npx tsc --noEmit` on the module — clean
- Full suite — 1757 pass. The one failure (`__tests__/forge-lackey.test.ts`, brigade parsing of `"Red"`) is **pre-existing on `main`** and unrelated; confirmed by re-running it with this change stashed.

## Deploying

Server-side only, so it needs a republish to take effect in game:

```bash
spacetime publish <db-name> --module-path spacetimedb
```

No `spacetime generate` needed — the reducer signatures didn't change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
