### PR TITLE
fix(forge): let Forge Warriors carry weapons

### DIFF
--- a/app/forge/lib/__tests__/playSerialize.test.ts
+++ b/app/forge/lib/__tests__/playSerialize.test.ts
@@ -19,6 +19,7 @@ const resolverEntry = (overrides: Partial<ForgePlayResolverEntry> = {}): ForgePl
   toughness: "",
   identifier: "",
   reference: "",
+  cardClass: "",
   ...overrides,
 });
 

--- a/app/forge/lib/playDecks.ts
+++ b/app/forge/lib/playDecks.ts
@@ -39,11 +39,14 @@ export async function loadForgeDeckForGame(deckId: string): Promise<ForgePlayDec
 // alignment/brigade/strength/toughness/identifier/reference ride the resolver so
 // the owner's client can re-hydrate them for the in-game deck search — the
 // world-readable STDB row deliberately blanks them (leak spine, playSerialize.ts).
+// cardClass rides it too: forge cards aren't in the public card index, so the
+// client's Warrior/Weapon equip test has no other way to learn a forge card's
+// class (see app/goldfish/utils/equipClass.ts).
 export type ForgePlayResolverEntry = {
   cardId: string; name: string; rawText: string;
   hasFinished: boolean; hasArt: boolean; versionId: string; typeDisplay: string;
   alignment: string; brigade: string; strength: string; toughness: string;
-  identifier: string; reference: string;
+  identifier: string; reference: string; cardClass: string;
 };
 
 function toResolverEntry(g: GrantedForgeCard): ForgePlayResolverEntry {
@@ -57,6 +60,7 @@ function toResolverEntry(g: GrantedForgeCard): ForgePlayResolverEntry {
     hasArt: g.hasApprovedArt,
     versionId: g.versionId,
     typeDisplay,
+    cardClass: (g.data.class ?? []).join("/"),
     ...designCardSearchFields(g.data),
   };
 }

--- a/app/forge/lib/playSerialize.ts
+++ b/app/forge/lib/playSerialize.ts
@@ -74,6 +74,7 @@ export function buildForgeGoldfishCards(
         card_brigade: r.brigade, card_strength: r.strength, card_toughness: r.toughness,
         card_special_ability: r.rawText,
         card_identifier: r.identifier, card_reference: r.reference, card_alignment: r.alignment,
+        card_class: r.cardClass,
         quantity: e.qty,
         is_reserve,
       });

--- a/app/goldfish/components/GoldfishCanvas.tsx
+++ b/app/goldfish/components/GoldfishCanvas.tsx
@@ -51,7 +51,8 @@ import { useCardEnterPlayPrompt } from '@/app/shared/hooks/useCardEnterPlayPromp
 import { CardChoicePromptContainer } from '@/app/shared/components/CardChoicePrompt';
 import { useRevealTick } from '@/app/shared/hooks/useRevealTick';
 import { computeEquipOffset, hitTestWarrior, MAX_EQUIPPED_WEAPONS_PER_WARRIOR } from '../utils/equipLayout';
-import { findCard, isWeapon, isWarrior } from '@/lib/cards/lookup';
+import { gameCardIsWarrior, gameCardIsWeapon } from '../utils/equipClass';
+import { findCard } from '@/lib/cards/lookup';
 import { compareCardsDefault } from '@/lib/cards/defaultSort';
 import { getEffectiveAbilities, isLostSoulCard, isHeroCard, simplifyLostSoulName } from '@/lib/cards/cardAbilities';
 import { ResurrectHeroesModal } from '@/app/shared/components/ResurrectHeroesModal';
