### PR TITLE
fix(forge): dispatch right-click abilities on Forge cards

### DIFF
--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -83,7 +83,7 @@ import { LostSoulDealLayer, type SoulDeal } from '@/app/shared/components/LostSo
 import { computeDealFlight } from '@/app/shared/utils/lostSoulDeal';
 import { useCardEnterPlayPrompt } from '@/app/shared/hooks/useCardEnterPlayPrompt';
 import { cardInstanceToGameCard } from '../utils/cardAdapter';
-import { resolveCardImageUrl, resolveBattleRowFields, type ForgeResolverMap } from '../utils/forgeResolver';
+import { resolveCardImageUrl, resolveBattleRowFields, resolveForgeCardName, type ForgeResolverMap } from '../utils/forgeResolver';
 import type { UndoStack, Captured } from '../hooks/useUndoStack';
 import { makeReverseAction, makeBatchReverseAction, reverseIsSafe } from '../hooks/useUndoStack';
 import {
@@ -1832,7 +1832,16 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
       // Use effective abilities so imitated souls' right-click abilities (e.g.
       // Lawless reveal-top-6 on an Imitate) dispatch correctly. Mirrors the
       // server's execute_card_ability dispatcher and the goldfish path.
-      const ability = source ? getEffectiveAbilities(source)[abilityIndex] : undefined;
+      // Forge rows blank cardName (leak spine) while the context menu builds
+      // its items off the RESOLVED name — so without this the menu offered an
+      // ability that then dispatched to nothing. Resolve for the lookup only;
+      // the log/broadcast uses below keep the blanked name on purpose.
+      const ability = source
+        ? getEffectiveAbilities({
+            cardName: resolveForgeCardName(source, forgeResolver),
+            imitatingName: source.imitatingName,
+          })[abilityIndex]
+        : undefined;
       // (Star) abilities fired from hand also reveal the source card to
       // opponents/spectators so the implicit "reveal from hand" cost is
       // visible. Reveal duration matches the standard 30s — see
@@ -2074,7 +2083,13 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
       // look_at_own_deck) — open the look modal with the player-chosen count
       // (capped at the ability limit) instead of routing through the server.
       const source = findAnyCardById(sourceInstanceId);
-      const ability = source ? getEffectiveAbilities(source)[abilityIndex] : undefined;
+      // Resolved name for the lookup — see executeCardAbility above.
+      const ability = source
+        ? getEffectiveAbilities({
+            cardName: resolveForgeCardName(source, forgeResolver),
+            imitatingName: source.imitatingName,
+          })[abilityIndex]
+        : undefined;
       if (ability?.type === 'look_at_own_deck_choose') {
         const n = Math.min(count, ability.maxCount);
         setLookState({ position: ability.position, count: n });
@@ -2212,7 +2227,7 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
       logDeckSearchNoShuffle: ({ topCount, bottomCount }) =>
         gameState.logDeckSearchNoShuffle(topCount, bottomCount),
     },
-  }), [myCards, counters, gameState, findMyCardById, checkReserveProtection, checkReserveBatchProtection, undoStack]);
+  }), [myCards, counters, gameState, findMyCardById, checkReserveProtection, checkReserveBatchProtection, undoStack, forgeResolver]);
 
   // ---- ModalGameProvider value for opponent deck modals (peek/search operate on opponent cards) ----
   const opponentModalGameValue = useMemo<ModalGameContextValue>(() => ({

--- a/app/play/utils/__tests__/forgeResolver.test.ts
+++ b/app/play/utils/__tests__/forgeResolver.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { forgeCardIdFromImgFile, forgeProxyUrl, resolveCardImageUrl, mergeForgeDeckData, resolveBattleRowFields } from "../forgeResolver";
+import { forgeCardIdFromImgFile, forgeProxyUrl, resolveCardImageUrl, mergeForgeDeckData, resolveBattleRowFields, resolveForgeCardName } from "../forgeResolver";
+import { getEffectiveAbilities } from "@/lib/cards/cardAbilities";
 import { getCardImageUrl, getCardImageUrlOrNull } from "@/app/shared/utils/cardImageUrl";
 
 const ID = "11111111-2222-3333-4444-555555555555";
@@ -63,6 +64,33 @@ describe("forge image seams", () => {
     expect(merged[0].toughness).toBe("6");
     expect(merged[0].identifier).toBe("Demon");
     expect(merged[0].reference).toBe("Revelation 8:11");
+  });
+});
+
+describe("resolveForgeCardName", () => {
+  // Right-click abilities are keyed by card name. The world-readable STDB row
+  // blanks the name on forge cards, so dispatching off the raw row found zero
+  // abilities even though the context menu (which uses the resolved name)
+  // offered them — the forge "Virgin Birth" right-click did nothing.
+  const forgeRow = { cardImgFile: `forge:${ID}`, cardName: "" };
+
+  it("returns the granted name for a forge row", () => {
+    expect(resolveForgeCardName(forgeRow, resolver)).toBe("Test Hero");
+  });
+
+  it("keeps the blank name when the viewer has no grant — fail-closed", () => {
+    expect(resolveForgeCardName(forgeRow, new Map())).toBe("");
+    expect(resolveForgeCardName(forgeRow, null)).toBe("");
+  });
+
+  it("passes public rows through untouched", () => {
+    expect(resolveForgeCardName({ cardImgFile: "Public.jpg", cardName: "Pub" }, resolver)).toBe("Pub");
+  });
+
+  it("makes a forge card's abilities dispatchable; blank name finds none", () => {
+    const vb = new Map([[ID, { ...entry, name: "Virgin Birth" }]]);
+    expect(getEffectiveAbilities({ cardName: resolveForgeCardName(forgeRow, vb) })).toHaveLength(1);
+    expect(getEffectiveAbilities({ cardName: forgeRow.cardName })).toHaveLength(0);
   });
 });
 

--- a/app/play/utils/forgeResolver.ts
+++ b/app/play/utils/forgeResolver.ts
@@ -27,6 +27,23 @@ export function resolveCardImageUrl(imgFile: string, resolver?: ForgeResolverMap
   return getCardImageUrl(imgFile);
 }
 
+// The real name of a forge card, for the viewer who has the grant. Right-click
+// abilities are keyed by card name (CARD_ABILITIES), and the world-readable
+// STDB row blanks the name on forge cards — so dispatching off the raw row
+// always found zero abilities. Ungranted forge rows keep the blank name and
+// stay ability-less, fail-closed.
+//
+// Callers must NOT feed the result into anything world-readable (game log
+// payloads, broadcast reveal labels) — those deliberately stay blanked.
+export function resolveForgeCardName(
+  row: { cardImgFile: string; cardName: string },
+  resolver?: ForgeResolverMap | null,
+): string {
+  const forgeId = forgeCardIdFromImgFile(row.cardImgFile);
+  const e = forgeId ? resolver?.get(forgeId) : undefined;
+  return e ? e.name : row.cardName;
+}
+
 // Re-hydrate the battle-math fields the leak spine blanked on a forge
 // CardInstance row (name/brigade/strength/toughness), from the viewer's
 // granted resolver. Deliberately NOT specialAbility: the auto-return summary


### PR DESCRIPTION
## The bug

Reported against forge **Virgin Birth** — its right-click ability (STAR: look at the top 6 cards) does nothing in Forge games.

The menu and the dispatcher disagreed about the card's name:

- **The context menu** builds its ability list from the adapted `GameCard`, whose forge name the granted resolver has already re-hydrated → `CARD_ABILITIES['Virgin Birth']` hits, so the menu item **appears**.
- **Dispatch** looked the card up with `findAnyCardById`, which returns the raw `CardInstance` — the world-readable STDB row, where the leak spine blanks `cardName` on forge cards. `getEffectiveAbilities({ cardName: '' })` → `[]` → `ability === undefined`, so every client-side branch was skipped and the call fell through to the server reducer, which throws `No such ability` off the same blanked row.

Net effect: the menu offers an ability that fires into nothing.

## The fix

Resolve the forge name **for the ability lookup only**, at the two dispatch sites (`executeCardAbility`, `executeCardAbilityWithCount`), via a new `resolveForgeCardName` helper alongside the existing `resolveBattleRowFields`.

The other `source.cardName` uses in those handlers — the game-log line, the broadcast reveal label, the undo description — deliberately keep the blanked name. Those surfaces are world-readable and must stay opaque; this is the same boundary that sank PR #186. An ungranted forge card still resolves to `''` and stays ability-less, fail-closed.

`forgeResolver` added to the `multiplayerActions` memo deps, since the handlers now read it.

## Scope — what this does not fix

This makes the **client-intercepted** abilities work on forge cards: `look_at_own_deck` (Virgin Birth), `look_at_own_deck_choose`, `reveal_own_deck`, the opponent-consent requests (`look`/`reveal`/`discard_opponent_deck`), `three_nails_reset`, `play_all_lost_souls`, `reserve_opponent_deck`, `draw_brigades`.

Abilities that fall through to `gameState.executeCardAbility(...)` — `spawn_token`, `shuffle_and_draw`, `underdeck_top_of_deck`, `resurrect_heroes`, `set_card_outline`, etc. — still throw `No such ability` for forge cards. The SpacetimeDB module only ever sees the blanked row, so fixing those means either sending forge names to a world-readable table (breaks the leak spine) or keying abilities on something else. Out of scope here; Virgin Birth is not one of them.

**Design note worth a look:** a forge card gets abilities because its name collides with a public card's. That's what makes Virgin Birth work as intended here, but it also means a forge card named after an unrelated public card would silently inherit that card's mechanics. Flagging it rather than changing it.

## Verification

- Full suite: **1776 passed / 138 files**, no regressions.
- `tsc --noEmit` clean apart from two pre-existing errors (`forge-anon-leak.test.ts`, `playDecksAuthorize.test.ts`) confirmed identical on `main`.
- New unit coverage on `resolveForgeCardName`: granted name resolves, ungranted stays blank, public rows pass through, and a case asserting a resolved forge name yields a dispatchable ability where the blanked name yields none.

Not verified by firing the ability in a live Forge game — coverage is unit-level at the name-resolution seam plus the type gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)