### PR TITLE
feat(ytg): close three deck-contents parser resolution gaps (scripture Lost Souls, or-option parens, pre-section prose)

### DIFF
--- a/lib/ytg/__tests__/deckContentsParser.test.ts
+++ b/lib/ytg/__tests__/deckContentsParser.test.ts
@@ -159,11 +159,18 @@ describe("fixture: fiery-furnace.html (live store description)", () => {
     expect(l.status).toBe("ambiguous");
     expect(l.candidates.length).toBeGreaterThanOrEqual(2); // TxP print + GoC LR print
   });
-  it("'Christian Martyr (I/J)' — unknown paren stays in the name → unresolved", () => {
+  it("'Christian Martyr (I/J)' — option paren splits on '/' → ambiguous across I and J", () => {
+    // Was unresolved before or-option parens: "I/J" fails as ONE alias, but
+    // splits into I and J, both real sets containing the card. Never
+    // auto-picked — the admin gets a one-click choice.
     const l = byRaw(lines, "Christian Martyr (I/J)");
-    expect(l.setAbbrev).toBeNull();
-    expect(l.name).toBe("Christian Martyr (I/J)");
-    expect(l.status).toBe("unresolved");
+    expect(l.setAbbrev).toBe("I/J");
+    expect(l.name).toBe("Christian Martyr");
+    expect(l.status).toBe("ambiguous");
+    expect(l.candidates.map((c) => c.cardKey).sort()).toEqual([
+      "Christian Martyr (I)|I|Christian_Martyr_(I)",
+      "Christian Martyr (J)|J|Christian_Martyr_(J)",
+    ]);
   });
   it("ambiguous alias RoA←{RoA, RoA 3} disambiguated by containment", () => {
     const l = byRaw(lines, "Scattered (RoA)");
@@ -203,6 +210,14 @@ describe("fixture: fiery-furnace.html (live store description)", () => {
 describe("fixture: daniel-contender.html (live store description)", () => {
   const lines = parseDeckContents(fixture("daniel-contender.html"), ALIASES);
 
+  it("resolution summary: 83 lines — 75 resolved, 2 ambiguous, 6 unresolved", () => {
+    // Was 86 lines with 68/1/17 before scripture matching, or-option parens
+    // and the pre-section prose drop.
+    expect(lines).toHaveLength(83);
+    const counts = { resolved: 0, ambiguous: 0, unresolved: 0 };
+    for (const l of lines) counts[l.status]++;
+    expect(counts).toEqual({ resolved: 75, ambiguous: 2, unresolved: 6 });
+  });
   it("auto-drops intro junk before the first section header", () => {
     for (const raw of [
       "And check out these videos to find out more about this deck!",
@@ -237,10 +252,21 @@ describe("fixture: daniel-contender.html (live store description)", () => {
     expect(l.status).toBe("ambiguous");
     expect(l.candidates.map((c) => c.setCode).sort()).toEqual(["K", "K1P"]);
   });
-  it("'New Jerusalem (I & J+ or Promo)' — prose-ish paren → unresolved, paren kept", () => {
+  it("'New Jerusalem (I & J+ or Promo)' — or-option paren → ambiguous with per-set candidates", () => {
+    // "I & J+" resolves whole (before the &// sub-split) → I/J+; "Promo" →
+    // Pmo-P1/P2/P3. Only I/J+ and Pmo-P2 actually contain a New Jerusalem.
+    // Always ambiguous: the line itself offers alternatives — never auto-pick.
     const l = byRaw(lines, "New Jerusalem (I & J+ or Promo)");
-    expect(l.setAbbrev).toBeNull();
-    expect(l.status).toBe("unresolved");
+    expect(l.setAbbrev).toBe("I & J+ or Promo");
+    expect(l.name).toBe("New Jerusalem");
+    expect(l.status).toBe("ambiguous");
+    expect(l.candidates.map((c) => c.cardKey).sort()).toEqual([
+      "New Jerusalem (I/J+)|I/J+|New-Jerusalem-IJ",
+      "New Jerusalem (Promo)|Pmo-P2|New_Jerusalem_(Promo)",
+    ]);
+  });
+  it("or-split leaves non-option parens alone ('2025 Promo' has no delimiter)", () => {
+    expect(byRaw(lines, "Raiders' Camp (2025 Promo)").status).toBe("unresolved");
   });
   it("folds doubled straight quotes to match carddata curly-quote names", () => {
     const l = byRaw(lines, "Lost Soul ''Idolaters'' [Daniel 3:7] (TtC)");

--- a/lib/ytg/__tests__/deckContentsParser.test.ts
+++ b/lib/ytg/__tests__/deckContentsParser.test.ts
@@ -203,6 +203,35 @@ describe("fixture: fiery-furnace.html (live store description)", () => {
 describe("fixture: daniel-contender.html (live store description)", () => {
   const lines = parseDeckContents(fixture("daniel-contender.html"), ALIASES);
 
+  it("auto-drops intro junk before the first section header", () => {
+    for (const raw of [
+      "And check out these videos to find out more about this deck!",
+      "Deck overview and intro",
+      "Live online Local tournament gameplay using budget-free version of the deck",
+    ]) {
+      expect(lines.some((l) => l.raw === raw)).toBe(false);
+    }
+    // Scope guard: prose AFTER the first section header is not auto-dropped —
+    // the review screen's explicit resolve-or-drop gate still owns those.
+    expect(byRaw(lines, "Deck strategy and tips:").status).toBe("unresolved");
+    expect(byRaw(lines, "OVERVIEW:").status).toBe("unresolved");
+  });
+  it("keeps pre-section lines that resolve as cards; no headers → nothing dropped", () => {
+    // Card line before any section header must survive the prose drop.
+    const withHeader = parseDeckContents(
+      "<p>Told to Take (TtC)</p><p>Some intro chatter here</p><p>Dominants</p><p>Son of God (K)</p>",
+      ALIASES,
+    );
+    expect(withHeader.map((l) => l.raw)).toEqual(["Told to Take (TtC)", "Son of God (K)"]);
+    expect(withHeader[0].status).toBe("resolved");
+    // Defensive: descriptions with no section headers at all drop nothing.
+    const headerless = parseDeckContents(
+      "<p>Some intro chatter here</p><p>Told to Take (TtC)</p>", ALIASES);
+    expect(headerless.map((l) => l.raw)).toEqual(
+      ["Some intro chatter here", "Told to Take (TtC)"]);
+    expect(headerless[0].status).toBe("unresolved");
+  });
+
   it("'Son of God (K Deck)' → ambiguous across K and K1P (both contain it)", () => {
     const l = byRaw(lines, "Son of God (K Deck)");
     expect(l.status).toBe("ambiguous");

--- a/lib/ytg/__tests__/deckContentsParser.test.ts
+++ b/lib/ytg/__tests__/deckContentsParser.test.ts
@@ -247,10 +247,57 @@ describe("fixture: daniel-contender.html (live store description)", () => {
     expect(l.status).toBe("resolved");
     expect(l.candidates[0].cardKey).toBe('Lost Soul "Idolaters" [Daniel 3:7]|T2C|021-Lost-Soul-Idolaters');
   });
-  it("smart-double-quoted scripture Lost Souls with reordered names stay unresolved", () => {
-    const l = byRaw(lines, "Lost Soul (Psalm 78:22) “O.T. Only” (FoM)");
-    expect(l.setAbbrev).toBe("FoM");
-    expect(l.status).toBe("unresolved"); // carddata: Lost Soul "O.T. Only" [Psalm 78:22]
+  it("scripture-ref matching resolves reordered Lost Soul lines within the parsed set", () => {
+    // Store order "(ref) “epithet”" vs carddata 'Lost Soul "epithet" [ref]' —
+    // the scripture ref is the stable token.
+    const ot = byRaw(lines, "Lost Soul (Psalm 78:22) “O.T. Only” (FoM)");
+    expect(ot.setAbbrev).toBe("FoM");
+    expect(ot.status).toBe("resolved");
+    expect(ot.candidates[0].cardKey).toBe(
+      'Lost Soul "O.T. Only" [Psalm 78:22]|FoM|140-Lost_Soul_Psalm_78-22');
+
+    const cb = byRaw(lines, "Lost Soul (Daniel 9:5) ''Covenant Breakers'' (PoC)");
+    expect(cb.status).toBe("resolved");
+    expect(cb.candidates[0].cardKey).toBe(
+      'Lost Soul "Covenant Breakers" [Daniel 9:5]|PoC|164-Lost-Soul-Covenant-Breakers-(Daniel-9_5)');
+  });
+  it("epithet tiebreaks when one set has two souls on the same verse", () => {
+    // PoC has both "Foreigner" and "Orphans" on Jeremiah 22:3.
+    const l = byRaw(lines, "Lost Soul (Jeremiah 22:3) “Foreigner” (PoC)");
+    expect(l.status).toBe("resolved");
+    expect(l.candidates[0].cardKey).toBe(
+      'Lost Soul "Foreigner" [Jeremiah 22:3]|PoC|128-Lost-Soul-Foreigner-(Jeremiah-22_3)');
+  });
+  it("handles multi-ref verses and rarity-suffixed brackets in carddata names", () => {
+    // Line "(James 4:6/Proverbs 3:34)" vs carddata "[James 4:6 / Proverbs 3:34 - RoJ]".
+    const humble = byRaw(lines, "Lost Soul (James 4:6/Proverbs 3:34) “Humble” (RoJ)");
+    expect(humble.status).toBe("resolved");
+    expect(humble.candidates[0].cardKey).toBe(
+      'Lost Soul "Humble" [James 4:6 / Proverbs 3:34 - RoJ]|RoJ|22-Lost-Soul-Humble-R');
+    // Line "(Jeremiah 13:10)" vs carddata "[Jeremiah 13:10 - RR]" — set-scoped
+    // to RR via Roots, so the Pri print with the same verse is not a candidate.
+    const cg = byRaw(lines, "Lost Soul ''Color Guard'' (Jeremiah 13:10) (Roots)");
+    expect(cg.status).toBe("resolved");
+    expect(cg.candidates[0].cardKey).toBe(
+      'Lost Soul "Color Guard" [Jeremiah 13:10 - RR]|RR|016-Lost-Soul-Color-Guard');
+  });
+  it("scripture match with several hits and no deciding epithet stays ambiguous", () => {
+    // Synthetic: no epithet on the line → both PoC Jeremiah 22:3 souls listed.
+    const [l] = parseDeckContents("<p>Lost Soul (Jeremiah 22:3) (PoC)</p>", ALIASES);
+    expect(l.status).toBe("ambiguous");
+    expect(l.candidates.map((c) => c.cardName).sort()).toEqual([
+      'Lost Soul "Foreigner" [Jeremiah 22:3]',
+      'Lost Soul "Orphans" [Jeremiah 22:3]',
+    ]);
+  });
+  it("scripture match spans all sets when no set abbrev parsed; unknown refs stay unresolved", () => {
+    const lines = parseDeckContents(
+      "<p>Lost Soul (Psalm 78:22) ''O.T. Only''<br>Lost Soul (Hezekiah 99:99) ''Nobody''</p>",
+      ALIASES,
+    );
+    expect(lines[0].status).toBe("resolved");
+    expect(lines[0].candidates[0].setCode).toBe("FoM");
+    expect(lines[1].status).toBe("unresolved");
   });
   it("attributes sections through 'Fortresses/Sites/Cities' and drops strategy prose", () => {
     expect(byRaw(lines, "Babylon (TtC)").section).toBe("Fortresses/Sites/Cities");

--- a/lib/ytg/deckContentsParser.ts
+++ b/lib/ytg/deckContentsParser.ts
@@ -262,8 +262,12 @@ export function parseDeckContents(
   const idx = cardIndex();
   const out: ParsedLine[] = [];
   let section: string | null = null;
+  const lines = htmlToLines(bodyHtml);
+  // Pre-section prose drop only applies when the description actually has
+  // section headers; otherwise everything is "before the first section".
+  const hasSections = lines.some((l) => sectionHeader(l) !== null);
 
-  for (const line of htmlToLines(bodyHtml)) {
+  for (const line of lines) {
     const header = sectionHeader(line);
     if (header) { section = header; continue; }
     // Prose/flavor-text heuristic: long sentence with no trailing paren.
@@ -271,7 +275,13 @@ export function parseDeckContents(
     if (!/[a-zA-Z]/.test(line)) continue;
 
     const { qty, rest } = parseQty(line);
-    out.push({ raw: line, qty, section, ...resolveLine(rest, aliasCandidates, idx) });
+    const res = resolveLine(rest, aliasCandidates, idx);
+    // Intro junk ("And check out these videos…") sits before the first
+    // section header; anything there that doesn't look like a card is
+    // dropped outright — same consumption semantics as the prose heuristic.
+    // Lines that DO resolve (or are ambiguous) as cards are kept.
+    if (hasSections && section === null && res.candidates.length === 0) continue;
+    out.push({ raw: line, qty, section, ...res });
   }
   return out;
 }

--- a/lib/ytg/deckContentsParser.ts
+++ b/lib/ytg/deckContentsParser.ts
@@ -141,6 +141,18 @@ function pushKey(map: Map<string, CardData[]>, key: string, card: CardData) {
   else map.set(key, [card]);
 }
 
+/** Strip a trailing paren/bracket that is exactly the card's OWN set code.
+ *  stripEmbeddedSet only handles short alphanumeric codes; names like
+ *  "New Jerusalem (I/J+)" (set I/J+) slip through and would otherwise never
+ *  be findable by their bare name within their set. */
+function ownSetStripped(name: string, set: string): string | null {
+  const esc = set.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`\\s*[(\\[]${esc}[)\\]]\\s*$`);
+  if (!re.test(name)) return null;
+  const stripped = name.replace(re, "").trim();
+  return stripped || null;
+}
+
 function cardIndex(): CardIndex {
   if (INDEX) return INDEX;
   const bySet = new Map<string, Map<string, CardData[]>>();
@@ -149,7 +161,10 @@ function cardIndex(): CardIndex {
     if (!card.name) continue;
     let setMap = bySet.get(card.set);
     if (!setMap) { setMap = new Map(); bySet.set(card.set, setMap); }
-    for (const key of nameKeyVariants(card.name)) {
+    const keys = nameKeyVariants(card.name);
+    const own = ownSetStripped(card.name, card.set);
+    if (own) keys.push(...nameKeyVariants(own));
+    for (const key of new Set(keys)) {
       pushKey(setMap, key, card);
       pushKey(global, key, card);
     }
@@ -287,6 +302,27 @@ function withLostSoulScripture(
   };
 }
 
+/** "Or"-option parens: "(I & J+ or Promo)", "(I/J)". The whole paren failed
+ *  as one alias; split it into tokens and alias-resolve each independently.
+ *  Top-level separators first (or, comma) so multi-word aliases like
+ *  "I & J+" resolve whole before the tighter &// split. Tokens that don't
+ *  resolve are ignored. */
+function splitParenSets(
+  abbrev: string,
+  aliasCandidates: Map<string, string[]>,
+): string[] {
+  const sets: string[] = [];
+  for (const token of abbrev.split(/\s+or\s+|,/i).map((t) => t.trim()).filter(Boolean)) {
+    const whole = aliasCandidates.get(normalize(token));
+    if (whole) { sets.push(...whole); continue; }
+    for (const sub of token.split(/[&/]/).map((s) => s.trim()).filter(Boolean)) {
+      const subSets = aliasCandidates.get(normalize(sub));
+      if (subSets) sets.push(...subSets);
+    }
+  }
+  return [...new Set(sets)];
+}
+
 function resolveLine(
   rest: string,
   aliasCandidates: Map<string, string[]>,
@@ -329,13 +365,40 @@ function resolveLine(
     );
   }
 
+  // Paren is not a single known set — maybe it's an option list of sets.
+  let orSets: string[] = [];
+  if (paren && abbrev !== null) {
+    orSets = splitParenSets(abbrev, aliasCandidates);
+    if (orSets.length > 0) {
+      const innerName = paren[1].trim();
+      let orHits: CardData[] = [];
+      for (const setCode of orSets) {
+        orHits.push(...lookup(idx.bySet.get(setCode), nameKeyVariants(innerName)));
+      }
+      orHits = [...new Set(orHits)];
+      const fullHits = lookup(idx.global, strictVariants(rest));
+      if (orHits.length > 0) {
+        // The source line itself offers alternatives — surface every print
+        // for a one-click pick, and NEVER auto-resolve (even a single hit
+        // still needs the admin to confirm which option the store meant).
+        const union = dedupeCandidates([
+          ...toCandidates(orHits, 0.5),
+          ...toCandidates(fullHits, 0.6),
+        ]);
+        return { name: innerName, setAbbrev: abbrev, candidates: union, status: "ambiguous" };
+      }
+      // No option-set contains the name → fall through to current behavior
+      // (paren stays part of the name).
+    }
+  }
+
   // No trailing paren, or the paren is not a known set → whole line is the name.
   const hits = lookup(idx.global, nameKeyVariants(rest));
   const cands = toCandidates(hits, hits.length === 1 ? 0.7 : 0.4);
   return withLostSoulScripture(
     { name: rest, setAbbrev: null, candidates: cands, status: statusFor(cands.length) },
     rest,
-    null,
+    orSets.length > 0 ? orSets : null,
   );
 }
 

--- a/lib/ytg/deckContentsParser.ts
+++ b/lib/ytg/deckContentsParser.ts
@@ -168,6 +168,47 @@ function lookup(map: Map<string, CardData[]> | undefined, variants: string[]): C
 }
 
 /* ------------------------------------------------------------------ */
+/*  Lost Soul scripture-reference matching                             */
+/* ------------------------------------------------------------------ */
+
+/** Book word + chapter:verse(-range). Book capture is deliberately just the
+ *  immediately-preceding word (plus optional 1-3 numeral) so extraction is
+ *  consistent between store lines ("(Daniel 9:5)") and carddata names
+ *  ("[Daniel 9:5]", "Lost Soul Jeremiah 13:10 (Color Guard)"). */
+const SCRIPTURE_RE = /(?:\b([1-3])\s+)?([A-Za-z][A-Za-z.]*)\s+(\d+):(\d+(?:\s*[-–]\s*\d+)?)/g;
+
+function scriptureRefs(s: string): string[] {
+  const out: string[] = [];
+  for (const m of s.matchAll(SCRIPTURE_RE)) {
+    const book = `${m[1] ? `${m[1]} ` : ""}${m[2].toLowerCase().replace(/\./g, "")}`;
+    const verse = m[4].replace(/\s*[-–]\s*/g, "-");
+    out.push(`${book} ${m[3]}:${verse}`);
+  }
+  return out;
+}
+
+/** First quoted span, quote styles folded ('' doubled-singles, smart quotes). */
+function epithetOf(s: string): string | null {
+  const m = /"([^"]+)"/.exec(normalize(s.replace(/''/g, '"')));
+  return m ? m[1].trim() : null;
+}
+
+interface LostSoulEntry { card: CardData; refs: string[]; epithet: string | null }
+
+let LS_INDEX: LostSoulEntry[] | null = null;
+
+function lostSoulIndex(): LostSoulEntry[] {
+  if (LS_INDEX) return LS_INDEX;
+  LS_INDEX = [];
+  for (const card of CARDS) {
+    if (!card.name || !/^lost soul/i.test(card.name)) continue;
+    const refs = scriptureRefs(card.name);
+    if (refs.length > 0) LS_INDEX.push({ card, refs, epithet: epithetOf(card.name) });
+  }
+  return LS_INDEX;
+}
+
+/* ------------------------------------------------------------------ */
 /*  Line grammar + resolution                                          */
 /* ------------------------------------------------------------------ */
 
@@ -207,6 +248,45 @@ function statusFor(n: number): ParsedLine["status"] {
   return n === 1 ? "resolved" : n > 1 ? "ambiguous" : "unresolved";
 }
 
+/** Scripture-ref rescue for otherwise-unresolved "Lost Soul …" lines.
+ *  Store descriptions freely reorder epithet/scripture and swap () for []
+ *  ("Lost Soul (Daniel 9:5) ''Covenant Breakers''" vs carddata's
+ *  'Lost Soul "Covenant Breakers" [Daniel 9:5]'), so name-shape matching
+ *  fails; the scripture ref is the stable token. Match primarily by ref
+ *  (within poolSets when a set abbrev parsed, else all sets); epithet is
+ *  only a tiebreaker. One hit → resolved; several → ambiguous (never
+ *  auto-pick); none → keep the base resolution. */
+function withLostSoulScripture(
+  base: Resolution,
+  rest: string,
+  poolSets: string[] | null,
+): Resolution {
+  if (base.status !== "unresolved") return base;
+  if (!/^lost soul/i.test(rest.trim())) return base;
+  const lineRefs = scriptureRefs(rest);
+  if (lineRefs.length === 0) return base;
+
+  let hits = lostSoulIndex().filter(
+    (e) =>
+      (poolSets === null || poolSets.includes(e.card.set)) &&
+      lineRefs.every((r) => e.refs.includes(r)),
+  );
+  if (hits.length === 0) return base;
+  if (hits.length > 1) {
+    const epithet = epithetOf(rest);
+    if (epithet !== null) {
+      const narrowed = hits.filter((e) => e.epithet === epithet);
+      if (narrowed.length === 1) hits = narrowed;
+    }
+  }
+  const cards = hits.map((e) => e.card);
+  return {
+    ...base,
+    candidates: toCandidates(cards, cards.length === 1 ? 0.9 : 0.5),
+    status: statusFor(cards.length),
+  };
+}
+
 function resolveLine(
   rest: string,
   aliasCandidates: Map<string, string[]>,
@@ -242,13 +322,21 @@ function resolveLine(
     // to a global search (full line first, then the paren-stripped name).
     const fallback = fullHits.length > 0 ? fullHits : lookup(idx.global, nameKeyVariants(rest));
     const cands = toCandidates(fallback, fallback.length === 1 ? 0.7 : 0.4);
-    return { name: innerName, setAbbrev: abbrev, candidates: cands, status: statusFor(cands.length) };
+    return withLostSoulScripture(
+      { name: innerName, setAbbrev: abbrev, candidates: cands, status: statusFor(cands.length) },
+      rest,
+      aliasSets,
+    );
   }
 
   // No trailing paren, or the paren is not a known set → whole line is the name.
   const hits = lookup(idx.global, nameKeyVariants(rest));
   const cands = toCandidates(hits, hits.length === 1 ? 0.7 : 0.4);
-  return { name: rest, setAbbrev: null, candidates: cands, status: statusFor(cands.length) };
+  return withLostSoulScripture(
+    { name: rest, setAbbrev: null, candidates: cands, status: statusFor(cands.length) },
+    rest,
+    null,
+  );
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
Closes three resolution gaps found running the live pull-contents wizard on the **\*New\* Daniel Heroes/Babylonians** contender deck.

## Before / after on the Daniel fixture (`daniel-contender.html`)

| | lines emitted | resolved | ambiguous | unresolved |
|---|---|---|---|---|
| before | 86 | 68 | 1 | 17 |
| after | **83** | **75** | **2** | **6** |

The 6 remaining unresolved are mid/post-section strategy prose ("Deck strategy and tips:", "OVERVIEW:", "THE OFFENSE:", …) plus `Raiders' Camp (2025 Promo)` — all correctly left to the review screen's explicit resolve-or-drop gate.

## 1. Scripture-reference matching for Lost Souls

Store lines reorder epithet/scripture and swap `()`/`[]` vs carddata (`Lost Soul (Daniel 9:5) ''Covenant Breakers''` vs `Lost Soul "Covenant Breakers" [Daniel 9:5]`), so name-shape matching never hit. Otherwise-unresolved lines starting with "Lost Soul" now match primarily by canonicalized scripture ref among Lost Soul cards — scoped to the parsed set's alias candidates when a set abbrev resolved, else all sets — with the quoted epithet only as a tiebreaker. One hit → resolved; several → ambiguous with candidates (**never auto-pick**); zero → unresolved as before.

Resolves all 7 previously-unresolved Lost Soul lines, including:
- `Lost Soul (Psalm 78:22) “O.T. Only” (FoM)` — carddata **does** have this card: `Lost Soul "O.T. Only" [Psalm 78:22]` in FoM (`140-Lost_Soul_Psalm_78-22`), so the old "stays unresolved" test assertion was updated to the resolved truth.
- `Lost Soul (Jeremiah 22:3) “Foreigner” (PoC)` — PoC has two souls on that verse (Foreigner/Orphans); epithet tiebreaks. Without an epithet the line stays ambiguous with both (tested).
- Multi-ref `(James 4:6/Proverbs 3:34)` vs carddata `[James 4:6 / Proverbs 3:34 - RoJ]`, and rarity-suffixed `[Jeremiah 13:10 - RR]`.

## 2. "Or"-option parens → ambiguous with candidates

`New Jerusalem (I & J+ or Promo)`: when the trailing paren fails as one alias, it's split on `or` / `,` first (so multi-word aliases like "I & J+" resolve whole), then `&` / `/`; each token alias-resolves independently, non-resolving tokens are ignored, and the name is looked up in every resolved set. Any hits → status **ambiguous** with the union of per-set candidates — always ambiguous even on a single hit, because the line itself offers alternatives; one click for the admin. Nothing resolving falls back to the previous paren-stays-in-name behavior (`Raiders' Camp (2025 Promo)` unchanged).

- The Daniel line now offers exactly `New Jerusalem (I/J+)|I/J+` and `New Jerusalem (Promo)|Pmo-P2`.
- Bonus from the same mechanism: fiery-furnace's `Christian Martyr (I/J)` goes unresolved → ambiguous across the I and J prints (test updated with rationale — this is the designed or-split behavior, not a precedence regression; precedence-rule tests all pass unchanged).
- Supporting index fix: cards whose name embeds their **own** set code in a shape `stripEmbeddedSet` can't handle (`New Jerusalem (I/J+)`) are now also indexed under the bare name within their set.

## 3. Pre-section prose auto-drop

Intro junk before the first recognized section header ("And check out these videos…", video-link titles) that doesn't resolve as a card is now consumed during parsing — same semantics as the existing >90-char prose heuristic. **UI-contract choice: such lines are not emitted at all**, which is the smallest diff — zero `ContentsWizard` changes (the alternative, a pre-dropped status, would have needed new `toRows`/badge handling). Pre-section lines that do resolve (or are ambiguous) as cards are kept, and descriptions with no section headers at all drop nothing (both tested).

## Verification

- `npm test`: 150 files / 1902 tests passed, 0 failures (parser suite 23 → 39 tests).
- `npx tsc --noEmit`: byte-identical to the pre-change baseline (only the 7 pre-existing errors in `__tests__/forge-anon-leak.test.ts` + `app/forge/lib/__tests__/playDecksAuthorize.test.ts`).
- Touched only `lib/ytg/deckContentsParser.ts` and its test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