@@ -952,8 +953,7 @@ export default function GoldfishCanvas({ containerWidth, containerHeight, scale,
       // Runs only for single-card drags (group drags are intentional batch moves).
       const isGroupDragForEquip = selectedIds.has(card.instanceId) && selectedIds.size > 1;
       if (!isGroupDragForEquip) {
-        const cardMeta = findCard(card.cardName, card.cardSet, card.cardImgFile);
-        if (isWeapon(cardMeta)) {
+        if (gameCardIsWeapon(card)) {
           const dropNode = e.target;
           const dropCenterX = dropNode.x() + cardWidth / 2;
           const dropCenterY = dropNode.y() + cardHeight / 2;
@@ -964,8 +964,7 @@ export default function GoldfishCanvas({ containerWidth, containerHeight, scale,
             const warriorCandidates = state.zones.territory.filter(c => {
               if (c.instanceId === card.instanceId) return false;
               if (c.equippedTo) return false; // a weapon attached to someone else isn't a valid target
-              const meta = findCard(c.cardName, c.cardSet, c.cardImgFile);
-              if (!isWarrior(meta)) return false;
+              if (!gameCardIsWarrior(c)) return false;
               const attached = state.zones.territory.filter(x => x.equippedTo === c.instanceId);
               return attached.length < MAX_EQUIPPED_WEAPONS_PER_WARRIOR;
             });

--- a/app/goldfish/state/gameInitializer.ts
+++ b/app/goldfish/state/gameInitializer.ts
@@ -36,6 +36,7 @@ function expandDeckCards(deck: DeckDataForGoldfish): { main: GameCard[]; reserve
         identifier: dc.card_identifier,
         reference: dc.card_reference,
         alignment: dc.card_alignment,
+        cardClass: dc.card_class,
         isMeek: false,
         counters: [],
         isFlipped: false,

--- a/app/goldfish/utils/__tests__/equipClass.test.ts
+++ b/app/goldfish/utils/__tests__/equipClass.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { gameCardIsWarrior, gameCardIsWeapon } from '../equipClass';
+
+// The equip hit-test used to resolve Warrior/Weapon class purely through
+// `findCard()` against the public card index. Forge cards are never in that
+// index, so every Forge card read as "not a Warrior" and could neither host
+// nor be a weapon (bug: forge "Red Dragon", class Warrior, refused weapons).
+// `cardClass` is the Forge-resolved class and, when present, is authoritative.
+
+const base = { cardName: '', cardSet: '', cardImgFile: '' };
+
+describe('gameCardIsWarrior', () => {
+  it('uses the forge-resolved class when present', () => {
+    expect(gameCardIsWarrior({ ...base, cardName: 'Red Dragon', cardSet: 'Forge', cardClass: 'Warrior' })).toBe(true);
+  });
+
+  it('is false for a forge card whose class is empty', () => {
+    expect(gameCardIsWarrior({ ...base, cardName: 'Red Dragon', cardSet: 'Forge', cardClass: '' })).toBe(false);
+  });
+
+  it('never falls back to a same-named public card when the class is known', () => {
+    // A forge card named exactly like a public Warrior must not inherit the
+    // public card's class — forge data is the only truth for forge cards.
+    // 'Goliath (LoC)' is Warrior-class in the public index.
+    expect(gameCardIsWarrior({ ...base, cardName: 'Goliath (LoC)', cardSet: 'Forge', cardClass: '' })).toBe(false);
+  });
+
+  it('falls back to the public card index for non-forge cards', () => {
+    expect(gameCardIsWarrior({ ...base, cardName: 'Red Dragon (RoJ)', cardSet: 'RoJ' })).toBe(true);
+    expect(gameCardIsWarrior({ ...base, cardName: 'Red Dragon (L)', cardSet: 'Main' })).toBe(false);
+  });
+
+  it('handles compound forge classes', () => {
+    expect(gameCardIsWarrior({ ...base, cardClass: 'Warrior/Weapon' })).toBe(true);
+  });
+
+  it('is false for an unknown card with no class', () => {
+    expect(gameCardIsWarrior({ ...base, cardName: 'Not A Real Card' })).toBe(false);
+  });
+});
+
+describe('gameCardIsWeapon', () => {
+  it('uses the forge-resolved class when present', () => {
+    expect(gameCardIsWeapon({ ...base, cardName: 'Sword of the Spirit', cardSet: 'Forge', cardClass: 'Weapon' })).toBe(true);
+    expect(gameCardIsWeapon({ ...base, cardName: 'Red Dragon', cardSet: 'Forge', cardClass: 'Warrior' })).toBe(false);
+  });
+
+  it('falls back to the public card index for non-forge cards', () => {
+    expect(gameCardIsWeapon({ ...base, cardName: "Abishai's Spear", cardSet: 'Ki' })).toBe(true);
+    expect(gameCardIsWeapon({ ...base, cardName: 'Red Dragon (RoJ)', cardSet: 'RoJ' })).toBe(false);
+  });
+});

--- a/app/goldfish/utils/equipClass.ts
+++ b/app/goldfish/utils/equipClass.ts
@@ -1,0 +1,24 @@
+import { findCard, classIsWarrior, classIsWeapon } from '@/lib/cards/lookup';
+import type { GameCard } from '../types';
+
+/** The fields a class test needs off a GameCard. */
+type ClassFields = Pick<GameCard, 'cardName' | 'cardSet' | 'cardImgFile'> &
+  Partial<Pick<GameCard, 'cardClass'>>;
+
+/** Forge cards are not in the public card index, so `findCard` can't tell you
+ *  their class — their class rides `cardClass` from the granted forge resolver.
+ *  When `cardClass` is set (including to '') it is authoritative: a forge card
+ *  must never inherit the class of a same-named public card. Everything else
+ *  resolves through the public index as before. */
+function classOf(card: ClassFields): string | undefined {
+  if (card.cardClass !== undefined) return card.cardClass;
+  return findCard(card.cardName, card.cardSet, card.cardImgFile)?.class;
+}
+
+export function gameCardIsWarrior(card: ClassFields): boolean {
+  return classIsWarrior(classOf(card));
+}
+
+export function gameCardIsWeapon(card: ClassFields): boolean {
+  return classIsWeapon(classOf(card));
+}

--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -69,7 +69,8 @@ import { getCardImageUrl as getSharedCardImageUrl } from '@/app/shared/utils/car
 import { preloadImitateSouls } from '@/app/shared/utils/preloadImitateSouls';
 import { useVirtualCanvas, VIRTUAL_WIDTH, VIRTUAL_HEIGHT, virtualToScreen } from '@/app/shared/layout/virtualCanvas';
 import { computeEquipOffset, hitTestWarrior, MAX_EQUIPPED_WEAPONS_PER_WARRIOR } from '@/app/goldfish/utils/equipLayout';
-import { findCard, isWarrior, isWeapon, isSite } from '@/lib/cards/lookup';
+import { gameCardIsWarrior, gameCardIsWeapon } from '@/app/goldfish/utils/equipClass';
+import { findCard, isSite } from '@/lib/cards/lookup';
 import { compareCardsDefault } from '@/lib/cards/defaultSort';
 import { normalizeDeckFormat } from '@/lib/deck-format';
 import { SOUL_DECK_BACK_IMG } from '@/app/shared/paragon/soulDeck';
@@ -3939,10 +3940,9 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
         hit.owner === 'my' &&
         card.ownerId === 'player1'
       ) {
-        const cardMeta = findCard(card.cardName, card.cardSet, card.cardImgFile);
         const isBattleTarget = targetZone === 'battle';
         const hostZoneRect = isBattleTarget ? battleBandRect : myZones['territory'];
-        if (isWeapon(cardMeta) && hostZoneRect) {
+        if (gameCardIsWeapon(card) && hostZoneRect) {
           const myHostRaw = isBattleTarget ? myCards['battle'] ?? [] : myCards['territory'] ?? [];
           const myHostCards = myHostRaw.map((c) => {
             const adapted = cardInstanceToGameCard(c, counters.get(c.id) ?? [], 'player1', forgeResolver);
@@ -3955,8 +3955,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
           const warriorCandidates = myHostCards.filter((c) => {
             if (c.instanceId === card.instanceId) return false;
             if (c.equippedTo) return false;
-            const meta = findCard(c.cardName, c.cardSet, c.cardImgFile);
-            if (!isWarrior(meta)) return false;
+            if (!gameCardIsWarrior(c)) return false;
             const attached = myHostCards.filter((x) => x.equippedTo === c.instanceId);
             return attached.length < MAX_EQUIPPED_WEAPONS_PER_WARRIOR;
           });
@@ -3983,7 +3982,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
             if (c.instanceId === card.instanceId) return false;
             if (c.equippedTo) return false;
             if (!isCharacterCard({ cardType: c.type })) return false;
-            return !isWarrior(findCard(c.cardName, c.cardSet, c.cardImgFile));
+            return !gameCardIsWarrior(c);
           });
           const hitNonWarrior = hitTestWarrior(
             center.x,

--- a/app/play/utils/__tests__/cardAdapterForge.test.ts
+++ b/app/play/utils/__tests__/cardAdapterForge.test.ts
@@ -5,7 +5,7 @@ const ID = "11111111-2222-3333-4444-555555555555";
 const entry = {
   cardId: ID, name: "Test Hero", rawText: "Does things.", hasFinished: false, hasArt: true, versionId: "v-9",
   typeDisplay: "Hero", alignment: "Good", brigade: "Blue", strength: "5", toughness: "4",
-  identifier: "Judah", reference: "Genesis 1:1",
+  identifier: "Judah", reference: "Genesis 1:1", cardClass: "Warrior",
 };
 
 function stubInstance(over: Record<string, unknown> = {}) {
@@ -54,5 +54,14 @@ describe("cardInstanceToGameCard forge resolution", () => {
     expect(gc.alignment).toBe("");
     expect(gc.brigade).toBe("");
     expect(gc.reference).toBe("");
+  });
+  it("carries the forge class so the weapon-equip hit-test can see it", () => {
+    // The STDB row has no class field at all and forge cards aren't in the
+    // public index, so without this a forge Warrior could never host a weapon.
+    expect(cardInstanceToGameCard(stubInstance(), [], "player1", new Map([[ID, entry]])).cardClass).toBe("Warrior");
+    // Unresolved stays undefined rather than '' — nothing to assert about it.
+    expect(cardInstanceToGameCard(stubInstance(), [], "player1", new Map()).cardClass).toBeUndefined();
+    // Public cards never carry it; their class comes from the card index.
+    expect(cardInstanceToGameCard(stubInstance({ cardImgFile: "Public.jpg" }), [], "player1", new Map([[ID, entry]])).cardClass).toBeUndefined();
   });
 });

--- a/app/play/utils/__tests__/forgeResolver.test.ts
+++ b/app/play/utils/__tests__/forgeResolver.test.ts
@@ -6,7 +6,7 @@ const ID = "11111111-2222-3333-4444-555555555555";
 const entry = {
   cardId: ID, name: "Test Hero", rawText: "Does things.", hasFinished: true, hasArt: true, versionId: "v-1",
   typeDisplay: "Hero", alignment: "Good", brigade: "Blue", strength: "5", toughness: "4",
-  identifier: "Judah", reference: "Genesis 1:1",
+  identifier: "Judah", reference: "Genesis 1:1", cardClass: "Warrior",
 };
 const resolver = new Map([[ID, entry]]);
 

--- a/app/play/utils/cardAdapter.ts
+++ b/app/play/utils/cardAdapter.ts
@@ -38,6 +38,10 @@ export function cardInstanceToGameCard(
     identifier: resolved ? resolved.identifier : card.identifier,
     reference: resolved ? resolved.reference : card.reference,
     alignment: resolved ? resolved.alignment : card.alignment,
+    // Forge only: the STDB row carries no class at all, so an unresolved forge
+    // card stays undefined (falls through to the public index, which won't know
+    // it either — fail-closed) while a resolved one is authoritative.
+    cardClass: resolved ? resolved.cardClass : undefined,
     isMeek: card.isMeek,
     isFlipped: card.isFlipped,
     isToken: card.isToken,
@@ -100,6 +104,7 @@ function gameCardEquals(a: GameCard, b: GameCard): boolean {
     a.identifier === b.identifier &&
     a.reference === b.reference &&
     a.alignment === b.alignment &&
+    a.cardClass === b.cardClass &&
     a.isMeek === b.isMeek &&
     a.isFlipped === b.isFlipped &&
     a.isToken === b.isToken &&

--- a/app/shared/types/gameCard.ts
+++ b/app/shared/types/gameCard.ts
@@ -75,6 +75,10 @@ export interface GameCard {
   counters: Counter[];
   isFlipped: boolean;
   isToken: boolean;
+  /** Warrior/Weapon class, set only for Forge cards (which are absent from the
+   *  public card index, so `findCard` can't supply it). Undefined for public
+   *  cards — those resolve their class through the index. See equipClass.ts. */
+  cardClass?: string;
   zone: ZoneId;
   ownerId: 'player1' | 'player2' | 'shared';
   isSoulDeckOrigin?: boolean;
@@ -186,6 +190,8 @@ export interface DeckDataForGoldfish {
     card_identifier: string;
     card_reference: string;
     card_alignment: string;
+    /** Forge cards only — see GameCard.cardClass. */
+    card_class?: string;
     quantity: number;
     is_reserve: boolean;
   }[];

--- a/lib/cards/lookup.ts
+++ b/lib/cards/lookup.ts
@@ -69,22 +69,33 @@ export function findCard(
   return CARD_BY_NAME.get(name) ?? CARD_BY_NAME_LOWER.get(lower);
 }
 
-function classTokens(card: CardData | undefined): string[] {
-  if (!card?.class) return [];
+function classTokens(cls: string | undefined): string[] {
+  if (!cls) return [];
   // Class strings use ',', '/', or ' / ' as separators — split on any run of
   // commas, slashes, or whitespace, then lowercase for case-insensitive matching.
-  return card.class
+  return cls
     .split(/[,\/\s]+/)
     .map((t) => t.trim().toLowerCase())
     .filter(Boolean);
 }
 
+/** Warrior/Weapon tests against a raw class string. Forge cards carry their
+ *  class this way (they're not in the public index), so callers holding a
+ *  class string — rather than a CardData — use these directly. */
+export function classIsWarrior(cls: string | undefined): boolean {
+  return classTokens(cls).includes('warrior');
+}
+
+export function classIsWeapon(cls: string | undefined): boolean {
+  return classTokens(cls).includes('weapon');
+}
+
 export function isWarrior(card: CardData | undefined): boolean {
-  return classTokens(card).includes('warrior');
+  return classIsWarrior(card?.class);
 }
 
 export function isWeapon(card: CardData | undefined): boolean {
-  return classTokens(card).includes('weapon');
+  return classIsWeapon(card?.class);
 }
 
 export function isSite(card: CardData | undefined): boolean {


### PR DESCRIPTION
## The bug

Reported against forge **Red Dragon** ([forge card page](https://redemptionccg.app/forge/cards/5394d39c-81da-4ea8-86fe-93418397260c)) — it refused to equip weapons despite its published version being `class: ["Warrior"]`.

The card data was fine. The weapon-equip hit-test resolved Warrior/Weapon class through `findCard()` against the **public** card index:

```ts
const meta = findCard(c.cardName, c.cardSet, c.cardImgFile);
if (!isWarrior(meta)) return false;
```

Forge cards are never in that index (it's the generated 5,691-card public dataset), and `ForgePlayResolverEntry` carried name/brigade/stats/alignment/identifier/reference but **not class**. So `findCard` returned `undefined` and `isWarrior` was false for every Forge card.

Consequences:

- Not specific to Red Dragon — **no Forge card could host a weapon**, in multiplayer or goldfish.
- **Forge Weapons were equally broken**: the drag entry gate is `isWeapon(cardMeta)`, so a Forge weapon never even attempted to attach.
- Purely client-side. The server's `attach_card` reducer never checked class, so no module change is needed.

There was also a latent hole in the other direction: a Forge card whose name *exactly* matched a public card would silently inherit the **public** card's class. Red Dragon dodged it only because public names carry set suffixes ("Red Dragon (RoJ)", "Red Dragon (L)") — none is bare "Red Dragon".

## The fix

`cardClass` rides `ForgePlayResolverEntry` (member-gated, same as the other re-hydrated fields) onto the adapted `GameCard`. The new `equipClass.ts` helper treats a present `cardClass` as authoritative — including when it's empty — and falls back to the public index only for public cards, which closes the name-collision hole too.

The world-readable SpacetimeDB row is untouched: it still carries no class, so the leak spine is unchanged.

| File | Change |
|---|---|
| `app/goldfish/utils/equipClass.ts` | New forge-aware Warrior/Weapon test, shared by both canvases |
| `app/forge/lib/playDecks.ts` | `cardClass` on `ForgePlayResolverEntry` |
| `app/play/utils/cardAdapter.ts` | Carries it onto `GameCard` (+ `gameCardEquals`, or memoized nodes go stale) |
| `app/forge/lib/playSerialize.ts`, `app/goldfish/state/gameInitializer.ts` | Goldfish path |
| `MultiplayerCanvas.tsx`, `GoldfishCanvas.tsx` | The two equip gates |
| `lib/cards/lookup.ts` | `classIsWarrior`/`classIsWeapon` take a raw class string; `isWarrior`/`isWeapon` delegate |

## Verification

- Full suite: **1781 passed / 139 files**, no regressions.
- `tsc --noEmit` clean apart from two pre-existing errors (`forge-anon-leak.test.ts`, `playDecksAuthorize.test.ts`) confirmed identical on `main`.
- New unit coverage: `equipClass.test.ts` (forge class wins, empty class is not a Warrior, no public-namesake fallback, public cards still resolve via the index) and a `cardAdapterForge.test.ts` case asserting the class reaches the adapted card and stays `undefined` when ungranted.

Not verified by driving a live playtest game — coverage is unit-level at the class-resolution seam plus the type gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)