### PR TITLE
feat: importer follow-ups — inventory 0, descriptions, permission + nav, clearer UI

### DIFF
--- a/app/admin/import-set/page.tsx
+++ b/app/admin/import-set/page.tsx
@@ -101,6 +101,20 @@ function humanizeWarning(code: string): string {
   return code;
 }
 
+// Best-effort summary of what the import is about to do. Uses plannedAction
+// (computed before the run) rather than re-deriving server-side rescue
+// logic (e.g. a titleOverride rescuing a skip-existing row) — close enough
+// for a confirmation prompt, not a substitute for the results table.
+function confirmImportIntro(createCount: number, updateCount: number, includedCount: number): string {
+  if (createCount > 0 && updateCount > 0) {
+    return `You're about to create ${createCount} and update ${updateCount} products in the Your Turn Games Shopify store.`;
+  }
+  if (updateCount > 0 && createCount === 0) {
+    return `You're about to update ${updateCount} product${updateCount === 1 ? "" : "s"} in the Your Turn Games Shopify store.`;
+  }
+  return `You're about to create ${includedCount} product${includedCount === 1 ? "" : "s"} in the Your Turn Games Shopify store.`;
+}
+
 export default function AdminImportSetPage() {
   const router = useRouter();
   const { isAdmin, permissions, loading: adminLoading } = useIsAdmin();
@@ -117,6 +131,7 @@ export default function AdminImportSetPage() {
   const [active, setActive] = useState(false);
   const [defaultPrice, setDefaultPrice] = useState("");
   const [running, setRunning] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [results, setResults] = useState<ImportResultRow[] | null>(null);
   const [summary, setSummary] = useState<ImportSummary | null>(null);
   const [dryRunMsg, setDryRunMsg] = useState("");
@@ -287,6 +302,17 @@ export default function AdminImportSetPage() {
   const finalBlankCount = plans.filter(
     (p) => rows[p.cardKey]?.include && !rows[p.cardKey].price.trim() && !defaultPrice.trim(),
   ).length;
+  const createCount = plans.filter((p) => rows[p.cardKey]?.include && p.plannedAction === "create").length;
+  const updateCount = plans.filter((p) => rows[p.cardKey]?.include && p.plannedAction === "update").length;
+
+  useEffect(() => {
+    if (!confirmOpen) return;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !running) setConfirmOpen(false);
+    };
+    document.addEventListener("keydown", handleEsc);
+    return () => document.removeEventListener("keydown", handleEsc);
+  }, [confirmOpen, running]);
 
   const buildCardsPayload = () =>
     plans.map((p) => {
@@ -327,13 +353,9 @@ export default function AdminImportSetPage() {
     }
   };
 
-  const handleImport = async () => {
+  const runImport = async () => {
     const statusLabel = active ? "ACTIVE" : "DRAFT";
-    const confirmed = window.confirm(
-      `Import ${includedCount} cards as ${statusLabel}?\n${finalBlankCount} card(s) will have a blank price.`,
-    );
-    if (!confirmed) return;
-
+    setConfirmOpen(false);
     setRunning(true);
     setError("");
     setDryRunMsg("");
@@ -569,8 +591,8 @@ export default function AdminImportSetPage() {
                 <Button variant="outline" onClick={handleDryRun} disabled={running}>
                   Dry run
                 </Button>
-                <Button onClick={handleImport} disabled={running || includedCount === 0}>
-                  Import {includedCount} cards
+                <Button onClick={() => setConfirmOpen(true)} disabled={running || includedCount === 0}>
+                  Import {includedCount} card{includedCount === 1 ? "" : "s"}
                 </Button>
                 {running && <span className="text-sm text-muted-foreground">Working, please wait…</span>}
                 {dryRunMsg && <span className="text-sm text-muted-foreground">{dryRunMsg}</span>}
@@ -624,6 +646,42 @@ export default function AdminImportSetPage() {
           )}
         </div>
       </div>
+
+      {confirmOpen && (
+        <div
+          className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4"
+          onClick={(e) => { if (e.target === e.currentTarget && !running) setConfirmOpen(false); }}
+        >
+          <div className="bg-card border rounded-lg shadow-lg p-6 w-full max-w-md">
+            <h2 className="text-xl font-semibold mb-3">Confirm import</h2>
+            <div className="space-y-2 mb-6">
+              <p className="text-sm">{confirmImportIntro(createCount, updateCount, includedCount)}</p>
+              {active ? (
+                <p className="text-sm text-amber-600 dark:text-amber-400">
+                  As ACTIVE — these go live in the store immediately.
+                </p>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  As Drafts — hidden from shoppers until published in Shopify.
+                </p>
+              )}
+              {finalBlankCount > 0 && (
+                <p className="text-sm text-amber-600 dark:text-amber-400">
+                  {finalBlankCount} of them {finalBlankCount === 1 ? "has" : "have"} no price and will import at $0.00.
+                </p>
+              )}
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setConfirmOpen(false)} disabled={running}>
+                Cancel
+              </Button>
+              <Button onClick={runImport} disabled={running}>
+                Import {includedCount} card{includedCount === 1 ? "" : "s"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/admin/import-set/page.tsx
+++ b/app/admin/import-set/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -67,6 +67,40 @@ function actionBadgeClass(action: CardPlan["plannedAction"] | ImportResultRow["a
   }
 }
 
+function planStatusLabel(action: CardPlan["plannedAction"]): string {
+  switch (action) {
+    case "create":
+      return "New";
+    case "update":
+      return "Update existing";
+    case "skip-existing":
+      return "Already in store";
+  }
+}
+
+function resultStatusLabel(action: ImportResultRow["action"]): string {
+  switch (action) {
+    case "created":
+      return "Created";
+    case "updated":
+      return "Updated";
+    case "skipped":
+      return "Skipped";
+    case "error":
+      return "Error";
+  }
+}
+
+// Humanizes plan-time warning codes for display under the title.
+// ('no-price' never appears at plan time — filtered out in planCard.)
+function humanizeWarning(code: string): string {
+  if (code === "no-image") return "No card image — imports without an image";
+  if (code === "no-set-alias") return "No set alias — set code used in title";
+  if (code.startsWith("brigade-unmapped:")) return `Unmapped brigade: ${code.slice("brigade-unmapped:".length)}`;
+  if (code.startsWith("type-unmapped:")) return `Unmapped type: ${code.slice("type-unmapped:".length)}`;
+  return code;
+}
+
 export default function AdminImportSetPage() {
   const router = useRouter();
   const { isAdmin, permissions, loading: adminLoading } = useIsAdmin();
@@ -74,6 +108,10 @@ export default function AdminImportSetPage() {
 
   const [sets, setSets] = useState<{ code: string; name: string; count: number }[]>([]);
   const [setCode, setSetCode] = useState("");
+  const [setSearch, setSetSearch] = useState("");
+  const [setPickerOpen, setSetPickerOpen] = useState(false);
+  const [activeSetIndex, setActiveSetIndex] = useState(-1);
+  const setPickerRef = useRef<HTMLDivElement>(null);
   const [plans, setPlans] = useState<CardPlan[]>([]);
   const [rows, setRows] = useState<Record<string, RowState>>({});
   const [active, setActive] = useState(false);
@@ -143,6 +181,47 @@ export default function AdminImportSetPage() {
       setError(err instanceof Error ? err.message : "Failed to load plans");
     } finally {
       if (seq === fetchSeq.current) setLoadingPlans(false);
+    }
+  };
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (setPickerRef.current && !setPickerRef.current.contains(e.target as Node)) {
+        setSetPickerOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  const filteredSets = useMemo(() => {
+    const q = setSearch.trim().toLowerCase();
+    if (!q) return sets;
+    return sets.filter((s) => s.name.toLowerCase().includes(q) || s.code.toLowerCase().includes(q));
+  }, [sets, setSearch]);
+
+  const handleSelectSet = (s: { code: string; name: string; count: number }) => {
+    setSetSearch(`${s.name} (${s.code})`);
+    setSetPickerOpen(false);
+    setActiveSetIndex(-1);
+    handleSetChange(s.code);
+  };
+
+  const handleSetPickerKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!setPickerOpen) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveSetIndex((prev) => Math.min(prev + 1, filteredSets.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveSetIndex((prev) => Math.max(prev - 1, 0));
+    } else if (e.key === "Enter") {
+      if (activeSetIndex >= 0 && activeSetIndex < filteredSets.length) {
+        e.preventDefault();
+        handleSelectSet(filteredSets[activeSetIndex]);
+      }
+    } else if (e.key === "Escape") {
+      setSetPickerOpen(false);
     }
   };
 
@@ -300,20 +379,39 @@ export default function AdminImportSetPage() {
 
           <div className="mb-6 max-w-md">
             <Label htmlFor="set-picker">Set</Label>
-            <select
-              id="set-picker"
-              value={setCode}
-              onChange={(e) => handleSetChange(e.target.value)}
-              disabled={loadingSets || loadingPlans || running}
-              className="mt-1 flex h-10 w-full rounded-md border-2 border-input bg-background px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <option value="">{loadingSets ? "Loading sets…" : "Select a set…"}</option>
-              {sets.map((s) => (
-                <option key={s.code} value={s.code}>
-                  {s.name} ({s.code}) — {s.count} cards
-                </option>
-              ))}
-            </select>
+            <div ref={setPickerRef} className="relative mt-1">
+              <Input
+                id="set-picker"
+                value={setSearch}
+                onChange={(e) => {
+                  setSetSearch(e.target.value);
+                  setActiveSetIndex(-1);
+                  setSetPickerOpen(true);
+                }}
+                onFocus={() => setSetPickerOpen(true)}
+                onKeyDown={handleSetPickerKeyDown}
+                placeholder="Search sets — e.g. Roots 2"
+                disabled={loadingSets || loadingPlans || running}
+                autoComplete="off"
+              />
+              {setPickerOpen && filteredSets.length > 0 && (
+                <div className="absolute mt-1 w-full bg-card border rounded-lg shadow-lg max-h-72 overflow-y-auto z-10">
+                  {filteredSets.map((s, i) => (
+                    <button
+                      key={s.code}
+                      type="button"
+                      onClick={() => handleSelectSet(s)}
+                      className={`w-full text-left px-3 py-2 ${i === activeSetIndex ? "bg-muted" : ""}`}
+                    >
+                      <div className="text-sm">
+                        {s.name} ({s.code})
+                      </div>
+                      <div className="text-xs text-muted-foreground">{s.count} cards</div>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
 
           {loadingPlans && <p className="text-muted-foreground mb-6">Loading cards…</p>}
@@ -349,15 +447,30 @@ export default function AdminImportSetPage() {
                 </div>
               </div>
 
-              <div className="flex items-center gap-2 mb-6">
-                <input
-                  id="active-toggle"
-                  type="checkbox"
-                  checked={active}
-                  onChange={(e) => setActive(e.target.checked)}
-                  className="w-4 h-4"
-                />
-                <Label htmlFor="active-toggle">Publish as ACTIVE immediately (default: DRAFT)</Label>
+              <div className="mb-6">
+                <div className="text-sm font-medium mb-2">Import as:</div>
+                <div className="flex flex-col gap-2">
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="radio"
+                      name="publish-status"
+                      checked={!active}
+                      onChange={() => setActive(false)}
+                      className="w-4 h-4"
+                    />
+                    Draft — hidden until published in Shopify
+                  </label>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="radio"
+                      name="publish-status"
+                      checked={active}
+                      onChange={() => setActive(true)}
+                      className="w-4 h-4"
+                    />
+                    Active — live in the store immediately
+                  </label>
+                </div>
               </div>
 
               <div className="bg-card border rounded-lg overflow-hidden mb-6">
@@ -365,13 +478,12 @@ export default function AdminImportSetPage() {
                   <table className="w-full">
                     <thead className="bg-muted">
                       <tr>
-                        <th className="px-4 py-3 text-left text-sm font-semibold"></th>
+                        <th className="px-4 py-3 text-left text-sm font-semibold">Import</th>
                         <th className="px-4 py-3 text-left text-sm font-semibold">Image</th>
                         <th className="px-4 py-3 text-left text-sm font-semibold">Card</th>
-                        <th className="px-4 py-3 text-left text-sm font-semibold">Title</th>
+                        <th className="px-4 py-3 text-left text-sm font-semibold">Shopify listing</th>
                         <th className="px-4 py-3 text-left text-sm font-semibold">Tags</th>
-                        <th className="px-4 py-3 text-left text-sm font-semibold">Action</th>
-                        <th className="px-4 py-3 text-left text-sm font-semibold">Warnings</th>
+                        <th className="px-4 py-3 text-left text-sm font-semibold">Status</th>
                         <th className="px-4 py-3 text-left text-sm font-semibold">Price</th>
                       </tr>
                     </thead>
@@ -386,6 +498,7 @@ export default function AdminImportSetPage() {
                                 type="checkbox"
                                 checked={row.include}
                                 onChange={(e) => updateRow(plan.cardKey, { include: e.target.checked })}
+                                aria-label={`Import ${plan.cardName}`}
                                 className="w-4 h-4"
                               />
                             </td>
@@ -405,29 +518,31 @@ export default function AdminImportSetPage() {
                             </td>
                             <td className="px-4 py-3 text-sm">{plan.cardName}</td>
                             <td className="px-4 py-3">
-                              <div className="text-sm text-muted-foreground mb-1">{plan.title}</div>
+                              <div className="text-sm mb-1">{plan.title}</div>
                               <Input
                                 value={row.titleOverride}
                                 onChange={(e) => updateRow(plan.cardKey, { titleOverride: e.target.value })}
-                                placeholder={plan.title}
+                                placeholder="Override title (optional)"
+                                aria-label={`Title override for ${plan.cardName}`}
                                 className="h-8 text-xs"
                               />
+                              {plan.warnings.length > 0 && (
+                                <div className="mt-1 space-y-0.5">
+                                  {plan.warnings.map((w) => (
+                                    <div key={w} className="text-xs text-amber-600 dark:text-amber-400">
+                                      {humanizeWarning(w)}
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
                             </td>
                             <td className="px-4 py-3 text-xs text-muted-foreground">{plan.tags.join(", ")}</td>
                             <td className="px-4 py-3">
                               <span
                                 className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${actionBadgeClass(plan.plannedAction)}`}
                               >
-                                {plan.plannedAction}
+                                {planStatusLabel(plan.plannedAction)}
                               </span>
-                              {plan.plannedAction === "skip-existing" && (
-                                <div className="mt-1 text-[10px] text-amber-600 dark:text-amber-400">
-                                  exists in store
-                                </div>
-                              )}
-                            </td>
-                            <td className="px-4 py-3 text-xs text-amber-600 dark:text-amber-400">
-                              {plan.warnings.join(", ")}
                             </td>
                             <td className="px-4 py-3">
                               <Input
@@ -435,6 +550,7 @@ export default function AdminImportSetPage() {
                                 value={row.price}
                                 onChange={(e) => handlePriceChange(plan.cardKey, e.target.value)}
                                 placeholder="0.00"
+                                aria-label={`Price for ${plan.cardName}`}
                                 className="h-8 w-20 text-xs"
                               />
                               {!row.price.trim() && (
@@ -494,7 +610,7 @@ export default function AdminImportSetPage() {
                           <span
                             className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${actionBadgeClass(r.action)}`}
                           >
-                            {r.action}
+                            {resultStatusLabel(r.action)}
                           </span>
                         </td>
                         <td className="px-4 py-2 text-sm text-muted-foreground">{r.productId ?? "—"}</td>

--- a/app/admin/import-set/page.tsx
+++ b/app/admin/import-set/page.tsx
@@ -69,7 +69,8 @@ function actionBadgeClass(action: CardPlan["plannedAction"] | ImportResultRow["a
 
 export default function AdminImportSetPage() {
   const router = useRouter();
-  const { isAdmin, loading: adminLoading } = useIsAdmin();
+  const { isAdmin, permissions, loading: adminLoading } = useIsAdmin();
+  const canImport = isAdmin && permissions.includes("manage_shopify_imports");
 
   const [sets, setSets] = useState<{ code: string; name: string; count: number }[]>([]);
   const [setCode, setSetCode] = useState("");
@@ -90,13 +91,13 @@ export default function AdminImportSetPage() {
   const fetchSeq = useRef(0);
 
   useEffect(() => {
-    if (!adminLoading && !isAdmin) {
+    if (!adminLoading && !canImport) {
       router.replace("/");
     }
-  }, [adminLoading, isAdmin, router]);
+  }, [adminLoading, canImport, router]);
 
   useEffect(() => {
-    if (!isAdmin) return;
+    if (!canImport) return;
     const loadSets = async () => {
       setLoadingSets(true);
       try {
@@ -111,7 +112,7 @@ export default function AdminImportSetPage() {
       }
     };
     loadSets();
-  }, [isAdmin]);
+  }, [canImport]);
 
   const handleSetChange = async (code: string) => {
     const seq = ++fetchSeq.current;
@@ -280,7 +281,7 @@ export default function AdminImportSetPage() {
     }
   };
 
-  if (adminLoading || !isAdmin) return null;
+  if (adminLoading || !canImport) return null;
 
   return (
     <div className="flex flex-col min-h-screen">

--- a/app/admin/permissions/lib/permissions.ts
+++ b/app/admin/permissions/lib/permissions.ts
@@ -6,6 +6,7 @@ export const ADMIN_PERMISSIONS = [
   { key: "manage_spoilers", label: "Spoilers" },
   { key: "manage_cards", label: "Cards" },
   { key: "manage_rulings", label: "Rulings" },
+  { key: "manage_shopify_imports", label: "Shopify Imports" },
   { key: "threshing_floor", label: "Threshing Floor" },
 ] as const;
 

--- a/app/admin/tags/actions.ts
+++ b/app/admin/tags/actions.ts
@@ -2,11 +2,11 @@
 
 import { createClient } from "../../../utils/supabase/server";
 import { revalidatePath } from "next/cache";
-import { requireRegistrationAdmin } from "../../../utils/adminUtils";
+import { requirePermission } from "../../../utils/adminUtils";
 
 export async function createGlobalTagAction(name: string, color: string) {
   try {
-    await requireRegistrationAdmin();
+    await requirePermission("manage_tags");
     const supabase = await createClient();
 
     const trimmed = name.trim();
@@ -34,7 +34,7 @@ export async function createGlobalTagAction(name: string, color: string) {
 
 export async function updateGlobalTagAction(id: string, name: string, color: string) {
   try {
-    await requireRegistrationAdmin();
+    await requirePermission("manage_tags");
     const supabase = await createClient();
 
     const trimmed = name.trim();
@@ -61,7 +61,7 @@ export async function updateGlobalTagAction(id: string, name: string, color: str
 
 export async function deleteGlobalTagAction(id: string) {
   try {
-    await requireRegistrationAdmin();
+    await requirePermission("manage_tags");
     const supabase = await createClient();
 
     const { error } = await supabase
@@ -81,7 +81,7 @@ export async function deleteGlobalTagAction(id: string) {
 
 export async function loadGlobalTagsAdminAction() {
   try {
-    await requireRegistrationAdmin();
+    await requirePermission("manage_tags");
     const supabase = await createClient();
 
     const { data, error } = await supabase

--- a/app/api/admin/import-set/route.ts
+++ b/app/api/admin/import-set/route.ts
@@ -10,7 +10,7 @@ export const maxDuration = 300;
 
 export async function GET(request: NextRequest) {
   if (!(await hasPermission('manage_shopify_imports'))) {
-    return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+    return NextResponse.json({ error: 'Shopify import permission required' }, { status: 403 });
   }
   try {
     const setCode = request.nextUrl.searchParams.get('set');
@@ -26,7 +26,7 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   if (!(await hasPermission('manage_shopify_imports'))) {
-    return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+    return NextResponse.json({ error: 'Shopify import permission required' }, { status: 403 });
   }
   try {
     const body = await request.json();

--- a/app/api/admin/import-set/route.ts
+++ b/app/api/admin/import-set/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { isRegistrationAdmin } from '@/utils/adminUtils';
+import { hasPermission } from '@/utils/adminUtils';
 import { planSetImport, executeImport, listImportableSets, type ImportRequest } from '@/lib/shopify/importSet';
 
 // A ~350-card set import plus the post-import reconcile (sync + matching +
@@ -9,7 +9,7 @@ import { planSetImport, executeImport, listImportableSets, type ImportRequest } 
 export const maxDuration = 300;
 
 export async function GET(request: NextRequest) {
-  if (!(await isRegistrationAdmin())) {
+  if (!(await hasPermission('manage_shopify_imports'))) {
     return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
   }
   try {
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  if (!(await isRegistrationAdmin())) {
+  if (!(await hasPermission('manage_shopify_imports'))) {
     return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
   }
   try {

--- a/components/top-nav.tsx
+++ b/components/top-nav.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import type { IconType } from "react-icons";
-import { HiMenu, HiDocumentText, HiArrowSmRight, HiUserAdd, HiShieldCheck, HiGlobeAlt, HiSparkles, HiCalendar, HiCollection, HiChartBar, HiKey, HiClipboardList } from "react-icons/hi";
+import { HiMenu, HiDocumentText, HiArrowSmRight, HiUserAdd, HiShieldCheck, HiGlobeAlt, HiSparkles, HiCalendar, HiCollection, HiChartBar, HiKey, HiClipboardList, HiShoppingCart } from "react-icons/hi";
 import { GiCrossedSwords, GiAnvil } from "react-icons/gi";
 import { IoClose } from "react-icons/io5";
 import { FaTrophy, FaBookOpen } from "react-icons/fa6";
@@ -301,6 +301,16 @@ const TopNav: React.FC = () => {
                         >
                           <HiDocumentText className="w-4 h-4" />
                           Manage Rulings
+                        </Link>
+                      )}
+                      {permissions.includes('manage_shopify_imports') && (
+                        <Link
+                          href="/admin/import-set"
+                          onClick={() => setIsAdminOpen(false)}
+                          className="flex items-center gap-2 px-4 py-2 text-sm text-foreground hover:bg-muted"
+                        >
+                          <HiShoppingCart className="w-4 h-4" />
+                          YTG Imports
                         </Link>
                       )}
                       {isSuperuser && (
@@ -725,6 +735,16 @@ const TopNav: React.FC = () => {
                       >
                         <HiDocumentText className="w-4 h-4" />
                         Manage Rulings
+                      </Link>
+                    )}
+                    {permissions.includes('manage_shopify_imports') && (
+                      <Link
+                        href="/admin/import-set"
+                        onClick={closeMobileMenu}
+                        className="flex items-center gap-2 px-3 py-2 rounded-md text-sm text-muted-foreground hover:bg-muted"
+                      >
+                        <HiShoppingCart className="w-4 h-4" />
+                        YTG Imports
                       </Link>
                     )}
                     {isSuperuser && (

--- a/lib/shopify/admin-write.test.ts
+++ b/lib/shopify/admin-write.test.ts
@@ -6,7 +6,7 @@ const INPUT: ShopifyProductSetInput = {
   title: 'Test Card (XX)', handle: 'test-card-xx', productType: 'Single',
   vendor: 'Your Turn Games', tags: ['Hero'], status: 'DRAFT',
   productOptions: [{ name: 'Title', values: [{ name: 'Default Title' }] }],
-  variants: [{ optionValues: [{ optionName: 'Title', name: 'Default Title' }], price: '1.00', sku: 'XX-test' }],
+  variants: [{ optionValues: [{ optionName: 'Title', name: 'Default Title' }], price: '1.00', sku: 'XX-test', inventoryItem: { tracked: true } }],
 };
 
 function jsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}) {

--- a/lib/shopify/importSet.ts
+++ b/lib/shopify/importSet.ts
@@ -328,6 +328,7 @@ export async function executeImport(
         titleOverride: spec.titleOverride,
         includeMedia,
         includeVariants,
+        includeDescription: !identifier,
       });
       const filesIncluded = built.input.files !== undefined;
 

--- a/lib/shopify/importSet.ts
+++ b/lib/shopify/importSet.ts
@@ -329,6 +329,7 @@ export async function executeImport(
         includeMedia,
         includeVariants,
         includeDescription: !identifier,
+        trackInventory: !identifier,
       });
       const filesIncluded = built.input.files !== undefined;
 

--- a/lib/shopify/productFromCard.test.ts
+++ b/lib/shopify/productFromCard.test.ts
@@ -185,6 +185,11 @@ describe('productFromCard', () => {
     expect(built.input.descriptionHtml).toBeUndefined();
   });
 
+  it('omits inventoryItem when trackInventory is false (update re-run)', () => {
+    const built = productFromCard(I_AM_HAS_SENT_ME, 'PoC', { ...opts, trackInventory: false });
+    expect(built.input.variants![0]).not.toHaveProperty('inventoryItem');
+  });
+
   it('omits descriptionHtml when specialAbility is empty', () => {
     const card: CardData = { ...ABUSIVE_SOLDIERS, specialAbility: '' };
     const built = productFromCard(card, 'GoC', opts);

--- a/lib/shopify/productFromCard.test.ts
+++ b/lib/shopify/productFromCard.test.ts
@@ -108,7 +108,7 @@ describe('productFromCard', () => {
     expect(built.input.vendor).toBe('Your Turn Games');
     expect(built.input.status).toBe('DRAFT');
     expect(built.input.productOptions).toEqual([{ name: 'Title', values: [{ name: 'Default Title' }] }]);
-    expect(built.input.variants).toEqual([{ optionValues: [{ optionName: 'Title', name: 'Default Title' }], price: '0.75', sku: cardSku(I_AM_HAS_SENT_ME) }]);
+    expect(built.input.variants).toEqual([{ optionValues: [{ optionName: 'Title', name: 'Default Title' }], price: '0.75', sku: cardSku(I_AM_HAS_SENT_ME), inventoryItem: { tracked: true } }]);
     expect(built.input.files).toEqual([{ originalSource: opts.imageUrl, contentType: 'IMAGE', alt: 'I AM Has Sent Me' }]);
     expect(built.warnings).toEqual([]);
   });
@@ -167,5 +167,33 @@ describe('productFromCard', () => {
     const built = productFromCard(I_AM_HAS_SENT_ME, 'PoC', opts);
     expect(built.input.variants).toBeDefined();
     expect(built.input.productOptions).toBeDefined();
+  });
+
+  it('sets descriptionHtml from the special ability by default', () => {
+    const built = productFromCard(ABUSIVE_SOLDIERS, 'GoC', opts);
+    expect(built.input.descriptionHtml).toBe(`<p>${ABUSIVE_SOLDIERS.specialAbility}</p>`);
+  });
+
+  it('HTML-escapes the special ability in descriptionHtml', () => {
+    const card: CardData = { ...ABUSIVE_SOLDIERS, specialAbility: `A "Test" & <tag> isn't fine` };
+    const built = productFromCard(card, 'GoC', opts);
+    expect(built.input.descriptionHtml).toBe('<p>A &quot;Test&quot; &amp; &lt;tag&gt; isn&#39;t fine</p>');
+  });
+
+  it('omits descriptionHtml when includeDescription is false', () => {
+    const built = productFromCard(ABUSIVE_SOLDIERS, 'GoC', { ...opts, includeDescription: false });
+    expect(built.input.descriptionHtml).toBeUndefined();
+  });
+
+  it('omits descriptionHtml when specialAbility is empty', () => {
+    const card: CardData = { ...ABUSIVE_SOLDIERS, specialAbility: '' };
+    const built = productFromCard(card, 'GoC', opts);
+    expect(built.input.descriptionHtml).toBeUndefined();
+  });
+
+  it('omits descriptionHtml when specialAbility is whitespace-only', () => {
+    const card: CardData = { ...ABUSIVE_SOLDIERS, specialAbility: '   ' };
+    const built = productFromCard(card, 'GoC', opts);
+    expect(built.input.descriptionHtml).toBeUndefined();
   });
 });

--- a/lib/shopify/productFromCard.ts
+++ b/lib/shopify/productFromCard.ts
@@ -11,7 +11,7 @@ export interface ShopifyProductSetInput {
   status: 'DRAFT' | 'ACTIVE';
   descriptionHtml?: string;
   productOptions?: { name: string; values: { name: string }[] }[];
-  variants?: { optionValues: { optionName: string; name: string }[]; price: string; sku: string; inventoryItem: { tracked: boolean } }[];
+  variants?: { optionValues: { optionName: string; name: string }[]; price: string; sku: string; inventoryItem?: { tracked: boolean } }[];
   files?: { originalSource: string; contentType: 'IMAGE'; alt: string }[];
   metafields?: { namespace: string; key: string; value: string; type: string }[];
 }
@@ -24,6 +24,7 @@ export interface ProductBuildOptions {
   includeMedia?: boolean;      // default true; false => omit files even if imageUrl set (update re-runs)
   includeVariants?: boolean;   // default true; false => omit variants + productOptions (blank-price updates leave live variant data untouched)
   includeDescription?: boolean; // default true; false => omit descriptionHtml even if specialAbility set (updates don't clobber store edits)
+  trackInventory?: boolean;    // default true; false on update re-runs — never toggle tracking on live products
 }
 
 export interface BuiltProduct {
@@ -118,6 +119,7 @@ export function productFromCard(card: CardData, ytgAbbrev: string | null, opts: 
   const includeVariants = opts.includeVariants !== false;
   if (includeVariants && opts.price === null) warnings.push('no-price');
   const price = opts.price ?? '0.00';
+  const trackInventory = opts.trackInventory !== false;
 
   // --- files / image ---
   if (opts.imageUrl === null) warnings.push('no-image');
@@ -141,7 +143,12 @@ export function productFromCard(card: CardData, ytgAbbrev: string | null, opts: 
     ...(descriptionHtml ? { descriptionHtml } : {}),
     ...(includeVariants ? {
       productOptions: [{ name: 'Title', values: [{ name: 'Default Title' }] }],
-      variants: [{ optionValues: [{ optionName: 'Title', name: 'Default Title' }], price, sku: cardSku(card), inventoryItem: { tracked: true } }],
+      variants: [{
+        optionValues: [{ optionName: 'Title', name: 'Default Title' }],
+        price,
+        sku: cardSku(card),
+        ...(trackInventory ? { inventoryItem: { tracked: true } } : {}),
+      }],
     } : {}),
     ...(files ? { files } : {}),
     metafields: [{ namespace: 'custom', key: 'rtt_card_key', value: cardKey, type: 'single_line_text_field' }],

--- a/lib/shopify/productFromCard.ts
+++ b/lib/shopify/productFromCard.ts
@@ -9,8 +9,9 @@ export interface ShopifyProductSetInput {
   vendor: string;
   tags: string[];
   status: 'DRAFT' | 'ACTIVE';
+  descriptionHtml?: string;
   productOptions?: { name: string; values: { name: string }[] }[];
-  variants?: { optionValues: { optionName: string; name: string }[]; price: string; sku: string }[];
+  variants?: { optionValues: { optionName: string; name: string }[]; price: string; sku: string; inventoryItem: { tracked: boolean } }[];
   files?: { originalSource: string; contentType: 'IMAGE'; alt: string }[];
   metafields?: { namespace: string; key: string; value: string; type: string }[];
 }
@@ -22,6 +23,7 @@ export interface ProductBuildOptions {
   titleOverride?: string;      // admin-entered title replaces the computed one verbatim
   includeMedia?: boolean;      // default true; false => omit files even if imageUrl set (update re-runs)
   includeVariants?: boolean;   // default true; false => omit variants + productOptions (blank-price updates leave live variant data untouched)
+  includeDescription?: boolean; // default true; false => omit descriptionHtml even if specialAbility set (updates don't clobber store edits)
 }
 
 export interface BuiltProduct {
@@ -56,6 +58,15 @@ export function cardSku(card: CardData): string {
 
 function normalizeRarity(rarity: string): string {
   return rarity === 'Ultra-Rare' ? 'Ultra Rare' : rarity;
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 export function productFromCard(card: CardData, ytgAbbrev: string | null, opts: ProductBuildOptions): BuiltProduct {
@@ -114,6 +125,12 @@ export function productFromCard(card: CardData, ytgAbbrev: string | null, opts: 
     ? [{ originalSource: opts.imageUrl, contentType: 'IMAGE' as const, alt: baseCardName(card.name) }]
     : undefined;
 
+  // --- description ---
+  const trimmedAbility = card.specialAbility.trim();
+  const descriptionHtml = opts.includeDescription !== false && trimmedAbility.length > 0
+    ? `<p>${escapeHtml(trimmedAbility)}</p>`
+    : undefined;
+
   const input: ShopifyProductSetInput = {
     title,
     handle,
@@ -121,9 +138,10 @@ export function productFromCard(card: CardData, ytgAbbrev: string | null, opts: 
     vendor: 'Your Turn Games',
     tags: Array.from(tags).sort(),
     status: opts.status,
+    ...(descriptionHtml ? { descriptionHtml } : {}),
     ...(includeVariants ? {
       productOptions: [{ name: 'Title', values: [{ name: 'Default Title' }] }],
-      variants: [{ optionValues: [{ optionName: 'Title', name: 'Default Title' }], price, sku: cardSku(card) }],
+      variants: [{ optionValues: [{ optionName: 'Title', name: 'Default Title' }], price, sku: cardSku(card), inventoryItem: { tracked: true } }],
     } : {}),
     ...(files ? { files } : {}),
     metafields: [{ namespace: 'custom', key: 'rtt_card_key', value: cardKey, type: 'single_line_text_field' }],

--- a/supabase/migrations/087_add_manage_shopify_imports_permission.sql
+++ b/supabase/migrations/087_add_manage_shopify_imports_permission.sql
@@ -1,0 +1,37 @@
+-- Add 'manage_shopify_imports' to the super_set_admin_permissions allowlist.
+-- Redefines the function verbatim from 062_superuser_admin_portal.sql (the
+-- latest/only prior definition), adding the one new permission key.
+-- Allowlist MIRRORS app/admin/permissions/lib/permissions.ts — update both together.
+create or replace function public.super_set_admin_permissions(p_user_id uuid, p_permissions text[])
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  allowed constant text[] := array[
+    'manage_registrations','manage_tags','manage_spoilers',
+    'manage_cards','manage_rulings','threshing_floor','manage_shopify_imports'
+  ];
+  perm text;
+  perms text[] := coalesce(p_permissions, '{}');
+begin
+  if not public.is_superuser() then
+    raise exception 'not authorized';
+  end if;
+  foreach perm in array perms loop
+    if not (perm = any(allowed)) then
+      raise exception 'unknown permission: %', perm;
+    end if;
+  end loop;
+  if not exists (select 1 from auth.users u where u.id = p_user_id) then
+    raise exception 'no such user';
+  end if;
+  insert into public.admin_users (user_id, permissions, created_by)
+  values (p_user_id, perms, auth.uid())
+  on conflict (user_id) do update set permissions = excluded.permissions;
+end;
+$$;
+
+revoke execute on function public.super_set_admin_permissions(uuid, text[]) from public, anon;
+grant execute on function public.super_set_admin_permissions(uuid, text[]) to authenticated;


### PR DESCRIPTION
## Summary
Follow-ups to #241 from the first live import session:

**Product data**
- Imported cards default to **tracked inventory** (`inventoryItem.tracked`, create-only) so published cards read 0 / sold-out until YTG stocks them — no more untracked=infinite. Updates never touch tracking (won't re-track deliberately untracked products).
- **Description = card's special ability** (HTML-escaped, create-only so store edits are never clobbered).

**Access control**
- New `manage_shopify_imports` permission: Admin-dropdown entry ("YTG Imports", desktop + mobile), page + API route now gate on it (was: any admin row). Migration 087 widens the superuser-portal allowlist — **already applied to prod**, and both intended users are **already granted** (so deploy causes no access gap).
- Related hardening: tags mutation actions now require `manage_tags` server-side (was bare admin).

**UI (from live-use feedback)**
- Type-to-search set picker (replaces the ~60-item select)
- Clearer table: "Import" checkbox header, no title echo (override input is clearly optional), friendly status badges (New / Update existing / Already in store), humanized warnings under the title, aria-labels
- Draft/Active is now an explicit radio pair with plain-language consequences
- In-app import confirmation modal (replaces the native window.confirm), correct pluralization, explicit "$0.00" blank-price warning

## Verified
- 38/38 lib/shopify tests (new: trackInventory create-only, description escaping/omission); full suite green; tsc clean (2 known pre-existing test-file groups)
- Reviewed by subagent pass; the one Important finding (tracking forced on updates) fixed in-branch
- Migration 087 body verified as a faithful copy of 062's latest `super_set_admin_permissions` definition + one allowlist entry

## Ops (already done, in order)
1. `set_aliases`: RR2 → "Roots 2" inserted (fixes the `no-set-alias` warnings / `(RR2)` titles)
2. Migration 087 applied to prod
3. `manage_shopify_imports` granted to baboonytim@gmail.com and yourturngamesin@gmail.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)