### PR TITLE
fix(standings): rank by head-to-head before differential everywhere

### DIFF
--- a/components/ui/InfoHint.tsx
+++ b/components/ui/InfoHint.tsx
@@ -5,7 +5,7 @@ import { HelpCircle } from "lucide-react";
 export const MP_HINT =
   "Match Points (MP) — points earned from wins, ties, and byes. The primary metric for ranking players.";
 export const DIFF_HINT =
-  "Differential (Diff) — cumulative lost-soul-score margin. Used to break ties between players with equal match points.";
+  "Differential (Diff) — cumulative lost-soul-score margin. Breaks ties between players with equal match points when head-to-head doesn't settle it.";
 
 /** Round-scoped variants for the Rounds tab, where the columns show what was
  * earned in THIS round only — not the running total. The Standings tab is the

--- a/components/ui/StandingsTable.tsx
+++ b/components/ui/StandingsTable.tsx
@@ -8,6 +8,9 @@ import {
   gameScoreForMatch,
   differentialForMatch,
 } from "../../lib/tournament/standingsScoring";
+import { orderByTiebreakers } from "../../lib/tournament/standings";
+import type { Tiebreak } from "../../lib/tournament/types";
+import { printFinalStandings } from "../../utils/printUtils";
 
 interface Participant {
   id: string;
@@ -48,9 +51,11 @@ interface StandingsTableProps {
   currentRound?: number | null;
 }
 
-interface StandingRow {
+export interface StandingRow {
   participant: Participant;
-  rank: number;
+  /** 1-indexed placing. Players a tiebreaker cannot separate share a place,
+   * and the next place skips ahead by the size of the tie. */
+  place: number;
   wins: number;
   losses: number;
   ties: number;
@@ -60,6 +65,8 @@ interface StandingRow {
   mp: number;
   /** Differential computed LIVE from matches (mirrors stored differential). */
   diff: number;
+  /** Which tiebreaker settled this placing, and against whom. */
+  tiebreak: Tiebreak;
 }
 
 /** Default tournament win threshold; only used when max_score isn't supplied
@@ -104,15 +111,11 @@ function computeRecord(
 }
 
 /**
- * Direct head-to-head between two participants (across all matches in the
- * tournament, not just within a tier). Used as the final tiebreaker after MP
- * and differential: if A beat B head-to-head, A ranks above B.
+ * Did `aId` defeat `bId`? True when a won more of their matches than b did —
+ * a pair normally meets at most once, but the rematch fallback can pair them
+ * twice in a small field.
  */
