### PR TITLE
chore(ui): drop the Hide 100-Card filter, move Spoilers right of Decks

### DIFF
--- a/app/decklist/actions.ts
+++ b/app/decklist/actions.ts
@@ -1289,7 +1289,6 @@ export interface LoadPublicDecksParams {
   tagIds?: string[];
   cardNames?: string[];
   tournamentOnly?: boolean;
-  excludeFullSize?: boolean;
 }
 
 export async function loadPublicDecksAction(params: LoadPublicDecksParams = {}) {
@@ -1305,7 +1304,6 @@ export async function loadPublicDecksAction(params: LoadPublicDecksParams = {}) 
       tagIds,
       cardNames,
       tournamentOnly,
-      excludeFullSize,
     } = params;
 
     const offset = (page - 1) * pageSize;
@@ -1387,10 +1385,6 @@ export async function loadPublicDecksAction(params: LoadPublicDecksParams = {}) 
       if (filter.kind === "or") query = query.or(filter.clause);
       else if (filter.kind === "in") query = query.in("format", filter.values);
       else query = query.eq("format", filter.value);
-    }
-
-    if (excludeFullSize) {
-      query = query.lt("card_count", 100);
     }
 
     // Filter by exact username (e.g. clicking a username link)

--- a/app/decklist/community/client.tsx
+++ b/app/decklist/community/client.tsx
@@ -118,8 +118,7 @@ export default function CommunityClient({ initialDecks, initialCount, currentUse
     searchParams.get("page") ||
     searchParams.get("tags") ||
     searchParams.getAll("card").length > 0 ||
-    searchParams.get("tournament") ||
-    searchParams.get("hide100")
+    searchParams.get("tournament")
   );
 
   const [decks, setDecks] = useState<PublicDeck[]>(hasInitialFilters ? [] : initialDecks);
@@ -139,7 +138,6 @@ export default function CommunityClient({ initialDecks, initialCount, currentUse
   const [search, setSearch] = useState(searchParams.get("q") || "");
   const [searchInput, setSearchInput] = useState(searchParams.get("q") || "");
   const [usernameFilter, setUsernameFilter] = useState(initialUsername);
-  const [excludeFullSize, setExcludeFullSize] = useState(searchParams.get("hide100") === "1");
   const [tournamentOnly, setTournamentOnly] = useState(searchParams.get("tournament") === "1");
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>(() => {
     const t = searchParams.get("tags");
@@ -228,7 +226,6 @@ export default function CommunityClient({ initialDecks, initialCount, currentUse
       tagIds: selectedTagIds.length > 0 ? selectedTagIds : undefined,
       cardNames: cardFilters.length > 0 ? cardFilters : undefined,
       tournamentOnly: tournamentOnly || undefined,
-      excludeFullSize: excludeFullSize || undefined,
     };
     const result = await loadPublicDecksAction(params);
     if (result.success) {
@@ -236,7 +233,7 @@ export default function CommunityClient({ initialDecks, initialCount, currentUse
       setTotalCount(result.totalCount);
     }
     setLoading(false);
-  }, [page, sort, format, search, usernameFilter, selectedTagIds, cardFilters, tournamentOnly, excludeFullSize]);
+  }, [page, sort, format, search, usernameFilter, selectedTagIds, cardFilters, tournamentOnly]);
 
   useEffect(() => {
     // Skip the initial fetch if we already have server-provided data (no URL filters)
@@ -257,14 +254,13 @@ export default function CommunityClient({ initialDecks, initialCount, currentUse
     if (selectedTagIds.length > 0) qs.set("tags", selectedTagIds.join(","));
     for (const name of cardFilters) qs.append("card", name);
     if (tournamentOnly) qs.set("tournament", "1");
-    if (excludeFullSize) qs.set("hide100", "1");
     if (usernameFilter) qs.set("username", usernameFilter);
     if (page > 1) qs.set("page", String(page));
     const next = qs.toString();
     if (next !== searchParams.toString()) {
       router.replace(next ? `/decklist/community?${next}` : "/decklist/community", { scroll: false });
     }
-  }, [search, format, sort, selectedTagIds, cardFilters, tournamentOnly, excludeFullSize, usernameFilter, page, router, searchParams]);
+  }, [search, format, sort, selectedTagIds, cardFilters, tournamentOnly, usernameFilter, page, router, searchParams]);
 
   // Reset to page 1 when filters change
   function handleSortChange(newSort: typeof sort) {
@@ -369,21 +365,6 @@ export default function CommunityClient({ initialDecks, initialCount, currentUse
             <option value="most_viewed">Most Viewed</option>
             <option value="name">Name A-Z</option>
           </select>
-
-          {/* Exclude 100-card decks toggle */}
-          <button
-            onClick={() => { setExcludeFullSize((v) => !v); setPage(1); }}
-            className={`flex items-center gap-1.5 px-3 py-2 border rounded-lg text-sm transition-colors ${
-              excludeFullSize
-                ? "border-red-500 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300"
-                : "border-border bg-card text-foreground hover:bg-muted"
-            }`}
-          >
-            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
-            </svg>
-            Hide 100-Card
-          </button>
 
           {/* Tournament-only toggle — hidden until any tournament has published decklists */}
           {showTournamentFilter && (

--- a/components/top-nav.tsx
+++ b/components/top-nav.tsx
@@ -394,8 +394,8 @@ const TopNav: React.FC = () => {
               )}
             </div>
 
-            {/* Rest of nav links (Play is rendered separately above, so exclude it) */}
-            {navLinks.filter((link) => !link.highlight && link.href !== "/play").map((link) => {
+            {/* Rest of nav links (Play and Spoilers are rendered separately, so exclude them) */}
+            {navLinks.filter((link) => !link.highlight && link.href !== "/play" && link.href !== "/spoilers").map((link) => {
               if (link.authRequired && !user) return null;
               const Icon = link.icon;
               const isHighlight = link.highlight;
@@ -465,6 +465,19 @@ const TopNav: React.FC = () => {
                 </div>
               )}
             </div>
+
+            {/* Spoilers link - after Decks */}
+            <Link
+              href="/spoilers"
+              className={`flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-colors
+                ${isActive('/spoilers')
+                ? 'bg-muted text-foreground'
+                : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                }`}
+            >
+              <HiSparkles className="w-4 h-4" />
+              Spoilers
+            </Link>
 
             {/* Resources Dropdown */}
             <div className="relative">
@@ -787,30 +800,6 @@ const TopNav: React.FC = () => {
               )}
             </div>
 
-            {/* Rest of nav links */}
-            {navLinks.slice(2).map((link) => {
-              if (link.authRequired && !user) return null;
-              const Icon = link.icon;
-              const isHighlight = link.highlight;
-              return (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  onClick={closeMobileMenu}
-                  className={`flex items-center gap-3 px-3 py-2 rounded-md text-base font-medium transition-colors
-                    ${isHighlight
-                      ? 'border-2 border-primary text-primary hover:bg-primary/10'
-                      : isActive(link.href)
-                      ? 'bg-muted text-foreground'
-                      : 'text-muted-foreground hover:bg-muted'
-                    }`}
-                >
-                  <Icon className="w-5 h-5" />
-                  {link.label}
-                </Link>
-              );
-            })}
-
             {/* Mobile Decks Section */}
             <div className="pt-2">
               <button
@@ -855,6 +844,30 @@ const TopNav: React.FC = () => {
                 </div>
               )}
             </div>
+
+            {/* Rest of nav links (Spoilers) - after Decks */}
+            {navLinks.slice(2).map((link) => {
+              if (link.authRequired && !user) return null;
+              const Icon = link.icon;
+              const isHighlight = link.highlight;
+              return (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  onClick={closeMobileMenu}
+                  className={`flex items-center gap-3 px-3 py-2 rounded-md text-base font-medium transition-colors
+                    ${isHighlight
+                      ? 'border-2 border-primary text-primary hover:bg-primary/10'
+                      : isActive(link.href)
+                      ? 'bg-muted text-foreground'
+                      : 'text-muted-foreground hover:bg-muted'
+                    }`}
+                >
+                  <Icon className="w-5 h-5" />
+                  {link.label}
+                </Link>
+              );
+            })}
 
             {/* Mobile Resources Section */}
             <div className="pt-2">


### PR DESCRIPTION
## What

- **Community Decks:** removed the **Hide 100-Card** toggle from the filter row. The `hide100` URL param and the now-orphaned `excludeFullSize` server filter in `loadPublicDecksAction` go with it — nothing else referenced them.
- **Top nav:** **Spoilers** now sits immediately to the right of the **Decks** dropdown (previously it was left of Deck Builder/Decks). Mirrored in the mobile menu so Spoilers appears after the Decks section there too.

Nav order is now: Admin · Play · Tournaments · Deck Builder · Decks · Spoilers · Resources.

## Verification

- `npx tsc --noEmit` — no errors in the three changed files (pre-existing test-file errors on `main` are unchanged).
- Ran the dev server and loaded `/decklist/community`: filter row is Format / Sort / Tags / Cards with no Hide 100-Card button, deck list still loads (366 decks), and the nav renders Deck Builder → Decks → Spoilers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)