### PR TITLE
fix(play): opponent-LoB token for Angel of the Harvest + 9 reprint gap-fills

### DIFF
--- a/lib/cards/cardAbilities.ts
+++ b/lib/cards/cardAbilities.ts
@@ -82,7 +82,10 @@ export const CARD_ABILITIES: Record<string, CardAbility[]> = {
   'The Accumulator (GoC)':                               [{ type: 'spawn_token', tokenName: 'Wicked Spirit Token', count: 7 }],
   'The Proselytizers (GoC)':                             [{ type: 'spawn_token', tokenName: 'Proselyte Token' }],
   'The Church of Christ (GoC)':                          [{ type: 'spawn_token', tokenName: 'Follower Token' }],
-  'Angel of the Harvest (GoC)':                          [{ type: 'spawn_token', tokenName: 'Harvest Soul Token' }, { type: 'look_at_own_deck_choose', position: 'top', defaultCount: 3, maxCount: 7 }],
+  // "You may create a Lost Soul token in opponent's Land of Bondage." The token
+  // belongs in the OPPONENT's Land of Bondage, same as the Lost Soul "Harvest"
+  // entries below — it was previously spawning into the caster's own territory.
+  'Angel of the Harvest (GoC)':                          [{ type: 'spawn_token', tokenName: 'Harvest Soul Token', defaultZone: 'land-of-bondage', spawnForOpponent: true }, { type: 'look_at_own_deck_choose', position: 'top', defaultCount: 3, maxCount: 7 }],
   'The Heavenly Host (GoC)':                             [{ type: 'spawn_token', tokenName: 'Heavenly Host Token', cyclingTokenNames: ['Heavenly Host Token (Blue)', 'Heavenly Host Token (Purple)', 'Heavenly Host Token (Silver)'], cyclingAllowedUsers: ['jaychambers'] }],
   'Kingdom of the Divine':                               [{ type: 'spawn_token', tokenName: 'Daniel Soul Token' }],
   'Kingdom of the Divine [T2C AB]':                      [{ type: 'spawn_token', tokenName: 'Daniel Soul Token' }],
@@ -112,15 +115,24 @@ export const CARD_ABILITIES: Record<string, CardAbility[]> = {
   'Chaldeans [T2C]':                                     [{ type: 'look_at_own_deck', position: 'top', count: 6 }],
   'Laban, the Deal Breaker (Roots)':                     [{ type: 'look_at_own_deck', position: 'top', count: 6 }],
   'Divination [K]':                                      [{ type: 'look_at_own_deck', position: 'top', count: 6 }],
+  'Divination (1st Print - K)':                          [{ type: 'look_at_own_deck', position: 'top', count: 6 }],
+  // TxP reprint words it as "look at the top six cards of deck" — same peek,
+  // then take one evil card; the return-order clause is manual either way.
+  'Divination (TxP)':                                    [{ type: 'look_at_own_deck', position: 'top', count: 6 }],
   'House of Samuel':                                     [{ type: 'look_at_own_deck', position: 'top', count: 7 }],
   'Mount Sinai':                                         [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
   'Faith of Isaac':                                      [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
+  'Faith of Isaac (CoW AB)':                             [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
   // "If you control Noah's Ark, look at the top X cards of deck" — X = # of
   // flood survivors you control (player picks the count; 8 survivors max).
   'Japheth':                                             [{ type: 'look_at_own_deck_choose', position: 'top', defaultCount: 3, maxCount: 8 }],
+  'Japheth (CoW AB)':                                    [{ type: 'look_at_own_deck_choose', position: 'top', defaultCount: 3, maxCount: 8 }],
   'False Prophecy (PoC)':                                [{ type: 'look_at_opponent_deck', position: 'top', count: 6 }],
   'The Ends of the Earth (RoJ AB)':                      [{ type: 'reveal_opponent_deck', position: 'top', count: 7 }],
   'The Ends of the Earth (RoJ)':                         [{ type: 'reveal_opponent_deck', position: 'top', count: 7 }],
+  // Promo printing reveals the top 3, NOT the 9 of the RR2 printing below —
+  // same card name, different printed count.
+  'Seeker of the Lost':                                  [{ type: 'reveal_opponent_deck', position: 'top', count: 3 }],
   'Matthew the Publican / Matthew (Levi) (GoC)':         [{ type: 'draw_brigades', alignment: 'total' }],
   // Reveal opponent's hand: draw X = distinct evil brigades (Ahijah limit 3).
   'Ahijah, Cloak Tearer':                                [{ type: 'draw_brigades', alignment: 'evil', limit: 3 }],
@@ -131,6 +143,10 @@ export const CARD_ABILITIES: Record<string, CardAbility[]> = {
   'The Divining Damsel [Fundraiser]':                    [{ type: 'draw_brigades', alignment: 'good', limit: 6 }],
   'The Lying Prophet':                                   [{ type: 'draw_brigades', alignment: 'good' }],
   'Delivered':                                           [{ type: 'discard_opponent_deck', position: 'top', count: 1, sourceZones: ['hand', 'territory', 'land-of-bondage', 'land-of-redemption'] }],
+  // Kings printing discards ONE card ("the top card from opponent's draw pile"),
+  // unlike the RR2 printing's 2. The paired "draw the top card from your draw
+  // pile" half is left to the deck menu.
+  'Plunderers':                                          [{ type: 'discard_opponent_deck', position: 'top', count: 1 }],
   // (Star) — "Reserve the top card of a deck". Surfaced as opponent-deck
   // since that's the impactful play; user can still manually move from
   // own deck via the deck-search modal.
@@ -159,12 +175,14 @@ export const CARD_ABILITIES: Record<string, CardAbility[]> = {
   'David, the Psalmist (CoW AB)':                        [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
   'Prophets of Gibeath (Promo)':                         [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
   "David's Spies [K]":                                   [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
+  "David's Spies (1st Print - K)":                       [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
   'Servants by the River [T2C AB]':                      [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
   'Servants by the River [T2C]':                         [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
   'The Angel of His Presence [T2C AB]':                  [{ type: 'look_at_own_deck', position: 'top', count: 7 }],
   'The Angel of His Presence [T2C]':                     [{ type: 'look_at_own_deck', position: 'top', count: 7 }],
   'The Three Visitors':                                  [{ type: 'look_at_own_deck', position: 'top', count: 9 }],
   'Women of Israel [L]':                                 [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
+  'Women of Israel (1st Print - L)':                     [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
   "Herod's Temple (GoC)":                                [{ type: 'reserve_top_of_deck', count: 1 }],
   "Herod's Temple [2022 - GoC P]":                       [{ type: 'reserve_top_of_deck', count: 1 }],
   'Treacherous Land':                                    [{ type: 'draw_bottom_of_deck', count: 1 }],
@@ -191,6 +209,11 @@ export const CARD_ABILITIES: Record<string, CardAbility[]> = {
   // and hands. Each player must draw 8. Begin a new turn." Same board reset as
   // Three Nails (GoC) — the reset banishes the source card.
   'A New Beginning (FoM)':                               [{ type: 'three_nails_reset' }],
+  // The original Patriarchs printing of the same reset: "ALL players shuffle ALL
+  // cards in the field of play, set-aside areas and their hands back into their
+  // draw pile … ALL players Draw 8." A Good Enhancement, so it fires from the
+  // battle zone — the path #293 unblocked for the RR2 printing.
+  'A New Beginning':                                     [{ type: 'three_nails_reset' }],
   // "You may discard this card to discard all characters from a Reserve."
   // Surfaced as two menu items so the activating player picks which Reserve;
   // no in-menu target picker needed.

--- a/spacetimedb/src/cardAbilities.ts
+++ b/spacetimedb/src/cardAbilities.ts
@@ -79,7 +79,10 @@ export const CARD_ABILITIES: Record<string, CardAbility[]> = {
   'The Accumulator (GoC)':                               [{ type: 'spawn_token', tokenName: 'Wicked Spirit Token', count: 7 }],
   'The Proselytizers (GoC)':                             [{ type: 'spawn_token', tokenName: 'Proselyte Token' }],
   'The Church of Christ (GoC)':                          [{ type: 'spawn_token', tokenName: 'Follower Token' }],
-  'Angel of the Harvest (GoC)':                          [{ type: 'spawn_token', tokenName: 'Harvest Soul Token' }, { type: 'look_at_own_deck_choose', position: 'top', defaultCount: 3, maxCount: 7 }],
+  // "You may create a Lost Soul token in opponent's Land of Bondage." The token
+  // belongs in the OPPONENT's Land of Bondage, same as the Lost Soul "Harvest"
+  // entries below — it was previously spawning into the caster's own territory.
+  'Angel of the Harvest (GoC)':                          [{ type: 'spawn_token', tokenName: 'Harvest Soul Token', defaultZone: 'land-of-bondage', spawnForOpponent: true }, { type: 'look_at_own_deck_choose', position: 'top', defaultCount: 3, maxCount: 7 }],
   'The Heavenly Host (GoC)':                             [{ type: 'spawn_token', tokenName: 'Heavenly Host Token', cyclingTokenNames: ['Heavenly Host Token (Blue)', 'Heavenly Host Token (Purple)', 'Heavenly Host Token (Silver)'], cyclingAllowedUsers: ['jaychambers'] }],
   'Kingdom of the Divine':                               [{ type: 'spawn_token', tokenName: 'Daniel Soul Token' }],
   'Kingdom of the Divine [T2C AB]':                      [{ type: 'spawn_token', tokenName: 'Daniel Soul Token' }],
@@ -109,15 +112,24 @@ export const CARD_ABILITIES: Record<string, CardAbility[]> = {
   'Chaldeans [T2C]':                                     [{ type: 'look_at_own_deck', position: 'top', count: 6 }],
   'Laban, the Deal Breaker (Roots)':                     [{ type: 'look_at_own_deck', position: 'top', count: 6 }],
   'Divination [K]':                                      [{ type: 'look_at_own_deck', position: 'top', count: 6 }],
+  'Divination (1st Print - K)':                          [{ type: 'look_at_own_deck', position: 'top', count: 6 }],
+  // TxP reprint words it as "look at the top six cards of deck" — same peek,
+  // then take one evil card; the return-order clause is manual either way.
+  'Divination (TxP)':                                    [{ type: 'look_at_own_deck', position: 'top', count: 6 }],
   'House of Samuel':                                     [{ type: 'look_at_own_deck', position: 'top', count: 7 }],
   'Mount Sinai':                                         [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
   'Faith of Isaac':                                      [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
+  'Faith of Isaac (CoW AB)':                             [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
   // "If you control Noah's Ark, look at the top X cards of deck" — X = # of
   // flood survivors you control (player picks the count; 8 survivors max).
   'Japheth':                                             [{ type: 'look_at_own_deck_choose', position: 'top', defaultCount: 3, maxCount: 8 }],
+  'Japheth (CoW AB)':                                    [{ type: 'look_at_own_deck_choose', position: 'top', defaultCount: 3, maxCount: 8 }],
   'False Prophecy (PoC)':                                [{ type: 'look_at_opponent_deck', position: 'top', count: 6 }],
   'The Ends of the Earth (RoJ AB)':                      [{ type: 'reveal_opponent_deck', position: 'top', count: 7 }],
   'The Ends of the Earth (RoJ)':                         [{ type: 'reveal_opponent_deck', position: 'top', count: 7 }],
+  // Promo printing reveals the top 3, NOT the 9 of the RR2 printing below —
+  // same card name, different printed count.
+  'Seeker of the Lost':                                  [{ type: 'reveal_opponent_deck', position: 'top', count: 3 }],
   'Matthew the Publican / Matthew (Levi) (GoC)':         [{ type: 'draw_brigades', alignment: 'total' }],
   // Reveal opponent's hand: draw X = distinct evil brigades (Ahijah limit 3).
   'Ahijah, Cloak Tearer':                                [{ type: 'draw_brigades', alignment: 'evil', limit: 3 }],
@@ -128,6 +140,10 @@ export const CARD_ABILITIES: Record<string, CardAbility[]> = {
   'The Divining Damsel [Fundraiser]':                    [{ type: 'draw_brigades', alignment: 'good', limit: 6 }],
   'The Lying Prophet':                                   [{ type: 'draw_brigades', alignment: 'good' }],
   'Delivered':                                           [{ type: 'discard_opponent_deck', position: 'top', count: 1, sourceZones: ['hand', 'territory', 'land-of-bondage', 'land-of-redemption'] }],
+  // Kings printing discards ONE card ("the top card from opponent's draw pile"),
+  // unlike the RR2 printing's 2. The paired "draw the top card from your draw
+  // pile" half is left to the deck menu.
+  'Plunderers':                                          [{ type: 'discard_opponent_deck', position: 'top', count: 1 }],
   'Contagious Fear (GoC)':                               [{ type: 'reserve_opponent_deck', position: 'top', count: 1, sourceZones: ['hand', 'territory', 'land-of-bondage', 'land-of-redemption'] }],
   'Jairus (GoC)':                                        [{ type: 'reserve_opponent_deck', position: 'top', count: 1, sourceZones: ['hand', 'territory', 'land-of-bondage', 'land-of-redemption'] }],
   "Jairus' Daughter (GoC)":                              [{ type: 'reserve_opponent_deck', position: 'top', count: 1, sourceZones: ['hand', 'territory', 'land-of-bondage', 'land-of-redemption'] }],
@@ -153,12 +169,14 @@ export const CARD_ABILITIES: Record<string, CardAbility[]> = {
   'David, the Psalmist (CoW AB)':                        [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
   'Prophets of Gibeath (Promo)':                         [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
   "David's Spies [K]":                                   [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
+  "David's Spies (1st Print - K)":                       [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
   'Servants by the River [T2C AB]':                      [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
   'Servants by the River [T2C]':                         [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
   'The Angel of His Presence [T2C AB]':                  [{ type: 'look_at_own_deck', position: 'top', count: 7 }],
   'The Angel of His Presence [T2C]':                     [{ type: 'look_at_own_deck', position: 'top', count: 7 }],
   'The Three Visitors':                                  [{ type: 'look_at_own_deck', position: 'top', count: 9 }],
   'Women of Israel [L]':                                 [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
+  'Women of Israel (1st Print - L)':                     [{ type: 'look_at_own_deck', position: 'top', count: 3 }],
   "Herod's Temple (GoC)":                                [{ type: 'reserve_top_of_deck', count: 1 }],
   "Herod's Temple [2022 - GoC P]":                       [{ type: 'reserve_top_of_deck', count: 1 }],
   'Treacherous Land':                                    [{ type: 'draw_bottom_of_deck', count: 1 }],
@@ -185,6 +203,11 @@ export const CARD_ABILITIES: Record<string, CardAbility[]> = {
   // and hands. Each player must draw 8. Begin a new turn." Same board reset as
   // Three Nails (GoC) — the reset banishes the source card.
   'A New Beginning (FoM)':                               [{ type: 'three_nails_reset' }],
+  // The original Patriarchs printing of the same reset: "ALL players shuffle ALL
+  // cards in the field of play, set-aside areas and their hands back into their
+  // draw pile … ALL players Draw 8." A Good Enhancement, so it fires from the
+  // battle zone — the path #293 unblocked for the RR2 printing.
+  'A New Beginning':                                     [{ type: 'three_nails_reset' }],
   // "You may discard this card to discard all characters from a Reserve."
   // Surfaced as two menu items so the activating player picks which Reserve;
   // no in-menu target picker needed.


### PR DESCRIPTION
Follow-up to #293. That PR audited Roots 2; this applies the same rule to the other **5,467 cards** (every remaining set, 19 parallel per-slice audits). This PR ships only the tranche I verified card-by-card against printed text — one real bug and nine reprint gap-fills. Registry lines only, no new ability types, no new reducers.

## The bug

`Angel of the Harvest (GoC)` prints *"You may create a Lost Soul token in **opponent's** Land of Bondage."* Its entry was a bare `spawn_token` with no `defaultZone` and no `spawnForOpponent`, so the token spawned in the **caster's own territory**. The identical `Harvest Soul Token` is wired correctly on the two `Lost Soul "Harvest"` entries a few lines below — this one just never got the fields.

Menu label before → after:

| | |
|---|---|
| before | `Create Harvest Soul Token` |
| after | `Create Harvest Soul Token in opponent's Land of Bondage` |

## The 9 gap-fills

Each is a printing of a card that's **already registered under a different printing's name** — so its twin has a right-click menu and this one silently has none (`getAbilitiesForCard` returns `[]`; nothing errors). Each new key is placed beside its counterpart, matching how the Mayhem / Gates of Hell / Three Woes families are already grouped.

| Card | Ability | Mirrors |
|---|---|---|
| `A New Beginning` (Patriarchs) | `three_nails_reset` | `A New Beginning (FoM)` / `[RR2]` |
| `Faith of Isaac (CoW AB)` | `look_at_own_deck` top 3 | `Faith of Isaac` |
| `Japheth (CoW AB)` | `look_at_own_deck_choose` top, 3/8 | `Japheth` |
| `Plunderers` (Kings) | `discard_opponent_deck` top **1** | `Plunderers [RR2]` (top 2) |
| `Seeker of the Lost` (Promo) | `reveal_opponent_deck` top **3** | `Seeker of the Lost [RR2]` (top 9) |
| `Divination (1st Print - K)` | `look_at_own_deck` top 6 | `Divination [K]` |
| `Divination (TxP)` | `look_at_own_deck` top 6 | `Divination [K]` |
| `David's Spies (1st Print - K)` | `look_at_own_deck` top 3 | `David's Spies [K]` |
| `Women of Israel (1st Print - L)` | `look_at_own_deck` top 3 | `Women of Israel [L]` |

**These are not blind copies.** Counts were re-read per printing, and two differ from the entry they mirror — `Plunderers` (Kings) discards 1 rather than 2, and `Seeker of the Lost` (Promo) reveals 3 rather than 9. Copying by name would have shipped both wrong.

`A New Beginning` (Patriarchs) is the *original* printing of that reset and needs no server work: #292 generalized `three_nails_reset` off the hardcoded `'Three Nails (GoC)'` name, and it's a Good Enhancement, so it fires from the battle zone — the path #293 unblocked for the RR2 printing. Confirmed via `hasUsableAbilityInZone({ zone: 'battle' }) === true`.

## Two cards deliberately held back

Both surfaced in the same tranche and both look like gap-fills until you read the text:

- **`Wash Basin` (Disciples)** — reveals *"the bottom X cards of an opponent's deck (limit 2)"*, a player-chosen count. The RR2 printing's fixed `bottom 2` would overstate it whenever X is 0 or 1. Needs `reveal_opponent_deck_choose`, which doesn't exist yet.
- **`Angel of the Harvest` (Rock of Ages)** — not a reprint at all, just a name collision. It discards the top of the opponent's deck with Lost-Soul routing, a shape no current type covers.

## Key exactness

Registry keys must match `card.name` byte-for-byte; a wrong key doesn't throw, it returns `[]` and the card silently has no menu. All 9 keys were confirmed to be **unique exact matches** in the card index (each name family — `A New Beginning`, `Seeker of the Lost`, `Plunderers`, `Divination` — has 3–4 printings, so bare names had to be checked, not assumed).

Worth knowing for future passes: the pool mixes apostrophe styles — **430** names use ASCII `'` and **52** use curly `’` (the existing `Philip’s Daughters [RR2]` entry is one). `findCard()` falls back to a lowercase match, so case errors self-heal but punctuation errors do not.

## Verification

- Full suite: **1985 passed**, 0 failed (155 files, 3 skipped)
- `cardAbilities` suite: **50/50**, including the lib↔spacetimedb parity deep-equality check and "every key resolves to a real card via `findCard()`"
- `tsc --noEmit`: no errors in either touched file. The 7 remaining errors are the pre-existing ones in `__tests__/forge-anon-leak.test.ts` and `app/forge/lib/__tests__/playDecksAuthorize.test.ts`, both untouched and both already noted in #293
- Each of the 9 entries confirmed to render a real menu label via `getAbilitiesForCard` + `abilityLabel`

## Not done

**The SpacetimeDB module is NOT published.** No schema or reducer change here — only `CARD_ABILITIES` data — but the server reads its own copy of the registry, so these cards won't get menus in multiplayer until the module is republished. Held for a human call, same as #293, since publishing targets both prod and dev.

Goldfish mode reads the `lib/` copy directly and works as soon as this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)