-function directHeadToHead(
-  aId: string,
-  bId: string,
-  matches: MatchRow[],
-): number {
+function beatHeadToHead(aId: string, bId: string, matches: MatchRow[]): boolean {
   let aWins = 0;
   let bWins = 0;
   for (const m of matches) {
@@ -125,14 +128,14 @@ function directHeadToHead(
     if (m.winner_id === aId) aWins++;
     else if (m.winner_id === bId) bWins++;
   }
-  return aWins - bWins;
+  return aWins > bWins;
 }
 
 /**
- * Build sorted standings rows. Sort order:
- *   1. MP desc
- *   2. Differential desc
- *   3. Direct head-to-head (A beat B → A ranks higher)
+ * Build sorted standings rows. Ordering is delegated to
+ * `orderByTiebreakers` so this tab ranks players exactly the way the
+ * published placings do: MP desc, then head-to-head, then differential, with
+ * shared places for players nothing separates.
  *
  * The Byes column shown in the UI reports how many byes each player has been
  * awarded in completed rounds (each counts as a win in the W-L-T record).
@@ -194,31 +197,172 @@ export function buildStandings(
     active.map((p) => [p.id, liveTotals(p.id)]),
   );
 
-  const sorted = [...active].sort((a, b) => {
-    const at = totals.get(a.id)!;
-    const bt = totals.get(b.id)!;
-    const mp = bt.mp - at.mp;
-    if (mp !== 0) return mp;
-    const diff = bt.diff - at.diff;
-    if (diff !== 0) return diff;
-    // Both tied on MP and differential — apply direct head-to-head.
-    return directHeadToHead(b.id, a.id, matches);
-  });
-  return sorted.map((p, idx) => {
+  const ranked = orderByTiebreakers(
+    active.map((p) => {
+      const t = totals.get(p.id)!;
+      return {
+        id: p.id,
+        gameScore: t.mp,
+        lostSoulScore: t.diff,
+        participant: p,
+      };
+    }),
+    (a, b) => beatHeadToHead(a, b, matches),
+  );
+
+  return ranked.map((entry) => {
+    const p = entry.row.participant;
     const record = computeRecord(p.id, matches, playedByes);
     const byeCount = playedByes.filter((b) => b.participant_id === p.id).length;
     const t = totals.get(p.id)!;
     return {
       participant: p,
-      rank: idx + 1,
+      place: entry.place,
       wins: record.wins,
       losses: record.losses,
       ties: record.ties,
       byes: byeCount,
       mp: t.mp,
       diff: t.diff,
+      tiebreak: entry.tiebreak,
     };
   });
+}
+
+/** Everything `buildStandings` needs beyond the participant roster. */
+async function fetchStandingsInputs(tournamentId: string): Promise<{
+  matches: MatchRow[];
+  byes: ByeRow[];
+  startedRounds: number[];
+  maxScore: number;
+}> {
+  const client = createClient();
+  const [matchesRes, byesRes, roundsRes, tournamentRes] = await Promise.all([
+    client
+      .from("matches")
+      .select(
+        "id, round, player1_id, player2_id, player1_score, player2_score, winner_id, is_tie",
+      )
+      .eq("tournament_id", tournamentId),
+    client
+      .from("byes")
+      .select("participant_id, round_number")
+      .eq("tournament_id", tournamentId),
+    // Started rounds gate which byes count — a bye only scores once its
+    // round has actually started (Option C), matching the server recompute.
+    client
+      .from("rounds")
+      .select("round_number, started_at")
+      .eq("tournament_id", tournamentId),
+    // max_score is the win threshold ("full win") used by the live MP
+    // formula — same value migration 039 reads from tournaments.max_score.
+    client
+      .from("tournaments")
+      .select("max_score")
+      .eq("id", tournamentId)
+      .single(),
+  ]);
+  const ms = (tournamentRes.data as any)?.max_score;
+  return {
+    matches: (matchesRes.data ?? []) as MatchRow[],
+    byes: (byesRes.data ?? []) as ByeRow[],
+    startedRounds: (roundsRes.data ?? [])
+      .filter((r: any) => r.started_at != null)
+      .map((r: any) => Number(r.round_number)),
+    maxScore: ms != null ? Number(ms) : DEFAULT_MAX_SCORE,
+  };
+}
+
+/**
+ * Print the final standings, ranked the same way this tab (and the published
+ * placings) rank them. The Print Final Standings buttons live outside this
+ * component, so they come back through here rather than re-deriving an order
+ * from the stored participant columns — that shortcut is what let the printed
+ * sheet disagree with the published result.
+ */
+export async function printFinalStandingsFor(
+  tournamentId: string,
+  participants: Participant[],
+  tournamentName?: string | null,
+): Promise<void> {
+  const inputs = await fetchStandingsInputs(tournamentId);
+  const rows = buildStandings(
+    participants,
+    inputs.matches,
+    inputs.byes,
+    null,
+    inputs.startedRounds,
+    inputs.maxScore,
+  );
+  printFinalStandings(
+    rows.map((r) => ({
+      place: r.place,
+      name: r.participant.name,
+      mp: r.mp,
+      diff: r.diff,
+    })),
+    tournamentName,
+    participants
+      .filter((p) => p.dropped_out)
+      .map((p) => ({
+        name: p.name,
+        match_points: p.match_points,
+        differential: p.differential,
+      })),
+  );
+}
+
+/** "Bob", "Bob and Carl", "Bob, Carl and Dave", "Bob, Carl, Dave and 3 others". */
+function nameList(ids: string[], nameOf: (id: string) => string): string {
+  const names = ids.map(nameOf);
+  if (names.length <= 1) return names.join("");
+  const MAX_NAMED = 3;
+  if (names.length <= MAX_NAMED) {
+    return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+  }
+  const rest = names.length - MAX_NAMED;
+  return `${names.slice(0, MAX_NAMED).join(", ")} and ${rest} other${rest === 1 ? "" : "s"}`;
+}
+
+function ordinal(n: number): string {
+  const mod100 = n % 100;
+  if (mod100 >= 11 && mod100 <= 13) return `${n}th`;
+  const suffix = { 1: "st", 2: "nd", 3: "rd" }[n % 10] ?? "th";
+  return `${n}${suffix}`;
+}
+
+/**
+ * Plain-language reason a row sits where it does, for the hover hint next to
+ * its place. Returns null when the player shared their game score with nobody
+ * and there was nothing to break.
+ *
+ * Exported for unit testing.
+ */
+export function explainTiebreak(
+  row: Pick<StandingRow, "place" | "mp" | "diff" | "tiebreak">,
+  nameOf: (id: string) => string,
+): string | null {
+  const { tiedWith, by, others } = row.tiebreak;
+  if (by === "none" || tiedWith.length === 0) return null;
+
+  const tied = `Tied on ${row.mp} MP with ${nameList(tiedWith, nameOf)}.`;
+  switch (by) {
+    case "head_to_head":
+      return `${tied} Placed ahead for beating ${nameList(others, nameOf)} head-to-head.`;
+    case "lost_soul_score":
+      return `${tied} No head-to-head win settled it, so the higher differential placed them ahead of ${nameList(
+        others,
+        nameOf,
+      )}.`;
+    case "shared":
+      return `${tied} Same ${row.diff} differential, and ${
+        others.length === 1
+          ? "neither beat the other"
+          : "nobody beat all the others"
+      }, so they share ${ordinal(row.place)} — ranking points and prizes are split.`;
+    case "behind":
+      return `${tied} Placed behind them on head-to-head and differential.`;
+  }
 }
 
 export default function StandingsTable({
@@ -236,44 +380,14 @@ export default function StandingsTable({
 
   useEffect(() => {
     if (!tournamentId) return;
-    const client = createClient();
     let cancelled = false;
     (async () => {
-      const [matchesRes, byesRes, roundsRes, tournamentRes] = await Promise.all([
-        client
-          .from("matches")
-          .select(
-            "id, round, player1_id, player2_id, player1_score, player2_score, winner_id, is_tie",
-          )
-          .eq("tournament_id", tournamentId),
-        client
-          .from("byes")
-          .select("participant_id, round_number")
-          .eq("tournament_id", tournamentId),
-        // Started rounds gate which byes count — a bye only scores once its
-        // round has actually started (Option C), matching the server recompute.
-        client
-          .from("rounds")
-          .select("round_number, started_at")
-          .eq("tournament_id", tournamentId),
-        // max_score is the win threshold ("full win") used by the live MP
-        // formula — same value migration 039 reads from tournaments.max_score.
-        client
-          .from("tournaments")
-          .select("max_score")
-          .eq("id", tournamentId)
-          .single(),
-      ]);
+      const inputs = await fetchStandingsInputs(tournamentId);
       if (cancelled) return;
-      setMatches((matchesRes.data ?? []) as MatchRow[]);
-      setByes((byesRes.data ?? []) as ByeRow[]);
-      setStartedRounds(
-        (roundsRes.data ?? [])
-          .filter((r: any) => r.started_at != null)
-          .map((r: any) => Number(r.round_number)),
-      );
-      const ms = (tournamentRes.data as any)?.max_score;
-      if (ms != null) setMaxScore(Number(ms));
+      setMatches(inputs.matches);
+      setByes(inputs.byes);
+      setStartedRounds(inputs.startedRounds);
+      setMaxScore(inputs.maxScore);
       setLoading(false);
     })();
     return () => {
@@ -294,6 +408,13 @@ export default function StandingsTable({
     [participants, matches, byes, currentRound, startedRounds, maxScore],
   );
 
+  // Tiebreak hints name the players a row was tied with, so the hint text
+  // needs id → name for everyone on the roster.
+  const nameOf = useMemo(() => {
+    const names = new Map(participants.map((p) => [p.id, p.name]));
+    return (id: string) => names.get(id) ?? "another player";
+  }, [participants]);
+
   if (loading) {
     return <p className="text-sm text-muted-foreground">Loading standings…</p>;
   }
@@ -311,7 +432,8 @@ export default function StandingsTable({
       {/* Mobile cards */}
       <ul className="md:hidden space-y-2">
         {rows.map((row) => {
-          const isWinner = tournamentEnded && row.rank === 1;
+          const isWinner = tournamentEnded && row.place === 1;
+          const why = explainTiebreak(row, nameOf);
           return (
             <li
               key={row.participant.id}
@@ -323,8 +445,9 @@ export default function StandingsTable({
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 min-w-0 flex-wrap">
                     <span className="text-sm font-semibold text-muted-foreground tabular-nums">
-                      #{row.rank}
+                      #{row.place}
                     </span>
+                    {why && <InfoHint text={why} />}
                     {isWinner && (
                       <Crown
                         className="w-4 h-4 text-orange-300 flex-shrink-0"
@@ -378,6 +501,8 @@ export default function StandingsTable({
             tiebreaker) read as `text-foreground` with a muted chevron;
             inactive headers stay muted with no chevron. Communicates active
             sort via header tint rather than a bright accent on the icon.
+            Head-to-head sits between the two but has no column of its own —
+            it shows up in the per-row hint next to the place instead.
           */}
           <thead className="text-xs uppercase font-medium bg-muted">
             <tr>
@@ -423,7 +548,8 @@ export default function StandingsTable({
           </thead>
           <tbody>
             {rows.map((row) => {
-              const isWinner = tournamentEnded && row.rank === 1;
+              const isWinner = tournamentEnded && row.place === 1;
+              const why = explainTiebreak(row, nameOf);
               return (
                 <tr
                   key={row.participant.id}
@@ -432,7 +558,10 @@ export default function StandingsTable({
                   }`}
                 >
                   <td className="px-4 py-3 font-semibold text-foreground tabular-nums">
-                    {row.rank}
+                    <span className="inline-flex items-center gap-1.5">
+                      {row.place}
+                      {why && <InfoHint text={why} />}
+                    </span>
                   </td>
                   <td className="px-4 py-3 text-foreground">
                     <span className="inline-flex items-center gap-2">

--- a/components/ui/TournamentRounds.tsx
+++ b/components/ui/TournamentRounds.tsx
@@ -10,7 +10,8 @@ import { reassignRoundTables } from "../../utils/tournament/reassignTables";
 import MatchEditModal from "./match-edit";
 import RepairPairingModal from "./RepairPairingModal";
 import { ArrowDown, ArrowUp, ArrowUpDown, MoreHorizontal, Printer } from "lucide-react";
-import { printTournamentPairings, printFinalStandings, printMatchSlips } from "../../utils/printUtils";
+import { printTournamentPairings, printMatchSlips } from "../../utils/printUtils";
+import { printFinalStandingsFor } from "./StandingsTable";
 import { Button } from "./button";
 import ToastNotification from "./toast-notification";
 import ConfirmationDialog from "./confirmation-dialog";
@@ -894,7 +895,11 @@ export default function TournamentRounds({
   };
 
   const handlePrintFinalStandings = () => {
-    printFinalStandings(participants, tournamentName || tournamentInfo.name);
+    printFinalStandingsFor(
+      tournamentId,
+      participants,
+      tournamentName || tournamentInfo.name,
+    );
   };
   
   // Update local tournament name from parent prop when it changes

--- a/components/ui/TournamentTabs.tsx
+++ b/components/ui/TournamentTabs.tsx
@@ -10,11 +10,10 @@ import TournamentSettings from "./TournamentSettings";
 import TournamentRounds from "./TournamentRounds";
 import ParticipantTable from "./ParticipantTable";
 import ParticipantFormModal from "./participant-form-modal";
-import StandingsTable from "./StandingsTable";
+import StandingsTable, { printFinalStandingsFor } from "./StandingsTable";
 import { HiPlus } from "react-icons/hi";
 import { GiCardPickup } from "react-icons/gi";
 import { HiOutlineChartBar } from "react-icons/hi2";
-import { printFinalStandings } from "../../utils/printUtils";
 import { Button } from "./button";
 import ExportTrackerButton from "./ExportTrackerButton";
 import { AuditLogPanel } from "./AuditLogPanel";
@@ -188,7 +187,7 @@ export default function TournamentTabs({
             )}
             {tournamentEnded && (
               <Button
-                onClick={() => printFinalStandings(participants, tournamentName || "Tournament")}
+                onClick={() => printFinalStandingsFor(tournamentId, participants, tournamentName || "Tournament")}
                 variant="accent"
                 size="sm"
               >
@@ -350,7 +349,7 @@ export default function TournamentTabs({
                 )}
                 {tournamentEnded && (
                   <Button
-                    onClick={() => printFinalStandings(participants, tournamentName || "Tournament")}
+                    onClick={() => printFinalStandingsFor(tournamentId, participants, tournamentName || "Tournament")}
                     variant="accent"
                     size="sm"
                   >

--- a/components/ui/__tests__/standingsTable.test.ts
+++ b/components/ui/__tests__/standingsTable.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildStandings } from "../StandingsTable";
+import { buildStandings, explainTiebreak } from "../StandingsTable";
 
 type Participant = {
   id: string;
@@ -72,31 +72,78 @@ function match(
 }
 
 describe("StandingsTable buildStandings", () => {
-  it("ranks A above B when live MP and differential tie and A beat B head-to-head", () => {
-    // Exact tie at 3 MP / 0 diff for both, with p06 winning the head-to-head:
+  it("shares the place across a head-to-head cycle with identical MP and differential", () => {
+    // Exact tie at 3 MP / 0 diff for all three, and the head-to-head results
+    // form a cycle (p06 > p12 > p99 > p06), so no player defeated all the
+    // others. Nothing is left to separate them — they share the place.
     //   r1: p06 beats p12  → p06 3MP/+5, p12 0MP/-5
-    //   r2: p12 beats p99  → p12 3MP/+5  (p12 total 3MP/0)
-    //   r2: p99 beats p06? no — give p06 a full loss to net 0 diff:
-    //   r2: p06 loses to p99 → p06 0MP/-5 (p06 total 3MP/0)
+    //   r2: p99 beats p06  → p99 3MP/+5, p06 0MP/-5 (p06 total 3MP/0)
+    //   r3: p12 beats p99  → p12 3MP/+5 (p12 total 3MP/0), p99 total 3MP/0
     const rows = buildStandings(
       [p("p12"), p("p06"), p("p99")],
       [
-        fullWin(1, "p06", "p12"), // p06: 3MP/+5 ; p12: 0MP/-5
-        fullWin(2, "p99", "p06"), // p06: 0MP/-5 -> p06 total 3MP/0
-        fullWin(3, "p12", "p99"), // p12: 3MP/+5 -> p12 total 3MP/0
+        fullWin(1, "p06", "p12"),
+        fullWin(2, "p99", "p06"),
+        fullWin(3, "p12", "p99"),
       ],
       [],
       null,
       null,
       MAX,
     );
-    const p06 = rows.find((r) => r.participant.id === "p06")!;
-    const p12 = rows.find((r) => r.participant.id === "p12")!;
-    expect(p06.mp).toBe(3);
-    expect(p12.mp).toBe(3);
-    expect(p06.diff).toBe(0);
-    expect(p12.diff).toBe(0);
-    expect(p06.rank).toBeLessThan(p12.rank);
+    expect(rows.map((r) => r.mp)).toEqual([3, 3, 3]);
+    expect(rows.map((r) => r.diff)).toEqual([0, 0, 0]);
+    expect(rows.map((r) => r.place)).toEqual([1, 1, 1]);
+    expect(rows[0].tiebreak.by).toBe("shared");
+  });
+
+  it("ranks A above B on head-to-head even when B has the better differential", () => {
+    // The head-to-head step comes BEFORE differential in the host guide.
+    //   r1: C beats A 5-0   → A 0MP/-5 ; C 3MP/+5
+    //   r1: B beats D 5-1   → B 3MP/+4 ; D 0MP/-4
+    //   r2: A beats B 5-4   → A 3MP/+1 (total 3MP/-4) ; B 0MP/-1 (total 3MP/+3)
+    //   r2: C beats D 5-0   → C 6MP/+10 ; D 0MP/-9
+    // The 3MP tie group is exactly {A, B}. B's differential (+3) beats A's
+    // (-4), but A beat B head-to-head, so A places above B.
+    const rows = buildStandings(
+      [p("A"), p("B"), p("C"), p("D")],
+      [
+        match(1, "C", "A", 5, 0),
+        match(1, "B", "D", 5, 1),
+        match(2, "A", "B", 5, 4),
+        match(2, "C", "D", 5, 0),
+      ],
+      [],
+      null,
+      null,
+      MAX,
+    );
+    const a = rows.find((r) => r.participant.id === "A")!;
+    const b = rows.find((r) => r.participant.id === "B")!;
+    expect(a.mp).toBe(3);
+    expect(b.mp).toBe(3);
+    expect(a.diff).toBe(-4);
+    expect(b.diff).toBe(3);
+    expect(a.place).toBe(2);
+    expect(b.place).toBe(3);
+    expect(a.tiebreak.by).toBe("head_to_head");
+    expect(a.tiebreak.others).toEqual(["B"]);
+  });
+
+  it("gives tied players the same place and skips the next place", () => {
+    // A and B both 3MP/+5 and never played each other → they share 1st, and
+    // the next players start at 3rd.
+    const rows = buildStandings(
+      [p("A"), p("B"), p("x"), p("y")],
+      [fullWin(1, "A", "x"), fullWin(1, "B", "y")],
+      [],
+      null,
+      null,
+      MAX,
+    );
+    expect(rows.map((r) => r.place)).toEqual([1, 1, 3, 3]);
+    expect(rows[0].tiebreak.by).toBe("shared");
+    expect(rows[0].tiebreak.others).toEqual(["B"]);
   });
 
   it("uses live MP as the primary sort and live differential second", () => {
@@ -231,5 +278,70 @@ describe("StandingsTable buildStandings", () => {
     const rows = buildStandings(participants, [], byes, null, null, MAX);
     expect(rows[0].wins).toBe(3);
     expect(rows[0].mp).toBe(9); // 3 byes × 3 MP
+  });
+});
+
+describe("explainTiebreak", () => {
+  const nameOf = (id: string) => ({ b: "Bob", c: "Carl", d: "Dave" })[id] ?? id;
+  const row = (
+    place: number,
+    mp: number,
+    diff: number,
+    tiebreak: any,
+  ): any => ({ place, mp, diff, tiebreak });
+
+  it("says nothing when the player was not tied with anyone", () => {
+    expect(
+      explainTiebreak(
+        row(1, 12, 4, { tiedWith: [], by: "none", others: [] }),
+        nameOf,
+      ),
+    ).toBeNull();
+  });
+
+  it("names the players beaten head-to-head", () => {
+    const text = explainTiebreak(
+      row(2, 12, -4, { tiedWith: ["b", "c"], by: "head_to_head", others: ["b", "c"] }),
+      nameOf,
+    )!;
+    expect(text).toContain("Tied on 12 MP with Bob and Carl");
+    expect(text).toContain("beating Bob and Carl head-to-head");
+  });
+
+  it("explains a differential win as the fallback after head-to-head", () => {
+    const text = explainTiebreak(
+      row(1, 12, 6, { tiedWith: ["b"], by: "lost_soul_score", others: ["b"] }),
+      nameOf,
+    )!;
+    expect(text).toContain("head-to-head");
+    expect(text).toContain("differential");
+    expect(text).toContain("Bob");
+  });
+
+  it("explains a shared place and the split", () => {
+    const text = explainTiebreak(
+      row(3, 12, 4, { tiedWith: ["b"], by: "shared", others: ["b"] }),
+      nameOf,
+    )!;
+    expect(text).toContain("share 3rd");
+    expect(text).toContain("split");
+  });
+
+  it("explains being placed behind the rest of the tie", () => {
+    const text = explainTiebreak(
+      row(4, 12, -4, { tiedWith: ["b", "c"], by: "behind", others: [] }),
+      nameOf,
+    )!;
+    expect(text).toContain("Bob and Carl");
+    expect(text).toContain("behind");
+  });
+
+  it("abbreviates a long list of tied players", () => {
+    const many = ["b", "c", "d", "e", "f", "g"];
+    const text = explainTiebreak(
+      row(7, 6, 0, { tiedWith: many, by: "behind", others: [] }),
+      nameOf,
+    )!;
+    expect(text).toContain("Bob, Carl, Dave and 3 others");
   });
 });

--- a/lib/tournament/__tests__/standings.test.ts
+++ b/lib/tournament/__tests__/standings.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeFinalStandings } from '../standings';
+import { computeFinalStandings, orderByTiebreakers } from '../standings';
 import type { TournamentState, Participant, Match, Bye } from '../types';
 
 function p(id: string, droppedOut = false): Participant {
@@ -88,12 +88,34 @@ describe('computeFinalStandings', () => {
     //   B: -5 (R1) + +4 (R2) + 0 (R3 bye) = -1
     //   C: 0 (R1 bye) + -4 (R2) + +3 (R3) = -1
     // No clean head-to-head (A>B, B>C, C>A — cycle).
-    // Falls to LSS: A=+2 first, then B and C tied at -1 → joint placement.
+    // Falls to LSS: A=+2 takes 1st. Then the host guide's "repeat this process
+    // (taking the 1st place player out of the group)" restarts at head-to-head
+    // for the remaining {B, C}: B beat C, so B is 2nd and C is 3rd. They are
+    // NOT jointly placed — the tie clause only applies to players who "did not
+    // face each other".
     const standings = computeFinalStandings(state(ps, matches, byes));
     expect(standings.find(s => s.participantId === 'A')?.place).toBe(1);
-    // B and C are jointly placed 2nd.
     expect(standings.find(s => s.participantId === 'B')?.place).toBe(2);
-    expect(standings.find(s => s.participantId === 'C')?.place).toBe(2);
+    expect(standings.find(s => s.participantId === 'C')?.place).toBe(3);
+  });
+
+  it('breaks an equal-lost-soul-score tie by head-to-head when the two players faced each other', () => {
+    // A and B end on identical game score AND identical lost soul score, and
+    // played each other in R2 (A won). The joint-placement clause requires
+    // "did not face each other", so A must be placed above B.
+    // C is kept on a different game score so the tie group is exactly {A, B}.
+    const ps = ['A', 'B', 'C', 'D'].map(x => p(x));
+    const matches: Match[] = [
+      fullWin(1, 'C', 'A'), // A 0MP/-5, C 3MP/+5
+      fullWin(1, 'B', 'D'), // B 3MP/+5, D 0MP/-5
+      fullWin(2, 'A', 'B'), // A 3MP/0 total, B 3MP/0 total
+      fullWin(2, 'C', 'D'), // C 6MP/+10, D 0MP/-10
+    ];
+    const standings = computeFinalStandings(state(ps, matches));
+    expect(standings.find(s => s.participantId === 'C')?.place).toBe(1);
+    expect(standings.find(s => s.participantId === 'A')?.place).toBe(2);
+    expect(standings.find(s => s.participantId === 'B')?.place).toBe(3);
+    expect(standings.find(s => s.participantId === 'D')?.place).toBe(4);
   });
 
   it('uses joint placement on true ties (next place skips by tie size)', () => {
@@ -114,6 +136,25 @@ describe('computeFinalStandings', () => {
     }
   });
 
+  it('reports why each player landed where they did', () => {
+    // Same shape as the test above: A and B tie on game score, A beat B,
+    // C and D sit alone on their own game scores.
+    const ps = ['A', 'B', 'C', 'D'].map(x => p(x));
+    const matches: Match[] = [
+      fullWin(1, 'C', 'A'),
+      fullWin(1, 'B', 'D'),
+      fullWin(2, 'A', 'B'),
+      fullWin(2, 'C', 'D'),
+    ];
+    const standings = computeFinalStandings(state(ps, matches));
+    const byId = (id: string) => standings.find(s => s.participantId === id)!;
+    expect(byId('C').tiebreak.by).toBe('none');
+    expect(byId('A').tiebreak.by).toBe('head_to_head');
+    expect(byId('A').tiebreak.others).toEqual(['B']);
+    expect(byId('B').tiebreak.by).toBe('behind');
+    expect(byId('B').tiebreak.tiedWith).toEqual(['A']);
+  });
+
   it('excludes dropped players from final standings entirely', () => {
     const ps = [
       p('A'),
@@ -127,5 +168,57 @@ describe('computeFinalStandings', () => {
     const standings = computeFinalStandings(state(ps, matches));
     expect(standings.map(s => s.participantId).sort()).toEqual(['A', 'C']);
     expect(standings.find(s => s.participantId === 'B')).toBeUndefined();
+  });
+});
+
+describe('orderByTiebreakers', () => {
+  const row = (id: string, gameScore: number, lostSoulScore: number) => ({
+    id, gameScore, lostSoulScore,
+  });
+  /** beat(a, b) from an explicit list of "a beat b" pairs. */
+  const beats = (...pairs: string[]) => (a: string, b: string) =>
+    pairs.includes(`${a}>${b}`);
+
+  it('applies head-to-head before lost soul score', () => {
+    // B has the better lost soul score, but A beat B and they are the whole
+    // tie group — head-to-head comes first.
+    const ranked = orderByTiebreakers(
+      [row('A', 3, -4), row('B', 3, 4)],
+      beats('A>B'),
+    );
+    expect(ranked.map(e => e.row.id)).toEqual(['A', 'B']);
+    expect(ranked.map(e => e.place)).toEqual([1, 2]);
+  });
+
+  it('needs a win over EVERY other player in the tie group, not just one', () => {
+    // A beat B but never played C, so no one "defeated all other tied
+    // players" → lost soul score decides.
+    const ranked = orderByTiebreakers(
+      [row('A', 3, -4), row('B', 3, 4), row('C', 3, 0)],
+      beats('A>B'),
+    );
+    expect(ranked.map(e => e.row.id)).toEqual(['B', 'C', 'A']);
+  });
+
+  it('shares a place when nothing separates the players, and skips ahead', () => {
+    const ranked = orderByTiebreakers(
+      [row('A', 3, 5), row('B', 3, 5), row('C', 1, 0)],
+      beats(),
+    );
+    expect(ranked.map(e => e.place)).toEqual([1, 1, 3]);
+    expect(ranked[0].tiebreak.by).toBe('shared');
+    expect(ranked[0].tiebreak.others).toEqual(['B']);
+    expect(ranked[2].tiebreak.by).toBe('none');
+  });
+
+  it('labels a lost-soul-score win with the players it out-scored', () => {
+    const ranked = orderByTiebreakers(
+      [row('A', 3, 5), row('B', 3, 1), row('C', 3, 0)],
+      beats(),
+    );
+    expect(ranked.map(e => e.row.id)).toEqual(['A', 'B', 'C']);
+    expect(ranked[0].tiebreak.by).toBe('lost_soul_score');
+    expect(ranked[0].tiebreak.others).toEqual(['B', 'C']);
+    expect(ranked[0].tiebreak.tiedWith).toEqual(['B', 'C']);
   });
 });

--- a/lib/tournament/standings.ts
+++ b/lib/tournament/standings.ts
@@ -3,14 +3,31 @@
 // Final standings per algorithm.md "Determining Final Standings":
 //   1. Drop-outs are removed entirely.
 //   2. Sort by gameScore DESC.
-//   3. Within a game-score tie, apply head-to-head: if exactly one player
-//      defeated all others in the tie group, they take the top place.
-//      Repeat for the next place.
-//   4. If no clean head-to-head winner remains, fall to lostSoulScore DESC.
-//   5. True ties → joint placement; next place skips by tie size.
+//   3. Within a game-score tie, apply head-to-head: if one player defeated
+//      ALL others in the tie group, they take the top place.
+//   4. Otherwise the highest lostSoulScore takes the top place.
+//   5. Either way, repeat the whole process on the players left in the group
+//      (the host guide's "taking the 1st place player out of the group"), so
+//      head-to-head is re-checked after every removal.
+//   6. Players who cannot be separated at all share the place, and the next
+//      place skips ahead by the size of the tie.
+//
+// `orderByTiebreakers` is the pure kernel of that. It is exported because the
+// live Standings tab has to rank the same players the same way from its own
+// client-side totals — two implementations of these rules is exactly how the
+// tab and the published placings drifted apart.
 
 import { recomputeTotalsFromHistory } from './results';
-import type { TournamentState, Placement, ParticipantId, ParticipantTotals } from './types';
+import type {
+  TournamentState,
+  Placement,
+  ParticipantId,
+  ParticipantTotals,
+  Tiebreak,
+  TiebreakBy,
+} from './types';
+
+export type { Tiebreak, TiebreakBy };
 
 /** Result of a head-to-head match between two participants, as recorded in matches. */
 type H2HResult = 'p1_won' | 'p2_won' | 'tie' | 'no_match';
@@ -33,85 +50,163 @@ function headToHead(
   return 'no_match';
 }
 
-/** Did `candidate` beat every other participant in `group`? */
-function beatAll(state: TournamentState, candidate: ParticipantId, group: ParticipantId[]): boolean {
-  for (const other of group) {
-    if (other === candidate) continue;
-    const r = headToHead(state, candidate, other);
-    if (r !== 'p1_won') return false;
-  }
-  return true;
+// ─── Pure ranking kernel ──────────────────────────────────────────────
+
+/** The minimum a row needs to be ranked. */
+export interface RankableRow {
+  id: ParticipantId;
+  gameScore: number;
+  lostSoulScore: number;
+}
+
+/** `beat(a, b)` is true iff `a` defeated `b` in a recorded match. */
+export type BeatFn = (a: ParticipantId, b: ParticipantId) => boolean;
+
+export interface RankedEntry<T> {
+  row: T;
+  /** 1-indexed. Players in a true tie share the same place. */
+  place: number;
+  tiebreak: Tiebreak;
+}
+
+/** One emitted block of players who end up on the same place. */
+interface Chunk<T> {
+  rows: T[];
+  by: TiebreakBy;
+  others: ParticipantId[];
 }
 
 /**
- * Resolve a tie group's internal order, returning groups of joint-placed players
- * in placement order. A returned `[['A'], ['B', 'C']]` means A is first, B and C
- * are jointly placed second.
+ * Resolve one game-score tie group into placement order.
+ *
+ * Recursive by design: the host guide says to repeat the *whole* process on
+ * the remaining players after each removal, so a group with no outright
+ * head-to-head winner can still be decided by head-to-head once the lost soul
+ * score has peeled the leader off.
  */
-function resolveTieGroup(
-  state: TournamentState,
-  group: ParticipantTotals[],
-): ParticipantTotals[][] {
-  const out: ParticipantTotals[][] = [];
-  let remaining = [...group];
-
-  // Step a: peel off head-to-head winners one at a time.
-  while (remaining.length > 1) {
-    const ids = remaining.map(p => p.participantId);
-    const winner = remaining.find(p => beatAll(state, p.participantId, ids));
-    if (!winner) break;
-    out.push([winner]);
-    remaining = remaining.filter(p => p.participantId !== winner.participantId);
+function resolveGroup<T extends RankableRow>(group: T[], beat: BeatFn, out: Chunk<T>[]): void {
+  if (group.length === 1) {
+    out.push({ rows: group, by: 'behind', others: [] });
+    return;
   }
 
-  // Step b: remaining players → fall to lostSoulScore DESC, then joint placement.
-  remaining.sort((a, b) => b.lostSoulScore - a.lostSoulScore);
+  // Step 1: did anyone defeat every other player still in the group?
+  const ids = group.map((r) => r.id);
+  const winner = group.find((r) => ids.every((id) => id === r.id || beat(r.id, id)));
+  if (winner) {
+    out.push({
+      rows: [winner],
+      by: 'head_to_head',
+      others: ids.filter((id) => id !== winner.id),
+    });
+    resolveGroup(
+      group.filter((r) => r.id !== winner.id),
+      beat,
+      out,
+    );
+    return;
+  }
+
+  // Step 2: highest lost soul score.
+  const topScore = Math.max(...group.map((r) => r.lostSoulScore));
+  const leaders = group.filter((r) => r.lostSoulScore === topScore);
+  if (leaders.length === group.length) {
+    // Same game score, same lost soul score, no decisive head-to-head — a
+    // true tie. Ranking points and prizes are split.
+    out.push({ rows: group, by: 'shared', others: ids });
+    return;
+  }
+
+  const rest = group.filter((r) => r.lostSoulScore !== topScore);
+  if (leaders.length === 1) {
+    out.push({ rows: leaders, by: 'lost_soul_score', others: rest.map((r) => r.id) });
+  } else {
+    // Several players share the top lost soul score — repeat the process on
+    // them, which re-checks head-to-head among just those players.
+    resolveGroup(leaders, beat, out);
+  }
+  resolveGroup(rest, beat, out);
+}
+
+/**
+ * Rank players by game score, then head-to-head, then lost soul score, with
+ * shared places for players nothing separates.
+ *
+ * Rows come back in placement order, each annotated with why it landed there
+ * so the UI can explain a surprising placing.
+ */
+export function orderByTiebreakers<T extends RankableRow>(
+  rows: T[],
+  beat: BeatFn,
+): RankedEntry<T>[] {
+  // Stable sort: players nothing separates keep their input order.
+  const sorted = [...rows].sort((a, b) => b.gameScore - a.gameScore);
+
+  const entries: RankedEntry<T>[] = [];
   let i = 0;
-  while (i < remaining.length) {
-    const lss = remaining[i].lostSoulScore;
-    const tied: ParticipantTotals[] = [];
-    while (i < remaining.length && remaining[i].lostSoulScore === lss) {
-      tied.push(remaining[i]);
+  let nextPlace = 1;
+  while (i < sorted.length) {
+    const gameScore = sorted[i].gameScore;
+    const group: T[] = [];
+    while (i < sorted.length && sorted[i].gameScore === gameScore) {
+      group.push(sorted[i]);
       i++;
     }
-    out.push(tied);
-  }
 
-  return out;
+    if (group.length === 1) {
+      entries.push({
+        row: group[0],
+        place: nextPlace,
+        tiebreak: { tiedWith: [], by: 'none', others: [] },
+      });
+      nextPlace += 1;
+      continue;
+    }
+
+    const tieGroupIds = group.map((r) => r.id);
+    const chunks: Chunk<T>[] = [];
+    resolveGroup(group, beat, chunks);
+    for (const chunk of chunks) {
+      for (const row of chunk.rows) {
+        entries.push({
+          row,
+          place: nextPlace,
+          tiebreak: {
+            tiedWith: tieGroupIds.filter((id) => id !== row.id),
+            by: chunk.by,
+            others: chunk.others.filter((id) => id !== row.id),
+          },
+        });
+      }
+      nextPlace += chunk.rows.length;
+    }
+  }
+  return entries;
 }
+
+// ─── Final standings ──────────────────────────────────────────────────
 
 /** Compute final standings per algorithm.md. */
 export function computeFinalStandings(state: TournamentState): Placement[] {
   // Step 1: exclude drop-outs.
-  const active = state.participants.filter(p => !p.droppedOut);
-  const totals = active.map(p => recomputeTotalsFromHistory(p.id, state));
+  const active = state.participants.filter((p) => !p.droppedOut);
+  const rows: (RankableRow & { totals: ParticipantTotals })[] = active.map((p) => {
+    const totals = recomputeTotalsFromHistory(p.id, state);
+    return {
+      id: totals.participantId,
+      gameScore: totals.gameScore,
+      lostSoulScore: totals.lostSoulScore,
+      totals,
+    };
+  });
 
-  // Step 2: sort by gameScore DESC, then group by gameScore.
-  totals.sort((a, b) => b.gameScore - a.gameScore);
+  const beat: BeatFn = (a, b) => headToHead(state, a, b) === 'p1_won';
 
-  const placements: Placement[] = [];
-  let i = 0;
-  let nextPlace = 1;
-  while (i < totals.length) {
-    const gs = totals[i].gameScore;
-    const group: ParticipantTotals[] = [];
-    while (i < totals.length && totals[i].gameScore === gs) {
-      group.push(totals[i]);
-      i++;
-    }
-    // Resolve internal order.
-    const subgroups = group.length === 1 ? [group] : resolveTieGroup(state, group);
-    for (const sub of subgroups) {
-      for (const t of sub) {
-        placements.push({
-          participantId: t.participantId,
-          place: nextPlace,
-          gameScore: t.gameScore,
-          lostSoulScore: t.lostSoulScore,
-        });
-      }
-      nextPlace += sub.length;
-    }
-  }
-  return placements;
+  return orderByTiebreakers(rows, beat).map((entry) => ({
+    participantId: entry.row.id,
+    place: entry.place,
+    gameScore: entry.row.totals.gameScore,
+    lostSoulScore: entry.row.totals.lostSoulScore,
+    tiebreak: entry.tiebreak,
+  }));
 }

--- a/lib/tournament/types.ts
+++ b/lib/tournament/types.ts
@@ -90,6 +90,28 @@ export interface ParticipantTotals {
   lostSoulScore: number;
 }
 
+/** Why a player sits where they do relative to the players they tied with. */
+export type TiebreakBy =
+  /** Nobody else finished on this game score — nothing to break. */
+  | "none"
+  /** Defeated every other player still tied with them. */
+  | "head_to_head"
+  /** Head-to-head was inconclusive; won on lost soul score. */
+  | "lost_soul_score"
+  /** Nothing separated them — the place is shared. */
+  | "shared"
+  /** Everyone else in the tie was placed above them. */
+  | "behind";
+
+export interface Tiebreak {
+  /** Everyone who finished on the same game score, excluding this player. */
+  tiedWith: ParticipantId[];
+  by: TiebreakBy;
+  /** Who `by` refers to: the players defeated ('head_to_head'), out-scored
+   * ('lost_soul_score'), or sharing the place ('shared'). Empty otherwise. */
+  others: ParticipantId[];
+}
+
 /** A single placement entry in the final standings. */
 export interface Placement {
   participantId: ParticipantId;
@@ -97,4 +119,6 @@ export interface Placement {
   place: number;
   gameScore: number;
   lostSoulScore: number;
+  /** Which tiebreaker settled this placing, and against whom. */
+  tiebreak: Tiebreak;
 }

--- a/prompt_context/algorithm.md
+++ b/prompt_context/algorithm.md
@@ -141,13 +141,15 @@ Per the official Redemption Host Guide, in this order:
 
 2. **Sort remaining players by `game_score DESC`.**
 
-3. **Within a game-score tie, apply the head-to-head rule**:
-   - If exactly one tied player defeated all other players in the tie group (head-to-head), they take the top place of the group.
-   - Repeat: remove that player from the group and re-check head-to-head among the remaining tied players for the next place.
+3. **Within a game-score tie, apply the head-to-head rule**: if one tied player defeated *all* other players in the tie group, they take the top place of the group. A win over only some of them does not count.
 
-4. **If no clean head-to-head winner remains**, fall to **`lost_soul_score DESC`** within the tie group.
+4. **If no head-to-head winner exists**, the highest **`lost_soul_score`** in the tie group takes the top place.
 
-5. **Joint placement on true ties**: if players are still tied in both game score and lost soul score (and have no decisive head-to-head among them), they share that placement. The next assigned place skips ahead by the size of the tie group. (E.g., two players tied for 3rd → next player is 5th.) Per official rules, ranking points and prizes are split.
+5. **Repeat the whole process on whoever is left** — the guide's "taking the 1st place player out of the group". Head-to-head is re-checked after *every* removal, whichever rule made the removal. So in a cyclic tie (A beat B, B beat C, C beat A) where lost soul score peels A off first, B still takes the next place for having beaten C; B and C are not tied.
+
+6. **Joint placement on true ties**: players who are tied in both game score and lost soul score *and* whom head-to-head cannot separate share that placement. The next assigned place skips ahead by the size of the tie group. (E.g., two players tied for 3rd → next player is 5th.) Per official rules, ranking points and prizes are split.
+
+> Implemented once, in `orderByTiebreakers` (`lib/tournament/standings.ts`). The live Standings tab ranks players through the same function so the tab, the printed sheet, and the published placings cannot disagree.
 
 > Redemption uses lost soul score as the primary numeric tiebreaker; it does **not** use OMW (opponent match-win percentage) or other strength-of-schedule tiebreakers, despite generic Swiss references mentioning them.
 

--- a/utils/printUtils.ts
+++ b/utils/printUtils.ts
@@ -30,38 +30,38 @@ const escapeHtml = (value: unknown): string =>
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
 
+/** One already-ranked row of the final standings. */
+export interface FinalStandingRow {
+  /** 1-indexed placing; tied players share one. */
+  place: number;
+  name: string;
+  mp: number;
+  diff: number;
+}
+
 /**
- * Prints the final standings of a tournament in a printer-friendly format
+ * Prints the final standings of a tournament in a printer-friendly format.
  *
- * @param participants - Array of participant objects containing ranking information
+ * Rows arrive already ranked — this function must not re-derive an order.
+ * Placings follow the host guide's tiebreaker chain (match points, then
+ * head-to-head, then differential), which cannot be reconstructed from the
+ * stored per-player totals alone; `printFinalStandingsFor` in StandingsTable
+ * is the single place that works it out.
+ *
+ * @param rows - Ranked standings rows for the active players
  * @param tournamentName - Name of the tournament
+ * @param droppedOut - Players who dropped; listed after the standings with no place
  * @returns void - Opens a new window with printable content
  */
 export const printFinalStandings = (
-  participants: any[],
+  rows: FinalStandingRow[],
   tournamentName?: string | null,
+  droppedOut: { name: string; match_points: number | null; differential: number | null }[] = [],
 ): void => {
   const pageTitle = tournamentName
     ? `${tournamentName} - Final Standings`
     : `Final Tournament Standings`;
-  
-  // Sort participants by match points (desc) then by differential (desc)
-  const sortedParticipants = [...participants].sort((a, b) => {
-    // Dropped players always rank after active players
-    if (a.dropped_out !== b.dropped_out) return a.dropped_out ? 1 : -1;
 
-    const mpA = a.match_points !== null ? a.match_points : -Infinity;
-    const mpB = b.match_points !== null ? b.match_points : -Infinity;
-
-    if (mpA !== mpB) {
-      return mpB - mpA; // sort descending by match_points
-    }
-
-    const diffA = a.differential !== null ? a.differential : -Infinity;
-    const diffB = b.differential !== null ? b.differential : -Infinity;
-    return diffB - diffA; // sort descending by differential if match_points are equal
-  });
-  
   // Create the print content HTML header
   let printContent = `
     <html>
@@ -88,7 +88,7 @@ export const printFinalStandings = (
   `;
 
   // Add standings table
-  if (sortedParticipants && sortedParticipants.length > 0) {
+  if (rows.length > 0 || droppedOut.length > 0) {
     printContent += `
       <table>
         <thead>
@@ -101,43 +101,31 @@ export const printFinalStandings = (
         </thead>
         <tbody>
     `;
-    
-    // Track places correctly, handling ties
-    let places = [];
-    let currentRank = 1;
-    
-    // First assign ranks properly handling ties
-    for (let i = 0; i < sortedParticipants.length; i++) {
-      if (i > 0) {
-        const prev = sortedParticipants[i-1];
-        const current = sortedParticipants[i];
-        
-        // If current participant has same points and differential as previous one, give them the same rank
-        if (current.match_points === prev.match_points && current.differential === prev.differential) {
-          places.push(places[i-1]); // Same place as previous participant
-        } else {
-          places.push(i + 1); // New place (1-based indexing)
-        }
-      } else {
-        places.push(1); // First place for first participant
-      }
-    }
-    
-    // Now render each row with the correct place number
-    for (let i = 0; i < sortedParticipants.length; i++) {
-      const participant = sortedParticipants[i];
-      const isWinner = i === 0;
-      
+
+    for (const row of rows) {
       printContent += `
-        <tr class="${isWinner ? 'winner' : ''}">
-          <td>${places[i]}</td>
-          <td>${participant.name}${participant.dropped_out ? ' (Dropped)' : ''}</td>
-          <td>${participant.match_points || 0}</td>
-          <td>${participant.differential || 0}</td>
+        <tr class="${row.place === 1 ? 'winner' : ''}">
+          <td>${row.place}</td>
+          <td>${escapeHtml(row.name)}</td>
+          <td>${row.mp}</td>
+          <td>${row.diff}</td>
         </tr>
       `;
     }
-    
+
+    // Drop-outs are excluded from the placings entirely (algorithm.md step 1)
+    // but still belong on the sheet, so they trail the standings with no place.
+    for (const player of droppedOut) {
+      printContent += `
+        <tr>
+          <td>&mdash;</td>
+          <td>${escapeHtml(player.name)} (Dropped)</td>
+          <td>${player.match_points ?? 0}</td>
+          <td>${player.differential ?? 0}</td>
+        </tr>
+      `;
+    }
+
     printContent += `
         </tbody>
       </table>


### PR DESCRIPTION
## Problem

Three code paths ranked players, and only one followed the host guide.

| Path | Order it used |
|---|---|
| `computeFinalStandings` → published `participants.place` | game score → head-to-head → lost soul score ✅ |
| Standings tab (`buildStandings`) | MP → **differential → head-to-head** ❌ |
| Print Final Standings | MP → differential, no head-to-head at all ❌ |

The official rule:

> If two or more players are tied for 1st place in game score, but one player defeated all other tied players, that player is the winner. If no player defeated all other tied players, then the lost soul score is examined… Repeat this process (taking the 1st place player out of the group)…

So a host reading placings off the Standings tab could call a different winner than the site published. Concretely: A and B tie at 12 MP, A beat B in round 3, B's differential is higher — the tab put B above A, the published result put A above B.

Two further defects in the tab's version:

- `directHeadToHead` was a **pairwise** comparator. The rule is "defeated *all* other tied players". On a rock-paper-scissors trio it's non-transitive, so the order depended on which pairs `Array.sort` happened to compare.
- Shared places were never shown — a true tie rendered as 3rd/4th rather than two 3rds.

## Change

All three paths now rank through one exported function, `orderByTiebreakers` in `lib/tournament/standings.ts`.

- **Head-to-head means beat-all**, not beat-one.
- **The whole process repeats after each removal**, per the guide. A cyclic tie broken by lost soul score still has head-to-head deciding the places below it. This also corrects `computeFinalStandings`, which previously jointly placed two players who had faced each other — the guide's tie clause requires that they "did not face each other".
- **Shared places and the place skip** now appear on the tab and the printed sheet, as they already did in the published result.
- Drop-outs print with no place instead of a number (algorithm.md step 1 removes them from placings entirely).

### Hover explanations

Every row that shared a game score with someone gets an info hint next to its place:

- *"Tied on 12 MP with Bob and Carl. Placed ahead for beating Bob and Carl head-to-head."*
- *"Tied on 12 MP with Bob. No head-to-head win settled it, so the higher differential placed them ahead of Bob."*
- *"Tied on 12 MP with Bob. Same 4 differential, and neither beat the other, so they share 3rd — ranking points and prizes are split."*
- *"Tied on 12 MP with Alice and Bob. Placed behind them on head-to-head and differential."*

Long ties abbreviate to "Bob, Carl, Dave and 3 others".

## Behavior changes to be aware of

1. Published placings can shift for tournaments with a cyclic tie where two of the tied players faced each other — they used to share a place, now the winner takes the higher one. `place` is recomputed on every publish, so re-publishing an affected past tournament would move those rows.
2. The Standings tab now shows shared places live, e.g. `1, 1, 3` after round 1 rather than `1, 2, 3`.

## Tests

`npm run test` — 24 tests across `lib/tournament/__tests__/standings.test.ts` and `components/ui/__tests__/standingsTable.test.ts`, written before the fix and confirmed failing for the right reasons first. New coverage: head-to-head ahead of differential, the beat-all requirement, repeat-after-removal, shared places and the place skip, and each hover string.

Two existing tests changed expectation, both because they encoded the old bug:
- `falls back to lost soul score when head-to-head has no clean winner` — B and C had faced each other, so they are no longer tied.
- the tab's cycle test — a 3-way cycle on identical MP and differential is genuinely unbreakable, so all three now share the place instead of taking the old comparator's arbitrary order.

Full suite: no new failures (`forge-lackey` brigade parsing fails on `main` too; two Forge suites need env vars absent from the worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
