### PR TITLE
fix(tournaments): stop the Add Tournament footer clipping on short screens

### DIFF
--- a/components/ui/tournament-form-modal.tsx
+++ b/components/ui/tournament-form-modal.tsx
@@ -186,7 +186,10 @@ const TournamentFormModal: React.FC<TournamentFormModalProps> = ({
         <DialogHeader>
           <DialogTitle className="text-xl font-bold">Add Tournament</DialogTitle>
         </DialogHeader>
-        <form onSubmit={handleSubmit}>
+        {/* The form is the dialog's flex child, so it has to be a shrinkable
+            column itself — otherwise it sizes to its content, the body never
+            scrolls, and the footer gets clipped by the dialog on short screens. */}
+        <form onSubmit={handleSubmit} className="flex min-h-0 flex-col">
           <DialogBody className="space-y-3">
             <div>
               <label


### PR DESCRIPTION
## Problem

On short/mobile viewports the **Add Tournament** modal's footer — the **Add** and **Cancel** buttons — was cut off entirely.

`DialogContent` is a `flex flex-col` box with `max-h-[calc(100dvh-2rem)]` and `overflow-hidden`; it relies on `DialogBody` scrolling so the header and footer stay pinned. In this modal the `<form>` sits between them as a plain block flex item, so with the default `min-height: auto` it sized to its content and never shrank. The body's `overflow-y-auto` never engaged, and the footer overflowed past the dialog's clipped edge.

## Fix

Make the form a shrinkable flex column so the scroll contract works through it:

```diff
-<form onSubmit={handleSubmit}>
+<form onSubmit={handleSubmit} className="flex min-h-0 flex-col">
```

## Verification

Driven in a real browser (dev server + Playwright, logged-in session) at iPhone SE 375×667:

| | Submit button Y | Result |
|---|---|---|
| Before | 753 (viewport 667) | clipped — reported bug |
| After | 594 | fully visible, `click({ trial: true })` passes |

Also confirmed: the body now actually scrolls (scrollHeight 658 vs clientHeight 499, name field reachable), the footer stays pinned while scrolling, and the wider multi-select label ("Add 3 tournaments") still fits. At 390×844 the modal fit before and still does — unchanged.

## Note (not changed here)

Two other dialogs wrap body + footer in a `<form>` the same way — `components/ui/participant-form-modal.tsx` and `components/ui/EditParticipantModal.tsx`. Their forms are short enough not to overflow today, but the same latent clipping exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)