### PR TITLE
test: green the suite — stale brigade expectation and eager anon clients

### DIFF
--- a/__tests__/forge-anon-leak.test.ts
+++ b/__tests__/forge-anon-leak.test.ts
@@ -19,12 +19,16 @@ const FORGE_TABLES = [
   "card_proposals", "card_comments", "forge_decks", "forge_card_art_candidates",
 ];
 
-describe.runIf(ENABLED)("Forge anon-leak guardrail", () => {
-  const anon = createClient(URL!, ANON!);
+// Built per test, not once in the describe body: vitest still evaluates the
+// body of a skipped `describe.runIf`, so constructing the client up there
+// threw "supabaseUrl is required" and failed the whole default run in any
+// checkout without a .env.local (a fresh clone or a git worktree).
+const anonClient = () => createClient(URL!, ANON!);
 
+describe.runIf(ENABLED)("Forge anon-leak guardrail", () => {
   for (const table of FORGE_TABLES) {
     it(`anon sees zero rows in ${table}`, async () => {
-      const { data, error } = await anon.from(table).select("*").limit(1000);
+      const { data, error } = await anonClient().from(table).select("*").limit(1000);
       const rows = data ?? [];
       // A permission error (REVOKE) or an empty result (RLS) is fine; a leak is not.
       expect(
@@ -94,7 +98,7 @@ describe.runIf(ENABLED)("Forge anon-leak guardrail", () => {
 
   for (const [fn, args] of FORGE_RPCS) {
     it(`anon cannot execute ${fn}`, async () => {
-      const { error } = await anon.rpc(fn, args);
+      const { error } = await anonClient().rpc(fn, args);
       expect(error, `anon was able to execute ${fn} — a definer grant leaked`).not.toBeNull();
     });
   }

--- a/__tests__/forge-lackey.test.ts
+++ b/__tests__/forge-lackey.test.ts
@@ -127,7 +127,12 @@ describe("lackeyRowToDesignCard", () => {
     expect(parse({ Brigade: "Good Gold" }).brigades).toEqual(["GoodGold"]);
     expect(parse({ Brigade: "Crimson/Orange/Pale Green" }).brigades).toEqual(["Crimson", "Orange", "PaleGreen"]);
     expect(parse({ Brigade: "Purple (Crimson)" }).brigades).toEqual(["Purple", "Crimson"]);
-    expect(parse({ Brigade: "Red" }).brigades).toBeUndefined();
+    // The three brigades added later than the rest of this map, so a
+    // regression in BRIGADE_MAP can't slip through as "unknown, dropped".
+    expect(parse({ Brigade: "Red" }).brigades).toEqual(["Red"]);
+    expect(parse({ Brigade: "Teal" }).brigades).toEqual(["Teal"]);
+    expect(parse({ Brigade: "Evil Gold" }).brigades).toEqual(["EvilGold"]);
+    expect(parse({ Brigade: "Mauve" }).brigades).toBeUndefined();
     expect(parse({ Brigade: "-" }).brigades).toBeUndefined();
   });
   it("maps '-' stats to absent and Territory class to icons", () => {

--- a/__tests__/superuser-anon-leak.test.ts
+++ b/__tests__/superuser-anon-leak.test.ts
@@ -11,11 +11,15 @@ const ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 // suite) so the default unit run stays hermetic (no network).
 const ENABLED = process.env.FORGE_LEAK_TEST === "1" && !!URL && !!ANON;
 
-describe.runIf(ENABLED)("Superuser portal anon-leak guardrail", () => {
-  const anon = createClient(URL!, ANON!);
+// Built per test, not once in the describe body: vitest still evaluates the
+// body of a skipped `describe.runIf`, so constructing the client up there
+// threw "supabaseUrl is required" and failed the whole default run in any
+// checkout without a .env.local (a fresh clone or a git worktree).
+const anonClient = () => createClient(URL!, ANON!);
 
+describe.runIf(ENABLED)("Superuser portal anon-leak guardrail", () => {
   it("anon sees zero rows in admin_users", async () => {
-    const { data, error } = await anon.from("admin_users").select("*").limit(1000);
+    const { data, error } = await anonClient().from("admin_users").select("*").limit(1000);
     const rows = data ?? [];
     // A permission error (REVOKE) or an empty result (RLS) is fine; a leak is not.
     expect(
@@ -36,7 +40,7 @@ describe.runIf(ENABLED)("Superuser portal anon-leak guardrail", () => {
 
   for (const [fn, args] of SUPER_RPCS) {
     it(`anon cannot execute ${fn}`, async () => {
-      const { error } = await anon.rpc(fn, args);
+      const { error } = await anonClient().rpc(fn, args);
       expect(error, `anon was able to execute ${fn} — a definer grant leaked`).not.toBeNull();
     });
   }


### PR DESCRIPTION
Three failing tests on `main`, two causes. Test-only change.

## 1. `forge-lackey` — stale brigade expectation

```
maps multi and parenthetical brigades, dropping unknowns
AssertionError: expected [ 'Red' ] to be undefined
```

The test used `"Red"` as its example of a brigade that should be dropped as unknown. Commit 3f9c9573 ("Forge: add Red/Teal good brigades and Evil Gold evil brigade") added `"red": "Red"` to `BRIGADE_MAP` and left the test alone, so the assertion has been failing since then.

Swapped in a brigade that will stay unknown (`"Mauve"`), which keeps the test's stated intent, and added the positive assertions 3f9c9573 never got — Red, Teal and Evil Gold had no coverage at all, so a regression in `BRIGADE_MAP` would have silently reappeared as "unknown, dropped".

## 2. Both anon-leak suites — client built at collection time

```
FAIL __tests__/forge-anon-leak.test.ts
FAIL __tests__/superuser-anon-leak.test.ts
Error: supabaseUrl is required.
```

Both built their Supabase client in the `describe` body:

```ts
describe.runIf(ENABLED)("Forge anon-leak guardrail", () => {
  const anon = createClient(URL!, ANON!);
```

vitest evaluates the body of a skipped `describe.runIf` — it collects first, then marks the tests skipped. With no `.env.local`, `URL` is `undefined` and the constructor throws during collection, failing the whole default `npm run test`. That's the opposite of the "so the default unit run stays hermetic" the comment right above it claims.

This does not reproduce in a checkout that has `.env.local` (the client constructs fine and the tests then skip), which is why it went unnoticed — it only bites a fresh clone, a git worktree, or CI without secrets.

The client is now built per test, so a skipped suite constructs nothing.

## Verification

- `npm run test` with **no** `.env.local`: 138 files passed, 3 skipped, 1772 tests passed, 0 failures. Previously 3 files failed.
- `npm run test:security` with env present: both suites still execute for real — 72 assertions against Supabase, all passing. The lazy client did not disable the opt-in path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
