### PR TITLE
feat(ytg): Matching tab — deterministic-first reconciliation (WS-2)

### DIFF
--- a/app/admin/ytg/components/HealthStrip.tsx
+++ b/app/admin/ytg/components/HealthStrip.tsx
@@ -17,7 +17,7 @@ function timeAgo(iso: string | null): string {
 export default async function HealthStrip() {
   const supabase = getSupabaseAdmin();
 
-  const [freshness, productCount, totalMappings, confirmedMappings, needsReview, unmatched] =
+  const [freshness, productCount, totalMappings, confirmedMappings, noPriceExists, needsReview, unmatched] =
     await Promise.all([
       supabase
         .from("shopify_products")
@@ -34,6 +34,10 @@ export default async function HealthStrip() {
       supabase
         .from("card_price_mappings")
         .select("*", { count: "exact", head: true })
+        .eq("status", "no_price_exists"),
+      supabase
+        .from("card_price_mappings")
+        .select("*", { count: "exact", head: true })
         .eq("status", "needs_review"),
       supabase
         .from("card_price_mappings")
@@ -44,13 +48,23 @@ export default async function HealthStrip() {
   const oldestSync: string | null = freshness.data?.[0]?.last_synced_at ?? null;
   const total = totalMappings.count ?? 0;
   const confirmed = confirmedMappings.count ?? 0;
-  const matchedPct = total > 0 ? Math.round((confirmed / total) * 1000) / 10 : 0;
+  const notSold = noPriceExists.count ?? 0;
+  // Matched % is of SELLABLE cards only — no_price_exists rows are cards YTG
+  // deliberately doesn't sell, not matching failures ("81.7% matched" read as
+  // a problem when the missing 18.3% was all no_price_exists).
+  const sellable = total - notSold;
+  const matchedPct = sellable > 0 ? Math.round((confirmed / sellable) * 1000) / 10 : 0;
 
   // Each stat links to the tab that acts on it.
-  const stats = [
+  const stats: { label: string; value: string; sub?: string; href: string }[] = [
     { label: "Synced", value: timeAgo(oldestSync), href: "/admin/ytg/matching" },
     { label: "Products", value: (productCount.count ?? 0).toLocaleString(), href: "/admin/ytg/products" },
-    { label: "Matched", value: `${matchedPct}%`, href: "/admin/ytg/matching" },
+    {
+      label: "Matched",
+      value: `${matchedPct}% of sellable`,
+      sub: `${notSold.toLocaleString()} not sold by YTG`,
+      href: "/admin/ytg/matching",
+    },
     { label: "Needs review", value: (needsReview.count ?? 0).toLocaleString(), href: "/admin/ytg/matching" },
     { label: "Unmatched", value: (unmatched.count ?? 0).toLocaleString(), href: "/admin/ytg/matching" },
   ];
@@ -67,6 +81,9 @@ export default async function HealthStrip() {
             {s.label}
           </span>
           <span className="text-sm font-semibold">{s.value}</span>
+          {s.sub && (
+            <span className="block text-[10px] text-muted-foreground">{s.sub}</span>
+          )}
         </Link>
       ))}
     </div>

--- a/app/admin/ytg/matching/actions.ts
+++ b/app/admin/ytg/matching/actions.ts
@@ -31,8 +31,11 @@ export async function planSkuBackfill(): Promise<{
   const supabase = getSupabaseAdmin();
   const pageSize = 1000;
 
-  // Confirmed mappings whose product is a Single with no SKU yet (!inner join
-  // makes the embedded filters constrain the parent rows).
+  // Confirmed mappings whose product is a Single (!inner join makes the
+  // embedded filters constrain the parent rows). NO sku-is-null prefilter:
+  // synced blank SKUs land as "" (empty string), so the "already has a SKU"
+  // decision belongs to planBackfillRows' trim check, which treats ""/null
+  // both as missing.
   const mappings: (BackfillMappingRow & { shopify_products: BackfillProductLite })[] = [];
   for (let offset = 0; ; offset += pageSize) {
     const { data, error } = await supabase
@@ -41,7 +44,6 @@ export async function planSkuBackfill(): Promise<{
       .in('status', ['auto_matched', 'manual'])
       .not('shopify_product_id', 'is', null)
       .eq('shopify_products.product_type', 'Single')
-      .is('shopify_products.sku', null)
       .range(offset, offset + pageSize - 1);
     if (error) throw new Error(`planSkuBackfill mappings: ${error.message}`);
     mappings.push(...((data ?? []) as unknown as (BackfillMappingRow & { shopify_products: BackfillProductLite })[]));
@@ -57,7 +59,9 @@ export async function planSkuBackfill(): Promise<{
       .not('sku', 'is', null)
       .range(offset, offset + pageSize - 1);
     if (error) throw new Error(`planSkuBackfill skus: ${error.message}`);
-    for (const p of data ?? []) existingSkuOwners.set(p.sku, p.id);
+    for (const p of data ?? []) {
+      if ((p.sku ?? '').trim() !== '') existingSkuOwners.set(p.sku, p.id);
+    }
     if (!data || data.length < pageSize) break;
   }
 

--- a/app/admin/ytg/matching/actions.ts
+++ b/app/admin/ytg/matching/actions.ts
@@ -1,0 +1,271 @@
+"use server";
+
+import { hasPermission } from '@/utils/adminUtils';
+import { getSupabaseAdmin } from '@/lib/pricing/supabase-admin';
+import { getShopifyAccessToken } from '@/lib/pricing/shopify';
+import { shopifyGraphQL } from '@/lib/shopify/admin-write';
+import { runAliasedMutations, type AliasedMutation } from '@/lib/shopify/aliasBatch';
+import {
+  planBackfillRows, skuFromCardKey,
+  type BackfillRow, type BackfillSkip, type BackfillMappingRow, type BackfillProductLite,
+} from '@/lib/shopify/skuBackfill';
+
+async function requireYtgPermission(): Promise<void> {
+  if (!(await hasPermission('manage_shopify_imports'))) {
+    throw new Error('Forbidden: manage_shopify_imports permission required');
+  }
+}
+
+export interface BackfillExecRow extends BackfillRow {
+  variantOk: boolean;
+  metafieldOk: boolean;
+  mirrorOk: boolean;
+  mock: boolean;
+  error: string | null;
+}
+
+export async function planSkuBackfill(): Promise<{
+  toWrite: BackfillRow[]; skippedPermanent: BackfillSkip[]; blocked: BackfillSkip[]; count: number;
+}> {
+  await requireYtgPermission();
+  const supabase = getSupabaseAdmin();
+  const pageSize = 1000;
+
+  // Confirmed mappings whose product is a Single with no SKU yet (!inner join
+  // makes the embedded filters constrain the parent rows).
+  const mappings: (BackfillMappingRow & { shopify_products: BackfillProductLite })[] = [];
+  for (let offset = 0; ; offset += pageSize) {
+    const { data, error } = await supabase
+      .from('card_price_mappings')
+      .select('card_key, shopify_product_id, confidence, match_method, status, shopify_products!inner(id, sku, product_type, raw_json)')
+      .in('status', ['auto_matched', 'manual'])
+      .not('shopify_product_id', 'is', null)
+      .eq('shopify_products.product_type', 'Single')
+      .is('shopify_products.sku', null)
+      .range(offset, offset + pageSize - 1);
+    if (error) throw new Error(`planSkuBackfill mappings: ${error.message}`);
+    mappings.push(...((data ?? []) as unknown as (BackfillMappingRow & { shopify_products: BackfillProductLite })[]));
+    if (!data || data.length < pageSize) break;
+  }
+
+  // Existing SKU owners (duplicate-SKU guard input)
+  const existingSkuOwners = new Map<string, string>();
+  for (let offset = 0; ; offset += pageSize) {
+    const { data, error } = await supabase
+      .from('shopify_products')
+      .select('id, sku')
+      .not('sku', 'is', null)
+      .range(offset, offset + pageSize - 1);
+    if (error) throw new Error(`planSkuBackfill skus: ${error.message}`);
+    for (const p of data ?? []) existingSkuOwners.set(p.sku, p.id);
+    if (!data || data.length < pageSize) break;
+  }
+
+  const productsById = new Map<string, BackfillProductLite>();
+  for (const m of mappings) productsById.set(m.shopify_products.id, m.shopify_products);
+
+  const plan = planBackfillRows(
+    mappings.map(m => ({
+      card_key: m.card_key, shopify_product_id: m.shopify_product_id,
+      confidence: m.confidence, match_method: m.match_method, status: m.status,
+    })),
+    productsById,
+    existingSkuOwners,
+  );
+  return { ...plan, count: plan.toWrite.length };
+}
+
+const METAFIELDS_SET_MUTATION = `
+mutation setCardKeys($metafields: [MetafieldsSetInput!]!) {
+  metafieldsSet(metafields: $metafields) {
+    metafields { id key }
+    userErrors { field message code }
+  }
+}`;
+
+export async function executeSkuBackfill(rows: BackfillRow[]): Promise<BackfillExecRow[]> {
+  await requireYtgPermission();
+  if (rows.length === 0) return [];
+  if (rows.length > 40) throw new Error('executeSkuBackfill: send at most 40 rows per call (client chunks)');
+
+  // Mock short-circuit, same pattern as productSetUpsert (admin-write.ts:113).
+  // runAliasedMutations does NOT handle SHOPIFY_WRITE_MOCK — this guard must
+  // come first. Do NOT touch the mirror in mock mode — a mirror sku the store
+  // doesn't have would poison pass 0.
+  if (process.env.SHOPIFY_WRITE_MOCK === '1') {
+    return rows.map(r => ({ ...r, variantOk: true, metafieldOk: true, mirrorOk: false, mock: true, error: null }));
+  }
+
+  // 1) Variant SKU writes — one aliased productVariantsBulkUpdate per product.
+  //    EXACT 2026-07 shape: sku lives at inventoryItem.sku in ProductVariantsBulkInput.
+  const calls: AliasedMutation[] = rows.map((r, i) => ({
+    alias: `v${i}`,
+    mutation: `productVariantsBulkUpdate(productId: ${JSON.stringify(r.productGid)}, variants: [{ id: ${JSON.stringify(r.variantGid)}, inventoryItem: { sku: ${JSON.stringify(r.sku)} } }])`,
+    selection: `{ productVariants { id } userErrors { field message } }`,
+  }));
+  const aliasResults = await runAliasedMutations(calls);
+  const byAlias = new Map(aliasResults.map(r => [r.alias, r]));
+
+  const out: BackfillExecRow[] = rows.map((r, i) => {
+    const res = byAlias.get(`v${i}`);
+    const errs = res ? res.userErrors : [{ message: 'no result returned for alias' }];
+    return {
+      ...r,
+      variantOk: errs.length === 0,
+      metafieldOk: false,
+      mirrorOk: false,
+      mock: false,
+      error: errs.length > 0 ? errs.map(e => e.message).join('; ') : null,
+    };
+  });
+
+  // 2) rtt_card_key metafields for variant-OK rows, chunks of 25 (metafieldsSet cap).
+  const okRows = out.filter(r => r.variantOk);
+  if (okRows.length > 0) {
+    const token = await getShopifyAccessToken();
+    for (let i = 0; i < okRows.length; i += 25) {
+      const chunk = okRows.slice(i, i + 25);
+      try {
+        const data = await shopifyGraphQL<{ metafieldsSet: { userErrors: { field?: string[] | null; message: string }[] } }>(
+          token, METAFIELDS_SET_MUTATION,
+          { metafields: chunk.map(r => ({ ownerId: r.productGid, namespace: 'custom', key: 'rtt_card_key', type: 'single_line_text_field', value: r.cardKey })) },
+        );
+        const errs = data.metafieldsSet.userErrors;
+        if (errs.length === 0) {
+          for (const r of chunk) r.metafieldOk = true;
+        } else {
+          // userError field paths look like ["metafields","3","value"] — map back per index when possible
+          const badIdx = new Set(errs.map(e => Number(e.field?.[1])).filter(n => Number.isInteger(n)));
+          chunk.forEach((r, idx) => {
+            const bad = badIdx.size > 0 ? badIdx.has(idx) : true;
+            r.metafieldOk = bad === false;
+            if (bad) r.error = [r.error, `metafield: ${errs.map(e => e.message).join('; ')}`].filter(Boolean).join(' | ');
+          });
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'metafieldsSet failed';
+        for (const r of chunk) r.error = [r.error, `metafield: ${msg}`].filter(Boolean).join(' | ');
+      }
+    }
+  }
+
+  // 3) Mirror update so pass 0 sees the new SKUs without waiting for a sync.
+  const supabase = getSupabaseAdmin();
+  for (const r of out) {
+    if (r.variantOk === false) continue;
+    const { error } = await supabase.from('shopify_products').update({ sku: r.sku }).eq('id', r.productId);
+    r.mirrorOk = !error;
+    if (error) r.error = [r.error, `mirror: ${error.message}`].filter(Boolean).join(' | ');
+  }
+  return out;
+}
+
+const STALE_IDENTITY_QUERY = `
+query staleIdentity($id: ID!) {
+  product(id: $id) {
+    id
+    metafield(namespace: "custom", key: "rtt_card_key") { id value }
+    variants(first: 1) { nodes { id inventoryItem { sku } } }
+  }
+}`;
+
+const VARIANT_SKU_CLEAR_MUTATION = `
+mutation clearVariantSku($productId: ID!, $variants: [ProductVariantsBulkInput!]!) {
+  productVariantsBulkUpdate(productId: $productId, variants: $variants) {
+    productVariants { id }
+    userErrors { field message }
+  }
+}`;
+
+const METAFIELDS_DELETE_MUTATION = `
+mutation deleteCardKey($metafields: [MetafieldIdentifierInput!]!) {
+  metafieldsDelete(metafields: $metafields) {
+    deletedMetafields { key namespace ownerId }
+    userErrors { field message }
+  }
+}`;
+
+/**
+ * Re-mapping hygiene (spec): when the review queue moves a card OFF a product,
+ * clear the old product's identity metadata IF it belongs to this card —
+ * stale SKU/rtt_card_key that outlives a mapping is how duplicate SKUs are born.
+ * Reads live Shopify state (mirror may be stale), then clears + updates mirror.
+ */
+export async function clearStaleIdentity(oldProductId: string, cardKey: string): Promise<{
+  clearedSku: boolean; clearedMetafield: boolean; mock: boolean;
+}> {
+  await requireYtgPermission();
+  const productGid = `gid://shopify/Product/${oldProductId}`;
+  const expectedSku = skuFromCardKey(cardKey);
+
+  if (process.env.SHOPIFY_WRITE_MOCK === '1') {
+    return { clearedSku: false, clearedMetafield: false, mock: true };
+  }
+
+  const token = await getShopifyAccessToken();
+  const data = await shopifyGraphQL<{
+    product: {
+      id: string;
+      metafield: { id: string; value: string } | null;
+      variants: { nodes: { id: string; inventoryItem: { sku: string | null } | null }[] };
+    } | null;
+  }>(token, STALE_IDENTITY_QUERY, { id: productGid });
+
+  const product = data.product;
+  if (!product) return { clearedSku: false, clearedMetafield: false, mock: false };
+
+  let clearedSku = false;
+  let clearedMetafield = false;
+
+  const variant = product.variants.nodes[0];
+  if (expectedSku !== null && variant && variant.inventoryItem && variant.inventoryItem.sku === expectedSku) {
+    // 2026-07: InventoryItemInput.sku is a nullable String — null is the documented
+    // "clear" value. If Shopify rejects null with a userError, fall back to "":
+    // an empty-string SKU renders as no SKU in Admin and can never collide with a
+    // cardSku (those always contain "<set>-"). Decision recorded here on purpose.
+    let result = await shopifyGraphQL<{ productVariantsBulkUpdate: { userErrors: { message: string }[] } }>(
+      token, VARIANT_SKU_CLEAR_MUTATION,
+      { productId: productGid, variants: [{ id: variant.id, inventoryItem: { sku: null } }] },
+    );
+    if (result.productVariantsBulkUpdate.userErrors.length > 0) {
+      result = await shopifyGraphQL<{ productVariantsBulkUpdate: { userErrors: { message: string }[] } }>(
+        token, VARIANT_SKU_CLEAR_MUTATION,
+        { productId: productGid, variants: [{ id: variant.id, inventoryItem: { sku: '' } }] },
+      );
+    }
+    clearedSku = result.productVariantsBulkUpdate.userErrors.length === 0;
+    if (clearedSku) {
+      await getSupabaseAdmin().from('shopify_products').update({ sku: null }).eq('id', oldProductId);
+    }
+  }
+
+  if (product.metafield && product.metafield.value === cardKey) {
+    const del = await shopifyGraphQL<{ metafieldsDelete: { userErrors: { message: string }[] } }>(
+      token, METAFIELDS_DELETE_MUTATION,
+      { metafields: [{ ownerId: productGid, namespace: 'custom', key: 'rtt_card_key' }] },
+    );
+    clearedMetafield = del.metafieldsDelete.userErrors.length === 0;
+  }
+
+  return { clearedSku, clearedMetafield, mock: false };
+}
+
+export async function searchSingleProducts(q: string): Promise<{
+  id: string; title: string; handle: string; price: number | null; tags: string | null; sku: string | null;
+}[]> {
+  await requireYtgPermission();
+  const term = q.trim().replace(/[%_]/g, ' ');
+  if (term.length < 2) return [];
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('shopify_products')
+    .select('id, title, handle, price, tags, sku')
+    // REQUIRED: nothing else enforces the Single filter on this new path —
+    // without it "Pick different" could map a card to a deck product.
+    .eq('product_type', 'Single')
+    .ilike('title', `%${term}%`)
+    .order('title')
+    .limit(20);
+  if (error) throw new Error(`searchSingleProducts: ${error.message}`);
+  return data ?? [];
+}

--- a/app/admin/ytg/matching/components/BackfillPanel.tsx
+++ b/app/admin/ytg/matching/components/BackfillPanel.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { planSkuBackfill, executeSkuBackfill, type BackfillExecRow } from '../actions';
+import type { BackfillRow, BackfillSkip } from '@/lib/shopify/skuBackfill';
+
+type Plan = { toWrite: BackfillRow[]; skippedPermanent: BackfillSkip[]; blocked: BackfillSkip[]; count: number };
+const CHUNK = 40; // matches aliasBatch's default per-document cost-cap sizing
+
+export default function BackfillPanel() {
+  const [plan, setPlan] = useState<Plan | null>(null);
+  const [planning, setPlanning] = useState(false);
+  const [executing, setExecuting] = useState(false);
+  const [done, setDone] = useState(0);
+  const [failures, setFailures] = useState<BackfillExecRow[]>([]);
+  const [succeeded, setSucceeded] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  async function doPlan() {
+    setPlanning(true); setError(null); setFailures([]); setSucceeded(0); setDone(0);
+    try { setPlan(await planSkuBackfill()); }
+    catch (err) { setError(err instanceof Error ? err.message : 'Plan failed'); }
+    finally { setPlanning(false); }
+  }
+
+  async function execute(rows: BackfillRow[]) {
+    setExecuting(true); setError(null); setDone(0); setFailures([]);
+    let ok = 0;
+    const failed: BackfillExecRow[] = [];
+    try {
+      for (let i = 0; i < rows.length; i += CHUNK) {
+        const results = await executeSkuBackfill(rows.slice(i, i + CHUNK));
+        for (const r of results) {
+          if (r.variantOk === true && r.metafieldOk === true) ok++;
+          else failed.push(r);
+        }
+        setDone(Math.min(i + CHUNK, rows.length));
+        setSucceeded(ok);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Execute failed');
+    } finally {
+      setFailures(failed);
+      setExecuting(false);
+    }
+  }
+
+  return (
+    <section className="rounded-lg bg-muted/40 p-4 space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h2 className="text-lg font-semibold">SKU backfill</h2>
+          <p className="text-xs text-muted-foreground">
+            Writes cardSku + rtt_card_key onto confirmed-mapped products missing a SKU. One-time; pass 0 self-matches afterward.
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={doPlan} disabled={planning || executing}>
+          {planning ? 'Planning…' : 'Plan SKU backfill'}
+        </Button>
+      </div>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      {plan && (
+        <div className="space-y-3">
+          <div className="flex flex-wrap gap-4 text-sm">
+            <span><span className="font-semibold tabular-nums">{plan.count}</span> products to write</span>
+            <span className="text-muted-foreground">
+              {plan.skippedPermanent.length} non-primary mappings skipped — permanent by design
+            </span>
+            {plan.blocked.length > 0 && (
+              <span className="text-amber-600 dark:text-amber-400">{plan.blocked.length} blocked (fix + re-plan)</span>
+            )}
+          </div>
+          {plan.toWrite.length > 0 && (
+            <div className="overflow-x-auto rounded-md bg-background">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="text-left text-muted-foreground">
+                    <th className="p-2">SKU</th><th className="p-2">Card key</th><th className="p-2">Product</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {plan.toWrite.slice(0, 20).map(r => (
+                    <tr key={r.productId} className="odd:bg-muted/30">
+                      <td className="p-2 font-mono">{r.sku}</td>
+                      <td className="p-2">{r.cardKey}</td>
+                      <td className="p-2 tabular-nums">{r.productId}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {plan.toWrite.length > 20 && (
+                <p className="p-2 text-xs text-muted-foreground">…and {plan.toWrite.length - 20} more</p>
+              )}
+            </div>
+          )}
+          {plan.blocked.length > 0 && (
+            <ul className="text-xs text-muted-foreground space-y-0.5">
+              {plan.blocked.slice(0, 10).map(b => (
+                <li key={`${b.productId}-${b.cardKey}`}>{b.cardKey}: {b.reason}</li>
+              ))}
+            </ul>
+          )}
+          <div className="flex items-center gap-3">
+            <Button size="sm" disabled={executing || plan.toWrite.length === 0}
+              onClick={() => execute(plan.toWrite)}>
+              {executing ? `Writing ${done}/${plan.toWrite.length}…` : `Execute (${plan.toWrite.length})`}
+            </Button>
+            {(succeeded > 0 || failures.length > 0) && !executing && (
+              <span className="text-sm tabular-nums">
+                {succeeded} ok{failures.length > 0 ? `, ${failures.length} failed` : ''}
+              </span>
+            )}
+            {failures.length > 0 && !executing && (
+              <Button variant="outline" size="sm" onClick={() => execute(failures)}>
+                Retry {failures.length} failed
+              </Button>
+            )}
+          </div>
+          {failures.length > 0 && (
+            <ul className="text-xs text-destructive space-y-0.5">
+              {failures.slice(0, 15).map(f => <li key={f.productId}>{f.sku}: {f.error}</li>)}
+            </ul>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/admin/ytg/matching/components/MatchingDashboard.tsx
+++ b/app/admin/ytg/matching/components/MatchingDashboard.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { RefreshCw, Play } from 'lucide-react';
+
+export default function MatchingDashboard({ byMethod, byStatus }: {
+  byMethod: Record<string, number>;
+  byStatus: Record<string, number>;
+}) {
+  const router = useRouter();
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function run(label: string, url: string) {
+    setBusy(label);
+    setError(null);
+    try {
+      const res = await fetch(url, { method: 'POST' });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error ?? `${label} failed (${res.status})`);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : `${label} failed`);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const methods = Object.entries(byMethod).sort((a, b) => b[1] - a[1]);
+  const needsReview = byStatus['needs_review'] ?? 0;
+  const unmatched = byStatus['unmatched'] ?? 0;
+
+  return (
+    <section className="rounded-lg bg-muted/40 p-4 space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-lg font-semibold">Matching</h2>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" disabled={busy !== null}
+            onClick={() => run('Sync', '/api/admin/sync-shopify')}>
+            <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${busy === 'Sync' ? 'animate-spin' : ''}`} />
+            {busy === 'Sync' ? 'Syncing…' : 'Sync products'}
+          </Button>
+          <Button size="sm" disabled={busy !== null}
+            onClick={() => run('Matching', '/api/admin/run-matching')}>
+            <Play className="mr-1.5 h-3.5 w-3.5" />
+            {busy === 'Matching' ? 'Matching…' : 'Run matching'}
+          </Button>
+        </div>
+      </div>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <div className="rounded-md bg-background p-3">
+          <div className="text-2xl font-semibold tabular-nums">{needsReview}</div>
+          <div className="text-xs text-muted-foreground">needs review</div>
+        </div>
+        <div className="rounded-md bg-background p-3">
+          <div className="text-2xl font-semibold tabular-nums">{unmatched}</div>
+          <div className="text-xs text-muted-foreground">unmatched</div>
+        </div>
+        <div className="rounded-md bg-background p-3 col-span-2">
+          <div className="text-xs text-muted-foreground mb-1.5">by match method</div>
+          <div className="flex flex-wrap gap-x-3 gap-y-1">
+            {methods.map(([m, n]) => (
+              <span key={m} className="text-xs tabular-nums">
+                <span className="text-muted-foreground">{m}</span> {n}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/admin/ytg/matching/components/ReviewQueue.tsx
+++ b/app/admin/ytg/matching/components/ReviewQueue.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { CheckCircle2 } from 'lucide-react';
+import { findCard } from '@/lib/cards/lookup';
+import { getCardImageUrl } from '@/app/shared/utils/cardImageUrl';
+import { stripHtmlToText } from '@/lib/pricing/abilityText';
+import { searchSingleProducts, clearStaleIdentity } from '../actions';
+
+interface QueueProduct {
+  id: string; title: string; handle: string; tags: string | null;
+  price: number | null; inventory_quantity: number | null;
+  body_html: string | null; sku: string | null;
+}
+interface QueueItem {
+  card_key: string; card_name: string; set_code: string;
+  confidence: number | null; match_method: string | null;
+  shopify_product_id: string | null;
+  shopify_products: QueueProduct | null;
+}
+type SearchHit = { id: string; title: string; handle: string; price: number | null; tags: string | null; sku: string | null };
+
+function parseCardKey(cardKey: string): { name: string; set: string; imgFile: string } {
+  const [name, set, imgFile] = cardKey.split('|');
+  return { name: name ?? '', set: set ?? '', imgFile: imgFile ?? '' };
+}
+
+export default function ReviewQueue() {
+  const [items, setItems] = useState<QueueItem[] | null>(null);
+  const [total, setTotal] = useState(0);
+  const [index, setIndex] = useState(0);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [hits, setHits] = useState<SearchHit[]>([]);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    fetch('/api/admin/review-queue')
+      .then(async res => {
+        const body = await res.json();
+        if (!res.ok) throw new Error(body.error ?? `review-queue failed (${res.status})`);
+        setItems(body.items ?? []);
+        setTotal((body.items ?? []).length);
+      })
+      .catch(err => setError(err instanceof Error ? err.message : 'Failed to load queue'));
+  }, []);
+
+  const current = items && items.length > 0 ? items[Math.min(index, items.length - 1)] : null;
+
+  const removeCurrent = useCallback(() => {
+    if (!items || !current) return;
+    const next = items.filter(i => i.card_key !== current.card_key);
+    setItems(next);
+    setIndex(i => Math.min(i, Math.max(0, next.length - 1)));
+    setSearchOpen(false); setQuery(''); setHits([]);
+  }, [items, current]);
+
+  const approve = useCallback(async (productId: string) => {
+    if (!current || busy) return;
+    setBusy(true); setError(null);
+    const oldProductId = current.shopify_product_id;
+    try {
+      const res = await fetch('/api/admin/approve-mapping', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ card_key: current.card_key, shopify_product_id: productId }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error ?? 'Approve failed');
+      // Re-mapping hygiene: if the card moved OFF a product that carries this
+      // card's SKU/rtt_card_key, clear the stale identity so duplicate SKUs
+      // are never born.
+      if (oldProductId !== null && oldProductId !== productId) {
+        await clearStaleIdentity(oldProductId, current.card_key);
+      }
+      removeCurrent();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Approve failed');
+    } finally {
+      setBusy(false);
+    }
+  }, [current, busy, removeCurrent]);
+
+  const reject = useCallback(async () => {
+    if (!current || busy) return;
+    setBusy(true); setError(null);
+    try {
+      const res = await fetch('/api/admin/reject-mapping', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ card_key: current.card_key }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error ?? 'Reject failed');
+      removeCurrent();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Reject failed');
+    } finally {
+      setBusy(false);
+    }
+  }, [current, busy, removeCurrent]);
+
+  // Keyboard: A approve, R reject, / focus search, ←/→ navigate
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || e.metaKey || e.ctrlKey || e.altKey) return;
+      if (!current) return;
+      if (e.key === 'a' || e.key === 'A') {
+        if (current.shopify_products) { e.preventDefault(); approve(current.shopify_products.id); }
+      } else if (e.key === 'r' || e.key === 'R') {
+        e.preventDefault(); reject();
+      } else if (e.key === '/') {
+        e.preventDefault(); setSearchOpen(true); setTimeout(() => searchRef.current?.focus(), 0);
+      } else if (e.key === 'ArrowRight' && items) {
+        e.preventDefault(); setIndex(i => Math.min(i + 1, items.length - 1));
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault(); setIndex(i => Math.max(i - 1, 0));
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [current, items, approve, reject]);
+
+  useEffect(() => {
+    if (!searchOpen || query.trim().length < 2) { setHits([]); return; }
+    const t = setTimeout(() => {
+      searchSingleProducts(query).then(setHits).catch(() => setHits([]));
+    }, 250);
+    return () => clearTimeout(t);
+  }, [query, searchOpen]);
+
+  if (error && items === null) return <section className="rounded-lg bg-muted/40 p-4 text-sm text-destructive">{error}</section>;
+  if (items === null) return <section className="rounded-lg bg-muted/40 p-4 text-sm text-muted-foreground">Loading review queue…</section>;
+
+  if (items.length === 0) {
+    return (
+      <section className="rounded-lg bg-muted/40 p-10 flex flex-col items-center gap-2 text-center">
+        <CheckCircle2 className="h-8 w-8 text-green-600 dark:text-green-500" />
+        <p className="font-semibold">Review queue clear</p>
+        <p className="text-sm text-muted-foreground">
+          {total > 0 ? `All ${total} mappings reviewed. Nice work.` : 'Nothing needs review right now.'}
+        </p>
+      </section>
+    );
+  }
+
+  const item = current!;
+  const card = parseCardKey(item.card_key);
+  const cardData = findCard(card.name, card.set, card.imgFile);
+  const product = item.shopify_products;
+  const done = total - items.length;
+
+  return (
+    <section className="rounded-lg bg-muted/40 p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Review queue</h2>
+        <span className="text-sm tabular-nums text-muted-foreground">{Math.min(done + 1, total)} of {total}</span>
+      </div>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {/* Card side */}
+        <div className="rounded-md bg-background p-3 space-y-2">
+          <div className="text-xs uppercase tracking-wide text-muted-foreground">Card</div>
+          <div className="flex gap-3">
+            {card.imgFile && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={getCardImageUrl(card.imgFile)} alt={card.name} className="h-40 w-auto rounded-sm" />
+            )}
+            <div className="min-w-0 space-y-1">
+              <p className="font-medium">{card.name}</p>
+              <p className="text-xs text-muted-foreground">{card.set}{cardData ? ` · ${cardData.officialSet}` : ''}</p>
+              {cardData && cardData.specialAbility && (
+                <p className="text-xs leading-relaxed">{cardData.specialAbility}</p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Proposed product side */}
+        <div className="rounded-md bg-background p-3 space-y-2">
+          <div className="flex items-center justify-between">
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">Proposed product</div>
+            <div className="flex gap-1.5">
+              <Badge variant="secondary">{item.match_method ?? 'unknown'}</Badge>
+              <Badge variant="outline">{((item.confidence ?? 0) * 100).toFixed(0)}%</Badge>
+            </div>
+          </div>
+          {product ? (
+            <div className="space-y-1.5">
+              <p className="font-medium">{product.title}</p>
+              <p className="text-sm tabular-nums">${product.price ?? '—'} · stock {product.inventory_quantity ?? '—'}{product.sku ? ` · SKU ${product.sku}` : ''}</p>
+              {product.tags && (
+                <div className="flex flex-wrap gap-1">
+                  {product.tags.split(',').slice(0, 8).map(t => (
+                    <span key={t} className="rounded bg-muted px-1.5 py-0.5 text-[11px]">{t.trim()}</span>
+                  ))}
+                </div>
+              )}
+              {product.body_html && (
+                <p className="text-xs leading-relaxed text-muted-foreground">{stripHtmlToText(product.body_html)}</p>
+              )}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">No product attached — use Pick different.</p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Button size="sm" disabled={busy || !product} onClick={() => product && approve(product.id)}>
+          Approve <kbd className="ml-1.5 text-[10px] opacity-70">A</kbd>
+        </Button>
+        <Button size="sm" variant="outline" disabled={busy} onClick={reject}>
+          Reject <kbd className="ml-1.5 text-[10px] opacity-70">R</kbd>
+        </Button>
+        <Button size="sm" variant="outline" disabled={busy}
+          onClick={() => { setSearchOpen(v => !v); setTimeout(() => searchRef.current?.focus(), 0); }}>
+          Pick different <kbd className="ml-1.5 text-[10px] opacity-70">/</kbd>
+        </Button>
+        <span className="ml-auto text-xs text-muted-foreground">←/→ navigate</span>
+      </div>
+
+      {searchOpen && (
+        <div className="rounded-md bg-background p-3 space-y-2">
+          <Input ref={searchRef} value={query} placeholder="Search Single products by title…"
+            onChange={e => setQuery(e.target.value)} />
+          <ul className="max-h-64 overflow-y-auto divide-y-0">
+            {hits.map(h => (
+              <li key={h.id}>
+                <button type="button" disabled={busy}
+                  className="w-full rounded px-2 py-1.5 text-left text-sm hover:bg-muted"
+                  onClick={() => approve(h.id)}>
+                  <span className="font-medium">{h.title}</span>
+                  <span className="ml-2 text-xs text-muted-foreground tabular-nums">${h.price ?? '—'}{h.sku ? ` · ${h.sku}` : ''}</span>
+                </button>
+              </li>
+            ))}
+            {query.trim().length >= 2 && hits.length === 0 && (
+              <li className="px-2 py-1.5 text-xs text-muted-foreground">No Single products match.</li>
+            )}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/admin/ytg/matching/page.tsx
+++ b/app/admin/ytg/matching/page.tsx
@@ -1,16 +1,39 @@
-export const metadata = { title: "YTG Store — Matching" };
+import { getSupabaseAdmin } from '@/lib/pricing/supabase-admin';
+import MatchingDashboard from './components/MatchingDashboard';
+import BackfillPanel from './components/BackfillPanel';
+import ReviewQueue from './components/ReviewQueue';
 
-// WS-0 skeleton. WS-2 (deterministic matching + review queue) replaces
-// this file wholesale — nothing else in the shell needs to change.
-export default function MatchingPage() {
+export const metadata = { title: "YTG Store — Matching" };
+export const dynamic = 'force-dynamic';
+
+async function loadDashboardCounts(): Promise<{ byMethod: Record<string, number>; byStatus: Record<string, number> }> {
+  const supabase = getSupabaseAdmin();
+  const byMethod: Record<string, number> = {};
+  const byStatus: Record<string, number> = {};
+  const pageSize = 1000;
+  for (let offset = 0; ; offset += pageSize) {
+    const { data, error } = await supabase
+      .from('card_price_mappings')
+      .select('match_method, status')
+      .range(offset, offset + pageSize - 1);
+    if (error) throw new Error(error.message);
+    for (const row of data ?? []) {
+      const m = row.match_method ?? 'none';
+      byMethod[m] = (byMethod[m] ?? 0) + 1;
+      byStatus[row.status] = (byStatus[row.status] ?? 0) + 1;
+    }
+    if (!data || data.length < pageSize) break;
+  }
+  return { byMethod, byStatus };
+}
+
+export default async function MatchingPage() {
+  const counts = await loadDashboardCounts();
   return (
-    <div className="rounded-lg bg-card px-6 py-16 text-center">
-      <h2 className="text-lg font-semibold mb-1">Matching</h2>
-      <p className="text-sm text-muted-foreground max-w-md mx-auto">
-        The matching dashboard and keyboard-driven review queue are coming
-        soon. Cards will match to store products by SKU first, with fuzzy
-        passes as fallback.
-      </p>
+    <div className="space-y-6">
+      <MatchingDashboard byMethod={counts.byMethod} byStatus={counts.byStatus} />
+      <BackfillPanel />
+      <ReviewQueue />
     </div>
   );
 }

--- a/app/api/admin/review-queue/route.ts
+++ b/app/api/admin/review-queue/route.ts
@@ -18,7 +18,9 @@ export async function GET() {
         handle,
         tags,
         price,
-        inventory_quantity
+        inventory_quantity,
+        body_html,
+        sku
       )
     `)
     .eq('status', 'needs_review')

--- a/lib/pricing/__tests__/abilityText.test.ts
+++ b/lib/pricing/__tests__/abilityText.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { stripHtmlToText, tokenSet, abilityTextScore } from '../abilityText';
+
+describe('stripHtmlToText', () => {
+  it('strips tags and collapses whitespace', () => {
+    expect(stripHtmlToText('<p>Negate  Evil\nCharacters.</p>')).toBe('Negate Evil Characters.');
+  });
+  it('decodes named entities the importer writes (escapeHtml output)', () => {
+    // productFromCard.escapeHtml emits &amp; &lt; &gt; &quot; &#39;
+    expect(stripHtmlToText('<p>Discard &amp; draw. Don&#39;t negate. &quot;Hold&quot;</p>'))
+      .toBe('Discard & draw. Don\'t negate. "Hold"');
+  });
+  it('decodes smart-quote entities AND passes literal smart quotes through (both occur in real YTG data)', () => {
+    // Live YTG bodies carry literal ’/“ (398/118 occurrences in tmp/products_export_1.csv);
+    // entity-encoded forms appear in hand-edited descriptions.
+    expect(stripHtmlToText('<p>opponents&rsquo; cards</p>')).toBe('opponents’ cards');
+    expect(stripHtmlToText('<p>&#8220;He is Risen&#8221;</p>')).toBe('“He is Risen”');
+    expect(stripHtmlToText('<p>opponents’ cards</p>')).toBe('opponents’ cards');
+  });
+  it('returns empty string for null/undefined/empty', () => {
+    expect(stripHtmlToText(null)).toBe('');
+    expect(stripHtmlToText(undefined)).toBe('');
+    expect(stripHtmlToText('')).toBe('');
+  });
+});
+
+describe('tokenSet', () => {
+  it('lowercases, drops stopwords, normalizes smart apostrophes so “opponents’” == "opponents\'"', () => {
+    const t = tokenSet('Protect your hand and deck from opponents’ cards.');
+    expect(t.has('protect')).toBe(true);
+    expect(t.has('opponents\'')).toBe(true);
+    expect(t.has('your')).toBe(false); // stopword
+    expect(t.has('and')).toBe(false);  // stopword
+  });
+});
+
+describe('abilityTextScore', () => {
+  it('identical ability text scores 1', () => {
+    const s = 'Negate Evil Characters. If alone, you may choose a human to block.';
+    expect(abilityTextScore(s, s)).toBe(1);
+  });
+  it('disjoint text scores 0; empty either side scores 0', () => {
+    expect(abilityTextScore('Discard a Hero', 'Protect deck sites')).toBe(0);
+    expect(abilityTextScore('Discard a Hero', '')).toBe(0);
+    expect(abilityTextScore('', 'Protect deck')).toBe(0);
+  });
+  it('partial overlap lands strictly between 0 and 1', () => {
+    const s = abilityTextScore('Discard a Hero in a territory', 'Discard a Hero to draw two cards');
+    expect(s).toBeGreaterThan(0);
+    expect(s).toBeLessThan(1);
+  });
+});

--- a/lib/pricing/__tests__/matching.test.ts
+++ b/lib/pricing/__tests__/matching.test.ts
@@ -27,6 +27,8 @@ function makeProduct(overrides: Partial<ShopifyProductRow>): ShopifyProductRow {
     price: null,
     inventory_quantity: null,
     raw_json: null,
+    sku: null,
+    body_html: null,
     last_synced_at: new Date().toISOString(),
     ...overrides,
   };

--- a/lib/pricing/__tests__/pass0.test.ts
+++ b/lib/pricing/__tests__/pass0.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let currentStub: any;
+vi.mock('../supabase-admin', () => ({ getSupabaseAdmin: () => currentStub }));
+
+import { pass0Sku, cardSkuFromRow, runMatchingPipeline, writeResults } from '../matching';
+import { cardSku } from '@/lib/shopify/productFromCard';
+import { CARDS } from '@/lib/cards/lookup';
+import { UNSOLD_SETS } from '../helpers';
+import type { CardRow, ShopifyProductRow, MatchResult } from '../types';
+
+function makeProduct(overrides: Partial<ShopifyProductRow>): ShopifyProductRow {
+  return {
+    id: 'p1', title: 'T', handle: 'h', tags: null, product_type: 'Single',
+    price: 1, inventory_quantity: 0, raw_json: null, sku: null, body_html: null,
+    last_synced_at: new Date().toISOString(), ...overrides,
+  };
+}
+function makeCard(overrides: Partial<CardRow>): CardRow {
+  return {
+    name: 'N', set_code: 'S', img_file: 'N.jpg', official_set: '', type: '',
+    brigade: '', rarity: '', special_ability: '', card_key: 'N|S|N.jpg', ...overrides,
+  };
+}
+function bySkuMap(products: ShopifyProductRow[]): Map<string, ShopifyProductRow[]> {
+  const m = new Map<string, ShopifyProductRow[]>();
+  for (const p of products) {
+    const s = (p.sku ?? '').trim();
+    if (!s) continue;
+    const list = m.get(s);
+    if (list) list.push(p); else m.set(s, [p]);
+  }
+  return m;
+}
+
+/**
+ * Minimal supabase stub covering every chain matching.ts uses:
+ *  - from('set_aliases').select('*')                              (awaited select — thenable)
+ *  - from('shopify_products').select('*').eq(...).range(...)      (loadShopifyProducts)
+ *  - from('card_price_mappings').select(...).or(...).range(...)   (loadProtectedKeys)
+ *  - from('card_price_mappings').select(...).in(...).range(...)   (writeResults manual refetch)
+ *  - from('card_price_mappings').select(...).in(...).not(...).range(...)  (regenerateCardPrices → return [])
+ *  - from('card_price_mappings').upsert(batch, opts)              (captured)
+ */
+function makeSupabaseStub(opts: {
+  products: ShopifyProductRow[];
+  mappings: { card_key: string; status: string; confidence?: number }[];
+}) {
+  const upserts: any[][] = [];
+  function makeQuery(table: string) {
+    const q: any = { _or: false, _in: null as null | { col: string; vals: string[] }, _not: false };
+    const resolve = () => {
+      if (table === 'set_aliases') return [];
+      if (table === 'shopify_products') return opts.products;
+      if (table === 'card_price_mappings') {
+        if (q._not) return []; // regenerateCardPrices query → early "no confirmed mappings" return
+        if (q._or) {
+          return opts.mappings
+            .filter(m => m.status === 'manual' || m.status === 'no_price_exists'
+              || (m.status === 'auto_matched' && (m.confidence ?? 0) >= 0.95))
+            .map(m => ({ card_key: m.card_key }));
+        }
+        if (q._in && q._in.col === 'status') {
+          return opts.mappings.filter(m => q._in!.vals.includes(m.status)).map(m => ({ card_key: m.card_key }));
+        }
+        return [];
+      }
+      return [];
+    };
+    q.select = () => q;
+    q.eq = () => q;
+    q.or = () => { q._or = true; return q; };
+    q.in = (col: string, vals: string[]) => { q._in = { col, vals }; return q; };
+    q.not = () => { q._not = true; return q; };
+    q.order = () => q;
+    q.range = (from: number) => Promise.resolve({ data: from > 0 ? [] : resolve(), error: null });
+    q.then = (onOk: any) => Promise.resolve({ data: resolve(), error: null }).then(onOk); // awaited-select support
+    q.upsert = (batch: any[]) => { upserts.push(batch); return Promise.resolve({ error: null }); };
+    q.update = () => ({ eq: () => Promise.resolve({ error: null }), not: () => Promise.resolve({ error: null }) });
+    return q;
+  }
+  return { from: (t: string) => makeQuery(t), rpc: async () => ({ data: [], error: null }), __upserts: upserts };
+}
+
+// A real, deterministic, sellable card — pass 0 computes its sku from CARDS data.
+const realCard = CARDS.find(c => !UNSOLD_SETS.has(c.set) && !/\bToken\b/.test(c.name))!;
+const realKey = `${realCard.name}|${realCard.set}|${realCard.imgFile}`;
+const realSku = cardSku(realCard);
+
+describe('pass0Sku (unit)', () => {
+  it('matches a card to the product carrying its cardSku: method sku, confidence 1.0, auto_matched', () => {
+    const card = makeCard({ name: 'Aaron', set_code: 'RoA 3', img_file: 'Aaron.jpg', card_key: 'Aaron|RoA 3|Aaron.jpg' });
+    // cardSku strips ALL whitespace: "RoA 3" → "RoA3-Aaron"
+    expect(cardSkuFromRow(card)).toBe('RoA3-Aaron');
+    const products = [makeProduct({ id: '111', sku: 'RoA3-Aaron' })];
+    const results = pass0Sku([card], bySkuMap(products));
+    expect(results).toEqual([{
+      card_key: 'Aaron|RoA 3|Aaron.jpg', card_name: 'Aaron', set_code: 'RoA 3',
+      shopify_product_id: '111', confidence: 1.0, match_method: 'sku', status: 'auto_matched',
+    }]);
+  });
+
+  it('duplicate SKU (2+ products) → needs_review / sku_duplicate / confidence 0, never auto-picks', () => {
+    const card = makeCard({ name: 'Eve', set_code: 'Pi', img_file: 'Eve.jpg', card_key: 'Eve|Pi|Eve.jpg' });
+    const products = [makeProduct({ id: '222', sku: 'Pi-Eve' }), makeProduct({ id: '333', sku: 'Pi-Eve' })];
+    const [r] = pass0Sku([card], bySkuMap(products));
+    expect(r.status).toBe('needs_review');
+    expect(r.match_method).toBe('sku_duplicate');
+    expect(r.confidence).toBe(0);
+    expect(r.shopify_product_id).toBe('222'); // deterministic: lowest id, a review suggestion only
+  });
+
+  it('no sku hit → no result (card falls through to later passes)', () => {
+    const card = makeCard({});
+    expect(pass0Sku([card], bySkuMap([makeProduct({ id: '1', sku: 'Other-Sku' })]))).toEqual([]);
+  });
+});
+
+describe('runMatchingPipeline pass 0 wiring (stubbed supabase)', () => {
+  beforeEach(() => { currentStub = null; });
+
+  it('CORRECTION CASE: pass 0 re-matches a protected auto_matched(≥0.95) card to a different product', async () => {
+    currentStub = makeSupabaseStub({
+      products: [makeProduct({ id: 'NEW-PRODUCT', sku: realSku })],
+      mappings: [{ card_key: realKey, status: 'auto_matched', confidence: 0.96 }], // in loadProtectedKeys' set
+    });
+    await runMatchingPipeline({ passes: [0], setCodes: [realCard.set] });
+    const rows = currentStub.__upserts.flat();
+    const row = rows.find((r: any) => r.card_key === realKey);
+    expect(row).toBeDefined(); // protection-EXEMPT: pass 0 ran despite auto_matched ≥ 0.95
+    expect(row.shopify_product_id).toBe('NEW-PRODUCT');
+    expect(row.match_method).toBe('sku');
+    expect(row.status).toBe('auto_matched');
+  });
+
+  it('MANUAL rows are never overwritten end-to-end (writeResults refetch-filter drops them)', async () => {
+    currentStub = makeSupabaseStub({
+      products: [makeProduct({ id: 'NEW-PRODUCT', sku: realSku })],
+      mappings: [{ card_key: realKey, status: 'manual' }],
+    });
+    await runMatchingPipeline({ passes: [0], setCodes: [realCard.set] });
+    const rows = currentStub.__upserts.flat();
+    // pass 0 produced a result for the manual card (exemption), but writeResults filtered it
+    expect(rows.find((r: any) => r.card_key === realKey)).toBeUndefined();
+  });
+
+  it('writeResults (direct): filters manual + no_price_exists keys, writes the rest', async () => {
+    currentStub = makeSupabaseStub({
+      products: [],
+      mappings: [{ card_key: 'M|S|f', status: 'manual' }, { card_key: 'NP|S|f', status: 'no_price_exists' }],
+    });
+    const results: MatchResult[] = [
+      { card_key: 'M|S|f', card_name: 'M', set_code: 'S', shopify_product_id: '1', confidence: 1, match_method: 'sku', status: 'auto_matched' },
+      { card_key: 'NP|S|f', card_name: 'NP', set_code: 'S', shopify_product_id: '2', confidence: 1, match_method: 'sku', status: 'auto_matched' },
+      { card_key: 'OK|S|f', card_name: 'OK', set_code: 'S', shopify_product_id: '3', confidence: 1, match_method: 'sku', status: 'auto_matched' },
+    ];
+    await writeResults(results);
+    const rows = currentStub.__upserts.flat();
+    expect(rows.map((r: any) => r.card_key)).toEqual(['OK|S|f']);
+  });
+});

--- a/lib/pricing/abilityText.ts
+++ b/lib/pricing/abilityText.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure helpers: strip product body_html to comparable text and score token
+ * overlap against a card's special ability. Client-safe (no server deps) —
+ * the review-queue UI reuses stripHtmlToText for display.
+ */
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ',
+  rsquo: '’', lsquo: '‘', rdquo: '”', ldquo: '“',
+  ndash: '–', mdash: '—', hellip: '…',
+};
+
+export function stripHtmlToText(html: string | null | undefined): string {
+  if (!html) return '';
+  let text = html
+    .replace(/<br\s*\/?>/gi, ' ')
+    .replace(/<\/(p|div|li|h[1-6]|tr)>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ');
+  text = text.replace(/&#x([0-9a-f]+);/gi, (_m, hex) => String.fromCodePoint(parseInt(hex, 16)));
+  text = text.replace(/&#(\d+);/g, (_m, dec) => String.fromCodePoint(parseInt(dec, 10)));
+  text = text.replace(/&([a-z]+);/gi, (m, name) => NAMED_ENTITIES[name.toLowerCase()] ?? m);
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+// Small, ability-text-tuned stopword list — connective glue that appears in
+// nearly every Redemption ability and carries no discriminating signal.
+const STOPWORDS = new Set([
+  'a', 'an', 'the', 'of', 'to', 'in', 'on', 'or', 'and', 'is', 'are', 'be',
+  'you', 'your', 'may', 'if', 'it', 'its', 'this', 'that', 'from', 'with',
+  'for', 'at', 'by', 'not', 'cannot',
+]);
+
+export function tokenSet(text: string): Set<string> {
+  const normalized = text.toLowerCase()
+    .replace(/[‘’]/g, "'")
+    .replace(/[“”]/g, '"');
+  const words = normalized.match(/[a-z0-9']+/g) ?? [];
+  const out = new Set<string>();
+  for (const w of words) if (!STOPWORDS.has(w)) out.add(w);
+  return out;
+}
+
+/** Jaccard similarity of stopword-filtered token sets. 0 when either side is empty. */
+export function abilityTextScore(cardAbility: string, bodyText: string): number {
+  const a = tokenSet(cardAbility);
+  const b = tokenSet(bodyText);
+  if (a.size === 0 || b.size === 0) return 0;
+  let inter = 0;
+  for (const t of a) if (b.has(t)) inter++;
+  const union = a.size + b.size - inter;
+  return union === 0 ? 0 : inter / union;
+}

--- a/lib/pricing/matching.ts
+++ b/lib/pricing/matching.ts
@@ -7,6 +7,7 @@ import type { DuplicateGroupIndex, DuplicateGroup, DuplicateSibling } from '@/li
 import { normalizeAbility } from '@/lib/pricing/budgetPricing';
 import { CARDS } from '@/lib/cards/lookup';
 import { cardSku } from '@/lib/shopify/productFromCard';
+import { stripHtmlToText, abilityTextScore } from './abilityText';
 import type { CardRow, SetAlias, ShopifyProductRow, MatchResult, MatchingSummary } from './types';
 
 /**
@@ -579,7 +580,9 @@ let fuzzyDebugCount = 0;
  */
 async function pass3and4Fuzzy(
   card: CardRow,
-  shopifyAbbrev: string | undefined
+  shopifyAbbrev: string | undefined,
+  productById?: Map<string, ShopifyProductRow>,
+  useAbilityText: boolean = true
 ): Promise<MatchResult | null> {
   const supabase = getSupabaseAdmin();
   const cleanName = stripEmbeddedSet(card.name);
@@ -660,6 +663,19 @@ async function pass3and4Fuzzy(
       }
     }
 
+    // Ability-text signal: ADDITIVE ONLY. Empty/missing body_html or a disabled
+    // flag leaves boostedScore untouched — behavior is byte-identical to the
+    // pre-signal pipeline in those cases. Tiered like the tag boosts above.
+    if (useAbilityText && card.special_ability && productById) {
+      const row = productById.get(candidate.id);
+      const bodyText = row && row.body_html ? stripHtmlToText(row.body_html) : '';
+      if (bodyText) {
+        const overlap = abilityTextScore(card.special_ability, bodyText);
+        if (overlap >= 0.6) boostedScore += 0.15;
+        else if (overlap >= 0.35) boostedScore += 0.08;
+      }
+    }
+
     if (!bestCandidate || boostedScore > bestCandidate.boostedScore) {
       bestCandidate = { id: candidate.id, rawScore, boostedScore, title: candidateTitle };
     }
@@ -725,10 +741,12 @@ export async function runMatchingPipeline(options?: {
   setCodes?: string[];
   force?: boolean;
   dryRun?: boolean;
+  abilityText?: boolean;
 }): Promise<MatchingSummary> {
   const passes = options?.passes ?? [0, 1, 2, 3, 4];
   const force = options?.force ?? false;
   const dryRun = options?.dryRun ?? false;
+  const abilityTextEnabled = options?.abilityText !== false;
 
   log('Loading data...');
   const [cards, aliases, shopify, protectedKeys] = await Promise.all([
@@ -872,7 +890,7 @@ export async function runMatchingPipeline(options?: {
       const batch = needsFuzzy.slice(i, i + concurrency);
       const batchResults = await Promise.all(
         batch.map(({ card, shopifyAbbrev }) =>
-          pass3and4Fuzzy(card, shopifyAbbrev).then(match => ({ card, match }))
+          pass3and4Fuzzy(card, shopifyAbbrev, shopify.byId, abilityTextEnabled).then(match => ({ card, match }))
         )
       );
 

--- a/lib/pricing/matching.ts
+++ b/lib/pricing/matching.ts
@@ -6,6 +6,7 @@ import { normalize as normalizeDup, stripSetSuffix, findGroup } from '@/lib/dupl
 import type { DuplicateGroupIndex, DuplicateGroup, DuplicateSibling } from '@/lib/duplicateCards';
 import { normalizeAbility } from '@/lib/pricing/budgetPricing';
 import { CARDS } from '@/lib/cards/lookup';
+import { cardSku } from '@/lib/shopify/productFromCard';
 import type { CardRow, SetAlias, ShopifyProductRow, MatchResult, MatchingSummary } from './types';
 
 /**
@@ -97,6 +98,8 @@ const TAG_SET_TO_ABBREV: Record<string, string> = {
  */
 async function loadShopifyProducts(): Promise<{
   byNormalizedTitle: Map<string, ShopifyProductRow>;
+  bySku: Map<string, ShopifyProductRow[]>;
+  byId: Map<string, ShopifyProductRow>;
   all: ShopifyProductRow[];
 }> {
   const supabase = getSupabaseAdmin();
@@ -117,12 +120,20 @@ async function loadShopifyProducts(): Promise<{
   }
 
   const byNormalizedTitle = new Map<string, ShopifyProductRow>();
+  const bySku = new Map<string, ShopifyProductRow[]>();
+  const byId = new Map<string, ShopifyProductRow>();
   for (const p of allProducts) {
     const cleanTitle = stripShopifySuffixes(p.title);
     byNormalizedTitle.set(normalize(cleanTitle), p);
+    byId.set(p.id, p);
+    const sku = (p.sku ?? '').trim();
+    if (sku) {
+      const list = bySku.get(sku);
+      if (list) list.push(p); else bySku.set(sku, [p]);
+    }
   }
 
-  return { byNormalizedTitle, all: allProducts };
+  return { byNormalizedTitle, bySku, byId, all: allProducts };
 }
 
 /**
@@ -146,6 +157,51 @@ async function loadProtectedKeys(): Promise<Set<string>> {
   }
 
   return keys;
+}
+
+/** Expected SKU for a pipeline CardRow — always via cardSku() (strips ALL whitespace:
+ *  "RoA 3" → "RoA3-..."). Never string-build `${set}-${imgFile}`. */
+export function cardSkuFromRow(card: CardRow): string {
+  return cardSku({ set: card.set_code, imgFile: card.img_file });
+}
+
+/**
+ * Pass 0: exact SKU identity. Deterministic — importer/backfill wrote cardSku(card)
+ * onto the product's variant; the mirror's sku column round-trips it.
+ *
+ * PROTECTION-EXEMPT by design (spec §Matching tab): loadProtectedKeys covers
+ * auto_matched ≥ 0.95, and nearly every match sits there — a pass 0 gated by it
+ * could never correct a confident-but-wrong fuzzy match. writeResults' re-fetched
+ * manual/no_price_exists filter remains the write-layer guard.
+ *
+ * Duplicate SKUs (2+ products): a data bug (see backfill hygiene) — surface as
+ * needs_review/sku_duplicate, never auto-pick. The carried product id is the
+ * lowest-id duplicate, purely as a review-queue suggestion.
+ */
+export function pass0Sku(
+  cards: CardRow[],
+  bySku: Map<string, ShopifyProductRow[]>
+): MatchResult[] {
+  const out: MatchResult[] = [];
+  for (const card of cards) {
+    const candidates = bySku.get(cardSkuFromRow(card));
+    if (!candidates || candidates.length === 0) continue;
+    if (candidates.length > 1) {
+      const sorted = [...candidates].sort((a, b) => a.id.localeCompare(b.id));
+      out.push({
+        card_key: card.card_key, card_name: card.name, set_code: card.set_code,
+        shopify_product_id: sorted[0].id, confidence: 0,
+        match_method: 'sku_duplicate', status: 'needs_review',
+      });
+      continue;
+    }
+    out.push({
+      card_key: card.card_key, card_name: card.name, set_code: card.set_code,
+      shopify_product_id: candidates[0].id, confidence: 1.0,
+      match_method: 'sku', status: 'auto_matched',
+    });
+  }
+  return out;
 }
 
 /**
@@ -662,7 +718,7 @@ function log(msg: string) {
 }
 
 /**
- * Run the full matching pipeline (passes 1-4) for all cards.
+ * Run the full matching pipeline (passes 0-4) for all cards.
  */
 export async function runMatchingPipeline(options?: {
   passes?: number[];
@@ -670,7 +726,7 @@ export async function runMatchingPipeline(options?: {
   force?: boolean;
   dryRun?: boolean;
 }): Promise<MatchingSummary> {
-  const passes = options?.passes ?? [1, 2, 3, 4];
+  const passes = options?.passes ?? [0, 1, 2, 3, 4];
   const force = options?.force ?? false;
   const dryRun = options?.dryRun ?? false;
 
@@ -700,12 +756,28 @@ export async function runMatchingPipeline(options?: {
     unmatched: 0,
   };
 
+  // ── Phase 0: SKU identity (runs against ALL cards, INCLUDING protected keys) ──
+  const pass0Handled = new Set<string>();
+  if (passes.includes(0)) {
+    log('Running pass 0 (SKU identity, protection-exempt)...');
+    const pass0Results = pass0Sku(filteredCards, shopify.bySku);
+    let dupCount = 0;
+    for (const r of pass0Results) {
+      results.push(r);
+      pass0Handled.add(r.card_key);
+      if (r.status === 'auto_matched') summary.matched++;
+      else { summary.needs_review++; dupCount++; }
+    }
+    log(`Pass 0 done: ${pass0Results.length} SKU hits (${dupCount} duplicate-SKU → needs_review)`);
+  }
+
   // ── Phase 1: In-memory passes (instant) ──
   log('Running passes 1 & 2 (exact + normalized)...');
   const needsFuzzy: { card: CardRow; shopifyAbbrev: string | undefined }[] = [];
 
   for (const card of filteredCards) {
-    if (protectedKeys.has(card.card_key)) continue;
+    if (pass0Handled.has(card.card_key)) continue;   // pass 0 already decided this card
+    if (protectedKeys.has(card.card_key)) continue;  // protection applies to passes 1-4 only
 
     // Unsold sets
     if (UNSOLD_SETS.has(card.set_code)) {
@@ -859,6 +931,7 @@ export async function runMatchingPipeline(options?: {
 
   summary.unmatchedCards = results.filter(r => r.status === 'unmatched');
   summary.noPriceCards = results.filter(r => r.status === 'no_price_exists');
+  if (dryRun) summary.results = results;
 
   log(`Done! matched=${summary.matched} review=${summary.needs_review} no_price=${summary.no_price_exists} unmatched=${summary.unmatched}`);
   return summary;
@@ -866,8 +939,10 @@ export async function runMatchingPipeline(options?: {
 
 /**
  * Write match results to card_price_mappings (upsert, never overwrite manual).
+ * Exported as a test seam only — the manual/no_price_exists refetch-filter
+ * below is load-bearing and force-proof; do not modify it.
  */
-async function writeResults(results: MatchResult[]): Promise<void> {
+export async function writeResults(results: MatchResult[]): Promise<void> {
   const supabase = getSupabaseAdmin();
 
   // Load manually-protected keys to exclude from writes.

--- a/lib/pricing/syncShopifyProducts.ts
+++ b/lib/pricing/syncShopifyProducts.ts
@@ -41,7 +41,10 @@ export async function syncShopifyProducts(): Promise<{ upserted: number; errors:
         product_type: p.product_type,
         price,
         inventory_quantity: inventory,
-        sku: p.variants[0]?.sku ?? null,
+        // `|| null`, not `?? null`: Shopify returns "" for blank SKUs, and an
+        // empty-string sku poisons the 088 partial index + backfill planning
+        // (pass 0 and planBackfillRows treat ""/null as "no SKU").
+        sku: p.variants[0]?.sku || null,
         body_html: p.body_html ?? null,
         raw_json: p,
         last_synced_at: new Date().toISOString(),

--- a/lib/pricing/types.ts
+++ b/lib/pricing/types.ts
@@ -36,6 +36,8 @@ export interface ShopifyProductRow {
   price: number | null;
   inventory_quantity: number | null;
   raw_json: ShopifyProduct | null;
+  sku: string | null;        // migration 088; written by sync + SKU backfill
+  body_html: string | null;  // migration 088; ability text source
   last_synced_at: string;
 }
 
@@ -87,6 +89,7 @@ export interface MatchingSummary {
   unmatched: number;
   unmatchedCards?: MatchResult[];
   noPriceCards?: MatchResult[];
+  results?: MatchResult[];   // populated only on dryRun — validation tooling reads per-method detail
 }
 
 export interface PricesResponse {

--- a/lib/shopify/productFromCard.test.ts
+++ b/lib/shopify/productFromCard.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { CardData } from '@/lib/cards/generated/cardData';
+import { CARDS } from '@/lib/cards/lookup';
 import { productFromCard, baseCardName, slugifyTitle, cardSku } from './productFromCard';
 
 // Fixtures: EXACT rows from lib/cards/generated/cardData.json (Step 1 extraction).
@@ -200,5 +201,26 @@ describe('productFromCard', () => {
     const card: CardData = { ...ABUSIVE_SOLDIERS, specialAbility: '   ' };
     const built = productFromCard(card, 'GoC', opts);
     expect(built.input.descriptionHtml).toBeUndefined();
+  });
+});
+
+describe('cardSku collision guard', () => {
+  it('collides for exactly one known pair: Angel of the Lord (G)/(H), both 10A, shared imgFile', () => {
+    // Spec §Matching tab: this collision is inert — 10A is in UNSOLD_SETS → no_price_exists.
+    // If card data ever grows a SECOND collision, pass 0 could silently mis-match; this test is the tripwire.
+    const bySku = new Map<string, string[]>();
+    for (const c of CARDS) {
+      const sku = cardSku(c);
+      const list = bySku.get(sku) ?? [];
+      list.push(`${c.name}|${c.set}|${c.imgFile}`);
+      bySku.set(sku, list);
+    }
+    const collisions = [...bySku.entries()].filter(([, keys]) => keys.length > 1);
+    expect(collisions).toHaveLength(1);
+    expect(collisions[0][0]).toBe('10A-Angel_of_the_Lord_(G)');
+    expect(collisions[0][1].map(k => k.split('|')[0]).sort()).toEqual([
+      'Angel of the Lord (G)',
+      'Angel of the Lord (H)',
+    ]);
   });
 });

--- a/lib/shopify/productFromCard.ts
+++ b/lib/shopify/productFromCard.ts
@@ -53,7 +53,7 @@ export function slugifyTitle(title: string): string {
   return title.toLowerCase().replace(/['‘’"“”]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
 }
 
-export function cardSku(card: CardData): string {
+export function cardSku(card: Pick<CardData, 'set' | 'imgFile'>): string {
   return `${card.set}-${sanitizeImgFile(card.imgFile)}`.replace(/\s+/g, '');
 }
 

--- a/lib/shopify/skuBackfill.test.ts
+++ b/lib/shopify/skuBackfill.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { planBackfillRows, skuFromCardKey } from './skuBackfill';
+import type { BackfillMappingRow, BackfillProductLite } from './skuBackfill';
+
+const product = (id: string, variantId: number | string | null = 900): BackfillProductLite => ({
+  id, sku: null,
+  raw_json: variantId == null ? { variants: [] } : { variants: [{ id: variantId }] },
+});
+const mapping = (over: Partial<BackfillMappingRow>): BackfillMappingRow => ({
+  card_key: 'Aaron|Pi|Aaron.jpg', shopify_product_id: '1',
+  confidence: 1, match_method: 'exact', status: 'auto_matched', ...over,
+});
+
+describe('skuFromCardKey', () => {
+  it('computes cardSku from the key parts, stripping whitespace ("RoA 3" → "RoA3-")', () => {
+    expect(skuFromCardKey('Aaron|RoA 3|Aaron.jpg')).toBe('RoA3-Aaron');
+  });
+  it('rejects malformed keys', () => {
+    expect(skuFromCardKey('not-a-key')).toBe(null);
+  });
+});
+
+describe('planBackfillRows', () => {
+  it('builds gids and sku for a simple confirmed mapping', () => {
+    const { toWrite, skippedPermanent, blocked } = planBackfillRows(
+      [mapping({})], new Map([['1', product('1', 456)]]), new Map(),
+    );
+    expect(blocked).toEqual([]);
+    expect(skippedPermanent).toEqual([]);
+    expect(toWrite).toEqual([{
+      productId: '1', productGid: 'gid://shopify/Product/1',
+      variantGid: 'gid://shopify/ProductVariant/456',
+      cardKey: 'Aaron|Pi|Aaron.jpg', sku: 'Pi-Aaron',
+    }]);
+  });
+
+  it('multi-mapping product: exact beats normalized regardless of confidence; rest skippedPermanent', () => {
+    const { toWrite, skippedPermanent } = planBackfillRows([
+      mapping({ card_key: 'A|Pi|A.jpg', match_method: 'normalized', confidence: 0.99 }),
+      mapping({ card_key: 'B|Pi|B.jpg', match_method: 'exact', confidence: 0.9 }),
+      mapping({ card_key: 'C|Pi|C.jpg', match_method: 'promo_fallback', confidence: 1.0 }),
+    ], new Map([['1', product('1')]]), new Map());
+    expect(toWrite).toHaveLength(1);
+    expect(toWrite[0].cardKey).toBe('B|Pi|B.jpg');
+    expect(skippedPermanent.map(s => s.cardKey).sort()).toEqual(['A|Pi|A.jpg', 'C|Pi|C.jpg']);
+    expect(skippedPermanent[0].reason).toContain('permanent by design');
+  });
+
+  it('ties on method rank break by highest confidence', () => {
+    const { toWrite } = planBackfillRows([
+      mapping({ card_key: 'A|Pi|A.jpg', match_method: 'normalized', confidence: 0.90 }),
+      mapping({ card_key: 'B|Pi|B.jpg', match_method: 'normalized', confidence: 0.95 }),
+    ], new Map([['1', product('1')]]), new Map());
+    expect(toWrite[0].cardKey).toBe('B|Pi|B.jpg');
+  });
+
+  it('missing variant in raw_json → blocked with re-sync hint', () => {
+    const { toWrite, blocked } = planBackfillRows([mapping({})], new Map([['1', product('1', null)]]), new Map());
+    expect(toWrite).toEqual([]);
+    expect(blocked[0].reason).toContain('re-sync');
+  });
+
+  it('target sku already owned by ANOTHER product → blocked (would manufacture duplicate SKU)', () => {
+    const { toWrite, blocked } = planBackfillRows(
+      [mapping({})], new Map([['1', product('1')]]), new Map([['Pi-Aaron', '999']]),
+    );
+    expect(toWrite).toEqual([]);
+    expect(blocked[0].reason).toContain('999');
+  });
+
+  it('product missing from the mirror map is ignored (mapping references a ghost)', () => {
+    const { toWrite, blocked } = planBackfillRows([mapping({})], new Map(), new Map());
+    expect(toWrite).toEqual([]);
+    expect(blocked).toEqual([]);
+  });
+});

--- a/lib/shopify/skuBackfill.ts
+++ b/lib/shopify/skuBackfill.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure planning logic for the one-time SKU/metafield backfill (spec §SKU backfill).
+ * IO lives in app/admin/ytg/matching/actions.ts; this module is fully unit-testable.
+ */
+import { cardSku } from './productFromCard';
+
+export interface BackfillMappingRow {
+  card_key: string;
+  shopify_product_id: string;
+  confidence: number | null;
+  match_method: string | null;
+  status: string;
+}
+export interface BackfillProductLite {
+  id: string;
+  sku: string | null;
+  raw_json: { variants?: { id: number | string }[] } | null;
+}
+export interface BackfillRow {
+  productId: string;
+  productGid: string;
+  variantGid: string;
+  cardKey: string;
+  sku: string;
+}
+export interface BackfillSkip { productId: string; cardKey: string; reason: string; }
+
+// Primary-mapping preference: deterministic methods first, then confidence.
+const METHOD_RANK: Record<string, number> = { sku: 0, exact: 1, normalized: 2 };
+const rank = (m: string | null) => {
+  const r = METHOD_RANK[m ?? ''];
+  return r === undefined ? 3 : r;
+};
+
+export function skuFromCardKey(cardKey: string): string | null {
+  const parts = cardKey.split('|');
+  if (parts.length !== 3 || parts[1] === '' || parts[2] === '') return null;
+  return cardSku({ set: parts[1], imgFile: parts[2] });
+}
+
+export function planBackfillRows(
+  mappings: BackfillMappingRow[],
+  productsById: Map<string, BackfillProductLite>,
+  existingSkuOwners: Map<string, string>,
+): { toWrite: BackfillRow[]; skippedPermanent: BackfillSkip[]; blocked: BackfillSkip[] } {
+  const byProduct = new Map<string, BackfillMappingRow[]>();
+  for (const m of mappings) {
+    const list = byProduct.get(m.shopify_product_id);
+    if (list) list.push(m); else byProduct.set(m.shopify_product_id, [m]);
+  }
+
+  const toWrite: BackfillRow[] = [];
+  const skippedPermanent: BackfillSkip[] = [];
+  const blocked: BackfillSkip[] = [];
+
+  for (const [productId, group] of byProduct) {
+    const product = productsById.get(productId);
+    if (!product) continue;                                   // ghost mapping — not ours to fix here
+    if ((product.sku ?? '').trim() !== '') continue;          // already has a SKU
+
+    const sorted = [...group].sort(
+      (a, b) => rank(a.match_method) - rank(b.match_method) || (b.confidence ?? 0) - (a.confidence ?? 0),
+    );
+    const primary = sorted[0];
+    for (const other of sorted.slice(1)) {
+      skippedPermanent.push({
+        productId, cardKey: other.card_key,
+        reason: 'non-primary mapping on a multi-mapped product — permanent by design, not a to-do',
+      });
+    }
+
+    const sku = skuFromCardKey(primary.card_key);
+    if (sku === null) {
+      blocked.push({ productId, cardKey: primary.card_key, reason: 'malformed card_key' });
+      continue;
+    }
+    const owner = existingSkuOwners.get(sku);
+    if (owner !== undefined && owner !== productId) {
+      blocked.push({ productId, cardKey: primary.card_key, reason: `sku already on product ${owner} — resolve that mapping first (duplicate-SKU guard)` });
+      continue;
+    }
+    const variantId = product.raw_json?.variants?.[0]?.id;
+    if (variantId === undefined || variantId === null) {
+      blocked.push({ productId, cardKey: primary.card_key, reason: 'no variant in raw_json — re-sync products, then re-plan' });
+      continue;
+    }
+    toWrite.push({
+      productId,
+      productGid: `gid://shopify/Product/${productId}`,
+      variantGid: `gid://shopify/ProductVariant/${variantId}`,
+      cardKey: primary.card_key,
+      sku,
+    });
+  }
+  return { toWrite, skippedPermanent, blocked };
+}

--- a/scripts/validate-matching.ts
+++ b/scripts/validate-matching.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env npx tsx
+/**
+ * A/B validation for the ability-text signal (spec §Matching tab).
+ * Runs the pipeline dry-run twice — signal OFF, then ON — and prints
+ * per-method counts plus a sample of card_keys whose outcome changed.
+ * No thresholds ship without this report in the PR body.
+ *
+ * Usage: npx tsx scripts/validate-matching.ts
+ */
+import { join } from 'path';
+import { existsSync, readFileSync } from 'fs';
+import { config } from 'dotenv';
+
+config({ path: join(__dirname, '..', '.env.local') });
+
+type Result = { card_key: string; shopify_product_id: string | null; match_method: string; status: string; confidence: number };
+
+function countBy(results: Result[], key: 'match_method' | 'status'): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const r of results) out[r[key]] = (out[r[key]] ?? 0) + 1;
+  return out;
+}
+
+function printCounts(label: string, counts: Record<string, number>) {
+  console.log(`\n${label}`);
+  for (const [k, v] of Object.entries(counts).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${k.padEnd(28)} ${String(v).padStart(6)}`);
+  }
+}
+
+async function main() {
+  // Deferred import so dotenv runs before supabase-admin reads env
+  const { runMatchingPipeline } = await import('../lib/pricing/matching');
+  const { getSupabaseAdmin } = await import('../lib/pricing/supabase-admin');
+
+  console.log('=== Run 1: ability-text signal DISABLED ===');
+  const before = await runMatchingPipeline({ dryRun: true, abilityText: false });
+  console.log('=== Run 2: ability-text signal ENABLED ===');
+  const after = await runMatchingPipeline({ dryRun: true, abilityText: true });
+
+  const beforeResults = (before.results ?? []) as Result[];
+  const afterResults = (after.results ?? []) as Result[];
+
+  printCounts('Per-method counts (signal OFF):', countBy(beforeResults, 'match_method'));
+  printCounts('Per-method counts (signal ON): ', countBy(afterResults, 'match_method'));
+  printCounts('Status counts (signal OFF):', countBy(beforeResults, 'status'));
+  printCounts('Status counts (signal ON): ', countBy(afterResults, 'status'));
+
+  const beforeByKey = new Map(beforeResults.map(r => [r.card_key, r]));
+  const changed = afterResults.filter(r => {
+    const b = beforeByKey.get(r.card_key);
+    return b && (b.shopify_product_id !== r.shopify_product_id || b.status !== r.status || b.match_method !== r.match_method);
+  });
+  console.log(`\nChanged outcomes: ${changed.length}`);
+  for (const r of changed.slice(0, 40)) {
+    const b = beforeByKey.get(r.card_key)!;
+    console.log(`  ${r.card_key}`);
+    console.log(`    OFF: ${b.match_method}/${b.status} → ${b.shopify_product_id}  (${b.confidence})`);
+    console.log(`    ON : ${r.match_method}/${r.status} → ${r.shopify_product_id}  (${r.confidence})`);
+  }
+  if (changed.length > 40) console.log(`  ... and ${changed.length - 40} more`);
+
+  // Offline spot-check: every changed match should point at a product whose
+  // handle exists in the store export (cheap sanity, skipped if CSV absent).
+  const csvPath = join(__dirname, '..', 'tmp', 'products_export_1.csv');
+  if (existsSync(csvPath) && changed.length > 0) {
+    const handles = new Set(
+      readFileSync(csvPath, 'utf-8').split('\n').slice(1)
+        .map(line => line.split(',')[0]?.replace(/^"|"$/g, '').trim()).filter(Boolean)
+    );
+    const supabase = getSupabaseAdmin();
+    const ids = changed.map(r => r.shopify_product_id).filter(Boolean).slice(0, 200);
+    const { data } = await supabase.from('shopify_products').select('id, handle').in('id', ids);
+    const handleById = new Map((data ?? []).map((p: any) => [p.id, p.handle]));
+    let inCsv = 0, missing = 0;
+    for (const r of changed.slice(0, 200)) {
+      if (!r.shopify_product_id) continue;
+      if (handles.has(handleById.get(r.shopify_product_id) ?? '')) inCsv++; else missing++;
+    }
+    console.log(`\nCSV spot-check (first 200 changed): ${inCsv} handles present in export, ${missing} not (new since export — expected small)`);
+  }
+
+  console.log('\nSummary deltas: matched %+d, needs_review %+d, unmatched %+d'
+    .replace('%+d', fmt(after.matched - before.matched))
+    .replace('%+d', fmt(after.needs_review - before.needs_review))
+    .replace('%+d', fmt(after.unmatched - before.unmatched)));
+  function fmt(n: number) { return (n >= 0 ? '+' : '') + n; }
+}
+
+main().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## WS-2: Matching tab — deterministic-first reconciliation

Implements spec §Matching tab (docs/superpowers/specs/2026-08-03-ytg-store-admin-design.md):

- **Pass 0** (SKU identity): protection-exempt, runs before the loadProtectedKeys skip so it can
  correct confident-but-wrong fuzzy matches; writeResults' manual/no_price_exists refetch-filter
  remains the write-layer guard. Duplicate SKUs → needs_review/sku_duplicate, never auto-picked.
- **SKU backfill**: productVariantsBulkUpdate with `inventoryItem.sku` (2026-07 shape) +
  metafieldsSet (custom.rtt_card_key, 25/chunk) via runAliasedMutations; primary-mapping-only
  guard (non-primary skips are permanent by design); mirror sync-back; SHOPIFY_WRITE_MOCK honored.
- **Re-mapping hygiene**: Pick different approves via the existing manual-status endpoint, then
  clearStaleIdentity strips the old product's matching SKU/rtt_card_key (duplicate-SKU prevention).
- **Ability-text signal**: body_html → text → Jaccard overlap vs specialAbility, additive-only
  boost in pass3and4Fuzzy; A/B-validated below.
- **Matching tab UI**: dashboard counts, backfill plan/execute/retry, keyboard review queue
  (A/R//, arrows, "1 of N" progress, end-of-queue state).
- **Health strip** (assigned extra): "Matched" is now % of *sellable* — (auto_matched+manual) /
  (total − no_price_exists) — with a "1,039 not sold by YTG" secondary line. The old 81.7%
  read as a matching failure when the missing 18.3% was all deliberately-unsold cards.

## Validation report (scripts/validate-matching.ts — real output, required before merge)

```
[dotenv@17.3.1] injecting env (39) from .env.local -- tip: 🛡️ auth for agents: https://vestauth.com
=== Run 1: ability-text signal DISABLED ===
[06:07:01] Loading data...
[06:07:03] Loaded 5691 cards, 47 aliases, 4874 Shopify products, 5352 protected
[06:07:03] Running pass 0 (SKU identity, protection-exempt)...
[06:07:03] Pass 0 done: 0 SKU hits (0 duplicate-SKU → needs_review)
[06:07:03] Running passes 1 & 2 (exact + normalized)...
[06:07:03] Passes 1 & 2 done: 338 matched, 0 no_price_exists, 2 need fuzzy matching
[06:07:03] Running fuzzy matching on 2 cards...
  [fuzzy debug] "The Blinding Angel (RoJ AB)" → "The Binding Angel (RoJ)" (0.740740716457367), "The Guiding Angel (RoJ)" (0.566666662693024)
  [fuzzy debug] "Lost Soul Psalm 119:50 (Martian) (FooF)" → "Lost Soul (Psalm 119:150) “Discarder” (FooF)" (0.541666686534882)
[06:07:04]   Fuzzy progress: 2/2 (2 matched, 0 review)
[06:07:04] Done! matched=340 review=0 no_price=0 unmatched=0
=== Run 2: ability-text signal ENABLED ===
[06:07:04] Loading data...
[06:07:07] Loaded 5691 cards, 47 aliases, 4874 Shopify products, 5352 protected
[06:07:07] Running pass 0 (SKU identity, protection-exempt)...
[06:07:07] Pass 0 done: 0 SKU hits (0 duplicate-SKU → needs_review)
[06:07:07] Running passes 1 & 2 (exact + normalized)...
[06:07:07] Passes 1 & 2 done: 338 matched, 0 no_price_exists, 2 need fuzzy matching
[06:07:07] Running fuzzy matching on 2 cards...
  [fuzzy debug] "The Blinding Angel (RoJ AB)" → "The Binding Angel (RoJ)" (0.740740716457367), "The Guiding Angel (RoJ)" (0.566666662693024)
  [fuzzy debug] "Lost Soul Psalm 119:50 (Martian) (FooF)" → "Lost Soul (Psalm 119:150) “Discarder” (FooF)" (0.541666686534882)
[06:07:07]   Fuzzy progress: 2/2 (2 matched, 0 review)
[06:07:07] Done! matched=340 review=0 no_price=0 unmatched=0

Per-method counts (signal OFF):
  normalized_ab_fallback          235
  normalized_variant               33
  normalized_legacy_rare           32
  promo_bracket_match              16
  promo_fallback_cheapest          12
  lost_soul_bracket                 7
  promo_fallback                    2
  multi_signal                      2
  banned_set_match                  1

Per-method counts (signal ON): 
  normalized_ab_fallback          235
  normalized_variant               33
  normalized_legacy_rare           32
  promo_bracket_match              16
  promo_fallback_cheapest          12
  lost_soul_bracket                 7
  promo_fallback                    2
  multi_signal                      2
  banned_set_match                  1

Status counts (signal OFF):
  auto_matched                    340

Status counts (signal ON): 
  auto_matched                    340

Changed outcomes: 0

Summary deltas: matched +0, needs_review +0, unmatched +0
```

**Reading the report:** run on live prod data (both runs `dryRun: true`, zero writes), after the
first post-088 cron sync populated `body_html` on all 4,967 mirror rows.

- **Pass 0: 0 SKU hits is correct.** The store has zero real SKUs today — all 1,533 "non-null"
  mirror skus from the sync are empty strings (see fix below). The backfill (planned 4,253
  products) is what seeds them; pass 0 takes over from the next sync onward.
- **Changed outcomes: 0.** Only 339 unprotected cards flow through the pipeline in a non-force
  run, and only 2 reach the fuzzy passes; both resolve identically with the signal on. The
  additive-only invariant held exactly (matched +0, needs_review +0, **unmatched +0** — the
  abort condition was "unmatched increases"). Identical OFF/ON counts are also the live proof
  of the "empty/missing body_html ⇒ byte-identical scoring" clause now that thresholds only
  fire on real overlap. No threshold values were changed from the plan (+0.15 @ ≥0.6,
  +0.08 @ ≥0.35).
- CSV spot-check line absent because zero outcomes changed (it only prints for changed rows).

## Live UI verification (mock mode, dev server, Playwright)

- `SHOPIFY_WRITE_MOCK=1` dev server, session minted for a `manage_shopify_imports` holder.
- Dashboard renders real prod counts; **Plan SKU backfill: 4,253 to write / 391 non-primary
  skipped ("permanent by design" label) / 0 blocked**, 20-row sample table.
- **Execute in mock: all 4,253 rows report ok, zero Shopify/mirror writes** (verified sku
  column count unchanged after the run).
- Review queue: empty state (prod queue is empty pre-matching-run) verified, then keyboard
  flow driven against stubbed queue/approve/reject endpoints (real UI code, zero prod writes):
  A approves with correct payload, R rejects, `/` focuses product search (hits from the real
  Singles-only server action), arrows navigate, typing in the search input does NOT trigger
  hotkeys, end-of-queue celebration renders. No console/page errors.

## Test evidence

```
Test Files  146 passed | 3 skipped (149)
     Tests  1851 passed | 80 skipped (1933)

npx tsc --noEmit: 7 pre-existing baseline errors only
  (3 __tests__/forge-anon-leak.test.ts, 4 app/forge/lib/__tests__/playDecksAuthorize.test.ts)
  — zero new errors.
```

## Notes for reviewer

- `writeResults` is now exported (test seam only; body unchanged).
- `cardSku` widened to `Pick<CardData, 'set'|'imgFile'>` — no import cycle (verified: productFromCard's
  import chain never touches lib/pricing), so the lib/shopify/sku.ts fallback was unnecessary.
- Variant-SKU clearing uses `inventoryItem: { sku: null }` with an in-code documented `""` fallback.
- `metafieldsDelete(metafields: [MetafieldIdentifierInput!]!)` re-verified current at shopify.dev for 2026-07.
- review-queue route: join select extended with body_html + sku only; WS-0 auth untouched.
- **Live finding + fix (last commit):** the first post-088 sync mirrored blank Shopify SKUs as
  `''` (not null) — `variants[0]?.sku ?? null` never nulls empty strings. This would have
  silently dropped ~1,500 products from the backfill plan via the `sku IS NULL` prefilter, and
  bloats the 088 partial index. Sync now normalizes `'' → null`; planSkuBackfill drops the SQL
  prefilter (the pure planner's trim check owns the "already has a SKU" decision) and ignores
  `''` when building duplicate-SKU owners. Verified read-only against prod: plan identical
  (4,253/391/0) before and after.
- matching.test.ts fixture gained the two new required `ShopifyProductRow` fields (sku, body_html) —
  direct consequence of the types change, not a drive-by.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
