### PR TITLE
fix(ytg): quote-safe in-lists — sale preview dropped mappings for quoted Lost Soul names

### DIFF
--- a/app/admin/ytg/decks/saleActions.ts
+++ b/app/admin/ytg/decks/saleActions.ts
@@ -13,6 +13,7 @@ import { getSupabaseAdmin } from "@/lib/pricing/supabase-admin";
 import { createClient } from "@/utils/supabase/server";
 import { getShopifyAccessToken, fetchProductInventory } from "@/lib/pricing/shopify";
 import { buildCardKey } from "@/lib/pricing/matching";
+import { pgrestInList } from "@/lib/pricing/helpers";
 import {
   getSingleLocationId, getInventoryItemIds, adjustAvailable, activateItem,
   idempotencyKey, inventoryWritesEnabled, isNotStockedError, isStaleCasError,
@@ -115,7 +116,7 @@ export async function previewSale(productId: string, qty: number): Promise<Previ
   const { data: mappings, error: mapErr } = await admin
     .from("card_price_mappings")
     .select("card_key, shopify_product_id")
-    .in("card_key", [...perKey.keys()])
+    .filter("card_key", "in", pgrestInList([...perKey.keys()]))
     .in("status", ["auto_matched", "manual"]);
   if (mapErr) return { success: false, error: mapErr.message };
 
@@ -484,7 +485,7 @@ const UNDO_CONFLICT_MSG =
 async function setItems(admin: any, saleId: string, cardKeys: string[], patch: Record<string, unknown>) {
   if (cardKeys.length === 0) return;
   await admin.from("ytg_deck_sale_items").update(patch)
-    .eq("sale_id", saleId).in("card_key", cardKeys);
+    .eq("sale_id", saleId).filter("card_key", "in", pgrestInList(cardKeys));
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -668,7 +669,7 @@ async function finishApplyPass(admin: any, token: string, locationId: string, sa
     const { data: flipped } = await admin
       .from("ytg_deck_sale_items").update({ status: "applying" })
       .eq("sale_id", saleId)
-      .in("card_key", batch.changes.map((c) => c.cardKey))
+      .filter("card_key", "in", pgrestInList(batch.changes.map((c) => c.cardKey)))
       .eq("status", "pending")
       .select("card_key");
     const owned = new Set((flipped ?? []).map((f: { card_key: string }) => f.card_key));

--- a/lib/pricing/__tests__/pgrestInList.test.ts
+++ b/lib/pricing/__tests__/pgrestInList.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { pgrestInList } from "../helpers";
+
+describe("pgrestInList", () => {
+  it("quotes every value", () => {
+    expect(pgrestInList(["a", "b"])).toBe('("a","b")');
+  });
+
+  it("escapes embedded double quotes (the Lost Soul case that corrupted previewSale)", () => {
+    expect(pgrestInList(['Lost Soul "Contempt" [Daniel 12:2]|T2C|x'])).toBe(
+      '("Lost Soul \\"Contempt\\" [Daniel 12:2]|T2C|x")',
+    );
+  });
+
+  it("escapes backslashes before quotes", () => {
+    expect(pgrestInList(['a\\b"c'])).toBe('("a\\\\b\\"c")');
+  });
+
+  it("commas and parens ride safely inside quotes", () => {
+    expect(pgrestInList(["Belshazzar's 1,000|T2C|119", "Abed-nego (Azariah) (PoC)|PoC|150"])).toBe(
+      '("Belshazzar\'s 1,000|T2C|119","Abed-nego (Azariah) (PoC)|PoC|150")',
+    );
+  });
+
+  it("empty input yields () — callers must guard non-empty", () => {
+    expect(pgrestInList([])).toBe("()");
+  });
+});

--- a/lib/pricing/helpers.ts
+++ b/lib/pricing/helpers.ts
@@ -79,3 +79,22 @@ export const UNSOLD_SETS = new Set([
   '1E', '1EU', '2E', '2ER', '3E',
   '10A', 'Fund',
 ]);
+
+/**
+ * Build a correctly-quoted PostgREST `in` filter list. postgrest-js's .in()
+ * wraps values containing ,() in double quotes but does NOT escape embedded
+ * double quotes — a card_key like `Lost Soul "Contempt" [Daniel 12:2]|...`
+ * corrupts the list and silently drops every value after it (previewSale saw
+ * 7/60 mappings). Use .filter(col, 'in', pgrestInList(values)) whenever the
+ * values can contain quotes (card_keys embed card names). Empty input yields
+ * "()" which PostgREST rejects — keep call-site non-empty guards.
+ */
+export function pgrestInList(values: string[]): string {
+  return (
+    '(' +
+    values
+      .map(v => '"' + v.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"')
+      .join(',') +
+    ')'
+  );
+}


### PR DESCRIPTION
Found completing the WS-4 dry-run checklist on the first real linked deck (Daniel contender): preview classified 53/60 cards unmapped despite all 60 having confirmed mappings.

**Root cause:** postgrest-js `.in()` quotes values containing `,()` but does not escape embedded double quotes. Lost Soul card_keys (`Lost Soul \"Contempt\" [Daniel 12:2]|T2C|…`) corrupt the filter list; every later value silently drops. Reproduced in isolation: 7/60 rows via `.in()`, 60/60 via a hand-quoted list.

**Fix:** `pgrestInList()` in lib/pricing/helpers.ts (escapes backslashes + quotes, wraps every value) used via `.filter(col, 'in', …)` at the three saleActions sites: previewSale mapping lookup, setItems item updates, per-batch pending→applying CAS flip — the latter two would have stranded item statuses mid-apply the same way.

**Not touched:** app/api/ytg-cart/route.ts already splits safe/quoted keys locally (prior workaround for this same footgun) — left as-is per surgical-change rules; consolidating it onto the helper is optional follow-up.

**Verified:** 5 new unit tests; e2e re-drive of the dry-run sale on this branch: preview 0 unmapped / 52 adjustable / 8 untracked, ledger snapshot 52 pending + 8 skipped_untracked, negative-ack gate exercised, dry-run recorded + history segregated. tsc zero new errors vs the 7-error baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)