### PR TITLE
feat(ytg): Record sale — crash-safe deck-sale inventory decrements (WS-4)

### DIFF
--- a/app/admin/ytg/decks/DeckProductList.tsx
+++ b/app/admin/ytg/decks/DeckProductList.tsx
@@ -87,6 +87,9 @@ export default function DeckProductList({ products }: { products: DeckProductRow
                 >
                   View deck
                 </Link>
+                <Link className="text-sm hover:underline" href={`/admin/ytg/decks/${p.productId}/sale`}>
+                  Record sale
+                </Link>
                 <Link className="text-sm hover:underline" href={`/admin/ytg/decks/${p.productId}`}>
                   Replace contents
                 </Link>

--- a/app/admin/ytg/decks/SalesHistory.tsx
+++ b/app/admin/ytg/decks/SalesHistory.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { undoSale } from "./saleActions";
+import type { SaleHistoryRow } from "./saleActions";
+
+const fmtWhen = (iso: string) => new Date(iso).toLocaleString();
+
+const STATUS_CLS: Record<string, string> = {
+  applied: "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300",
+  partial: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
+  failed: "bg-destructive/10 text-destructive",
+  pending: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
+  applying: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
+  undoing: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
+  undone: "bg-muted text-muted-foreground",
+  undo_partial: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
+  dry_run: "bg-muted text-muted-foreground",
+};
+
+function Row({ s, onUndo, pending }: { s: SaleHistoryRow; onUndo: ((id: string) => void) | null; pending: boolean }) {
+  const [armed, setArmed] = useState(false);
+  const stuck = s.status === "pending" || s.status === "applying";
+  return (
+    <div className="px-3 py-2 flex items-center gap-3">
+      <div className="min-w-0 flex-1">
+        <div className="text-sm truncate">
+          {s.productTitle} <span className="text-muted-foreground">× {s.qty}</span>
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {fmtWhen(s.createdAt)}{s.createdByName ? ` · by ${s.createdByName}` : ""}
+          {" "}· {s.appliedCount}/{s.totalItems} items applied
+          {s.skippedCount > 0 ? `, ${s.skippedCount} skipped` : ""}
+          {s.troubleCount > 0 ? `, ${s.troubleCount} need attention` : ""}
+          {s.undoneAt ? ` · undone ${fmtWhen(s.undoneAt)}${s.undoneByName ? ` by ${s.undoneByName}` : ""}` : ""}
+        </div>
+      </div>
+      <span className={`px-1.5 py-0.5 rounded text-xs shrink-0 ${STATUS_CLS[s.status] ?? "bg-muted"}`}>
+        {s.status.replace(/_/g, " ")}
+      </span>
+      {stuck && (
+        <Link className="text-sm hover:underline shrink-0" href={`/admin/ytg/decks/${s.productId}/sale`}>
+          Resume
+        </Link>
+      )}
+      {/* Undo appears only where eligible; it is ABSENT on dry_run rows. */}
+      {onUndo !== null && (s.status === "applied" || s.status === "partial") && (
+        armed ? (
+          <>
+            <Button size="sm" variant="destructive" disabled={pending} onClick={() => onUndo(s.id)}>
+              Confirm undo
+            </Button>
+            <Button size="sm" variant="ghost" disabled={pending} onClick={() => setArmed(false)}>
+              Cancel
+            </Button>
+          </>
+        ) : (
+          <Button size="sm" variant="ghost" disabled={pending} onClick={() => setArmed(true)}>
+            Undo
+          </Button>
+        )
+      )}
+    </div>
+  );
+}
+
+export default function SalesHistory({
+  sales, writesEnabled, loadError,
+}: {
+  sales: SaleHistoryRow[]; writesEnabled: boolean; loadError: string;
+}) {
+  const [error, setError] = useState("");
+  const [pending, startTransition] = useTransition();
+  const router = useRouter();
+
+  const doUndo = (saleId: string) => {
+    startTransition(async () => {
+      const res = await undoSale(saleId);
+      if (res.success === false) setError(res.error);
+      else { setError(""); router.refresh(); }
+    });
+  };
+
+  const dryRuns = sales.filter((s) => s.status === "dry_run");
+  const real = sales.filter((s) => s.status !== "dry_run");
+
+  return (
+    <div className="space-y-3">
+      <h2 className="text-lg font-semibold">Sales history</h2>
+      {loadError !== "" && (
+        <div className="px-4 py-2 rounded-md bg-destructive/10 text-destructive text-sm">{loadError}</div>
+      )}
+      {error !== "" && (
+        <div className="px-4 py-2 rounded-md bg-destructive/10 text-destructive text-sm">{error}</div>
+      )}
+      {sales.length === 0 && loadError === "" && (
+        <p className="text-sm text-muted-foreground">
+          No sales recorded yet. Record one from a linked deck product above.
+        </p>
+      )}
+      {real.length > 0 && (
+        <div className="rounded-lg bg-muted/30 divide-y divide-background">
+          {real.map((s) => (
+            <Row key={s.id} s={s} pending={pending} onUndo={writesEnabled ? doUndo : null} />
+          ))}
+        </div>
+      )}
+      {dryRuns.length > 0 && (
+        <div className="space-y-1">
+          <div className="text-xs uppercase tracking-wide text-muted-foreground">
+            Dry runs — recorded before inventory writes were enabled — not applied
+          </div>
+          <div className="rounded-lg bg-muted/20 divide-y divide-background opacity-75">
+            {dryRuns.map((s) => (
+              <Row key={s.id} s={s} pending={pending} onUndo={null} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/admin/ytg/decks/[productId]/sale/SaleFlow.tsx
+++ b/app/admin/ytg/decks/[productId]/sale/SaleFlow.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { getCardImageUrl } from "@/app/shared/utils/cardImageUrl";
+import { Button } from "@/components/ui/button";
+import {
+  previewSale, confirmSale, applySale, resumeSale, retrySaleItem, undoSale,
+} from "../../saleActions";
+import type { SalePreview, SalePreviewRow, SaleView } from "../../saleActions";
+
+const imgOf = (cardKey: string) => cardKey.split("|")[2] ?? "";
+const fmtWhen = (iso: string) => new Date(iso).toLocaleString();
+
+const FLAG_BADGE: Record<string, { label: string; cls: string }> = {
+  ok: { label: "ok", cls: "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300" },
+  unmapped: { label: "unmapped", cls: "bg-destructive/10 text-destructive" },
+  untracked: { label: "untracked", cls: "bg-muted text-muted-foreground" },
+  would_go_negative: { label: "would go negative", cls: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300" },
+};
+
+const ITEM_EXPLAIN: Record<string, string> = {
+  applied: "Inventory decremented in Shopify.",
+  pending: "Not applied yet.",
+  applying: "Was in flight when this loaded — use Resume to reconcile against live inventory.",
+  skipped_unmapped: "No confirmed card-product mapping; nothing was adjusted.",
+  skipped_untracked: "Variant does not track inventory; nothing was adjusted.",
+  error: "Shopify rejected this change.",
+  conflict: "Live quantity moved between preview and apply — the compare-and-swap refused it. Verify in Shopify, then Retry with fresh numbers.",
+  undone: "Reversed by undo.",
+  undo_conflict: "Live quantity moved since the sale — undo refused to stack stock. Review in Shopify.",
+};
+
+export default function SaleFlow({ initialPreview }: { initialPreview: SalePreview }) {
+  const [preview, setPreview] = useState<SalePreview>(initialPreview);
+  const [dropped, setDropped] = useState<Set<string>>(new Set());
+  const [ack, setAck] = useState(false);
+  const [error, setError] = useState("");
+  const [inProgress, setInProgress] = useState<{ createdAt: string; createdByName: string | null } | null>(null);
+  const [deckChanged, setDeckChanged] = useState(false);
+  const [dryRunDone, setDryRunDone] = useState<string | null>(null); // saleId
+  const [sale, setSale] = useState<SaleView | null>(null);
+  const [undoArmed, setUndoArmed] = useState(false);
+  const [pending, startTransition] = useTransition();
+
+  const productId = preview.product.productId;
+  const activeRows = preview.rows.filter((r) => !dropped.has(r.cardKey));
+  const negatives = activeRows.filter((r) => r.flag === "would_go_negative");
+  const adjustable = activeRows.filter((r) => r.flag === "ok" || r.flag === "would_go_negative");
+  const flagged = activeRows.filter((r) => r.flag !== "ok");
+
+  const reload = (qty: number) => {
+    startTransition(async () => {
+      setError("");
+      setDeckChanged(false);
+      const res = await previewSale(productId, qty);
+      if (res.success === false) { setError(res.error); return; }
+      setPreview(res.preview);
+      setAck(false);
+    });
+  };
+
+  const toggleDrop = (cardKey: string) => {
+    setDropped((prev) => {
+      const next = new Set(prev);
+      if (next.has(cardKey)) next.delete(cardKey);
+      else next.add(cardKey);
+      return next;
+    });
+  };
+
+  const confirm = () => {
+    startTransition(async () => {
+      setError("");
+      setInProgress(null);
+      const rows: SalePreviewRow[] = activeRows;
+      const res = await confirmSale({
+        productId,
+        qty: preview.qty,
+        deckId: preview.deckId,
+        deckUpdatedAt: preview.deckUpdatedAt,
+        rows,
+        ackNegative: ack,
+      });
+      if (res.success === false) {
+        if (res.code === "deck_changed") setDeckChanged(true);
+        else if (res.code === "sale_in_progress") setInProgress(res.inProgress ?? { createdAt: "", createdByName: null });
+        else setError(res.error);
+        return;
+      }
+      if (res.dryRun === true) { setDryRunDone(res.saleId); return; }
+      const applied = await applySale(res.saleId);
+      if (applied.success === false) { setError(applied.error); return; }
+      setSale(applied.sale);
+    });
+  };
+
+  const resume = (saleId: string) => {
+    startTransition(async () => {
+      setError("");
+      const res = await resumeSale(saleId);
+      if (res.success === false) { setError(res.error); return; }
+      setSale(res.sale);
+    });
+  };
+
+  const retry = (cardKey: string, ackNeg: boolean) => {
+    if (sale === null) return;
+    startTransition(async () => {
+      setError("");
+      const res = await retrySaleItem(sale.id, cardKey, ackNeg);
+      if (res.success === false) {
+        if ("needsAck" in res && res.needsAck === true) {
+          setError(`Retry for this row would go negative (${res.qtyBefore} to ${res.qtyAfter}). Click Retry again to acknowledge.`);
+          return;
+        }
+        setError(res.error);
+        return;
+      }
+      setSale(res.sale);
+    });
+  };
+
+  const doUndo = () => {
+    if (sale === null) return;
+    startTransition(async () => {
+      setError("");
+      const res = await undoSale(sale.id);
+      if (res.success === false) { setError(res.error); return; }
+      setSale(res.sale);
+      setUndoArmed(false);
+    });
+  };
+
+  // ── Dry-run recorded ────────────────────────────────────────────────────
+  if (dryRunDone !== null) {
+    return (
+      <div className="max-w-xl space-y-4">
+        <h2 className="text-lg font-semibold">Dry-run sale recorded</h2>
+        <div className="px-4 py-2 rounded-md bg-amber-100 dark:bg-amber-950 text-amber-800 dark:text-amber-300 text-sm">
+          Inventory writes are not enabled yet — this sale was recorded before inventory
+          writes were enabled and was <strong>not applied</strong>. It cannot be replayed later.
+        </div>
+        <div className="flex gap-3">
+          <Link href="/admin/ytg/decks"><Button>Back to deck products</Button></Link>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Results screen ──────────────────────────────────────────────────────
+  if (sale !== null) {
+    const troubled = sale.items.filter((i) => i.status === "error" || i.status === "conflict");
+    const canUndo = sale.status === "applied" || sale.status === "partial";
+    const isDryRun = sale.status === "dry_run";
+    return (
+      <div className="space-y-4">
+        <h2 className="text-lg font-semibold">
+          Sale result — {preview.product.title} × {sale.qty}
+        </h2>
+        <div className="text-sm">
+          Status: <span className="font-medium">{sale.status}</span>
+          {" "}· recorded {fmtWhen(sale.createdAt)}
+        </div>
+        {sale.degraded === "scope_missing" && (
+          <div className="px-4 py-2 rounded-md bg-amber-100 dark:bg-amber-950 text-amber-800 dark:text-amber-300 text-sm">
+            Shopify refused the inventory write: the <code>write_inventory</code> scope is not
+            yet granted. The sale was parked as a dry-run and was not applied.
+          </div>
+        )}
+        {error !== "" && (
+          <div className="px-4 py-2 rounded-md bg-destructive/10 text-destructive text-sm">{error}</div>
+        )}
+        {sale.status === "applying" && (
+          <div className="px-4 py-2 rounded-md bg-blue-100 dark:bg-blue-950 text-blue-800 dark:text-blue-300 text-sm flex items-center gap-3">
+            <span>Some items were in flight — reconcile against live inventory.</span>
+            <Button size="sm" disabled={pending} onClick={() => resume(sale.id)}>Resume</Button>
+          </div>
+        )}
+        <div className="rounded-lg bg-muted/30 divide-y divide-background">
+          {sale.items.map((i) => (
+            <div key={i.cardKey} className="px-3 py-2 flex items-center gap-3">
+              <img src={getCardImageUrl(imgOf(i.cardKey))} alt="" className="w-7 h-10 rounded-sm object-cover shrink-0" />
+              <div className="min-w-0 flex-1">
+                <div className="text-sm truncate">{i.cardName ?? i.cardKey}</div>
+                <div className="text-xs text-muted-foreground">
+                  {i.qtyPerDeck} per deck · delta {i.delta}
+                  {i.qtyBefore !== null && i.qtyAfter !== null && (
+                    <span> · {i.qtyBefore} to {i.qtyAfter}</span>
+                  )}
+                </div>
+                {(i.status === "conflict" || i.status === "error" || i.status === "undo_conflict") && (
+                  <div className="text-xs text-destructive mt-0.5">
+                    {ITEM_EXPLAIN[i.status]}{i.error ? ` (${i.error})` : ""}
+                  </div>
+                )}
+              </div>
+              <span className={`px-1.5 py-0.5 rounded text-xs shrink-0 ${
+                i.status === "applied" || i.status === "undone"
+                  ? "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300"
+                  : i.status === "skipped_unmapped" || i.status === "skipped_untracked" || i.status === "pending"
+                    ? "bg-muted text-muted-foreground"
+                    : "bg-destructive/10 text-destructive"
+              }`}>
+                {i.status.replace(/_/g, " ")}
+              </span>
+              {(i.status === "error" || i.status === "conflict") && (
+                <Button size="sm" variant="outline" disabled={pending}
+                  onClick={() => retry(i.cardKey, error.includes("acknowledge"))}>
+                  Retry
+                </Button>
+              )}
+            </div>
+          ))}
+        </div>
+        {troubled.length > 0 && (
+          <p className="text-sm text-muted-foreground">
+            Retries are safe: each retry re-reads live inventory and uses a fresh
+            compare-and-swap anchor plus an idempotency key.
+          </p>
+        )}
+        <div className="flex items-center gap-3">
+          {/* Undo is ABSENT (not disabled) on dry_run sales. */}
+          {!isDryRun && canUndo && (
+            undoArmed ? (
+              <>
+                <Button variant="destructive" disabled={pending} onClick={doUndo}>
+                  Confirm undo — restore {sale.items.filter((i) => i.status === "applied").length} item quantities
+                </Button>
+                <Button variant="ghost" disabled={pending} onClick={() => setUndoArmed(false)}>Cancel</Button>
+              </>
+            ) : (
+              <Button variant="outline" disabled={pending} onClick={() => setUndoArmed(true)}>
+                Undo sale
+              </Button>
+            )
+          )}
+          <Link href="/admin/ytg/decks" className="ml-auto text-sm text-muted-foreground hover:underline">
+            Back to deck products
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Preview screen ──────────────────────────────────────────────────────
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        {preview.product.imageUrl && (
+          <img src={preview.product.imageUrl} alt="" className="w-12 h-12 rounded object-cover" />
+        )}
+        <div className="min-w-0">
+          <h2 className="text-lg font-semibold truncate">Record sale — {preview.product.title}</h2>
+          <p className="text-sm text-muted-foreground">
+            Preview reads live Shopify inventory (main + reserve zones, summed per card).
+          </p>
+        </div>
+        <div className="ml-auto flex items-center rounded bg-muted shrink-0">
+          <button type="button" className="px-3 py-1 text-sm" disabled={pending || preview.qty <= 1}
+            onClick={() => reload(preview.qty - 1)}>−</button>
+          <span className="px-2 text-sm tabular-nums">{preview.qty}</span>
+          <button type="button" className="px-3 py-1 text-sm" disabled={pending}
+            onClick={() => reload(preview.qty + 1)}>+</button>
+        </div>
+      </div>
+
+      {preview.writesEnabled === false && (
+        <div className="px-4 py-2 rounded-md bg-amber-100 dark:bg-amber-950 text-amber-800 dark:text-amber-300 text-sm">
+          Dry-run mode: the <code>write_inventory</code> scope is not enabled
+          (<code>YTG_INVENTORY_WRITES</code> unset). Confirming records the sale in the
+          ledger as a dry-run — no inventory moves, and dry-runs cannot be replayed later.
+        </div>
+      )}
+      {preview.activeSale !== null && (
+        <div className="px-4 py-2 rounded-md bg-blue-100 dark:bg-blue-950 text-blue-800 dark:text-blue-300 text-sm flex items-center gap-3">
+          <span>
+            A sale for this product is {preview.activeSale.status}
+            {preview.activeSale.createdByName ? ` (by ${preview.activeSale.createdByName})` : ""} since {fmtWhen(preview.activeSale.createdAt)}.
+          </span>
+          <Button size="sm" disabled={pending} onClick={() => resume(preview.activeSale!.id)}>
+            Resume it
+          </Button>
+        </div>
+      )}
+      {preview.recentSale !== null && (
+        <div className="px-4 py-2 rounded-md bg-amber-100 dark:bg-amber-950 text-amber-800 dark:text-amber-300 text-sm">
+          {preview.recentSale.createdByName ?? "Someone"} recorded a sale of this product
+          {" "}{fmtWhen(preview.recentSale.createdAt)} (qty {preview.recentSale.qty}) — record another?
+        </div>
+      )}
+      {inProgress !== null && (
+        <div className="px-4 py-2 rounded-md bg-destructive/10 text-destructive text-sm">
+          A sale is already being recorded for this product
+          {inProgress.createdByName ? ` by ${inProgress.createdByName}` : ""}
+          {inProgress.createdAt ? ` (started ${fmtWhen(inProgress.createdAt)})` : ""}.
+          Wait for it to finish, or reload to resume it.
+        </div>
+      )}
+      {deckChanged && (
+        <div className="px-4 py-2 rounded-md bg-destructive/10 text-destructive text-sm flex items-center gap-3">
+          <span>The deck changed since this preview — re-preview before recording.</span>
+          <Button size="sm" variant="outline" disabled={pending} onClick={() => reload(preview.qty)}>
+            Re-preview
+          </Button>
+        </div>
+      )}
+      {error !== "" && (
+        <div className="px-4 py-2 rounded-md bg-destructive/10 text-destructive text-sm">{error}</div>
+      )}
+
+      {flagged.length > 0 && (
+        <div className="px-4 py-2 rounded-md bg-muted/50 text-sm space-y-1">
+          <div className="font-medium">{flagged.length} flagged row{flagged.length === 1 ? "" : "s"}</div>
+          {flagged.some((r) => r.flag === "unmapped") && (
+            <div>
+              Unmapped cards will be recorded as skipped.{" "}
+              <Link className="underline" href="/admin/ytg/matching">Fix in Matching</Link>
+            </div>
+          )}
+          {flagged.some((r) => r.flag === "untracked") && (
+            <div>Untracked variants will be recorded as skipped (Shopify does not track their inventory).</div>
+          )}
+          {negatives.length > 0 && (
+            <div className="text-destructive">
+              {negatives.length} row{negatives.length === 1 ? "" : "s"} would drive inventory negative.
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="rounded-lg bg-muted/30 divide-y divide-background">
+        {preview.rows.map((r) => {
+          const isDropped = dropped.has(r.cardKey);
+          const badge = FLAG_BADGE[r.flag];
+          return (
+            <div key={r.cardKey} className={`px-3 py-2 flex items-center gap-3 ${isDropped ? "opacity-40" : ""}`}>
+              <img src={getCardImageUrl(imgOf(r.cardKey))} alt="" className="w-7 h-10 rounded-sm object-cover shrink-0" />
+              <div className="min-w-0 flex-1">
+                <div className="text-sm truncate">{r.cardName}</div>
+                <div className="text-xs text-muted-foreground">
+                  {r.qtyPerDeck} per deck · delta {r.delta}
+                  {r.qtyBefore !== null && r.qtyAfter !== null && (
+                    <span> · {r.qtyBefore} to <span className={r.qtyAfter < 0 ? "text-destructive font-medium" : ""}>{r.qtyAfter}</span></span>
+                  )}
+                </div>
+              </div>
+              <span className={`px-1.5 py-0.5 rounded text-xs shrink-0 ${badge.cls}`}>{badge.label}</span>
+              <button type="button" className="text-xs text-muted-foreground underline shrink-0"
+                onClick={() => toggleDrop(r.cardKey)}>
+                {isDropped ? "restore" : "drop"}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      {negatives.length > 0 && (
+        <label className="flex items-center gap-2 text-sm">
+          <input type="checkbox" checked={ack} onChange={(e) => setAck(e.target.checked)} />
+          I understand {negatives.length} row{negatives.length === 1 ? "" : "s"} will drive
+          available inventory negative in Shopify.
+        </label>
+      )}
+
+      <div className="flex items-center gap-3">
+        <Button
+          disabled={pending || adjustable.length === 0 || (negatives.length > 0 && !ack) || preview.activeSale !== null}
+          onClick={confirm}
+        >
+          {pending
+            ? "Working…"
+            : preview.writesEnabled === false
+              ? `Record dry-run sale (${adjustable.length} adjustable rows)`
+              : `Confirm sale — decrement ${adjustable.length} singles`}
+        </Button>
+        {adjustable.length === 0 && (
+          <span className="text-sm text-muted-foreground">Nothing adjustable — every row is flagged or dropped.</span>
+        )}
+        <Link href="/admin/ytg/decks" className="ml-auto text-sm text-muted-foreground hover:underline">
+          Cancel
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/ytg/decks/[productId]/sale/page.tsx
+++ b/app/admin/ytg/decks/[productId]/sale/page.tsx
@@ -1,0 +1,23 @@
+import { notFound } from "next/navigation";
+import { previewSale } from "../../saleActions";
+import SaleFlow from "./SaleFlow";
+
+export const dynamic = "force-dynamic";
+
+export default async function RecordSalePage({
+  params,
+}: {
+  params: Promise<{ productId: string }>;
+}) {
+  const { productId } = await params;
+  const res = await previewSale(productId, 1);
+  if (res.success === false) {
+    if (res.error === "forbidden") notFound();
+    return (
+      <div className="px-4 py-2 rounded-md bg-destructive/10 text-destructive text-sm">
+        {res.error}
+      </div>
+    );
+  }
+  return <SaleFlow initialPreview={res.preview} />;
+}

--- a/app/admin/ytg/decks/page.tsx
+++ b/app/admin/ytg/decks/page.tsx
@@ -1,10 +1,12 @@
 import { listDeckProducts } from "./actions";
+import { listSales } from "./saleActions";
 import DeckProductList from "./DeckProductList";
+import SalesHistory from "./SalesHistory";
 
 export const dynamic = "force-dynamic";
 
 export default async function DecksPage() {
-  const res = await listDeckProducts();
+  const [res, salesRes] = await Promise.all([listDeckProducts(), listSales()]);
   if (res.success === false) {
     return (
       <div className="px-4 py-2 rounded-md bg-destructive/10 text-destructive text-sm">
@@ -12,5 +14,14 @@ export default async function DecksPage() {
       </div>
     );
   }
-  return <DeckProductList products={res.products} />;
+  return (
+    <div className="space-y-8">
+      <DeckProductList products={res.products} />
+      <SalesHistory
+        sales={salesRes.success === false ? [] : salesRes.sales}
+        writesEnabled={salesRes.success === false ? false : salesRes.writesEnabled}
+        loadError={salesRes.success === false ? salesRes.error : ""}
+      />
+    </div>
+  );
 }

--- a/app/admin/ytg/decks/saleActions.ts
+++ b/app/admin/ytg/decks/saleActions.ts
@@ -1,0 +1,472 @@
+"use server";
+
+/**
+ * WS-4 Record-sale server actions (spec §Record sale + Addendum 2026-08-04).
+ * Thin executors over the pure planner in lib/ytg/saleStateMachine.ts and
+ * the gated Shopify client in lib/shopify/inventory.ts. Every action
+ * re-checks hasPermission (layout gating does not protect actions) and uses
+ * the service-role client — the ledger tables revoke anon/authenticated.
+ */
+
+import { hasPermission } from "@/utils/adminUtils";
+import { getSupabaseAdmin } from "@/lib/pricing/supabase-admin";
+import { createClient } from "@/utils/supabase/server";
+import { getShopifyAccessToken, fetchProductInventory } from "@/lib/pricing/shopify";
+import { buildCardKey } from "@/lib/pricing/matching";
+import {
+  getSingleLocationId, getInventoryItemIds, adjustAvailable, activateItem,
+  idempotencyKey, inventoryWritesEnabled, isNotStockedError, isStaleCasError,
+  changeIndexOf, type InventoryChange, type InventoryUserError,
+} from "@/lib/shopify/inventory";
+import {
+  classifyPreviewRow, deriveSaleStatus, deriveUndoStatus, planApply,
+  planResume, planUndo, type PlannedBatch, type PreviewFlag,
+  type SaleItemState, type ItemStatus,
+} from "@/lib/ytg/saleStateMachine";
+
+const PERM = "manage_shopify_imports";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function usernamesById(admin: any, ids: (string | null)[]): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  const unique = [...new Set(ids.filter((x): x is string => Boolean(x)))];
+  if (unique.length === 0) return out;
+  const { data } = await admin.from("profiles").select("id, username").in("id", unique);
+  for (const p of data ?? []) if (p.username) out.set(p.id, p.username);
+  return out;
+}
+
+async function actingUserId(): Promise<string | null> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  return user?.id ?? null;
+}
+
+export interface SalePreviewRow {
+  cardKey: string;
+  cardName: string;
+  qtyPerDeck: number;            // zone IN ('main','reserve'), summed per card_key
+  delta: number;                 // -(qtyPerDeck × saleQty)
+  qtyBefore: number | null;      // LIVE quantity (never the mirror)
+  qtyAfter: number | null;
+  singleProductId: string | null;
+  variantId: string | null;
+  flag: PreviewFlag;
+}
+
+export interface SalePreview {
+  product: { productId: string; title: string; handle: string; imageUrl: string | null };
+  deckId: string;
+  deckUpdatedAt: string;
+  qty: number;
+  rows: SalePreviewRow[];
+  recentSale: { id: string; qty: number; createdAt: string; createdByName: string | null } | null;
+  activeSale: { id: string; status: string; createdAt: string; createdByName: string | null } | null;
+  writesEnabled: boolean;
+}
+
+export type PreviewResult =
+  | { success: true; preview: SalePreview }
+  | { success: false; error: string };
+
+export async function previewSale(productId: string, qty: number): Promise<PreviewResult> {
+  if (!(await hasPermission(PERM))) return { success: false, error: "forbidden" };
+  if (!Number.isInteger(qty) || qty < 1 || qty > 99) {
+    return { success: false, error: "qty must be an integer between 1 and 99" };
+  }
+  const admin = getSupabaseAdmin();
+
+  const { data: link, error: linkErr } = await admin
+    .from("ytg_deck_links").select("deck_id")
+    .eq("shopify_product_id", productId).maybeSingle();
+  if (linkErr) return { success: false, error: linkErr.message };
+  if (!link) return { success: false, error: "product is not linked to a deck — pull contents first" };
+
+  const { data: p, error: prodErr } = await admin
+    .from("shopify_products").select("id, title, handle, raw_json")
+    .eq("id", productId).maybeSingle();
+  if (prodErr) return { success: false, error: prodErr.message };
+  if (!p) return { success: false, error: "product not found in the mirror" };
+
+  const { data: deck, error: deckErr } = await admin
+    .from("decks").select("updated_at").eq("id", link.deck_id).maybeSingle();
+  if (deckErr) return { success: false, error: deckErr.message };
+  if (!deck) return { success: false, error: "linked deck no longer exists" };
+
+  // Addendum 2026-08-04: the box physically includes the Reserve —
+  // decrement reads zone IN ('main','reserve'), SUMMED per card_key.
+  const { data: cards, error: cardsErr } = await admin
+    .from("deck_cards")
+    .select("card_name, card_set, card_img_file, quantity, zone")
+    .eq("deck_id", link.deck_id)
+    .in("zone", ["main", "reserve"]);
+  if (cardsErr) return { success: false, error: cardsErr.message };
+
+  const perKey = new Map<string, { cardName: string; qtyPerDeck: number }>();
+  for (const c of cards ?? []) {
+    const key = buildCardKey(c.card_name, c.card_set, c.card_img_file);
+    const prev = perKey.get(key);
+    if (prev) prev.qtyPerDeck += c.quantity ?? 0;
+    else perKey.set(key, { cardName: c.card_name, qtyPerDeck: c.quantity ?? 0 });
+  }
+  if (perKey.size === 0) return { success: false, error: "linked deck has no main/reserve cards" };
+
+  // Confirmed mappings are exactly auto_matched|manual (no 'matched' status exists).
+  const { data: mappings, error: mapErr } = await admin
+    .from("card_price_mappings")
+    .select("card_key, shopify_product_id")
+    .in("card_key", [...perKey.keys()])
+    .in("status", ["auto_matched", "manual"]);
+  if (mapErr) return { success: false, error: mapErr.message };
+
+  const productByKey = new Map<string, string>();
+  for (const m of mappings ?? []) {
+    if (m.shopify_product_id) productByKey.set(m.card_key, String(m.shopify_product_id));
+  }
+
+  // LIVE inventory — never the mirror (mirror staleness → oversell; Shopify
+  // happily drives available negative with no error).
+  const token = await getShopifyAccessToken();
+  const live = await fetchProductInventory(token, [...new Set(productByKey.values())]);
+
+  // Sequential CAS anchors when several card_keys share one single product
+  // (promo-fallback mappings): row 2's qtyBefore = row 1's qtyAfter.
+  const runningQty = new Map<string, number>();
+  const rows: SalePreviewRow[] = [...perKey.entries()]
+    .sort((a, b) => (a[0] < b[0] ? -1 : 1))
+    .map(([cardKey, v]) => {
+      const singleProductId = productByKey.get(cardKey) ?? null;
+      const inv = singleProductId !== null ? live.get(singleProductId) : undefined;
+      const delta = -(v.qtyPerDeck * qty);
+      const tracked = inv !== undefined && inv.tracked === true;
+      let qtyBefore: number | null = null;
+      let qtyAfter: number | null = null;
+      if (singleProductId !== null && inv !== undefined && tracked) {
+        const start = runningQty.get(singleProductId);
+        qtyBefore = start === undefined ? inv.inventory : start;
+        qtyAfter = qtyBefore + delta;
+        runningQty.set(singleProductId, qtyAfter);
+      }
+      return {
+        cardKey,
+        cardName: v.cardName,
+        qtyPerDeck: v.qtyPerDeck,
+        delta,
+        qtyBefore,
+        qtyAfter,
+        singleProductId,
+        variantId: inv !== undefined ? inv.variantId : null,
+        flag: classifyPreviewRow({
+          mapped: singleProductId !== null && inv !== undefined,
+          tracked,
+          qtyAfter,
+        }),
+      };
+    });
+
+  const tenMinAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+  const { data: recent } = await admin
+    .from("ytg_deck_sales").select("id, qty, created_at, created_by")
+    .eq("shopify_product_id", productId)
+    .in("status", ["applied", "partial"])
+    .gte("created_at", tenMinAgo)
+    .order("created_at", { ascending: false }).limit(1);
+  const { data: active } = await admin
+    .from("ytg_deck_sales").select("id, status, created_at, created_by")
+    .eq("shopify_product_id", productId)
+    .in("status", ["pending", "applying"]).limit(1);
+
+  const names = await usernamesById(admin, [
+    ...(recent ?? []).map((r: { created_by: string | null }) => r.created_by),
+    ...(active ?? []).map((r: { created_by: string | null }) => r.created_by),
+  ]);
+  const r0 = (recent ?? [])[0];
+  const a0 = (active ?? [])[0];
+
+  return {
+    success: true,
+    preview: {
+      product: {
+        productId: p.id,
+        title: p.title,
+        handle: p.handle,
+        imageUrl: p.raw_json?.images?.[0]?.src ?? p.raw_json?.image?.src ?? null,
+      },
+      deckId: link.deck_id,
+      deckUpdatedAt: deck.updated_at,
+      qty,
+      rows,
+      recentSale: r0
+        ? { id: r0.id, qty: r0.qty, createdAt: r0.created_at, createdByName: names.get(r0.created_by) ?? null }
+        : null,
+      activeSale: a0
+        ? { id: a0.id, status: a0.status, createdAt: a0.created_at, createdByName: names.get(a0.created_by) ?? null }
+        : null,
+      writesEnabled: inventoryWritesEnabled(),
+    },
+  };
+}
+
+export interface ConfirmInput {
+  productId: string;
+  qty: number;
+  deckId: string;
+  deckUpdatedAt: string;   // snapshot-integrity check (spec pt. 3)
+  rows: SalePreviewRow[];  // the previewed (possibly row-dropped) snapshot
+  ackNegative: boolean;
+}
+
+export type ConfirmResult =
+  | { success: true; saleId: string; dryRun: boolean }
+  | {
+      success: false;
+      code: "deck_changed" | "needs_ack" | "sale_in_progress" | "empty" | "error";
+      error: string;
+      inProgress?: { createdAt: string; createdByName: string | null };
+    };
+
+export async function confirmSale(input: ConfirmInput): Promise<ConfirmResult> {
+  if (!(await hasPermission(PERM))) return { success: false, code: "error", error: "forbidden" };
+  const admin = getSupabaseAdmin();
+  const { productId, qty, deckId, deckUpdatedAt, rows, ackNegative } = input;
+
+  if (!Number.isInteger(qty) || qty < 1 || qty > 99) {
+    return { success: false, code: "error", error: "qty must be an integer between 1 and 99" };
+  }
+  const adjustable = (rows ?? []).filter(
+    (r) => r.flag === "ok" || r.flag === "would_go_negative",
+  );
+  if (!rows || rows.length === 0 || adjustable.length === 0) {
+    return { success: false, code: "empty", error: "nothing to apply — every row is unmapped/untracked or dropped" };
+  }
+  if (rows.some((r) => r.flag === "would_go_negative") && ackNegative !== true) {
+    return { success: false, code: "needs_ack", error: "some rows would go negative — acknowledge to proceed" };
+  }
+
+  // Deck-changed check: apply acts on the previewed snapshot, never a re-read.
+  const { data: deck, error: deckErr } = await admin
+    .from("decks").select("updated_at").eq("id", deckId).maybeSingle();
+  if (deckErr) return { success: false, code: "error", error: deckErr.message };
+  if (!deck || deck.updated_at !== deckUpdatedAt) {
+    return { success: false, code: "deck_changed", error: "deck changed since preview — re-preview before recording" };
+  }
+
+  const createdBy = await actingUserId();
+  const { data: inserted, error: insErr } = await admin
+    .from("ytg_deck_sales")
+    .insert({ shopify_product_id: productId, deck_id: deckId, qty, status: "pending", created_by: createdBy })
+    .select("id");
+  if (insErr) {
+    if (insErr.code === "23505") {
+      // Partial unique index: one active sale per product (WS-3 guard reads the same rows).
+      const { data: who } = await admin
+        .from("ytg_deck_sales").select("created_at, created_by")
+        .eq("shopify_product_id", productId)
+        .in("status", ["pending", "applying"]).limit(1);
+      const w = (who ?? [])[0];
+      const names = await usernamesById(admin, [w?.created_by ?? null]);
+      return {
+        success: false, code: "sale_in_progress",
+        error: "a sale is already being recorded for this product",
+        inProgress: w
+          ? { createdAt: w.created_at, createdByName: names.get(w.created_by) ?? null }
+          : undefined,
+      };
+    }
+    return { success: false, code: "error", error: insErr.message };
+  }
+  const saleId: string = inserted[0].id;
+
+  // Snapshot items — quantities already summed per card_key (items PK).
+  const itemRows = rows.map((r) => ({
+    sale_id: saleId,
+    card_key: r.cardKey,
+    card_name: r.cardName,
+    qty_per_deck: r.qtyPerDeck,
+    delta: r.delta,
+    qty_before: r.qtyBefore,
+    qty_after: r.qtyAfter,
+    single_product_id: r.singleProductId,
+    variant_id: r.variantId,
+    inventory_item_id: null,
+    status:
+      r.flag === "unmapped" ? "skipped_unmapped"
+      : r.flag === "untracked" ? "skipped_untracked"
+      : "pending",
+    error: null,
+  }));
+  const { error: itemsErr } = await admin.from("ytg_deck_sale_items").insert(itemRows);
+  if (itemsErr) {
+    await admin.from("ytg_deck_sales").delete().eq("id", saleId); // items cascade
+    return { success: false, code: "error", error: `snapshot failed: ${itemsErr.message}` };
+  }
+
+  // Dry-run short-circuit: recorded, visibly segregated, never applied, non-replayable.
+  if (inventoryWritesEnabled() === false) {
+    const { error: dryErr } = await admin
+      .from("ytg_deck_sales").update({ status: "dry_run" }).eq("id", saleId);
+    if (dryErr) return { success: false, code: "error", error: dryErr.message };
+    return { success: true, saleId, dryRun: true };
+  }
+
+  // Server-side claim: CAS pending→applying. A refresh-and-resume or a
+  // second admin loses this and sees "already being applied".
+  const { data: claimed, error: claimErr } = await admin
+    .from("ytg_deck_sales").update({ status: "applying" })
+    .eq("id", saleId).eq("status", "pending").select("id");
+  if (claimErr) return { success: false, code: "error", error: claimErr.message };
+  if (!claimed || claimed.length === 0) {
+    return { success: false, code: "sale_in_progress", error: "sale is already being applied" };
+  }
+  return { success: true, saleId, dryRun: false };
+}
+
+export interface SaleItemView {
+  cardKey: string;
+  cardName: string | null;
+  qtyPerDeck: number;
+  delta: number;
+  qtyBefore: number | null;
+  qtyAfter: number | null;
+  singleProductId: string | null;
+  status: string;
+  error: string | null;
+}
+
+export interface SaleView {
+  id: string;
+  productId: string;
+  productTitle: string | null;
+  qty: number;
+  status: string;
+  createdAt: string;
+  undoneAt: string | null;
+  items: SaleItemView[];
+  writesEnabled: boolean;
+  degraded: "scope_missing" | null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function loadSaleView(admin: any, saleId: string, degraded: "scope_missing" | null = null): Promise<
+  { success: true; sale: SaleView } | { success: false; error: string }
+> {
+  const { data: sale, error: saleErr } = await admin
+    .from("ytg_deck_sales")
+    .select("id, shopify_product_id, qty, status, created_at, undone_at")
+    .eq("id", saleId).maybeSingle();
+  if (saleErr) return { success: false, error: saleErr.message };
+  if (!sale) return { success: false, error: "sale not found" };
+  const { data: items, error: itemsErr } = await admin
+    .from("ytg_deck_sale_items")
+    .select("card_key, card_name, qty_per_deck, delta, qty_before, qty_after, single_product_id, status, error")
+    .eq("sale_id", saleId).order("card_key");
+  if (itemsErr) return { success: false, error: itemsErr.message };
+  const { data: prod } = await admin
+    .from("shopify_products").select("title").eq("id", sale.shopify_product_id).maybeSingle();
+  return {
+    success: true,
+    sale: {
+      id: sale.id,
+      productId: sale.shopify_product_id,
+      productTitle: prod ? prod.title : null,
+      qty: sale.qty,
+      status: sale.status,
+      createdAt: sale.created_at,
+      undoneAt: sale.undone_at,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      items: (items ?? []).map((i: any) => ({
+        cardKey: i.card_key, cardName: i.card_name, qtyPerDeck: i.qty_per_deck,
+        delta: i.delta, qtyBefore: i.qty_before, qtyAfter: i.qty_after,
+        singleProductId: i.single_product_id, status: i.status, error: i.error,
+      })),
+      writesEnabled: inventoryWritesEnabled(),
+      degraded,
+    },
+  };
+}
+
+export type SaleResult = { success: true; sale: SaleView } | { success: false; error: string };
+
+export async function getSale(saleId: string): Promise<SaleResult> {
+  if (!(await hasPermission(PERM))) return { success: false, error: "forbidden" };
+  return loadSaleView(getSupabaseAdmin(), saleId);
+}
+
+export interface SaleHistoryRow {
+  id: string;
+  productId: string;
+  productTitle: string;
+  qty: number;
+  status: string;
+  createdAt: string;
+  createdByName: string | null;
+  undoneAt: string | null;
+  undoneByName: string | null;
+  appliedCount: number;
+  skippedCount: number;
+  troubleCount: number;   // error|conflict|undo_conflict
+  totalItems: number;
+}
+
+export async function listSales(): Promise<
+  { success: true; sales: SaleHistoryRow[]; writesEnabled: boolean } | { success: false; error: string }
+> {
+  if (!(await hasPermission(PERM))) return { success: false, error: "forbidden" };
+  const admin = getSupabaseAdmin();
+  const { data: sales, error } = await admin
+    .from("ytg_deck_sales")
+    .select("id, shopify_product_id, qty, status, created_at, created_by, undone_at, undone_by")
+    .order("created_at", { ascending: false })
+    .limit(100);
+  if (error) return { success: false, error: error.message };
+  const rows = sales ?? [];
+  if (rows.length === 0) return { success: true, sales: [], writesEnabled: inventoryWritesEnabled() };
+
+  const { data: items } = await admin
+    .from("ytg_deck_sale_items").select("sale_id, status")
+    .in("sale_id", rows.map((s: { id: string }) => s.id));
+  const counts = new Map<string, { applied: number; skipped: number; trouble: number; total: number }>();
+  for (const it of items ?? []) {
+    const c = counts.get(it.sale_id) ?? { applied: 0, skipped: 0, trouble: 0, total: 0 };
+    c.total += 1;
+    if (it.status === "applied" || it.status === "undone") c.applied += 1;
+    if (it.status === "skipped_unmapped" || it.status === "skipped_untracked") c.skipped += 1;
+    if (it.status === "error" || it.status === "conflict" || it.status === "undo_conflict") c.trouble += 1;
+    counts.set(it.sale_id, c);
+  }
+
+  const { data: prods } = await admin
+    .from("shopify_products").select("id, title")
+    .in("id", [...new Set(rows.map((s: { shopify_product_id: string }) => s.shopify_product_id))]);
+  const titleById = new Map<string, string>();
+  for (const pr of prods ?? []) titleById.set(String(pr.id), pr.title);
+
+  const names = await usernamesById(admin, [
+    ...rows.map((s: { created_by: string | null }) => s.created_by),
+    ...rows.map((s: { undone_by: string | null }) => s.undone_by),
+  ]);
+
+  return {
+    success: true,
+    writesEnabled: inventoryWritesEnabled(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sales: rows.map((s: any) => {
+      const c = counts.get(s.id) ?? { applied: 0, skipped: 0, trouble: 0, total: 0 };
+      return {
+        id: s.id,
+        productId: s.shopify_product_id,
+        productTitle: titleById.get(s.shopify_product_id) ?? s.shopify_product_id,
+        qty: s.qty,
+        status: s.status,
+        createdAt: s.created_at,
+        createdByName: s.created_by ? (names.get(s.created_by) ?? null) : null,
+        undoneAt: s.undone_at,
+        undoneByName: s.undone_by ? (names.get(s.undone_by) ?? null) : null,
+        appliedCount: c.applied,
+        skippedCount: c.skipped,
+        troubleCount: c.trouble,
+        totalItems: c.total,
+      };
+    }),
+  };
+}

--- a/app/admin/ytg/decks/saleActions.ts
+++ b/app/admin/ytg/decks/saleActions.ts
@@ -470,3 +470,445 @@ export async function listSales(): Promise<
     }),
   };
 }
+
+// ─── Apply / resume / retry / undo executors ────────────────────────────────
+
+const CONFLICT_MSG =
+  "live quantity moved between preview and apply (compare-and-swap rejected) — verify in Shopify, then retry";
+const RESUME_CONFLICT_MSG =
+  "live quantity matches neither anchor — a third party moved stock; resolve in Shopify";
+const UNDO_CONFLICT_MSG =
+  "live quantity moved since the sale — undo refused to stack stock; review in Shopify";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function setItems(admin: any, saleId: string, cardKeys: string[], patch: Record<string, unknown>) {
+  if (cardKeys.length === 0) return;
+  await admin.from("ytg_deck_sale_items").update(patch)
+    .eq("sale_id", saleId).in("card_key", cardKeys);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function loadItemStates(admin: any, saleId: string): Promise<
+  { success: true; items: (SaleItemState & { variantId: string | null; singleProductId: string | null })[] }
+  | { success: false; error: string }
+> {
+  const { data, error } = await admin
+    .from("ytg_deck_sale_items")
+    .select("card_key, status, delta, qty_before, qty_after, inventory_item_id, variant_id, single_product_id")
+    .eq("sale_id", saleId);
+  if (error) return { success: false, error: error.message };
+  return {
+    success: true,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    items: (data ?? []).map((i: any) => ({
+      cardKey: i.card_key,
+      status: i.status as ItemStatus,
+      delta: i.delta,
+      qtyBefore: i.qty_before,
+      qtyAfter: i.qty_after,
+      inventoryItemId: i.inventory_item_id,
+      variantId: i.variant_id,
+      singleProductId: i.single_product_id,
+    })),
+  };
+}
+
+/**
+ * Resolve inventory_item_ids for adjustable items that still lack them and
+ * persist onto the rows (idempotent; resume re-runs this harmlessly).
+ * Items whose variant has no inventory item become 'error'.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function resolveInventoryItemIds(admin: any, token: string, saleId: string): Promise<void> {
+  const loaded = await loadItemStates(admin, saleId);
+  if (loaded.success === false) return;
+  const need = loaded.items.filter(
+    (i) => (i.status === "pending" || i.status === "applying")
+      && i.inventoryItemId === null && i.variantId !== null,
+  );
+  if (need.length === 0) return;
+  const gidOf = (variantId: string) => `gid://shopify/ProductVariant/${variantId}`;
+  const map = await getInventoryItemIds(token, need.map((i) => gidOf(i.variantId as string)));
+  for (const i of need) {
+    const itemGid = map.get(gidOf(i.variantId as string));
+    if (itemGid) {
+      await admin.from("ytg_deck_sale_items")
+        .update({ inventory_item_id: itemGid })
+        .eq("sale_id", saleId).eq("card_key", i.cardKey);
+    } else {
+      await setItems(admin, saleId, [i.cardKey], {
+        status: "error", error: "variant has no inventory item in Shopify",
+      });
+    }
+  }
+}
+
+/**
+ * Execute one planned batch. The mutation is atomic — on userErrors, mark
+ * the offending changes (stale → conflict, not-stocked → activate then
+ * retry, other → error) and re-run the pruned remainder under its new
+ * (payload-derived) key. Bounded passes; leftovers become 'error'.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function runBatch(
+  admin: any, token: string, locationId: string, saleId: string, batch: PlannedBatch,
+): Promise<void> {
+  let changes = batch.changes.slice();
+  for (let pass = 0; pass < 4 && changes.length > 0; pass++) {
+    const invChanges: InventoryChange[] = changes.map((c) => ({
+      inventoryItemId: c.inventoryItemId, delta: c.delta, changeFromQuantity: c.changeFromQuantity,
+    }));
+    const key = idempotencyKey(batch.baseKey, invChanges);
+    const outcome = await adjustAvailable(token, {
+      idempotencyKey: key, locationId, changes: invChanges,
+    });
+
+    if (outcome.userErrors.length === 0) {
+      await setItems(admin, saleId, changes.map((c) => c.cardKey), { status: "applied", error: null });
+      return;
+    }
+
+    // Whole-mutation idempotency signals (no change index):
+    const concurrent = outcome.userErrors.some((e) => e.code === "IDEMPOTENCY_CONCURRENT_REQUEST");
+    if (concurrent) return; // another tab is applying this exact payload — leave 'applying', Resume reconciles
+    const prevFailed = outcome.userErrors.some(
+      (e) => e.code === "IDEMPOTENCY_PREVIOUS_ATTEMPT_FAILED" || e.code === "IDEMPOTENCY_KEY_PARAMETER_MISMATCH",
+    );
+    if (prevFailed) {
+      // The key is burned but nothing applied (previous attempt failed).
+      // changeFromQuantity remains the true guard — retry under a salted key.
+      const salted = `${batch.baseKey}:retry:${pass + 1}`;
+      const retry = await adjustAvailable(token, {
+        idempotencyKey: idempotencyKey(salted, invChanges), locationId, changes: invChanges,
+      });
+      if (retry.userErrors.length === 0) {
+        await setItems(admin, saleId, changes.map((c) => c.cardKey), { status: "applied", error: null });
+        return;
+      }
+      outcome.userErrors = retry.userErrors;
+    }
+
+    const failedIdx = new Set<number>();
+    const activations: { idx: number; inventoryItemId: string }[] = [];
+    let unattributed: InventoryUserError | null = null;
+    for (const e of outcome.userErrors) {
+      const idx = changeIndexOf(e);
+      if (idx === null || idx >= changes.length) { unattributed = e; continue; }
+      failedIdx.add(idx);
+      if (isNotStockedError(e)) {
+        activations.push({ idx, inventoryItemId: changes[idx].inventoryItemId });
+      } else if (isStaleCasError(e)) {
+        await setItems(admin, saleId, [changes[idx].cardKey], { status: "conflict", error: CONFLICT_MSG });
+      } else {
+        await setItems(admin, saleId, [changes[idx].cardKey], {
+          status: "error", error: `${e.code ?? "SHOPIFY_ERROR"}: ${e.message}`,
+        });
+      }
+    }
+    if (unattributed !== null && failedIdx.size === 0) {
+      await setItems(admin, saleId, changes.map((c) => c.cardKey), {
+        status: "error", error: `${unattributed.code ?? "SHOPIFY_ERROR"}: ${unattributed.message}`,
+      });
+      return;
+    }
+
+    // Never-activated items: inventoryActivate(available: 0) with the
+    // spec-pinned key, then the change goes back into the retry payload.
+    const reactivated = new Set<number>();
+    for (const a of activations) {
+      const act = await activateItem(token, {
+        idempotencyKey: `sale:${saleId}:activate:${a.inventoryItemId}`,
+        inventoryItemId: a.inventoryItemId, locationId,
+      });
+      if (act.userErrors.length === 0) reactivated.add(a.idx);
+      else await setItems(admin, saleId, [changes[a.idx].cardKey], {
+        status: "error", error: `activate failed: ${act.userErrors.map((e) => e.message).join("; ")}`,
+      });
+    }
+
+    // Atomicity: non-failing changes were NOT applied — re-run them, plus
+    // any freshly-activated ones. Pruned payload ⇒ new fingerprint ⇒ new key.
+    changes = changes.filter((c, idx) => !failedIdx.has(idx) || reactivated.has(idx));
+  }
+  if (changes.length > 0) {
+    await setItems(admin, saleId, changes.map((c) => c.cardKey), {
+      status: "error", error: "retry passes exhausted — use per-row Retry",
+    });
+  }
+}
+
+function isAccessDenied(e: unknown): boolean {
+  return e instanceof Error && /ACCESS_DENIED|access denied/i.test(e.message);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function degradeToDryRun(admin: any, saleId: string): Promise<void> {
+  // Scope not granted after all: revert in-flight items, park the sale as
+  // dry_run (visibly segregated, never applied, non-replayable — spec).
+  const { data: inflight } = await admin
+    .from("ytg_deck_sale_items").select("card_key")
+    .eq("sale_id", saleId).eq("status", "applying");
+  await setItems(admin, saleId, (inflight ?? []).map((i: { card_key: string }) => i.card_key), {
+    status: "pending", error: null,
+  });
+  await admin.from("ytg_deck_sales").update({ status: "dry_run" }).eq("id", saleId);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function finishApplyPass(admin: any, token: string, locationId: string, saleId: string): Promise<void> {
+  const loaded = await loadItemStates(admin, saleId);
+  if (loaded.success === false) return;
+  const plan = planApply(saleId, loaded.items);
+  await setItems(admin, saleId, plan.unresolvable, {
+    status: "error", error: "missing inventory item id or CAS anchors",
+  });
+  for (const batch of plan.batches) {
+    // CAS the batch's items pending→applying BEFORE the Shopify call —
+    // losing rows here means another tab owns them; skip those.
+    const { data: flipped } = await admin
+      .from("ytg_deck_sale_items").update({ status: "applying" })
+      .eq("sale_id", saleId)
+      .in("card_key", batch.changes.map((c) => c.cardKey))
+      .eq("status", "pending")
+      .select("card_key");
+    const owned = new Set((flipped ?? []).map((f: { card_key: string }) => f.card_key));
+    const ownedChanges = batch.changes.filter((c) => owned.has(c.cardKey));
+    if (ownedChanges.length === 0) continue;
+    await runBatch(admin, token, locationId, saleId, { ...batch, changes: ownedChanges });
+  }
+  // Sale status is DERIVED from items.
+  const after = await loadItemStates(admin, saleId);
+  if (after.success === false) return;
+  if (after.items.some((i) => i.status === "applying")) return; // concurrent tab still in flight
+  await admin.from("ytg_deck_sales")
+    .update({ status: deriveSaleStatus(after.items) })
+    .eq("id", saleId).eq("status", "applying");
+}
+
+export async function applySale(saleId: string): Promise<SaleResult> {
+  if (!(await hasPermission(PERM))) return { success: false, error: "forbidden" };
+  const admin = getSupabaseAdmin();
+  const { data: sale, error: saleErr } = await admin
+    .from("ytg_deck_sales").select("id, status").eq("id", saleId).maybeSingle();
+  if (saleErr) return { success: false, error: saleErr.message };
+  if (!sale) return { success: false, error: "sale not found" };
+  if (sale.status === "pending") {
+    // Crash between confirm-insert and claim: re-claim.
+    const { data: claimed } = await admin
+      .from("ytg_deck_sales").update({ status: "applying" })
+      .eq("id", saleId).eq("status", "pending").select("id");
+    if (!claimed || claimed.length === 0) return loadSaleView(admin, saleId);
+  } else if (sale.status !== "applying") {
+    return loadSaleView(admin, saleId); // terminal — just show it
+  }
+  if (inventoryWritesEnabled() === false) {
+    await degradeToDryRun(admin, saleId);
+    return loadSaleView(admin, saleId, "scope_missing");
+  }
+  try {
+    const token = await getShopifyAccessToken();
+    const locationId = await getSingleLocationId(token);
+    await resolveInventoryItemIds(admin, token, saleId);
+    await finishApplyPass(admin, token, locationId, saleId);
+  } catch (e) {
+    if (isAccessDenied(e)) {
+      await degradeToDryRun(admin, saleId);
+      return loadSaleView(admin, saleId, "scope_missing");
+    }
+    return { success: false, error: e instanceof Error ? e.message : "apply failed" };
+  }
+  return loadSaleView(admin, saleId);
+}
+
+export async function resumeSale(saleId: string): Promise<SaleResult> {
+  if (!(await hasPermission(PERM))) return { success: false, error: "forbidden" };
+  const admin = getSupabaseAdmin();
+  const { data: sale, error: saleErr } = await admin
+    .from("ytg_deck_sales").select("id, status").eq("id", saleId).maybeSingle();
+  if (saleErr) return { success: false, error: saleErr.message };
+  if (!sale) return { success: false, error: "sale not found" };
+  if (sale.status === "pending") return applySale(saleId);
+  if (sale.status !== "applying") return loadSaleView(admin, saleId);
+  if (inventoryWritesEnabled() === false) {
+    await degradeToDryRun(admin, saleId);
+    return loadSaleView(admin, saleId, "scope_missing");
+  }
+  try {
+    const token = await getShopifyAccessToken();
+    const locationId = await getSingleLocationId(token);
+    await resolveInventoryItemIds(admin, token, saleId);
+
+    // Oracle phase: 'applying' items are UNKNOWN — re-read live quantities.
+    const loaded = await loadItemStates(admin, saleId);
+    if (loaded.success === false) return { success: false, error: loaded.error };
+    const stranded = loaded.items.filter((i) => i.status === "applying");
+    if (stranded.length > 0) {
+      const live = await fetchProductInventory(
+        token,
+        [...new Set(stranded.map((i) => i.singleProductId).filter((x): x is string => Boolean(x)))],
+      );
+      const liveByCardKey = new Map<string, number>();
+      for (const i of stranded) {
+        const inv = i.singleProductId !== null ? live.get(i.singleProductId) : undefined;
+        if (inv !== undefined) liveByCardKey.set(i.cardKey, inv.inventory);
+      }
+      const plan = planResume(saleId, loaded.items, liveByCardKey);
+      await setItems(admin, saleId, plan.markApplied, { status: "applied", error: null });
+      await setItems(admin, saleId, plan.conflicts, { status: "conflict", error: RESUME_CONFLICT_MSG });
+      for (const batch of plan.reapply) {
+        // Same payload ⇒ same key ⇒ Shopify dedupes even if the original
+        // call arrived late (spec: "makes even the re-apply race safe").
+        await runBatch(admin, token, locationId, saleId, batch);
+      }
+    }
+    await finishApplyPass(admin, token, locationId, saleId);
+  } catch (e) {
+    if (isAccessDenied(e)) {
+      await degradeToDryRun(admin, saleId);
+      return loadSaleView(admin, saleId, "scope_missing");
+    }
+    return { success: false, error: e instanceof Error ? e.message : "resume failed" };
+  }
+  return loadSaleView(admin, saleId);
+}
+
+export type RetryResult =
+  | SaleResult
+  | { success: false; error: string; needsAck: true; qtyBefore: number; qtyAfter: number };
+
+/**
+ * Per-row retry for 'error'/'conflict' items: re-read live quantity (the
+ * spec's "after re-preview"), refresh the CAS anchors on the row, then a
+ * single-change adjust under a payload-derived key. Undo stays correct
+ * because qty_after is refreshed too.
+ */
+export async function retrySaleItem(
+  saleId: string, cardKey: string, ackNegative: boolean,
+): Promise<RetryResult> {
+  if (!(await hasPermission(PERM))) return { success: false, error: "forbidden" };
+  const admin = getSupabaseAdmin();
+  if (inventoryWritesEnabled() === false) {
+    return { success: false, error: "inventory writes are not enabled — retry is unavailable in dry-run" };
+  }
+  const { data: item, error: itemErr } = await admin
+    .from("ytg_deck_sale_items")
+    .select("card_key, status, delta, single_product_id, variant_id, inventory_item_id")
+    .eq("sale_id", saleId).eq("card_key", cardKey).maybeSingle();
+  if (itemErr) return { success: false, error: itemErr.message };
+  if (!item) return { success: false, error: "sale item not found" };
+  if (item.status !== "error" && item.status !== "conflict") {
+    return loadSaleView(admin, saleId);
+  }
+  if (!item.single_product_id) return { success: false, error: "item has no mapped product" };
+  try {
+    const token = await getShopifyAccessToken();
+    const locationId = await getSingleLocationId(token);
+    await resolveInventoryItemIds(admin, token, saleId);
+    const live = await fetchProductInventory(token, [item.single_product_id]);
+    const inv = live.get(item.single_product_id);
+    if (inv === undefined || inv.tracked === false) {
+      return { success: false, error: "product is gone or untracked in Shopify — fix in Matching/Shopify first" };
+    }
+    const qtyBefore = inv.inventory;
+    const qtyAfter = qtyBefore + item.delta;
+    if (qtyAfter < 0 && ackNegative !== true) {
+      return { success: false, error: "would go negative — acknowledge to proceed", needsAck: true, qtyBefore, qtyAfter };
+    }
+    const { data: fresh } = await admin
+      .from("ytg_deck_sale_items").select("inventory_item_id")
+      .eq("sale_id", saleId).eq("card_key", cardKey).maybeSingle();
+    const inventoryItemId: string | null = fresh ? fresh.inventory_item_id : null;
+    if (inventoryItemId === null) return { success: false, error: "no inventory item id for this variant" };
+    // CAS claim + refreshed anchors (the resume oracle keys off these).
+    const { data: claimed } = await admin
+      .from("ytg_deck_sale_items")
+      .update({ status: "applying", qty_before: qtyBefore, qty_after: qtyAfter, error: null })
+      .eq("sale_id", saleId).eq("card_key", cardKey)
+      .in("status", ["error", "conflict"]).select("card_key");
+    if (!claimed || claimed.length === 0) return loadSaleView(admin, saleId);
+    await runBatch(admin, token, locationId, saleId, {
+      n: 0,
+      baseKey: `sale:${saleId}:item:${inventoryItemId}`,
+      changes: [{ cardKey, inventoryItemId, delta: item.delta, changeFromQuantity: qtyBefore }],
+    });
+    const after = await loadItemStates(admin, saleId);
+    if (after.success === true && !after.items.some((i) => i.status === "applying")) {
+      await admin.from("ytg_deck_sales")
+        .update({ status: deriveSaleStatus(after.items) })
+        .eq("id", saleId).in("status", ["applied", "partial", "failed", "applying"]);
+    }
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : "retry failed" };
+  }
+  return loadSaleView(admin, saleId);
+}
+
+export async function undoSale(saleId: string): Promise<SaleResult> {
+  if (!(await hasPermission(PERM))) return { success: false, error: "forbidden" };
+  const admin = getSupabaseAdmin();
+  if (inventoryWritesEnabled() === false) {
+    return { success: false, error: "inventory writes are not enabled — undo is unavailable" };
+  }
+  // Double-click/two-tab safe claim; a sale stranded in 'undoing' (crash)
+  // may re-enter — payload-derived keys make the re-run dedupe-safe.
+  const { data: claimed, error: claimErr } = await admin
+    .from("ytg_deck_sales").update({ status: "undoing" })
+    .eq("id", saleId).in("status", ["applied", "partial"]).select("id");
+  if (claimErr) return { success: false, error: claimErr.message };
+  if (!claimed || claimed.length === 0) {
+    const { data: cur } = await admin
+      .from("ytg_deck_sales").select("status").eq("id", saleId).maybeSingle();
+    if (!cur || cur.status !== "undoing") {
+      return { success: false, error: "sale is not undoable (only applied/partial sales can be undone, once)" };
+    }
+  }
+  try {
+    const token = await getShopifyAccessToken();
+    const locationId = await getSingleLocationId(token);
+    const loaded = await loadItemStates(admin, saleId);
+    if (loaded.success === false) return { success: false, error: loaded.error };
+    const plan = planUndo(saleId, loaded.items);
+    for (const batch of plan.batches) {
+      let changes = batch.changes.slice();
+      for (let pass = 0; pass < 3 && changes.length > 0; pass++) {
+        const invChanges: InventoryChange[] = changes.map((c) => ({
+          inventoryItemId: c.inventoryItemId, delta: c.delta, changeFromQuantity: c.changeFromQuantity,
+        }));
+        const outcome = await adjustAvailable(token, {
+          idempotencyKey: idempotencyKey(batch.baseKey, invChanges), locationId, changes: invChanges,
+        });
+        if (outcome.userErrors.length === 0) {
+          await setItems(admin, saleId, changes.map((c) => c.cardKey), { status: "undone", error: null });
+          changes = [];
+          break;
+        }
+        const failedIdx = new Set<number>();
+        for (const e of outcome.userErrors) {
+          const idx = changeIndexOf(e);
+          if (idx === null || idx >= changes.length) continue;
+          failedIdx.add(idx);
+          await setItems(admin, saleId, [changes[idx].cardKey], {
+            status: "undo_conflict",
+            error: isStaleCasError(e) ? UNDO_CONFLICT_MSG : `${e.code ?? "SHOPIFY_ERROR"}: ${e.message}`,
+          });
+        }
+        if (failedIdx.size === 0) {
+          // Whole-mutation failure (idempotency signal etc.) — leave items
+          // 'applied'; deriveUndoStatus lands on undo_partial below.
+          break;
+        }
+        changes = changes.filter((_, idx) => !failedIdx.has(idx));
+      }
+    }
+    const after = await loadItemStates(admin, saleId);
+    if (after.success === false) return { success: false, error: after.error };
+    await admin.from("ytg_deck_sales").update({
+      status: deriveUndoStatus(after.items),
+      undone_by: await actingUserId(),
+      undone_at: new Date().toISOString(),
+    }).eq("id", saleId).eq("status", "undoing");
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : "undo failed" };
+  }
+  return loadSaleView(admin, saleId);
+}

--- a/lib/pricing/matching.ts
+++ b/lib/pricing/matching.ts
@@ -30,6 +30,14 @@ const ART_VARIANT_PATTERNS = [
 ];
 
 /**
+ * Canonical card_key used across card_price_mappings, card_prices, and the
+ * WS-4 sale ledger. Single source of truth — do not string-build elsewhere.
+ */
+export function buildCardKey(name: string, set: string, imgFile: string): string {
+  return `${name}|${set}|${imgFile}`;
+}
+
+/**
  * Load card data from the build-time generated module.
  */
 export async function loadCardData(): Promise<CardRow[]> {
@@ -44,7 +52,7 @@ export async function loadCardData(): Promise<CardRow[]> {
     // (strength) into `rarity`. Unread today but kept for behavior parity.
     rarity: c.strength,
     special_ability: c.specialAbility,
-    card_key: `${c.name}|${c.set}|${c.imgFile}`,
+    card_key: buildCardKey(c.name, c.set, c.imgFile),
   }));
 }
 

--- a/lib/shopify/inventory.test.ts
+++ b/lib/shopify/inventory.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { shopifyGraphQLMock } = vi.hoisted(() => ({ shopifyGraphQLMock: vi.fn() }));
+vi.mock('./admin-write', () => ({ shopifyGraphQL: shopifyGraphQLMock }));
+
+import {
+  inventoryWritesEnabled, payloadFingerprint, idempotencyKey,
+  getSingleLocationId, getInventoryItemIds, adjustAvailable, activateItem,
+  isNotStockedError, isStaleCasError, changeIndexOf,
+  type InventoryChange,
+} from './inventory';
+
+const CH = (item: string, delta: number, from: number | null): InventoryChange =>
+  ({ inventoryItemId: item, delta, changeFromQuantity: from });
+
+beforeEach(() => {
+  shopifyGraphQLMock.mockReset();
+  vi.stubEnv('YTG_INVENTORY_WRITES', '1');
+  vi.stubEnv('SHOPIFY_WRITE_MOCK', '');
+});
+afterEach(() => vi.unstubAllEnvs());
+
+describe('write gating', () => {
+  it('is disabled when YTG_INVENTORY_WRITES is not "1"', () => {
+    vi.stubEnv('YTG_INVENTORY_WRITES', '');
+    expect(inventoryWritesEnabled()).toBe(false);
+  });
+  it('is disabled when SHOPIFY_WRITE_MOCK=1 even with writes on', () => {
+    vi.stubEnv('SHOPIFY_WRITE_MOCK', '1');
+    expect(inventoryWritesEnabled()).toBe(false);
+  });
+  it('mutations short-circuit to fabricated mock success without calling Shopify', async () => {
+    vi.stubEnv('YTG_INVENTORY_WRITES', '');
+    const out = await adjustAvailable('tok', {
+      idempotencyKey: 'sale:S:batch:0:abc', locationId: 'gid://shopify/Location/1',
+      changes: [CH('gid://shopify/InventoryItem/1', -3, 10)],
+    });
+    expect(out).toEqual({ mock: true, userErrors: [] });
+    const act = await activateItem('tok', {
+      idempotencyKey: 'sale:S:activate:1', inventoryItemId: 'gid://shopify/InventoryItem/1',
+      locationId: 'gid://shopify/Location/1',
+    });
+    expect(act).toEqual({ mock: true, userErrors: [] });
+    expect(shopifyGraphQLMock).not.toHaveBeenCalled();
+  });
+  it('reads are never gated', async () => {
+    vi.stubEnv('YTG_INVENTORY_WRITES', '');
+    shopifyGraphQLMock.mockResolvedValue({
+      locations: { nodes: [{ id: 'gid://shopify/Location/1', name: 'HQ', isActive: true }] },
+    });
+    expect(await getSingleLocationId('tok')).toBe('gid://shopify/Location/1');
+    expect(shopifyGraphQLMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('idempotency keys', () => {
+  it('fingerprint is order-independent and payload-sensitive', () => {
+    const a = [CH('i1', -2, 5), CH('i2', -1, 3)];
+    const b = [CH('i2', -1, 3), CH('i1', -2, 5)];
+    expect(payloadFingerprint(a)).toBe(payloadFingerprint(b));
+    expect(payloadFingerprint([CH('i1', -2, 5)])).not.toBe(payloadFingerprint(a));
+    expect(payloadFingerprint([CH('i1', -2, 6)])).not.toBe(payloadFingerprint([CH('i1', -2, 5)]));
+  });
+  it('key = spec base + 8-hex fingerprint', () => {
+    const key = idempotencyKey('sale:S1:batch:0', [CH('i1', -2, 5)]);
+    expect(key).toMatch(/^sale:S1:batch:0:[0-9a-f]{8}$/);
+    expect(idempotencyKey('sale:S1:batch:0', [CH('i1', -2, 5)])).toBe(key); // deterministic
+  });
+});
+
+describe('getSingleLocationId', () => {
+  it('returns the single active location', async () => {
+    shopifyGraphQLMock.mockResolvedValue({
+      locations: { nodes: [
+        { id: 'gid://shopify/Location/9', name: 'Old', isActive: false },
+        { id: 'gid://shopify/Location/1', name: 'HQ', isActive: true },
+      ] },
+    });
+    expect(await getSingleLocationId('tok')).toBe('gid://shopify/Location/1');
+    expect(shopifyGraphQLMock.mock.calls[0][1]).toContain('locations(first: 5)');
+  });
+  it('throws loudly on zero or multiple active locations', async () => {
+    shopifyGraphQLMock.mockResolvedValue({ locations: { nodes: [
+      { id: 'a', name: 'A', isActive: true }, { id: 'b', name: 'B', isActive: true },
+    ] } });
+    await expect(getSingleLocationId('tok')).rejects.toThrow(/exactly one active/);
+    shopifyGraphQLMock.mockResolvedValue({ locations: { nodes: [] } });
+    await expect(getSingleLocationId('tok')).rejects.toThrow(/exactly one active/);
+  });
+});
+
+describe('getInventoryItemIds', () => {
+  it('maps variant gid → inventoryItem gid, skipping null nodes', async () => {
+    shopifyGraphQLMock.mockResolvedValue({ nodes: [
+      { id: 'gid://shopify/ProductVariant/1', inventoryItem: { id: 'gid://shopify/InventoryItem/11' } },
+      null,
+      { id: 'gid://shopify/ProductVariant/2', inventoryItem: null },
+    ] });
+    const map = await getInventoryItemIds('tok', ['gid://shopify/ProductVariant/1', 'gid://shopify/ProductVariant/2', 'gid://shopify/ProductVariant/3']);
+    expect(map.get('gid://shopify/ProductVariant/1')).toBe('gid://shopify/InventoryItem/11');
+    expect(map.size).toBe(1);
+  });
+  it('chunks at 250 ids per query', async () => {
+    shopifyGraphQLMock.mockResolvedValue({ nodes: [] });
+    await getInventoryItemIds('tok', Array.from({ length: 501 }, (_, i) => `gid://shopify/ProductVariant/${i}`));
+    expect(shopifyGraphQLMock).toHaveBeenCalledTimes(3);
+    expect((shopifyGraphQLMock.mock.calls[0][2] as { ids: string[] }).ids).toHaveLength(250);
+    expect((shopifyGraphQLMock.mock.calls[2][2] as { ids: string[] }).ids).toHaveLength(1);
+  });
+});
+
+describe('adjustAvailable mutation construction', () => {
+  it('carries the @idempotent directive after the field args, CAS numbers, and explicit null opt-outs', async () => {
+    shopifyGraphQLMock.mockResolvedValue({
+      inventoryAdjustQuantities: { inventoryAdjustmentGroup: { reason: 'correction' }, userErrors: [] },
+    });
+    const out = await adjustAvailable('tok', {
+      idempotencyKey: 'sale:S1:batch:0:deadbeef',
+      locationId: 'gid://shopify/Location/1',
+      changes: [CH('gid://shopify/InventoryItem/11', -3, 10), CH('gid://shopify/InventoryItem/12', -1, null)],
+    });
+    expect(out.mock).toBe(false);
+    expect(out.userErrors).toEqual([]);
+    const [, query, vars] = shopifyGraphQLMock.mock.calls[0];
+    expect(query).toContain('inventoryAdjustQuantities(input: $input) @idempotent(key: $key)');
+    expect(query).toContain('userErrors { field message code }');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const input = (vars as any).input;
+    expect((vars as { key: string }).key).toBe('sale:S1:batch:0:deadbeef');
+    expect(input.reason).toBe('correction');
+    expect(input.name).toBe('available');
+    expect(input.changes[0]).toEqual({
+      inventoryItemId: 'gid://shopify/InventoryItem/11',
+      locationId: 'gid://shopify/Location/1', delta: -3, changeFromQuantity: 10,
+    });
+    // 2026-04: changeFromQuantity must be PRESENT even when opting out (explicit null)
+    expect(Object.prototype.hasOwnProperty.call(input.changes[1], 'changeFromQuantity')).toBe(true);
+    expect(input.changes[1].changeFromQuantity).toBeNull();
+  });
+  it('returns userErrors verbatim', async () => {
+    shopifyGraphQLMock.mockResolvedValue({
+      inventoryAdjustQuantities: { inventoryAdjustmentGroup: null, userErrors: [
+        { field: ['input', 'changes', '0', 'changeFromQuantity'], message: 'stale', code: 'CHANGE_FROM_QUANTITY_STALE' },
+      ] },
+    });
+    const out = await adjustAvailable('tok', {
+      idempotencyKey: 'k', locationId: 'l', changes: [CH('i', -1, 4)],
+    });
+    expect(out.userErrors[0].code).toBe('CHANGE_FROM_QUANTITY_STALE');
+  });
+});
+
+describe('activateItem mutation construction', () => {
+  it('activates with available: 0 and the @idempotent directive', async () => {
+    shopifyGraphQLMock.mockResolvedValue({
+      inventoryActivate: { inventoryLevel: { id: 'gid://shopify/InventoryLevel/1' }, userErrors: [] },
+    });
+    const out = await activateItem('tok', {
+      idempotencyKey: 'sale:S1:activate:gid://shopify/InventoryItem/11',
+      inventoryItemId: 'gid://shopify/InventoryItem/11', locationId: 'gid://shopify/Location/1',
+    });
+    expect(out.mock).toBe(false);
+    const [, query, vars] = shopifyGraphQLMock.mock.calls[0];
+    expect(query).toContain('inventoryActivate(inventoryItemId: $inventoryItemId, locationId: $locationId, available: $available) @idempotent(key: $key)');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((vars as any).available).toBe(0);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((vars as any).key).toBe('sale:S1:activate:gid://shopify/InventoryItem/11');
+  });
+});
+
+describe('error classifiers', () => {
+  it('isNotStockedError by code and by message', () => {
+    expect(isNotStockedError({ field: null, message: 'x', code: 'ITEM_NOT_STOCKED_AT_LOCATION' })).toBe(true);
+    expect(isNotStockedError({ field: null, message: 'The inventory item is not stocked at the location', code: null })).toBe(true);
+    expect(isNotStockedError({ field: null, message: 'other', code: 'INVALID_REASON' })).toBe(false);
+  });
+  it('isStaleCasError by code and by message', () => {
+    expect(isStaleCasError({ field: null, message: 'x', code: 'CHANGE_FROM_QUANTITY_STALE' })).toBe(true);
+    expect(isStaleCasError({ field: null, message: 'The changeFromQuantity argument no longer matches', code: null })).toBe(true);
+    expect(isStaleCasError({ field: null, message: 'other', code: null })).toBe(false);
+  });
+  it('changeIndexOf parses the numeric path segment', () => {
+    expect(changeIndexOf({ field: ['input', 'changes', '3', 'delta'], message: '', code: null })).toBe(3);
+    expect(changeIndexOf({ field: ['input', 'reason'], message: '', code: null })).toBeNull();
+    expect(changeIndexOf({ field: null, message: '', code: null })).toBeNull();
+  });
+});

--- a/lib/shopify/inventory.ts
+++ b/lib/shopify/inventory.ts
@@ -1,0 +1,200 @@
+/**
+ * Shopify inventory client for WS-4 record-sale (GraphQL Admin 2026-07 via
+ * shopifyGraphQL — THROTTLED retries inherited).
+ *
+ * 2026-04 breaking changes (overview §Global constraints) are load-bearing:
+ * - every inventory mutation carries @idempotent(key:), placed after the
+ *   field arguments, before the selection set (verified on shopify.dev);
+ * - every InventoryChangeInput carries changeFromQuantity — the sale path
+ *   always passes the live pre-quantity as a compare-and-swap anchor
+ *   (explicit null opt-out exists in the type; never used by sales).
+ *
+ * Write gating (spec §Record sale prerequisite): mutations short-circuit to
+ * fabricated success tagged { mock: true } unless YTG_INVENTORY_WRITES=1 AND
+ * SHOPIFY_WRITE_MOCK≠1. Reads are never gated.
+ */
+import { shopifyGraphQL } from './admin-write';
+
+export interface InventoryUserError {
+  field: string[] | null;
+  message: string;
+  code: string | null;
+}
+
+export interface InventoryChange {
+  inventoryItemId: string;           // gid://shopify/InventoryItem/…
+  delta: number;
+  changeFromQuantity: number | null; // null = CAS opt-out (sale path never opts out)
+}
+
+export interface AdjustOutcome {
+  mock: boolean;
+  userErrors: InventoryUserError[];
+}
+
+export function inventoryWritesEnabled(): boolean {
+  return process.env.YTG_INVENTORY_WRITES === '1' && process.env.SHOPIFY_WRITE_MOCK !== '1';
+}
+
+/** FNV-1a 32-bit over the canonicalized change list — order-independent. */
+export function payloadFingerprint(changes: InventoryChange[]): string {
+  const canon = changes
+    .map((c) => `${c.inventoryItemId}:${c.delta}:${c.changeFromQuantity}`)
+    .sort()
+    .join('|');
+  let h = 0x811c9dc5;
+  for (let i = 0; i < canon.length; i++) {
+    h ^= canon.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(16).padStart(8, '0');
+}
+
+/**
+ * Spec base key (`sale:<id>:batch:<n>` / `undo:<id>:batch:<n>`) + payload
+ * fingerprint. Identical payload ⇒ identical key, so crash-resume and
+ * two-tab races dedupe server-side (the spec's intent); a pruned/changed
+ * payload ⇒ new key, which Shopify requires (reusing a key with different
+ * parameters is IDEMPOTENCY_KEY_PARAMETER_MISMATCH).
+ */
+export function idempotencyKey(base: string, changes: InventoryChange[]): string {
+  return `${base}:${payloadFingerprint(changes)}`;
+}
+
+const LOCATIONS_QUERY = `
+query ytgLocations {
+  locations(first: 5) {
+    nodes { id name isActive }
+  }
+}
+`;
+
+/** Single-location assumption is asserted, never assumed (spec §API contract). */
+export async function getSingleLocationId(token: string): Promise<string> {
+  const data = await shopifyGraphQL<{
+    locations: { nodes: { id: string; name: string; isActive: boolean }[] };
+  }>(token, LOCATIONS_QUERY, {});
+  const active = (data.locations?.nodes ?? []).filter((n) => n.isActive);
+  if (active.length !== 1) {
+    throw new Error(
+      `expected exactly one active Shopify location, found ${active.length}`
+      + ` (${active.map((n) => n.name).join(', ') || 'none'}) — refusing to guess`,
+    );
+  }
+  return active[0].id;
+}
+
+const VARIANT_ITEMS_QUERY = `
+query ytgVariantItems($ids: [ID!]!) {
+  nodes(ids: $ids) {
+    ... on ProductVariant { id inventoryItem { id } }
+  }
+}
+`;
+
+/** variant GID → inventoryItem GID, chunked ≤250 ids/query. Missing/null nodes are simply absent. */
+export async function getInventoryItemIds(
+  token: string,
+  variantGids: string[],
+): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  for (let i = 0; i < variantGids.length; i += 250) {
+    const chunk = variantGids.slice(i, i + 250);
+    const data = await shopifyGraphQL<{
+      nodes: ({ id: string; inventoryItem: { id: string } | null } | null)[];
+    }>(token, VARIANT_ITEMS_QUERY, { ids: chunk });
+    for (const node of data.nodes ?? []) {
+      if (node && node.inventoryItem) out.set(node.id, node.inventoryItem.id);
+    }
+  }
+  return out;
+}
+
+// Pinned mutation strings — directive placement verified against shopify.dev
+// (2026-07): after the field arguments, before the selection set.
+export const ADJUST_MUTATION = `
+mutation ytgInventoryAdjust($input: InventoryAdjustQuantitiesInput!, $key: String!) {
+  inventoryAdjustQuantities(input: $input) @idempotent(key: $key) {
+    inventoryAdjustmentGroup { reason }
+    userErrors { field message code }
+  }
+}
+`;
+
+export const ACTIVATE_MUTATION = `
+mutation ytgInventoryActivate($inventoryItemId: ID!, $locationId: ID!, $available: Int, $key: String!) {
+  inventoryActivate(inventoryItemId: $inventoryItemId, locationId: $locationId, available: $available) @idempotent(key: $key) {
+    inventoryLevel { id }
+    userErrors { field message }
+  }
+}
+`;
+
+export async function adjustAvailable(
+  token: string,
+  args: { idempotencyKey: string; locationId: string; changes: InventoryChange[] },
+): Promise<AdjustOutcome> {
+  if (!inventoryWritesEnabled()) return { mock: true, userErrors: [] };
+  const data = await shopifyGraphQL<{
+    inventoryAdjustQuantities: {
+      inventoryAdjustmentGroup: { reason: string } | null;
+      userErrors: InventoryUserError[];
+    };
+  }>(token, ADJUST_MUTATION, {
+    key: args.idempotencyKey,
+    input: {
+      reason: 'correction',
+      name: 'available',
+      changes: args.changes.map((c) => ({
+        inventoryItemId: c.inventoryItemId,
+        locationId: args.locationId,
+        delta: c.delta,
+        changeFromQuantity: c.changeFromQuantity,
+      })),
+    },
+  });
+  return { mock: false, userErrors: data.inventoryAdjustQuantities?.userErrors ?? [] };
+}
+
+/** ITEM_NOT_STOCKED_AT_LOCATION remedy — activate tracked-at-zero (spec §API contract). */
+export async function activateItem(
+  token: string,
+  args: { idempotencyKey: string; inventoryItemId: string; locationId: string },
+): Promise<AdjustOutcome> {
+  if (!inventoryWritesEnabled()) return { mock: true, userErrors: [] };
+  const data = await shopifyGraphQL<{
+    inventoryActivate: {
+      inventoryLevel: { id: string } | null;
+      userErrors: { field: string[] | null; message: string }[];
+    };
+  }>(token, ACTIVATE_MUTATION, {
+    key: args.idempotencyKey,
+    inventoryItemId: args.inventoryItemId,
+    locationId: args.locationId,
+    available: 0,
+  });
+  return {
+    mock: false,
+    userErrors: (data.inventoryActivate?.userErrors ?? []).map((e) => ({
+      field: e.field, message: e.message, code: null,
+    })),
+  };
+}
+
+export function isNotStockedError(e: InventoryUserError): boolean {
+  return e.code === 'ITEM_NOT_STOCKED_AT_LOCATION'
+    || /not stocked at the location/i.test(e.message);
+}
+
+export function isStaleCasError(e: InventoryUserError): boolean {
+  return e.code === 'CHANGE_FROM_QUANTITY_STALE'
+    || /changeFromQuantity/i.test(e.message);
+}
+
+/** userError field path → change index (['input','changes','3',…] → 3), else null. */
+export function changeIndexOf(e: InventoryUserError): number | null {
+  for (const part of e.field ?? []) {
+    if (/^\d+$/.test(part)) return Number(part);
+  }
+  return null;
+}

--- a/lib/ytg/__tests__/saleApply.test.ts
+++ b/lib/ytg/__tests__/saleApply.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import {
+  planApply, planResume, planUndo, MAX_CHANGES_PER_CALL,
+  type SaleItemState, type ItemStatus,
+} from "../saleStateMachine";
+import { idempotencyKey } from "../../shopify/inventory";
+
+const it_ = (cardKey: string, status: ItemStatus, over: Partial<SaleItemState> = {}): SaleItemState => ({
+  cardKey, status, delta: -2, qtyBefore: 10, qtyAfter: 8,
+  inventoryItemId: `gid://shopify/InventoryItem/${cardKey}`, ...over,
+});
+
+describe("planApply", () => {
+  it("orders by card_key, includes only pending items, baseKey pinned to spec format", () => {
+    const items = [
+      it_("b|S|b.jpg", "pending"),
+      it_("a|S|a.jpg", "pending"),
+      it_("c|S|c.jpg", "skipped_unmapped"),
+      it_("d|S|d.jpg", "applied"),
+    ];
+    const plan = planApply("S1", items);
+    expect(plan.unresolvable).toEqual([]);
+    expect(plan.batches).toHaveLength(1);
+    expect(plan.batches[0].n).toBe(0);
+    expect(plan.batches[0].baseKey).toBe("sale:S1:batch:0");
+    expect(plan.batches[0].changes.map((c) => c.cardKey)).toEqual(["a|S|a.jpg", "b|S|b.jpg"]);
+    expect(plan.batches[0].changes[0]).toEqual({
+      cardKey: "a|S|a.jpg", inventoryItemId: "gid://shopify/InventoryItem/a|S|a.jpg",
+      delta: -2, changeFromQuantity: 10,
+    });
+  });
+  it("chunks at 250 with stable ordinals", () => {
+    const items = Array.from({ length: 501 }, (_, i) =>
+      it_(`k${String(i).padStart(4, "0")}|S|x.jpg`, "pending"));
+    const plan = planApply("S1", items);
+    expect(plan.batches.map((b) => b.n)).toEqual([0, 1, 2]);
+    expect(plan.batches[0].changes).toHaveLength(MAX_CHANGES_PER_CALL);
+    expect(plan.batches[2].changes).toHaveLength(1);
+  });
+  it("splits duplicate inventoryItemIds across batches (one change per item per call; sequential CAS anchors)", () => {
+    const shared = "gid://shopify/InventoryItem/promo";
+    const items = [
+      it_("a|S|a.jpg", "pending", { inventoryItemId: shared, qtyBefore: 10, qtyAfter: 8 }),
+      it_("b|S|b.jpg", "pending", { inventoryItemId: shared, qtyBefore: 8, qtyAfter: 6 }),
+    ];
+    const plan = planApply("S1", items);
+    expect(plan.batches).toHaveLength(2);
+    expect(plan.batches[0].changes.map((c) => c.cardKey)).toEqual(["a|S|a.jpg"]);
+    expect(plan.batches[1].changes.map((c) => c.cardKey)).toEqual(["b|S|b.jpg"]);
+    expect(plan.batches[1].n).toBe(1);
+  });
+  it("pending items missing ids/anchors are unresolvable, not silently dropped", () => {
+    const plan = planApply("S1", [
+      it_("a|S|a.jpg", "pending", { inventoryItemId: null }),
+      it_("b|S|b.jpg", "pending", { qtyBefore: null }),
+      it_("c|S|c.jpg", "pending"),
+    ]);
+    expect(plan.unresolvable.sort()).toEqual(["a|S|a.jpg", "b|S|b.jpg"]);
+    expect(plan.batches[0].changes.map((c) => c.cardKey)).toEqual(["c|S|c.jpg"]);
+  });
+});
+
+describe("planResume — the three crash scenarios (spec pt. 4)", () => {
+  it("ack-then-crash: live == qty_after → marked applied, NO re-adjustment planned", () => {
+    const items = [it_("a|S|a.jpg", "applying"), it_("b|S|b.jpg", "applying")];
+    const live = new Map([["a|S|a.jpg", 8], ["b|S|b.jpg", 8]]);
+    const plan = planResume("S1", items, live);
+    expect(plan.markApplied.sort()).toEqual(["a|S|a.jpg", "b|S|b.jpg"]);
+    expect(plan.conflicts).toEqual([]);
+    expect(plan.reapply).toEqual([]);
+  });
+  it("crash-before-call: live == qty_before → reapply with the IDENTICAL payload, hence the SAME idempotency key", () => {
+    const items = [it_("a|S|a.jpg", "applying"), it_("b|S|b.jpg", "applying")];
+    const original = planApply("S1", items.map((i) => ({ ...i, status: "pending" as ItemStatus })));
+    const live = new Map([["a|S|a.jpg", 10], ["b|S|b.jpg", 10]]);
+    const plan = planResume("S1", items, live);
+    expect(plan.markApplied).toEqual([]);
+    expect(plan.reapply).toHaveLength(1);
+    expect(plan.reapply[0].n).toBe(0);
+    // Shopify dedupes because base + fingerprint reproduce byte-identically:
+    expect(idempotencyKey(plan.reapply[0].baseKey, plan.reapply[0].changes))
+      .toBe(idempotencyKey(original.batches[0].baseKey, original.batches[0].changes));
+  });
+  it("third-party moved stock: live matches neither anchor → conflict, human resolves", () => {
+    const plan = planResume("S1", [it_("a|S|a.jpg", "applying")], new Map([["a|S|a.jpg", 9]]));
+    expect(plan.conflicts).toEqual(["a|S|a.jpg"]);
+    expect(plan.reapply).toEqual([]);
+  });
+  it("mixed batch: applied+reapply+conflict+missing-live all classified; reapply subset gets a NEW key (payload differs)", () => {
+    const items = [
+      it_("a|S|a.jpg", "applying"), // landed
+      it_("b|S|b.jpg", "applying"), // not landed
+      it_("c|S|c.jpg", "applying"), // moved
+      it_("d|S|d.jpg", "applying"), // vanished from live read
+      it_("e|S|e.jpg", "pending"),  // untouched by resume
+    ];
+    const live = new Map([["a|S|a.jpg", 8], ["b|S|b.jpg", 10], ["c|S|c.jpg", 3]]);
+    const plan = planResume("S1", items, live);
+    expect(plan.markApplied).toEqual(["a|S|a.jpg"]);
+    expect(plan.conflicts.sort()).toEqual(["c|S|c.jpg", "d|S|d.jpg"]);
+    expect(plan.reapply[0].changes.map((c) => c.cardKey)).toEqual(["b|S|b.jpg"]);
+    const original = planApply("S1", items.map((i) => ({ ...i, status: "pending" as ItemStatus })));
+    expect(idempotencyKey(plan.reapply[0].baseKey, plan.reapply[0].changes))
+      .not.toBe(idempotencyKey(original.batches[0].baseKey, original.batches[0].changes));
+  });
+});
+
+describe("planUndo (spec pt. 7)", () => {
+  it("reverses ONLY applied items: +|delta| with changeFromQuantity = qty_after, undo base key", () => {
+    const items = [
+      it_("a|S|a.jpg", "applied"),
+      it_("b|S|b.jpg", "error"),
+      it_("c|S|c.jpg", "skipped_untracked"),
+      it_("d|S|d.jpg", "conflict"),
+    ];
+    const plan = planUndo("S9", items);
+    expect(plan.batches).toHaveLength(1);
+    expect(plan.batches[0].baseKey).toBe("undo:S9:batch:0");
+    expect(plan.batches[0].changes).toEqual([{
+      cardKey: "a|S|a.jpg", inventoryItemId: "gid://shopify/InventoryItem/a|S|a.jpg",
+      delta: 2, changeFromQuantity: 8,
+    }]);
+  });
+  it("ordinals stay stable when earlier items are already undone (crash-resume of undo)", () => {
+    const mk = (i: number, status: ItemStatus) =>
+      it_(`k${String(i).padStart(4, "0")}|S|x.jpg`, status);
+    const items = Array.from({ length: 251 }, (_, i) => mk(i, i < 250 ? "undone" : "applied"));
+    const plan = planUndo("S9", items);
+    expect(plan.batches).toHaveLength(1);
+    expect(plan.batches[0].n).toBe(1); // batch 0 fully undone → skipped, ordinal preserved
+    expect(plan.batches[0].changes).toHaveLength(1);
+  });
+});

--- a/lib/ytg/__tests__/saleStateMachine.test.ts
+++ b/lib/ytg/__tests__/saleStateMachine.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyPreviewRow, adjustableItems, deriveSaleStatus, deriveUndoStatus,
+  resumeOracle, type ItemStatus,
+} from "../saleStateMachine";
+
+const item = (status: ItemStatus) => ({ status });
+
+describe("classifyPreviewRow — every branch", () => {
+  it("unmapped beats everything", () => {
+    expect(classifyPreviewRow({ mapped: false, tracked: false, qtyAfter: null })).toBe("unmapped");
+    expect(classifyPreviewRow({ mapped: false, tracked: true, qtyAfter: -1 })).toBe("unmapped");
+  });
+  it("untracked when mapped but inventory_management ≠ shopify", () => {
+    expect(classifyPreviewRow({ mapped: true, tracked: false, qtyAfter: null })).toBe("untracked");
+  });
+  it("would_go_negative when qtyAfter < 0", () => {
+    expect(classifyPreviewRow({ mapped: true, tracked: true, qtyAfter: -1 })).toBe("would_go_negative");
+  });
+  it("ok at exactly zero and above", () => {
+    expect(classifyPreviewRow({ mapped: true, tracked: true, qtyAfter: 0 })).toBe("ok");
+    expect(classifyPreviewRow({ mapped: true, tracked: true, qtyAfter: 7 })).toBe("ok");
+  });
+  it("ok when qtyAfter unknown (null) but mapped+tracked", () => {
+    expect(classifyPreviewRow({ mapped: true, tracked: true, qtyAfter: null })).toBe("ok");
+  });
+});
+
+describe("adjustableItems", () => {
+  it("excludes exactly the snapshot skips", () => {
+    const all: ItemStatus[] = ["pending","applying","applied","skipped_unmapped","skipped_untracked","error","conflict","undone","undo_conflict"];
+    const kept = adjustableItems(all.map(item)).map((i) => i.status);
+    expect(kept).toEqual(["pending","applying","applied","error","conflict","undone","undo_conflict"]);
+  });
+});
+
+describe("deriveSaleStatus — every branch (spec pt. 5)", () => {
+  it("all adjustable applied → applied (skips don't count against it)", () => {
+    expect(deriveSaleStatus([item("applied"), item("applied"), item("skipped_unmapped"), item("skipped_untracked")])).toBe("applied");
+  });
+  it("some applied → partial", () => {
+    expect(deriveSaleStatus([item("applied"), item("error")])).toBe("partial");
+    expect(deriveSaleStatus([item("applied"), item("conflict")])).toBe("partial");
+    expect(deriveSaleStatus([item("applied"), item("pending")])).toBe("partial");
+  });
+  it("none applied → failed (undo offered only on applied/partial, so failed strands nothing)", () => {
+    expect(deriveSaleStatus([item("error"), item("conflict")])).toBe("failed");
+    expect(deriveSaleStatus([item("skipped_unmapped")])).toBe("failed");
+    expect(deriveSaleStatus([])).toBe("failed");
+  });
+});
+
+describe("deriveUndoStatus — every branch (spec pt. 7)", () => {
+  it("all reversed → undone", () => {
+    expect(deriveUndoStatus([item("undone"), item("undone"), item("skipped_untracked")])).toBe("undone");
+  });
+  it("any undo_conflict → undo_partial", () => {
+    expect(deriveUndoStatus([item("undone"), item("undo_conflict")])).toBe("undo_partial");
+  });
+  it("any still-applied leftover → undo_partial", () => {
+    expect(deriveUndoStatus([item("undone"), item("applied")])).toBe("undo_partial");
+  });
+});
+
+describe("resumeOracle — every branch (spec pt. 4)", () => {
+  const anchors = { qtyBefore: 10, qtyAfter: 7 };
+  it("live == qty_after → applied (ack-then-crash: never re-adjust)", () => {
+    expect(resumeOracle(anchors, 7)).toBe("applied");
+  });
+  it("live == qty_before → reapply (crash before the call landed)", () => {
+    expect(resumeOracle(anchors, 10)).toBe("reapply");
+  });
+  it("anything else → conflict (third party moved stock)", () => {
+    expect(resumeOracle(anchors, 8)).toBe("conflict");
+    expect(resumeOracle(anchors, 0)).toBe("conflict");
+  });
+  it("null anchors can never claim applied/reapply", () => {
+    expect(resumeOracle({ qtyBefore: null, qtyAfter: null }, 5)).toBe("conflict");
+  });
+  it("qty_after checked FIRST (delta is never 0, but ordering is pinned)", () => {
+    expect(resumeOracle({ qtyBefore: 7, qtyAfter: 7 }, 7)).toBe("applied");
+  });
+});

--- a/lib/ytg/saleStateMachine.ts
+++ b/lib/ytg/saleStateMachine.ts
@@ -77,3 +77,143 @@ export function resumeOracle(
   if (item.qtyBefore !== null && liveQty === item.qtyBefore) return "reapply";
   return "conflict";
 }
+
+// ─── Apply/undo planner ─────────────────────────────────────────────────────
+// Batch ordinals derive from the IMMUTABLE full adjustable set (sorted by
+// card_key, first-fit chunked, duplicate inventoryItemIds pushed to later
+// batches — one change per item per call, and sequential CAS anchors need
+// ordering). A resume recomputes identical ordinals from DB state alone, so
+// an unchanged payload re-fingerprints to the SAME idempotency key.
+
+export const MAX_CHANGES_PER_CALL = 250;
+
+export interface SaleItemState {
+  cardKey: string;
+  status: ItemStatus;
+  delta: number;               // negative on a sale
+  qtyBefore: number | null;    // CAS anchors; also the resume oracle
+  qtyAfter: number | null;
+  inventoryItemId: string | null;
+}
+
+export interface PlannedChange {
+  cardKey: string;
+  inventoryItemId: string;
+  delta: number;
+  changeFromQuantity: number;
+}
+
+export interface PlannedBatch {
+  n: number;        // stable ordinal over the full adjustable set
+  baseKey: string;  // spec format; executor appends the payload fingerprint
+  changes: PlannedChange[];
+}
+
+function batchLayout(items: SaleItemState[]): SaleItemState[][] {
+  const sorted = adjustableItems(items).slice().sort((a, b) =>
+    a.cardKey < b.cardKey ? -1 : a.cardKey > b.cardKey ? 1 : 0);
+  const batches: SaleItemState[][] = [];
+  for (const item of sorted) {
+    let placed = false;
+    for (const b of batches) {
+      const dup = item.inventoryItemId !== null
+        && b.some((x) => x.inventoryItemId === item.inventoryItemId);
+      if (b.length < MAX_CHANGES_PER_CALL && !dup) {
+        b.push(item);
+        placed = true;
+        break;
+      }
+    }
+    if (!placed) batches.push([item]);
+  }
+  return batches;
+}
+
+export interface ApplyPlan {
+  batches: PlannedBatch[];
+  unresolvable: string[]; // pending card_keys missing inventoryItemId/anchors
+}
+
+export function planApply(saleId: string, items: SaleItemState[]): ApplyPlan {
+  const batches: PlannedBatch[] = [];
+  const unresolvable: string[] = [];
+  batchLayout(items).forEach((members, n) => {
+    const changes: PlannedChange[] = [];
+    for (const m of members) {
+      if (m.status !== "pending") continue;
+      if (m.inventoryItemId === null || m.qtyBefore === null || m.qtyAfter === null) {
+        unresolvable.push(m.cardKey);
+        continue;
+      }
+      changes.push({
+        cardKey: m.cardKey, inventoryItemId: m.inventoryItemId,
+        delta: m.delta, changeFromQuantity: m.qtyBefore,
+      });
+    }
+    if (changes.length > 0) batches.push({ n, baseKey: `sale:${saleId}:batch:${n}`, changes });
+  });
+  return { batches, unresolvable };
+}
+
+export interface ResumePlan {
+  markApplied: string[];   // landed — flip to applied, never re-adjust
+  conflicts: string[];     // live matches neither anchor (or item unreadable)
+  reapply: PlannedBatch[]; // identical payload ⇒ identical key ⇒ server-side dedupe
+}
+
+export function planResume(
+  saleId: string,
+  items: SaleItemState[],
+  liveQtyByCardKey: Map<string, number>,
+): ResumePlan {
+  const markApplied: string[] = [];
+  const conflicts: string[] = [];
+  const reapply: PlannedBatch[] = [];
+  batchLayout(items).forEach((members, n) => {
+    const changes: PlannedChange[] = [];
+    for (const m of members) {
+      if (m.status !== "applying") continue;
+      const live = liveQtyByCardKey.get(m.cardKey);
+      if (live === undefined || m.inventoryItemId === null) {
+        conflicts.push(m.cardKey);
+        continue;
+      }
+      const verdict = resumeOracle({ qtyBefore: m.qtyBefore, qtyAfter: m.qtyAfter }, live);
+      if (verdict === "applied") markApplied.push(m.cardKey);
+      else if (verdict === "conflict") conflicts.push(m.cardKey);
+      else changes.push({
+        cardKey: m.cardKey, inventoryItemId: m.inventoryItemId,
+        delta: m.delta, changeFromQuantity: m.qtyBefore as number,
+      });
+    }
+    if (changes.length > 0) reapply.push({ n, baseKey: `sale:${saleId}:batch:${n}`, changes });
+  });
+  return { markApplied, conflicts, reapply };
+}
+
+export interface UndoPlan {
+  batches: PlannedBatch[];
+  unresolvable: string[];
+}
+
+/** Positive adjustments with changeFromQuantity = qty_after — never blindly stacks stock. */
+export function planUndo(saleId: string, items: SaleItemState[]): UndoPlan {
+  const batches: PlannedBatch[] = [];
+  const unresolvable: string[] = [];
+  batchLayout(items).forEach((members, n) => {
+    const changes: PlannedChange[] = [];
+    for (const m of members) {
+      if (m.status !== "applied") continue;
+      if (m.inventoryItemId === null || m.qtyAfter === null) {
+        unresolvable.push(m.cardKey);
+        continue;
+      }
+      changes.push({
+        cardKey: m.cardKey, inventoryItemId: m.inventoryItemId,
+        delta: Math.abs(m.delta), changeFromQuantity: m.qtyAfter,
+      });
+    }
+    if (changes.length > 0) batches.push({ n, baseKey: `undo:${saleId}:batch:${n}`, changes });
+  });
+  return { batches, unresolvable };
+}

--- a/lib/ytg/saleStateMachine.ts
+++ b/lib/ytg/saleStateMachine.ts
@@ -1,0 +1,79 @@
+/**
+ * PURE sale state machine + apply/undo planner for WS-4 (spec §Record sale).
+ * No I/O anywhere in this module — every branch is unit-tested, and the
+ * server actions in app/admin/ytg/decks/saleActions.ts are thin executors.
+ *
+ * Status enums mirror migration 089 exactly.
+ */
+
+export const SALE_STATUSES = [
+  "pending", "applying", "applied", "partial", "failed",
+  "dry_run", "undoing", "undone", "undo_partial",
+] as const;
+export type SaleStatus = (typeof SALE_STATUSES)[number];
+
+export const ITEM_STATUSES = [
+  "pending", "applying", "applied", "skipped_unmapped",
+  "skipped_untracked", "error", "conflict", "undone", "undo_conflict",
+] as const;
+export type ItemStatus = (typeof ITEM_STATUSES)[number];
+
+export type PreviewFlag = "ok" | "unmapped" | "untracked" | "would_go_negative";
+
+/** Preview flag classes (spec pt. 2). unmapped ≻ untracked ≻ would_go_negative ≻ ok. */
+export function classifyPreviewRow(row: {
+  mapped: boolean;    // confirmed mapping (auto_matched|manual) AND product present in the live read
+  tracked: boolean;   // variant inventory_management === 'shopify'
+  qtyAfter: number | null;
+}): PreviewFlag {
+  if (!row.mapped) return "unmapped";
+  if (!row.tracked) return "untracked";
+  if (row.qtyAfter !== null && row.qtyAfter < 0) return "would_go_negative";
+  return "ok";
+}
+
+/** Items the apply/undo loops may touch — snapshot skips never adjust. */
+export function adjustableItems<T extends { status: ItemStatus }>(items: T[]): T[] {
+  return items.filter(
+    (i) => i.status !== "skipped_unmapped" && i.status !== "skipped_untracked",
+  );
+}
+
+/** Sale status is DERIVED from items (spec pt. 5). */
+export function deriveSaleStatus(
+  items: { status: ItemStatus }[],
+): "applied" | "partial" | "failed" {
+  const adj = adjustableItems(items);
+  const applied = adj.filter((i) => i.status === "applied").length;
+  if (adj.length > 0 && applied === adj.length) return "applied";
+  if (applied > 0) return "partial";
+  return "failed";
+}
+
+/** Undo terminal status (spec pt. 7): all reversed → undone, else undo_partial. */
+export function deriveUndoStatus(
+  items: { status: ItemStatus }[],
+): "undone" | "undo_partial" {
+  const touched = adjustableItems(items).filter(
+    (i) => i.status === "undone" || i.status === "undo_conflict" || i.status === "applied",
+  );
+  const undone = touched.filter((i) => i.status === "undone").length;
+  return touched.length > 0 && undone === touched.length ? "undone" : "undo_partial";
+}
+
+export type ResumeVerdict = "applied" | "reapply" | "conflict";
+
+/**
+ * Resume oracle for an item stranded in 'applying' (spec pt. 4):
+ *   live == qty_after  → the adjustment landed; mark applied, never re-adjust
+ *   live == qty_before → it never landed; re-apply (same payload ⇒ same key)
+ *   anything else      → third party moved stock; human resolves.
+ */
+export function resumeOracle(
+  item: { qtyBefore: number | null; qtyAfter: number | null },
+  liveQty: number,
+): ResumeVerdict {
+  if (item.qtyAfter !== null && liveQty === item.qtyAfter) return "applied";
+  if (item.qtyBefore !== null && liveQty === item.qtyBefore) return "reapply";
+  return "conflict";
+}


### PR DESCRIPTION
## Summary

WS-4 of the YTG Store plan set (spec §Record sale + Addendum 2026-08-04). Selling a deck product now decrements the mapped singles' inventory with a full safety protocol:

- **Live preview** (`previewSale`): deck contents read `zone IN ('main','reserve')` summed per card_key; confirmed mappings (`auto_matched`/`manual`); quantities from live Shopify (`fetchProductInventory`), never the mirror. Flags: unmapped (Fix in Matching link), untracked, would-go-negative (explicit ack required).
- **Snapshot confirm** (`confirmSale`): deck-changed check via `decks.updated_at`; sale inserted `pending` (partial unique index → "sale in progress" with who/when); items snapshotted with `qty_before`/`qty_after` CAS anchors incl. skipped rows; dry-run short-circuit when `YTG_INVENTORY_WRITES` is unset; CAS `pending→applying` claim.
- **Crash-safe apply** (`applySale`/`resumeSale`): items flip to `applying` BEFORE each Shopify call; `inventoryAdjustQuantities` carries the mandatory `@idempotent(key:)` directive (2026-07-verified placement) and mandatory `changeFromQuantity` CAS; `ITEM_NOT_STOCKED_AT_LOCATION` → `inventoryActivate(available: 0)` then retry; single-active-location asserted. Resume oracle: live == qty_after → applied, == qty_before → re-apply (identical payload ⇒ identical key ⇒ server-side dedupe), else conflict. Keys are the spec's `sale:<id>:batch:<n>` / `undo:<id>:batch:<n>` bases plus a deterministic payload fingerprint (Shopify rejects key reuse with different parameters).
- **Derived statuses**, per-row retry with fresh anchors, **single-shot undo** (`undoSale`, `applied|partial→undoing` CAS, `+|delta|` with `changeFromQuantity = qty_after`, conflicts never stack stock), history with dry-runs segregated ("recorded before inventory writes were enabled — not applied") and undo absent on dry-runs.
- UI extends the Decks tab least-invasively: `Record sale` link on linked rows, `/admin/ytg/decks/[productId]/sale` route, history section.
- `buildCardKey` extracted from `lib/pricing/matching.ts` so the ledger and matcher can never drift.

Migrations 088/089 were already applied — this PR ships no DDL. `YTG_INVENTORY_WRITES` remains unset everywhere until the `write_inventory` scope is granted; every mutation short-circuits to mock success until then.

## Test plan

- `npm test` — new suites: `lib/shopify/inventory.test.ts` (mutation-string construction: directive placement, key format, `changeFromQuantity` null-vs-number; write gating; location assertion; 250-chunking), `lib/ytg/__tests__/saleStateMachine.test.ts` (every enum branch of classify/derive/oracle), `lib/ytg/__tests__/saleApply.test.ts` (planner crash scenarios: ack-then-crash resumes without re-adjusting; crash-before-call re-applies under the byte-identical key; third-party movement conflicts; undo ordinal stability).
- `npx tsc --noEmit` — zero new errors vs the 7-error baseline.
- Dry-run e2e partially executed (see below); post-scope-grant checklist documented in `docs/superpowers/plans/2026-08-03-ytg-store/ws4-record-sale.md` Task 10 for the first real sale + undo.

### Dry-run e2e status

Executed against the worktree dev server with a real minted admin session (`manage_shopify_imports`) and `YTG_INVENTORY_WRITES` unset:

- Decks tab renders with the Deck products list + new Sales history section (empty state) — verified via Playwright + screenshots.
- No "Record sale" link on unlinked products (93/93 unlinked in prod today); unlinked rows show "Pull contents".
- Sale route on an unlinked product shows the friendly "product is not linked to a deck — pull contents first" error inside the shell.
- Signed-in user WITHOUT the permission → 404 on the sale route; anon → 307 to /sign-in (same middleware behavior as every /admin/ytg route).

**Deferred to the primary session** (prod has zero `ytg_deck_links` rows, and creating one is a prod write outside this workstream's permit): linked-product preview rows/qty stepper/ack flow, dry-run confirm + ledger row inspection, history segregation with a real dry-run row, WS-3 replace-guard interplay, and the two-tab race. No test ledger rows were created; nothing to clean up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)