### PR TITLE
fix(play): closing a deck peek no longer moves the cards to the top

### DIFF
--- a/app/goldfish/components/GoldfishCanvas.tsx
+++ b/app/goldfish/components/GoldfishCanvas.tsx
@@ -217,8 +217,7 @@ export default function GoldfishCanvas({ containerWidth, containerHeight, scale,
       // (Star) abilities fired from hand — flash the source card so the implicit
       // "reveal from hand" cost is visible (parity with multiplayer behavior).
       if (source && source.zone === 'hand') revealCardInHand(source.instanceId);
-      // Bottom/random reveals must not relocate cards to the top on dismiss.
-      setPeekState({ cardIds: ids, title, preserveOnDismiss: position !== 'top' });
+      setPeekState({ cardIds: ids, title });
     },
     [state.zones, revealCardInHand],
   );
@@ -407,7 +406,7 @@ export default function GoldfishCanvas({ containerWidth, containerHeight, scale,
   const [deckMenu, setDeckMenu] = useState<{ x: number; y: number } | null>(null);
   const [soulDeckMenu, setSoulDeckMenu] = useState<{ x: number; y: number } | null>(null);
   const [browseSoulDeck, setBrowseSoulDeck] = useState(false);
-  const [peekState, setPeekState] = useState<{ cardIds: string[]; title: string; sourceZone?: ZoneId; preserveOnDismiss?: boolean } | null>(null);
+  const [peekState, setPeekState] = useState<{ cardIds: string[]; title: string; sourceZone?: ZoneId } | null>(null);
   const [lookState, setLookState] = useState<{ cardIds: string[]; title: string; sourceZone?: ZoneId } | null>(null);
   const [deckDropPopup, setDeckDropPopup] = useState<{ cardInstanceId: string; x: number; y: number } | null>(null);
   const [soulDeckDropPopup, setSoulDeckDropPopup] = useState<{ cardInstanceId: string; batchIds?: string[]; x: number; y: number } | null>(null);
@@ -1363,9 +1362,7 @@ export default function GoldfishCanvas({ containerWidth, containerHeight, scale,
         : mode === 'bottom'
           ? `Bottom ${count} of Soul Deck`
           : `Random ${count} from Soul Deck`;
-      // Dismissing a soul-deck reveal should leave the soul deck untouched, not
-      // relocate cards to the main deck's top.
-      setPeekState({ cardIds: ids, title, sourceZone: 'soul-deck', preserveOnDismiss: true });
+      setPeekState({ cardIds: ids, title, sourceZone: 'soul-deck' });
     },
     [state.zones, pickSoulDeckIds],
   );
@@ -2829,7 +2826,7 @@ export default function GoldfishCanvas({ containerWidth, containerHeight, scale,
             if (deck.length === 0) { showGameToast('Deck is empty'); return; }
             const n = Math.min(count, deck.length);
             const ids = deck.slice(-n).map(c => c.instanceId);
-            setPeekState({ cardIds: ids, title: `Bottom ${n} of Deck`, preserveOnDismiss: true });
+            setPeekState({ cardIds: ids, title: `Bottom ${n} of Deck` });
           }}
           onDiscardBottom={(count) => {
             setDeckMenu(null);
@@ -2883,7 +2880,7 @@ export default function GoldfishCanvas({ containerWidth, containerHeight, scale,
             }
             const n = Math.min(count, deck.length);
             const ids = shuffled.slice(0, n).map(c => c.instanceId);
-            setPeekState({ cardIds: ids, title: `Random ${n} from Deck`, preserveOnDismiss: true });
+            setPeekState({ cardIds: ids, title: `Random ${n} from Deck` });
           }}
           onDiscardRandom={(count) => {
             setDeckMenu(null);
@@ -2991,7 +2988,6 @@ export default function GoldfishCanvas({ containerWidth, containerHeight, scale,
             didDragRef={modalDidDragRef}
             isDragActive={modalDrag.isDragging}
             sourceZone={peekState.sourceZone}
-            preserveOnDismiss={peekState.preserveOnDismiss}
           />
         )}
 

--- a/app/shared/components/DeckPeekModal.tsx
+++ b/app/shared/components/DeckPeekModal.tsx
@@ -152,17 +152,9 @@ interface DeckPeekModalProps {
   isPrivateLook?: boolean;
   /** Zone to look up peeked cards in. Defaults to 'deck'. */
   sourceZone?: ZoneId;
-  /**
-   * When true, dismissing the modal (X / Escape / click-away) leaves the deck
-   * order untouched instead of returning the revealed cards to the top. Callers
-   * that reveal from the bottom or a random position pass this so a revealed
-   * bottom card isn't silently relocated to the top (and drawn next). The
-   * explicit footer buttons still reorder.
-   */
-  preserveOnDismiss?: boolean;
 }
 
-export function DeckPeekModal({ cardIds, title, onClose, onStartDrag, onStartMultiDrag, didDragRef, isDragActive, isPrivateLook, sourceZone = 'deck', preserveOnDismiss = false }: DeckPeekModalProps) {
+export function DeckPeekModal({ cardIds, title, onClose, onStartDrag, onStartMultiDrag, didDragRef, isDragActive, isPrivateLook, sourceZone = 'deck' }: DeckPeekModalProps) {
   const { dragHandleProps, modalStyle } = useDraggableModal();
   const { zones, actions } = useModalGame();
   const { moveCard, moveCardsBatch, moveCardToTopOfDeck, moveCardToBottomOfDeck, shuffleDeck, shuffleCardIntoDeck } = actions;
@@ -274,13 +266,13 @@ export function DeckPeekModal({ cardIds, title, onClose, onStartDrag, onStartMul
     onClose();
   };
 
-  // Dismissing without an explicit choice (X / Escape / click-away). For a
-  // bottom or random reveal, returning cards to the top would relocate the
-  // revealed bottom card and cause it to be drawn next — so those callers pass
-  // preserveOnDismiss to leave the deck untouched.
+  // Dismissing without an explicit choice (X / Escape / click-away) leaves the
+  // deck untouched: peeking never moves cards, so doing nothing is what puts
+  // them back where they came from. Reordering here instead would relocate a
+  // bottom/random peek to the top and hand it to the next draw. The footer
+  // buttons remain the way to say "put these somewhere else".
   const handleDismiss = () => {
-    if (preserveOnDismiss) { onClose?.(); return; }
-    handleCloseAction('top');
+    onClose?.();
   };
 
   useEffect(() => {
@@ -295,7 +287,7 @@ export function DeckPeekModal({ cardIds, title, onClose, onStartDrag, onStartMul
     };
     document.addEventListener('keydown', handleKey);
     return () => document.removeEventListener('keydown', handleKey);
-  }, [hasRemaining, remainingIds, selectedIds.size]);
+  }, [onClose, selectedIds.size]);
 
   // Outside-click / outside-right-click behavior. The backdrop is
   // pointer-events: none so cards underneath can fire hover previews, so we
@@ -325,7 +317,7 @@ export function DeckPeekModal({ cardIds, title, onClose, onStartDrag, onStartMul
       document.removeEventListener('mousedown', handleMouseDown);
       document.removeEventListener('contextmenu', handleContextMenu);
     };
-  }, [onClose, readyForClose, didDragRef, hasRemaining, remainingIds]);
+  }, [onClose, readyForClose, didDragRef]);
 
   // Track pointer down card to distinguish click from drag on pointer up
   const pointerDownCardRef = useRef<string | null>(null);


### PR DESCRIPTION
## The bug

Reported from a live game: a player looked at the bottom 6 cards of their deck, took one, and closed the window with the X. Their next draw phase handed them the other cards from the bottom — three Lost Souls in a row.

Dismissing `DeckPeekModal` (X / Escape / click-away) ran `handleCloseAction('top')`, which physically moved every remaining revealed card to the top of the deck.

Reproduced before fixing: look at bottom 6 → X out → look at top 6 returned the identical six cards.

## Why it slipped through

`preserveOnDismiss` was added for exactly this in 5bd622a5, but only wired to goldfish's **Reveal** path — its own commit message says "multiplayer unchanged". All seven `DeckPeekModal` call sites in `MultiplayerCanvas.tsx` and goldfish's **Look** path still had the old behavior.

## The fix

Rather than pass the opt-out at eight more call sites (which is how this bug happened in the first place), remove the footgun. Dismissal now just closes:

- Peeking never moves cards, so **doing nothing is what puts them back where they came from**. Bottom stays bottom, random stays put, and top peeks are unaffected — the old code already no-op'd those via its `alreadyOnTop` check.
- The **Top of Deck / Bottom of Deck / Shuffle In** footer buttons still reorder, and are now the only way anything moves.
- One change covers multiplayer, goldfish, both private Look modals, the soul-deck modals, and the opponent-reveal mirror — no call-site edits.

It also closes a nastier latent case: dismissing a goldfish soul-deck **Look** ran `MOVE_TO_TOP_OF_DECK`, which unshifts into `zones.deck` regardless of source zone, pushing Lost Souls into the main deck.

Net −12 lines.

## Verification

Scripted in a real browser against goldfish (the same shared modal the multiplayer canvas renders):

- ✅ X-ing out of a bottom look does not move cards to the top
- ✅ the looked-at cards are still on the bottom, in the same order
- ✅ **the reported scenario** — take one card to hand, X out, the other 5 stay on the bottom
- ✅ "Top of Deck" button still moves the revealed cards to the top

`npm test`: 1985 passed / 80 skipped. `tsc --noEmit`: 7 errors, all pre-existing in test files (identical count with these changes stashed), none in the touched files.

No automated regression test: vitest here is node-only (`*.test.ts`, no jsdom), so this modal can't be rendered in the suite. Happy to add an e2e spec if that's worth the seeded-deck dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)