### PR TITLE
feat(ytg): import Reserve-section lines as zone='reserve' in the deck-contents wizard

### DIFF
--- a/app/admin/ytg/decks/[productId]/ContentsWizard.tsx
+++ b/app/admin/ytg/decks/[productId]/ContentsWizard.tsx
@@ -10,12 +10,14 @@ import {
 import type { DeckProductMeta } from "../actions";
 import type { ParsedLine, ParsedCandidate } from "@/lib/ytg/deckContentsParser";
 import type { ResolvedEntry } from "@/lib/ytg/deckLinkOps";
+import { sectionZone, type DeckZone } from "@/lib/ytg/deckZones";
 import CardPickerInline, { type PickedCard } from "./CardPickerInline";
 
 const imgFileFromCardKey = (cardKey: string) => cardKey.split("|")[2] ?? "";
 
 interface RowState {
   line: ParsedLine;
+  zone: DeckZone;    // derived from the parsed section — not user-editable (v1)
   chosen: PickedCard | null;
   qty: number;
   dropped: boolean;
@@ -24,6 +26,7 @@ interface RowState {
 function toRows(lines: ParsedLine[]): RowState[] {
   return lines.map((line) => ({
     line,
+    zone: sectionZone(line.section),
     chosen:
       line.status === "resolved"
         ? {
@@ -36,6 +39,11 @@ function toRows(lines: ParsedLine[]): RowState[] {
     qty: line.qty,
     dropped: false,
   }));
+}
+
+/** "50 main + 10 reserve", or just "50 cards" when there is no Reserve section. */
+function countLabel(main: number, reserve: number): string {
+  return reserve > 0 ? `${main} main + ${reserve} reserve` : `${main} cards`;
 }
 
 export default function ContentsWizard({
@@ -56,13 +64,16 @@ export default function ContentsWizard({
 
   const counts = useMemo(() => {
     const active = rows.filter((r) => !r.dropped);
+    const qtyIn = (zone: DeckZone) =>
+      active.reduce((s, r) => s + (r.chosen && r.zone === zone ? r.qty : 0), 0);
     return {
       total: rows.length,
       resolved: active.filter((r) => r.chosen !== null).length,
       ambiguous: active.filter((r) => r.chosen === null && r.line.status === "ambiguous").length,
       unresolved: active.filter((r) => r.chosen === null && r.line.status !== "ambiguous").length,
       dropped: rows.filter((r) => r.dropped).length,
-      qtyTotal: active.reduce((s, r) => s + (r.chosen ? r.qty : 0), 0),
+      qtyMain: qtyIn("main"),
+      qtyReserve: qtyIn("reserve"),
     };
   }, [rows]);
 
@@ -71,6 +82,110 @@ export default function ContentsWizard({
 
   const patch = (i: number, p: Partial<RowState>) =>
     setRows((rs) => rs.map((r, j) => (j === i ? { ...r, ...p } : r)));
+
+  // Partition for grouped rendering; indices stay row-state indices so
+  // patch(i, …) keeps working from either group.
+  const indexed = rows.map((r, i) => [r, i] as const);
+  const mainRows = indexed.filter(([r]) => r.zone === "main");
+  const reserveRows = indexed.filter(([r]) => r.zone === "reserve");
+
+  const renderRow = (r: RowState, i: number) => (
+    <div key={i} className={`px-3 py-2 ${r.dropped ? "opacity-40" : ""}`}>
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="w-full sm:w-64 shrink-0">
+          <div className="text-xs text-muted-foreground font-mono truncate" title={r.line.raw}>
+            {r.line.raw}
+          </div>
+          {r.line.section && (
+            <div className="text-[10px] uppercase tracking-wide text-muted-foreground/70">
+              {r.line.section}
+            </div>
+          )}
+        </div>
+
+        <div className="min-w-0 flex-1">
+          {r.chosen !== null ? (
+            <div className="flex items-center gap-2">
+              <img src={getCardImageUrl(r.chosen.imgFile)} alt="" className="w-7 h-10 rounded-sm object-cover" />
+              <span className="truncate text-sm">{r.chosen.cardName}</span>
+              <span className="text-xs text-muted-foreground">{r.chosen.setCode}</span>
+              {!r.dropped && (
+                <button
+                  type="button"
+                  className="text-xs text-muted-foreground underline"
+                  onClick={() => patch(i, { chosen: null })}
+                >
+                  change
+                </button>
+              )}
+            </div>
+          ) : r.dropped ? (
+            <span className="text-sm text-muted-foreground">dropped</span>
+          ) : (
+            <div className="space-y-1">
+              {r.line.candidates.length > 0 && (
+                <div className="flex flex-wrap gap-1">
+                  {r.line.candidates.map((c: ParsedCandidate) => (
+                    <button
+                      key={c.cardKey}
+                      type="button"
+                      className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-muted hover:bg-muted/70 text-xs"
+                      onClick={() =>
+                        patch(i, {
+                          chosen: {
+                            cardKey: c.cardKey, cardName: c.cardName,
+                            setCode: c.setCode, imgFile: imgFileFromCardKey(c.cardKey),
+                          },
+                        })
+                      }
+                    >
+                      <img src={getCardImageUrl(imgFileFromCardKey(c.cardKey))} alt="" className="w-5 h-7 rounded-sm object-cover" />
+                      {c.cardName} <span className="text-muted-foreground">({c.setCode})</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+              <CardPickerInline
+                preferredSets={[...new Set(r.line.candidates.map((c) => c.setCode))]}
+                initialQuery={r.line.name}
+                onPick={(card) => patch(i, { chosen: card })}
+              />
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2 shrink-0">
+          <span
+            className={`px-1.5 py-0.5 rounded text-xs ${
+              r.dropped
+                ? "bg-muted text-muted-foreground"
+                : r.chosen !== null
+                  ? "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300"
+                  : r.line.status === "ambiguous"
+                    ? "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300"
+                    : "bg-destructive/10 text-destructive"
+            }`}
+          >
+            {r.dropped ? "dropped" : r.chosen !== null ? "resolved" : r.line.status}
+          </span>
+          <div className="flex items-center rounded bg-muted">
+            <button type="button" className="px-2 py-0.5 text-sm" disabled={r.dropped || r.qty <= 1}
+              onClick={() => patch(i, { qty: Math.max(1, r.qty - 1) })}>−</button>
+            <span className="px-1 text-sm tabular-nums">{r.qty}</span>
+            <button type="button" className="px-2 py-0.5 text-sm" disabled={r.dropped}
+              onClick={() => patch(i, { qty: r.qty + 1 })}>+</button>
+          </div>
+          <button
+            type="button"
+            className="text-xs text-muted-foreground underline"
+            onClick={() => patch(i, { dropped: !r.dropped })}
+          >
+            {r.dropped ? "restore" : "drop"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 
   const submit = () => {
     const resolved: ResolvedEntry[] = rows
@@ -81,6 +196,7 @@ export default function ContentsWizard({
         setCode: r.chosen!.setCode,
         imgFile: r.chosen!.imgFile,
         qty: r.qty,
+        zone: r.zone,
       }));
     startTransition(async () => {
       setError("");
@@ -116,7 +232,8 @@ export default function ContentsWizard({
           {replaceMode ? "Contents replaced" : "Deck created"} — {done.deckName}
         </h2>
         <p className="text-sm text-muted-foreground">
-          This deck is now the source of truth for &ldquo;{product.title}&rdquo;.
+          {countLabel(counts.qtyMain, counts.qtyReserve)} imported. This deck is now the
+          source of truth for &ldquo;{product.title}&rdquo;.
         </p>
         <div className="flex gap-3">
           <Link href={`/decklist/${done.deckId}`}><Button>View public deck</Button></Link>
@@ -154,8 +271,8 @@ export default function ContentsWizard({
 
       {replaceMode && (
         <div className="px-4 py-2 rounded-md bg-blue-100 dark:bg-blue-950 text-blue-800 dark:text-blue-300 text-sm">
-          Replace mode: deck currently has {linked!.currentCardCount} cards; this parse
-          resolves {counts.qtyTotal}. Replacing rewrites the deck&apos;s contents.
+          Replace mode: deck currently has {linked!.currentCardCount} cards (all zones); this parse
+          resolves {countLabel(counts.qtyMain, counts.qtyReserve)}. Replacing rewrites the deck&apos;s contents.
           {" "}<Link className="underline" href={`/decklist/${linked!.deckId}`}>View current deck</Link>
         </div>
       )}
@@ -179,114 +296,38 @@ export default function ContentsWizard({
       <div className="sticky top-0 z-10 bg-background/95 backdrop-blur px-1 py-2 text-sm">
         <span className="font-medium">{counts.resolved} of {counts.total} resolved</span>
         <span className="text-muted-foreground">
-          {" "}· {counts.ambiguous} ambiguous · {counts.unresolved} unresolved · {counts.dropped} dropped · {counts.qtyTotal} cards total
+          {" "}· {counts.ambiguous} ambiguous · {counts.unresolved} unresolved · {counts.dropped} dropped · {countLabel(counts.qtyMain, counts.qtyReserve)}
         </span>
       </div>
 
-      {/* Review table */}
+      {/* Review table — Main section(s) first, then the Reserve group. Zone is
+          not editable: it follows the parsed section (mis-sectioned card → drop
+          here, add manually in the deck builder later). */}
+      {reserveRows.length > 0 && (
+        <div className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Main deck <span className="font-normal normal-case">· {counts.qtyMain} cards</span>
+        </div>
+      )}
       <div className="rounded-lg bg-muted/30 divide-y divide-background">
-        {rows.map((r, i) => (
-          <div key={i} className={`px-3 py-2 ${r.dropped ? "opacity-40" : ""}`}>
-            <div className="flex flex-wrap items-center gap-3">
-              <div className="w-full sm:w-64 shrink-0">
-                <div className="text-xs text-muted-foreground font-mono truncate" title={r.line.raw}>
-                  {r.line.raw}
-                </div>
-                {r.line.section && (
-                  <div className="text-[10px] uppercase tracking-wide text-muted-foreground/70">
-                    {r.line.section}
-                  </div>
-                )}
-              </div>
-
-              <div className="min-w-0 flex-1">
-                {r.chosen !== null ? (
-                  <div className="flex items-center gap-2">
-                    <img src={getCardImageUrl(r.chosen.imgFile)} alt="" className="w-7 h-10 rounded-sm object-cover" />
-                    <span className="truncate text-sm">{r.chosen.cardName}</span>
-                    <span className="text-xs text-muted-foreground">{r.chosen.setCode}</span>
-                    {!r.dropped && (
-                      <button
-                        type="button"
-                        className="text-xs text-muted-foreground underline"
-                        onClick={() => patch(i, { chosen: null })}
-                      >
-                        change
-                      </button>
-                    )}
-                  </div>
-                ) : r.dropped ? (
-                  <span className="text-sm text-muted-foreground">dropped</span>
-                ) : (
-                  <div className="space-y-1">
-                    {r.line.candidates.length > 0 && (
-                      <div className="flex flex-wrap gap-1">
-                        {r.line.candidates.map((c: ParsedCandidate) => (
-                          <button
-                            key={c.cardKey}
-                            type="button"
-                            className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-muted hover:bg-muted/70 text-xs"
-                            onClick={() =>
-                              patch(i, {
-                                chosen: {
-                                  cardKey: c.cardKey, cardName: c.cardName,
-                                  setCode: c.setCode, imgFile: imgFileFromCardKey(c.cardKey),
-                                },
-                              })
-                            }
-                          >
-                            <img src={getCardImageUrl(imgFileFromCardKey(c.cardKey))} alt="" className="w-5 h-7 rounded-sm object-cover" />
-                            {c.cardName} <span className="text-muted-foreground">({c.setCode})</span>
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                    <CardPickerInline
-                      preferredSets={[...new Set(r.line.candidates.map((c) => c.setCode))]}
-                      initialQuery={r.line.name}
-                      onPick={(card) => patch(i, { chosen: card })}
-                    />
-                  </div>
-                )}
-              </div>
-
-              <div className="flex items-center gap-2 shrink-0">
-                <span
-                  className={`px-1.5 py-0.5 rounded text-xs ${
-                    r.dropped
-                      ? "bg-muted text-muted-foreground"
-                      : r.chosen !== null
-                        ? "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300"
-                        : r.line.status === "ambiguous"
-                          ? "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300"
-                          : "bg-destructive/10 text-destructive"
-                  }`}
-                >
-                  {r.dropped ? "dropped" : r.chosen !== null ? "resolved" : r.line.status}
-                </span>
-                <div className="flex items-center rounded bg-muted">
-                  <button type="button" className="px-2 py-0.5 text-sm" disabled={r.dropped || r.qty <= 1}
-                    onClick={() => patch(i, { qty: Math.max(1, r.qty - 1) })}>−</button>
-                  <span className="px-1 text-sm tabular-nums">{r.qty}</span>
-                  <button type="button" className="px-2 py-0.5 text-sm" disabled={r.dropped}
-                    onClick={() => patch(i, { qty: r.qty + 1 })}>+</button>
-                </div>
-                <button
-                  type="button"
-                  className="text-xs text-muted-foreground underline"
-                  onClick={() => patch(i, { dropped: !r.dropped })}
-                >
-                  {r.dropped ? "restore" : "drop"}
-                </button>
-              </div>
-            </div>
-          </div>
-        ))}
+        {mainRows.map(([r, i]) => renderRow(r, i))}
       </div>
+
+      {reserveRows.length > 0 && (
+        <>
+          <div className="px-1 pt-2 text-xs font-semibold uppercase tracking-wide text-violet-700 dark:text-violet-400">
+            Reserve <span className="font-normal normal-case text-muted-foreground">· {counts.qtyReserve} cards · imports as reserve zone</span>
+          </div>
+          <div className="rounded-lg bg-violet-500/5 divide-y divide-background border border-violet-500/30">
+            {reserveRows.map(([r, i]) => renderRow(r, i))}
+          </div>
+        </>
+      )}
 
       <div className="flex items-center gap-3">
         <Button disabled={!allSettled || pending || conflictDeckId !== null} onClick={submit}>
-          {replaceMode ? `Replace contents (${counts.qtyTotal} cards)` : `Create deck (${counts.qtyTotal} cards)`}
+          {replaceMode
+            ? `Replace contents (${countLabel(counts.qtyMain, counts.qtyReserve)})`
+            : `Create deck (${countLabel(counts.qtyMain, counts.qtyReserve)})`}
         </Button>
         {!allSettled && (
           <span className="text-sm text-muted-foreground">

--- a/lib/ytg/__tests__/deckLinkOps.test.ts
+++ b/lib/ytg/__tests__/deckLinkOps.test.ts
@@ -33,10 +33,13 @@ function stubAdmin(script: Step[]) {
 }
 
 const RESOLVED: ResolvedEntry[] = [
-  { cardKey: "Son of God [K]|K|K1-Son-of-God", cardName: "Son of God [K]", setCode: "K", imgFile: "K1-Son-of-God", qty: 1 },
-  { cardKey: "Told to Take|T2C|123-Told-to-Take", cardName: "Told to Take", setCode: "T2C", imgFile: "123-Told-to-Take", qty: 2 },
-  // Same card appears in a second section — must merge (deck_cards UNIQUE).
-  { cardKey: "Told to Take|T2C|123-Told-to-Take", cardName: "Told to Take", setCode: "T2C", imgFile: "123-Told-to-Take", qty: 1 },
+  { cardKey: "Son of God [K]|K|K1-Son-of-God", cardName: "Son of God [K]", setCode: "K", imgFile: "K1-Son-of-God", qty: 1, zone: "main" },
+  { cardKey: "Told to Take|T2C|123-Told-to-Take", cardName: "Told to Take", setCode: "T2C", imgFile: "123-Told-to-Take", qty: 2, zone: "main" },
+  // Same card appears in a second MAIN section — must merge (deck_cards UNIQUE).
+  { cardKey: "Told to Take|T2C|123-Told-to-Take", cardName: "Told to Take", setCode: "T2C", imgFile: "123-Told-to-Take", qty: 1, zone: "main" },
+  // Same card ALSO in the Reserve section — separate row, never merged across zones.
+  { cardKey: "Told to Take|T2C|123-Told-to-Take", cardName: "Told to Take", setCode: "T2C", imgFile: "123-Told-to-Take", qty: 1, zone: "reserve" },
+  { cardKey: "Scattered|RoA 3|RoA3-Scattered", cardName: "Scattered", setCode: "RoA 3", imgFile: "RoA3-Scattered", qty: 2, zone: "reserve" },
 ];
 const ARGS = { productId: "p1", handle: "the-fiery-furnace", productTitle: "*New* The Fiery Furnace", createdBy: "admin-1", resolved: RESOLVED };
 
@@ -64,18 +67,43 @@ describe("createDeckLinkedOp", () => {
     expect(deckRow.user_id).toBe(YTG_ACCOUNT_USER_ID);
     expect(deckRow.visibility).toBe("public");
     expect(deckRow.format).toBe("Limited");
-    expect(deckRow.card_count).toBe(4);
+    expect(deckRow.card_count).toBe(4); // MAIN qty only — the 3 reserve cards don't count
     expect(deckRow.preview_card_1).toBe("K1-Son-of-God");
     expect(deckRow.preview_card_2).toBe("123-Told-to-Take");
     expect(deckRow.description).toBe('Contents of the YTG product "*New* The Fiery Furnace" — source of truth for store inventory.');
 
     const cardRows = calls[4].args[0][0] as Record<string, unknown>[];
-    expect(cardRows).toHaveLength(2); // merged
-    const ttt = cardRows.find((r) => r.card_name === "Told to Take")!;
-    expect(ttt.quantity).toBe(3);
-    expect(ttt.zone).toBe("main");
-    expect(ttt.card_set).toBe("T2C");
-    expect(ttt.card_img_file).toBe("123-Told-to-Take");
+    expect(cardRows).toHaveLength(4); // merged within zone; main+reserve stay separate rows
+    const tttMain = cardRows.find((r) => r.card_name === "Told to Take" && r.zone === "main")!;
+    expect(tttMain.quantity).toBe(3);
+    expect(tttMain.card_set).toBe("T2C");
+    expect(tttMain.card_img_file).toBe("123-Told-to-Take");
+    const tttReserve = cardRows.find((r) => r.card_name === "Told to Take" && r.zone === "reserve")!;
+    expect(tttReserve.quantity).toBe(1);
+    const scattered = cardRows.find((r) => r.card_name === "Scattered")!;
+    expect(scattered.zone).toBe("reserve");
+    expect(scattered.quantity).toBe(2);
+  });
+
+  it("previews come from MAIN entries even when a reserve entry sorts first", async () => {
+    const reserveFirst: ResolvedEntry[] = [
+      { cardKey: "Scattered|RoA 3|RoA3-Scattered", cardName: "Scattered", setCode: "RoA 3", imgFile: "RoA3-Scattered", qty: 2, zone: "reserve" },
+      { cardKey: "Son of God [K]|K|K1-Son-of-God", cardName: "Son of God [K]", setCode: "K", imgFile: "K1-Son-of-God", qty: 1, zone: "main" },
+      { cardKey: "Told to Take|T2C|123-Told-to-Take", cardName: "Told to Take", setCode: "T2C", imgFile: "123-Told-to-Take", qty: 2, zone: "main" },
+    ];
+    const { admin, calls } = stubAdmin([
+      { table: "ytg_deck_links", result: { data: null } },
+      { table: "decks", result: { data: [] } },
+      { table: "decks", result: { data: null } },
+      { table: "ytg_deck_links", result: { data: [{ shopify_product_id: "p1" }] } },
+      { table: "deck_cards", result: { data: null } },
+    ]);
+    const res = await createDeckLinkedOp(admin, { ...ARGS, resolved: reserveFirst });
+    if (res.success === false) throw new Error(res.error);
+    const deckRow = calls[2].args[0][0] as Record<string, unknown>;
+    expect(deckRow.card_count).toBe(3);
+    expect(deckRow.preview_card_1).toBe("K1-Son-of-God");
+    expect(deckRow.preview_card_2).toBe("123-Told-to-Take");
   });
 
   it("lost claim race: compensating deck delete, conflict result, NO cards insert", async () => {
@@ -163,9 +191,17 @@ describe("replaceDeckContentsOp", () => {
     ]);
     const res = await replaceDeckContentsOp(admin, { productId: "p1", resolved: RESOLVED });
     if (res.success === false) throw new Error(res.error);
-    expect(res.cardCount).toBe(4);
+    expect(res.cardCount).toBe(4); // MAIN only
     const upd = calls[4].args[0][0] as Record<string, unknown>;
     expect(upd.card_count).toBe(4);
     expect(upd.preview_card_1).toBe("K1-Son-of-God");
+
+    // Re-inserted rows preserve zones: merged within zone, split across zones.
+    const rows = calls[3].args[0][0] as Record<string, unknown>[];
+    expect(rows).toHaveLength(4);
+    expect(rows.filter((r) => r.zone === "reserve").map((r) => r.card_name).sort())
+      .toEqual(["Scattered", "Told to Take"]);
+    expect(rows.find((r) => r.card_name === "Told to Take" && r.zone === "main")!.quantity).toBe(3);
+    expect(rows.find((r) => r.card_name === "Told to Take" && r.zone === "reserve")!.quantity).toBe(1);
   });
 });

--- a/lib/ytg/__tests__/deckZones.test.ts
+++ b/lib/ytg/__tests__/deckZones.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import path from "path";
+import { sectionZone } from "../deckZones";
+import { parseDeckContents, buildAliasCandidates } from "../deckContentsParser";
+
+describe("sectionZone", () => {
+  it("maps the Reserve section to 'reserve', everything else to 'main'", () => {
+    expect(sectionZone("Reserve")).toBe("reserve");
+    expect(sectionZone("RESERVE")).toBe("reserve");
+    expect(sectionZone("Heroes")).toBe("main");
+    expect(sectionZone("Lost Souls")).toBe("main");
+    expect(sectionZone("Fortresses/Sites/Cities")).toBe("main");
+    expect(sectionZone(null)).toBe("main"); // pre-section lines are main
+  });
+
+  it("catches Reserve inside a slash-composed header", () => {
+    expect(sectionZone("Reserve/Misc")).toBe("reserve");
+  });
+});
+
+describe("fixture: fiery-furnace.html section→zone derivation", () => {
+  // READ-ONLY use of the parser. Section attribution doesn't depend on alias
+  // rows, so an empty seed (carddata identity entries only) is enough here.
+  const fixture = readFileSync(
+    path.join(__dirname, "fixtures", "fiery-furnace.html"), "utf8");
+  const lines = parseDeckContents(fixture, buildAliasCandidates([]));
+
+  it("maps the fixture's Reserve-section lines to 'reserve', the rest to 'main'", () => {
+    const reserve = lines.filter((l) => sectionZone(l.section) === "reserve");
+    expect(reserve.length).toBeGreaterThan(0);
+    expect(reserve.every((l) => l.section === "Reserve")).toBe(true);
+    expect(reserve.map((l) => l.raw)).toContain("Scattered (RoA)");
+
+    const dominants = lines.filter((l) => l.section === "Dominants");
+    expect(dominants.length).toBeGreaterThan(0);
+    expect(dominants.every((l) => sectionZone(l.section) === "main")).toBe(true);
+  });
+});

--- a/lib/ytg/deckLinkOps.ts
+++ b/lib/ytg/deckLinkOps.ts
@@ -5,6 +5,7 @@
  * decks/deck_cards and the decks belong to YTG_ACCOUNT_USER_ID.
  */
 import { YTG_ACCOUNT_USER_ID } from "./constants";
+import type { DeckZone } from "./deckZones";
 
 export interface ResolvedEntry {
   cardKey: string;   // `${name}|${set}|${imgFile}`
@@ -12,6 +13,9 @@ export interface ResolvedEntry {
   setCode: string;
   imgFile: string;   // raw carddata imgFile
   qty: number;
+  // Derived by the wizard from the parsed line's section (Reserve section →
+  // 'reserve', else 'main' — see lib/ytg/deckZones.ts); ops trust it.
+  zone: DeckZone;
 }
 
 export type CreateDeckResult =
@@ -20,7 +24,7 @@ export type CreateDeckResult =
   | { success: false; conflict?: false; error: string };
 
 export type ReplaceResult =
-  | { success: true; deckId: string; cardCount: number }
+  | { success: true; deckId: string; cardCount: number } // cardCount = main-zone qty (matches decks.card_count)
   | { success: false; error: string };
 
 // Canonical format id — 'T1' is legacy (migration 081 retired it;
@@ -31,21 +35,26 @@ export function cleanDeckName(title: string): string {
   return title.replace(/^\*New\*\s*/i, "").trim();
 }
 
+// Entries cross the client→server boundary; anything that isn't exactly
+// 'reserve' lands in 'main' so the deck_cards CHECK can never reject a row.
+const zoneOf = (r: ResolvedEntry): DeckZone => (r.zone === "reserve" ? "reserve" : "main");
+
 function mergeRows(deckId: string, resolved: ResolvedEntry[]) {
   // deck_cards is UNIQUE (deck_id, card_name, card_set, zone); the same card
-  // can appear in two description sections (e.g. Heroes AND Reserve) and
-  // everything lands in zone 'main' (spec) — so duplicates must be summed.
+  // can repeat within a zone (e.g. two Heroes-section lines) — summed — while
+  // a card in both Heroes AND Reserve keeps one row per zone.
   const byKey = new Map<string, {
     deck_id: string; card_name: string; card_set: string;
-    card_img_file: string; quantity: number; zone: "main";
+    card_img_file: string; quantity: number; zone: DeckZone;
   }>();
   for (const r of resolved) {
-    const k = `${r.cardName}|${r.setCode}`;
+    const zone = zoneOf(r);
+    const k = `${r.cardName}|${r.setCode}|${zone}`;
     const prev = byKey.get(k);
     if (prev) prev.quantity += r.qty;
     else byKey.set(k, {
       deck_id: deckId, card_name: r.cardName, card_set: r.setCode,
-      card_img_file: r.imgFile, quantity: r.qty, zone: "main",
+      card_img_file: r.imgFile, quantity: r.qty, zone,
     });
   }
   return [...byKey.values()];
@@ -77,7 +86,10 @@ export async function createDeckLinkedOp(admin: any, args: {
   if (nameHit && nameHit.length > 0) deckName = `${deckName} — ${handle}`;
 
   const deckId = crypto.randomUUID();
-  const totalQty = resolved.reduce((s, r) => s + r.qty, 0);
+  // card_count is MAIN-only app-wide (app/decklist/actions.ts convention);
+  // previews likewise come from main-zone entries.
+  const mains = resolved.filter((r) => zoneOf(r) === "main");
+  const mainQty = mains.reduce((s, r) => s + r.qty, 0);
 
   // (3) Insert the deck. True link-first (per the spec's wording) is
   // impossible: links.deck_id is NOT NULL REFERENCES decks(id). The link
@@ -90,9 +102,9 @@ export async function createDeckLinkedOp(admin: any, args: {
     description: `Contents of the YTG product "${productTitle}" — source of truth for store inventory.`,
     format: DECK_FORMAT,
     visibility: "public",
-    card_count: totalQty,
-    preview_card_1: resolved[0]?.imgFile ?? null,
-    preview_card_2: resolved[1]?.imgFile ?? null,
+    card_count: mainQty,
+    preview_card_1: mains[0]?.imgFile ?? null,
+    preview_card_2: mains[1]?.imgFile ?? null,
   });
   if (deckErr) return { success: false, error: `deck insert failed: ${deckErr.message}` };
 
@@ -117,7 +129,7 @@ export async function createDeckLinkedOp(admin: any, args: {
     return { success: false, conflict: true, existingDeckId: winner ? winner.deck_id : null, error: conflictMsg };
   }
 
-  // (5) Bulk insert contents — zone 'main' only, raw carddata img files.
+  // (5) Bulk insert contents — per-entry zone (main/reserve), raw carddata img files.
   const { error: cardsErr } = await admin.from("deck_cards").insert(mergeRows(deckId, resolved));
   if (cardsErr) {
     // Compensate: link first (frees ON DELETE RESTRICT), then the deck.
@@ -163,16 +175,18 @@ export async function replaceDeckContentsOp(admin: any, args: {
     return { success: false, error: `re-insert failed — deck is now empty, re-run the wizard: ${insErr.message}` };
   }
 
-  const totalQty = resolved.reduce((s, r) => s + r.qty, 0);
+  // MAIN-only count + previews, same convention as create.
+  const mains = resolved.filter((r) => zoneOf(r) === "main");
+  const mainQty = mains.reduce((s, r) => s + r.qty, 0);
   const { error: updErr } = await admin.from("decks").update({
-    card_count: totalQty,
-    preview_card_1: resolved[0]?.imgFile ?? null,
-    preview_card_2: resolved[1]?.imgFile ?? null,
+    card_count: mainQty,
+    preview_card_1: mains[0]?.imgFile ?? null,
+    preview_card_2: mains[1]?.imgFile ?? null,
     // updated_at is maintained by the decks BEFORE UPDATE trigger (001).
   }).eq("id", deckId);
   if (updErr) return { success: false, error: updErr.message };
 
-  return { success: true, deckId, cardCount: totalQty };
+  return { success: true, deckId, cardCount: mainQty };
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/lib/ytg/deckZones.ts
+++ b/lib/ytg/deckZones.ts
@@ -1,0 +1,20 @@
+/**
+ * Section → deck_cards zone derivation for the YTG deck-contents wizard.
+ * 91 of 93 deck products ship a Reserve section (product copy: "50 card
+ * deck, 10 card Reserve") — those lines import as zone 'reserve'; every
+ * other section (and pre-section lines) is 'main'. Maybeboard is never
+ * used. The wizard derives the zone from the parsed line's section; the
+ * deckLinkOps write path trusts the entry. Kept out of the parser on
+ * purpose — the parser reports sections, it doesn't assign zones.
+ */
+
+export type DeckZone = "main" | "reserve";
+
+export function sectionZone(section: string | null): DeckZone {
+  if (!section) return "main";
+  // Section headers can be slash-composed ("Artifacts/Covenants/Curses");
+  // any "Reserve" part makes the whole section the Reserve group.
+  return section.split("/").some((p) => p.trim().toLowerCase() === "reserve")
+    ? "reserve"
+    : "main";
+}


### PR DESCRIPTION
## Why

An audit of all 93 YTG deck-product descriptions found **91 ship a Reserve section** (~10 cards; product copy literally says e.g. "50 card deck, 10 card Reserve") — the physical box includes the reserve cards. The wizard wrote every resolved line as `zone='main'`, so deck contents (and any future inventory decrement built on them) were wrong for essentially every product.

## ⚠️ WS-4 (Record sale) contract note — prominent on purpose

**WS-4 must read `zone IN ('main','reserve')` and sum per card_key — spec addendum forthcoming from primary session.** The spec's current §Record sale wording ("read `zone='main'` only") predates this change and would under-decrement by the ~10 reserve cards per box. No docs were edited in this PR; the primary session owns spec edits.

## What changed

- **`lib/ytg/deckZones.ts` (new):** `sectionZone(section)` — Reserve section → `'reserve'`, everything else (incl. pre-section lines) → `'main'`. Kept out of the parser on purpose: the parser reports sections, it doesn't assign zones.
- **`lib/ytg/deckLinkOps.ts`:** `ResolvedEntry` gains `zone: 'main' | 'reserve'` (wizard derives, ops trust — with a one-line normalization so a garbage zone can never hit the deck_cards CHECK). Row merging is now per `(name, set, zone)` — a card in Heroes AND Reserve keeps one row per zone. `decks.card_count` + `preview_card_1/2` are **MAIN-only** on both create and replace (app-wide convention, `app/decklist/actions.ts`; previously summed everything). `ReplaceResult.cardCount` is now the main-zone count.
- **`ContentsWizard.tsx`:** review list groups Main section(s) first, then a visually distinct **Reserve** group (violet border, "imports as reserve zone" label) with its own count. Running header, replace banner, create/replace buttons, and done screen all show "N main + M reserve" (plain "N cards" when no Reserve section). Reserve rows resolve/change/qty/drop identically. Zone is **not user-editable** (v1): it follows the parsed section; a mis-sectioned card is fixed by drop + manual add later.

## Tests

- `deckLinkOps.test.ts`: reserve entries insert with `zone='reserve'`; `card_count` excludes reserve (create + replace); same card in main+reserve stays two rows with correct per-zone quantities; previews come from MAIN entries even when a reserve entry sorts first; replace preserves zones.
- `deckZones.test.ts` (new): unit coverage of `sectionZone` + integration-flavored parse of the live `fiery-furnace.html` fixture (read-only use of the parser) asserting its Reserve-section lines (incl. "Scattered (RoA)") derive `'reserve'` and Dominants derive `'main'`.

Gates: full `npm test` 151 files / 1906 tests, zero failures; `npx tsc --noEmit` identical to the 7-error baseline (`__tests__/forge-anon-leak.test.ts` + `app/forge/lib/__tests__/playDecksAuthorize.test.ts`). Only `app/admin/ytg/decks/*`, `lib/ytg/deckLinkOps.ts` (+ tests), and the new derivation module touched — `deckContentsParser.ts` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)