### PR TITLE
fix(results): render the tournament results index on demand

### DIFF
--- a/app/tournaments/results/page.tsx
+++ b/app/tournaments/results/page.tsx
@@ -8,6 +8,13 @@ export const metadata = {
   description: "Browse published standings and decklists from past Redemption CCG tournaments.",
 };
 
+// Nothing on this page reads cookies or headers — TopNav/SponsorFooter are
+// client components and the index query uses the service-role client — so Next
+// prerenders it at build time and never regenerates. That froze the list to
+// whatever was published at the last deploy; newly published events only showed
+// on their own /results/[id] page (a dynamic segment) and never in the index.
+export const dynamic = "force-dynamic";
+
 function formatEndedAt(endedAt: string | null): string | null {
   if (!endedAt) return null;
   return new Date(endedAt).toLocaleDateString("en-US", {


### PR DESCRIPTION
## Problem

Published tournaments weren't showing up on [/tournaments/results](https://redemptionccg.app/tournaments/results). Three tournaments currently have `results_published = true` in prod, but the index rendered only one — the oldest.

The data was fine. `/tournaments/results` was being served as build-time static HTML:

```
$ curl -sI https://redemptionccg.app/tournaments/results
x-nextjs-prerender: 1
x-vercel-cache: HIT
age: 397
```

Nothing on the page opts it out of static rendering — `TopNav` and `SponsorFooter` are `"use client"`, and `loadPublicResultsIndexAction` uses the service-role admin client (env vars only, no `cookies()`/`headers()`). With no `revalidate` either, Next prerenders it at deploy time and never regenerates it. The list was frozen to whatever had been published at the last deploy.

`/tournaments/results/[id]` was unaffected — it's a dynamic segment with no `generateStaticParams`, so it renders per request (`x-vercel-cache: MISS`, `no-store`). That's why a newly published event was reachable at its own URL but invisible in the index.

`/tournaments` and `/decklist/community` were already dynamic; this is the only affected public page.

## Fix

`export const dynamic = "force-dynamic"` on the index page, with a comment explaining why it's needed so it doesn't get "cleaned up" later.

`force-dynamic` rather than `revalidate = 60` because the page exists specifically to reflect just-published events — with ISR the first visitor after a publish still sees a stale list. It's two cheap Supabase queries.

## Verification

`npm run build` succeeds, and the route table confirms the change:

```
before:  ○ /tournaments/results          (Static)
after:   ƒ /tournaments/results          (Dynamic)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)