### PR TITLE
feat(play): right-click abilities for A New Beginning (FoM) and Japheth

### DIFF
--- a/app/play/components/ChatPanel.tsx
+++ b/app/play/components/ChatPanel.tsx
@@ -919,7 +919,14 @@ function formatActionType(actionType: string, payload?: string, playerNames?: Re
         case 'random_hand_to_deck_top': return `asked to send ${count} random card${plural} from ${targetName}'s hand to the top of their deck`;
         case 'random_hand_to_deck_bottom': return `asked to send ${count} random card${plural} from ${targetName}'s hand to the bottom of their deck`;
         case 'random_hand_to_deck_shuffle': return `asked to shuffle ${count} random card${plural} from ${targetName}'s hand into their deck`;
-        case 'three_nails_reset': return `asked to activate Three Nails (GoC) reset`;
+        case 'three_nails_reset': {
+          let name = 'Three Nails (GoC)';
+          try {
+            const p = data.actionParams ? JSON.parse(data.actionParams) : {};
+            if (p.cardName) name = p.cardName;
+          } catch { /* legacy request without cardName */ }
+          return `asked to activate ${name} reset`;
+        }
         case 'shuffle_and_draw': {
           let s = 0, d = 0;
           try {
@@ -965,10 +972,20 @@ function formatActionType(actionType: string, payload?: string, playerNames?: Re
     } catch { /* fall through */ }
   }
   if (actionType === 'THREE_NAILS_RESET') {
-    return 'activated Three Nails (GoC) reset — both players drew 8';
+    let name = 'Three Nails (GoC)';
+    try {
+      const p = JSON.parse(payload ?? '{}');
+      if (p.cardName) name = p.cardName;
+    } catch { /* legacy log without cardName */ }
+    return `activated ${name} reset — both players drew 8`;
   }
   if (actionType === 'THREE_NAILS_RESET_CANCELLED') {
-    return 'tried to activate Three Nails (GoC), but the source card was no longer in play';
+    let name = 'Three Nails (GoC)';
+    try {
+      const p = JSON.parse(payload ?? '{}');
+      if (p.cardName) name = p.cardName;
+    } catch { /* legacy log without cardName */ }
+    return `tried to activate ${name}, but the source card was no longer in play`;
   }
   if (actionType === 'IMITATE_LOST_SOUL') {
     try {

--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -1912,10 +1912,12 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
       }
       if (ability?.type === 'three_nails_reset') {
         // Requires opponent consent. On approve, the approvedSearchRequest
-        // effect dispatches three_nails_reset_execute.
+        // effect dispatches three_nails_reset_execute. cardName rides along so
+        // the approval banner + chat log can name the reset card (Three Nails
+        // vs A New Beginning).
         requestOpponentAction(
           'three_nails_reset',
-          JSON.stringify({ sourceInstanceId: sourceInstanceId.toString() }),
+          JSON.stringify({ sourceInstanceId: sourceInstanceId.toString(), cardName: source?.cardName }),
         );
         return;
       }
@@ -8822,26 +8824,33 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
         />
       )}
 
-      {/* Three Nails (GoC) reset approval — floating in center of board */}
-      {incomingSearchRequest && incomingSearchRequest.action === 'three_nails_reset' && (
-        <BoardRequestBanner
-          maxWidth={460}
-          message={
-            <>
-              <strong style={{ color: '#c4955a' }}>
-                {gameState.opponentPlayer?.displayName ?? 'Opponent'}
-              </strong>{' '}
-              is activating <strong style={{ color: '#c4955a' }}>Three Nails (GoC)</strong> — shuffles all hands, territories, and lands of bondage; each player draws 8.
-            </>
-          }
-          affirmLabel="Approve"
-          onAffirm={() => {
-            approveZoneSearch(BigInt(incomingSearchRequest.id));
-            showGameToast('Three Nails reset approved');
-          }}
-          onDeny={() => denyZoneSearch(BigInt(incomingSearchRequest.id))}
-        />
-      )}
+      {/* Board reset approval (Three Nails / A New Beginning) — floating in center of board */}
+      {incomingSearchRequest && incomingSearchRequest.action === 'three_nails_reset' && (() => {
+        let resetCardName = 'Three Nails (GoC)';
+        try {
+          const p = JSON.parse(incomingSearchRequest.actionParams ?? '{}');
+          if (p.cardName) resetCardName = p.cardName;
+        } catch { /* legacy request without cardName */ }
+        return (
+          <BoardRequestBanner
+            maxWidth={460}
+            message={
+              <>
+                <strong style={{ color: '#c4955a' }}>
+                  {gameState.opponentPlayer?.displayName ?? 'Opponent'}
+                </strong>{' '}
+                is activating <strong style={{ color: '#c4955a' }}>{resetCardName}</strong> — shuffles all hands, territories, and lands of bondage; each player draws 8.
+              </>
+            }
+            affirmLabel="Approve"
+            onAffirm={() => {
+              approveZoneSearch(BigInt(incomingSearchRequest.id));
+              showGameToast(`${resetCardName} reset approved`);
+            }}
+            onDeny={() => denyZoneSearch(BigInt(incomingSearchRequest.id))}
+          />
+        );
+      })()}
 
       {/* Priority request — floating in center of board between territories */}
       {incomingSearchRequest && incomingSearchRequest.zone === 'action-priority' && (

--- a/lib/cards/cardAbilities.ts
+++ b/lib/cards/cardAbilities.ts
@@ -109,6 +109,9 @@ export const CARD_ABILITIES: Record<string, CardAbility[]> = {
   'House of Samuel':                                     [{ type: 'look_at_own_deck', position: 'top', count: 7 }],
   'Mount Sinai':                                         [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
   'Faith of Isaac':                                      [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
+  // "If you control Noah's Ark, look at the top X cards of deck" — X = # of
+  // flood survivors you control (player picks the count; 8 survivors max).
+  'Japheth':                                             [{ type: 'look_at_own_deck_choose', position: 'top', defaultCount: 3, maxCount: 8 }],
   'False Prophecy (PoC)':                                [{ type: 'look_at_opponent_deck', position: 'top', count: 6 }],
   'The Ends of the Earth (RoJ AB)':                      [{ type: 'reveal_opponent_deck', position: 'top', count: 7 }],
   'The Ends of the Earth (RoJ)':                         [{ type: 'reveal_opponent_deck', position: 'top', count: 7 }],
@@ -178,6 +181,10 @@ export const CARD_ABILITIES: Record<string, CardAbility[]> = {
   'Harvest Time (GoC)':                                  [{ type: 'play_all_lost_souls' }],
   'Harvest Time [Fundraiser]':                           [{ type: 'play_all_lost_souls' }],
   'Three Nails (GoC)':                                   [{ type: 'three_nails_reset' }],
+  // "If it is your turn banish this card: Shuffle all cards in play, set-aside,
+  // and hands. Each player must draw 8. Begin a new turn." Same board reset as
+  // Three Nails (GoC) — the reset banishes the source card.
+  'A New Beginning (FoM)':                               [{ type: 'three_nails_reset' }],
   // "You may discard this card to discard all characters from a Reserve."
   // Surfaced as two menu items so the activating player picks which Reserve;
   // no in-menu target picker needed.
@@ -530,7 +537,7 @@ export function abilityLabel(a: CardAbility): string {
     case 'play_all_lost_souls':
       return 'Play all Lost Souls from each deck';
     case 'three_nails_reset':
-      return 'Reset (banishes Nails, both players draw 8)';
+      return 'Reset (banish this card, both players draw 8)';
     case 'imitate_lost_soul':
       return 'Imitate...';
     case 'draw_and_topdeck_self':

--- a/spacetimedb/src/cardAbilities.ts
+++ b/spacetimedb/src/cardAbilities.ts
@@ -106,6 +106,9 @@ export const CARD_ABILITIES: Record<string, CardAbility[]> = {
   'House of Samuel':                                     [{ type: 'look_at_own_deck', position: 'top', count: 7 }],
   'Mount Sinai':                                         [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
   'Faith of Isaac':                                      [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
+  // "If you control Noah's Ark, look at the top X cards of deck" — X = # of
+  // flood survivors you control (player picks the count; 8 survivors max).
+  'Japheth':                                             [{ type: 'look_at_own_deck_choose', position: 'top', defaultCount: 3, maxCount: 8 }],
   'False Prophecy (PoC)':                                [{ type: 'look_at_opponent_deck', position: 'top', count: 6 }],
   'The Ends of the Earth (RoJ AB)':                      [{ type: 'reveal_opponent_deck', position: 'top', count: 7 }],
   'The Ends of the Earth (RoJ)':                         [{ type: 'reveal_opponent_deck', position: 'top', count: 7 }],
@@ -172,6 +175,10 @@ export const CARD_ABILITIES: Record<string, CardAbility[]> = {
   'Harvest Time (GoC)':                                  [{ type: 'play_all_lost_souls' }],
   'Harvest Time [Fundraiser]':                           [{ type: 'play_all_lost_souls' }],
   'Three Nails (GoC)':                                   [{ type: 'three_nails_reset' }],
+  // "If it is your turn banish this card: Shuffle all cards in play, set-aside,
+  // and hands. Each player must draw 8. Begin a new turn." Same board reset as
+  // Three Nails (GoC) — the reset banishes the source card.
+  'A New Beginning (FoM)':                               [{ type: 'three_nails_reset' }],
   // "You may discard this card to discard all characters from a Reserve."
   // Surfaced as two menu items so the activating player picks which Reserve;
   // no in-menu target picker needed.

--- a/spacetimedb/src/index.ts
+++ b/spacetimedb/src/index.ts
@@ -5916,9 +5916,11 @@ export const opponent_shuffle_and_draw = spacetimedb.reducer(
 // ---------------------------------------------------------------------------
 // Reducer: three_nails_reset_execute
 // Authorised via an approved ZoneSearchRequest (action='three_nails_reset').
-// Banishes the source Three Nails (GoC), then for each player sweeps their
-// hand + territory + land-of-bondage into their deck (lost souls owned by
-// the shared paragon soul-deck route back there), reshuffles, and draws 8.
+// Banishes the source reset card (any card registered with a
+// three_nails_reset ability — Three Nails (GoC), A New Beginning (FoM)),
+// then for each player sweeps their hand + territory + land-of-bondage into
+// their deck (lost souls owned by the shared paragon soul-deck route back
+// there), reshuffles, and draws 8.
 // Dispatched by the requester after the opponent approves.
 // ---------------------------------------------------------------------------
 export const three_nails_reset_execute = spacetimedb.reducer(
@@ -5949,26 +5951,27 @@ export const three_nails_reset_execute = spacetimedb.reducer(
       throw new SenderError('Invalid actionParams');
     }
 
-    // Locate Three Nails (GoC) — verify still in territory and owned by requester
+    // Locate the reset card — verify it carries a three_nails_reset ability,
+    // is still in territory, and is owned by the requester.
     const source = ctx.db.CardInstance.id.find(sourceInstanceId);
     if (
       !source ||
       source.gameId !== gameId ||
       source.ownerId !== player.id ||
-      source.cardName !== 'Three Nails (GoC)' ||
+      !getEffectiveAbilities(source).some((a) => a.type === 'three_nails_reset') ||
       source.zone !== 'territory'
     ) {
-      // No-op path: Nails was moved/negated mid-flight.
+      // No-op path: the reset card was moved/negated mid-flight.
       logAction(
         ctx, gameId, player.id, 'THREE_NAILS_RESET_CANCELLED',
-        JSON.stringify({ reason: 'source_card_not_in_territory' }),
+        JSON.stringify({ reason: 'source_card_not_in_territory', cardName: source?.cardName }),
         game.turnNumber, game.currentPhase,
       );
       // Leave request cleanup to complete_zone_search (client responsibility).
       return;
     }
 
-    // Banish Three Nails (GoC) — clear in-play state before leaving territory.
+    // Banish the reset card — clear in-play state before leaving territory.
     clearCountersIfLeavingPlay(ctx, source.id, 'territory', 'banish');
 
     ctx.db.CardInstance.id.update({
@@ -5986,7 +5989,7 @@ export const three_nails_reset_execute = spacetimedb.reducer(
     const SWEEP_ZONES = new Set(['hand', 'territory', 'land-of-bondage']);
 
     // Track swept card IDs for defensive cascade below.
-    // Include the source (Three Nails) so accessories linked to it are also cleared.
+    // Include the source (the reset card) so accessories linked to it are also cleared.
     const sweptIds = new Set<bigint>([sourceInstanceId]);
 
     for (const card of [...ctx.db.CardInstance.card_instance_game_id.filter(gameId)]) {
@@ -6037,7 +6040,7 @@ export const three_nails_reset_execute = spacetimedb.reducer(
     if (finalGame) {
       logAction(
         ctx, gameId, player.id, 'THREE_NAILS_RESET',
-        JSON.stringify({ requesterId: player.id.toString() }),
+        JSON.stringify({ requesterId: player.id.toString(), cardName: source.cardName }),
         finalGame.turnNumber, finalGame.currentPhase,
       );
     }


### PR DESCRIPTION
## Summary

Adds right-click shortcuts for two flood cards:

- **Japheth (CoW)** — "Look at top X cards of deck…" via the existing `look_at_own_deck_choose` type (count prompt, default 3, capped at 8 — the eight flood survivors). Fully client-driven, works in goldfish and multiplayer.
- **A New Beginning (FoM)** — "Reset (banish this card, both players draw 8)" reusing the `three_nails_reset` flow: opponent approval banner → banish the source card, sweep both players' hands/territories/lands of bondage into their decks, reshuffle, each player draws 8. "Begin a new turn" stays manual.

## Server changes

- `three_nails_reset_execute` no longer hardcodes `'Three Nails (GoC)'` — it accepts any card registered with a `three_nails_reset` ability (still requires territory + requester ownership).
- `cardName` now rides along in the request actionParams and the `THREE_NAILS_RESET` / `_CANCELLED` log payloads, so the approval banner and chat log name the actual reset card. Legacy requests/logs without `cardName` fall back to the old Three Nails text.

## Verification

- All 50 `cardAbilities` parity tests pass (registry copies in sync, keys resolve via `findCard`)
- `tsc --noEmit` clean for touched files (remaining errors are pre-existing, unrelated test files)
- Module published in-place to `redemption-multiplayer-dev` and `redemption-multiplayer` (no schema change, no data loss); regenerated bindings had zero diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)