### PR TITLE
feat(tournaments): join-by-code entry + prominent Start Tournament button

### DIFF
--- a/app/tracker/tournaments/[id]/page.tsx
+++ b/app/tracker/tournaments/[id]/page.tsx
@@ -4,7 +4,7 @@ import { Button } from "../../../../components/ui/button";
 import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { HiPencil } from "react-icons/hi";
-import { Wrench, RefreshCw, Unlock, SquarePen } from "lucide-react";
+import { Wrench, RefreshCw, Unlock, SquarePen, Play } from "lucide-react";
 import CountdownTimer from "../../../../components/ui/CountdownTimer";
 import RoundProgressBar from "../../../../components/ui/RoundProgressBar";
 import EditParticipantModal from "../../../../components/ui/EditParticipantModal";
@@ -923,17 +923,18 @@ export default function TournamentPage({
                   {/* Push actions to the right */}
                   <div className="ml-auto flex items-center gap-2">
                     {/* Start Tournament — primary pre-start action stays inline so
-                        a host can see it without opening the menu. Outline, not
-                        green: the filled CTA belongs to the Participants toolbar
-                        (Add Participant), and two greens on one screen made it
-                        unclear which action came first. */}
+                        a host can see it without opening the menu. Filled amber,
+                        not green: it echoes the "Not Started" status pill it sits
+                        beside, and the filled green CTA belongs to the
+                        Participants toolbar (Add Participant) — two greens on one
+                        screen made it unclear which action came first. */}
                     {!tournament?.has_started && !tournament?.has_ended && (
                       <Button
                         disabled={participants.length === 0 || togglingStatus}
-                        variant="outline"
                         onClick={handleTournamentStatusToggle}
-                        size="sm"
+                        className="bg-amber-500 text-amber-950 hover:bg-amber-400 font-semibold shadow-sm"
                       >
+                        <Play className="w-4 h-4 mr-1.5 fill-current" />
                         Start Tournament
                       </Button>
                     )}

--- a/app/tracker/tournaments/page.tsx
+++ b/app/tracker/tournaments/page.tsx
@@ -6,9 +6,10 @@ import { createClient } from "../../../utils/supabase/client";
 import { getUserSafe } from "../../../utils/supabase/getUserSafe";
 import ToastNotification from "../../../components/ui/toast-notification";
 import { Button } from "../../../components/ui/button";
-import { HiPencil, HiTrash, HiPlus, HiOutlineDesktopComputer } from "react-icons/hi";
+import { HiPencil, HiTrash, HiPlus, HiOutlineDesktopComputer, HiOutlineLogin } from "react-icons/hi";
 import { useRouter, useSearchParams } from "next/navigation";
 import TournamentFormModal from "../../../components/ui/tournament-form-modal";
+import JoinCodeDialog from "../../../components/ui/JoinCodeDialog";
 import { categoryDefaults, requireDecklistsDefault } from "../../../utils/tournament/categoryDefaults";
 import { normalizeTier } from "../../../utils/tournament/tiers";
 import { getFormatDef } from "@/lib/formats";
@@ -23,6 +24,7 @@ function TournamentsPageInner() {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isAddTournamentModalOpen, setisAddTournamentModalOpen] =
     useState(false);
+  const [isJoinDialogOpen, setIsJoinDialogOpen] = useState(false);
   const [currentTournament, setCurrentTournament] = useState(null);
   const [newTournamentName, setNewTournamentName] = useState("");
   const [listingCity, setListingCity] = useState("");
@@ -342,6 +344,14 @@ function TournamentsPageInner() {
               </a>
             </Button>
             <Button
+              variant="outline"
+              onClick={() => setIsJoinDialogOpen(true)}
+              className="flex items-center gap-2"
+            >
+              <HiOutlineLogin className="w-4 h-4" />
+              <span>Join a Tournament</span>
+            </Button>
+            <Button
               onClick={() => setisAddTournamentModalOpen(true)}
               className="flex items-center gap-3 bg-primary text-primary-foreground hover:bg-primary/90"
             >
@@ -369,6 +379,10 @@ function TournamentsPageInner() {
             categoryOptions={listingFormats.length > 0 ? listingFormats : undefined}
             listingState={listingState}
             defaultTier={listingTier}
+          />
+          <JoinCodeDialog
+            isOpen={isJoinDialogOpen}
+            onClose={() => setIsJoinDialogOpen(false)}
           />
         </div>
         {loading ? (

--- a/components/ui/JoinCodeDialog.tsx
+++ b/components/ui/JoinCodeDialog.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogBody,
+} from "./dialog";
+import { Button } from "./button";
+import { normalizeJoinCode } from "../../lib/tournament/joinCodeShared";
+
+interface JoinCodeDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+// Code-entry counterpart to the /join landing page for players already in the
+// app: same input, same normalization, and the same /join/<code> flow handles
+// everything past this point (bad codes, name pre-fill, decklist requirement).
+export default function JoinCodeDialog({ isOpen, onClose }: JoinCodeDialogProps) {
+  const router = useRouter();
+  const [value, setValue] = useState("");
+  const [error, setError] = useState(false);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const code = normalizeJoinCode(value);
+    if (code === null) {
+      setError(true);
+      return;
+    }
+    router.push(`/join/${code}`);
+  }
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          setValue("");
+          setError(false);
+          onClose();
+        }
+      }}
+    >
+      <DialogContent size="sm">
+        <DialogHeader>
+          <DialogTitle>Join a tournament</DialogTitle>
+          <DialogDescription>Enter the code your host gave you.</DialogDescription>
+        </DialogHeader>
+        <DialogBody className="pb-6">
+          <form onSubmit={handleSubmit}>
+            <label className="block text-sm font-medium text-foreground">
+              Join code
+              <input
+                value={value}
+                onChange={(e) => {
+                  setValue(e.target.value.toUpperCase());
+                  setError(false);
+                }}
+                autoFocus
+                inputMode="text"
+                autoCapitalize="characters"
+                autoComplete="off"
+                autoCorrect="off"
+                spellCheck={false}
+                maxLength={12}
+                placeholder="T7K2QF"
+                className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-center text-lg uppercase tracking-[0.3em] text-foreground"
+              />
+            </label>
+            {error && (
+              <p className="mt-2 text-sm text-destructive">
+                That doesn&apos;t look like a valid code. Double-check and try
+                again.
+              </p>
+            )}
+            <Button type="submit" className="mt-4 w-full">
+              Continue
+            </Button>
+          </form>
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## What

**Join a Tournament from the Your Tournaments screen.** New outline button in the header opens a small dialog with the same 6-character code input as the `/join` landing page (same `normalizeJoinCode` handling of Crockford aliases and separators). A valid code routes straight into the existing `/join/<code>` flow, which already handles unknown codes, name pre-fill, and decklist requirements — no new server surface.

**More obvious Start Tournament button.** The pre-start action was an outline `sm` button that faded into the header. It's now a filled amber button with a play icon — it echoes the amber "Not Started" status pill beside it and stays clearly distinct from the green Add Participant CTA (the original reason it wasn't green still holds; comment updated).

## Why

Players at a table shouldn't have to know the `/join` URL to enter a code they were read aloud; hosts kept missing the Start button.

## Notes

- No schema or server-action changes; UI only.
- `tsc --noEmit` clean for the touched files (pre-existing test-file errors on main unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)