### PR TITLE
feat(play): player-chosen-count reveal/look/discard on either deck

### DIFF
--- a/app/goldfish/components/GoldfishCanvas.tsx
+++ b/app/goldfish/components/GoldfishCanvas.tsx
@@ -279,8 +279,19 @@ export default function GoldfishCanvas({ containerWidth, containerHeight, scale,
         if (found) { source = found; break; }
       }
       const ability = source ? getEffectiveAbilities(source)[abilityIndex] : undefined;
-      if (ability?.type === 'look_at_own_deck_choose') {
+      if (ability?.type === 'look_at_own_deck_choose' || ability?.type === 'reveal_own_deck_choose') {
+        // Goldfish is single-player, so look and reveal collapse to the same
+        // modal — matching how the fixed-count pair is handled above.
         openOwnDeckPeek(ability.position, Math.min(count, ability.maxCount), source);
+        return;
+      }
+      if (
+        ability?.type === 'look_at_opponent_deck_choose'
+        || ability?.type === 'reveal_opponent_deck_choose'
+        || ability?.type === 'discard_opponent_deck_choose'
+      ) {
+        // No opponent in goldfish — same no-op as the fixed-count opponent
+        // abilities in gameReducer's ability switch.
         return;
       }
       dispatch(gameActionCreators.executeCardAbilityWithCount(cardId, abilityIndex, count));

--- a/app/goldfish/state/gameReducer.ts
+++ b/app/goldfish/state/gameReducer.ts
@@ -1500,9 +1500,13 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         case 'reveal_own_deck':
         case 'look_at_own_deck':
         case 'look_at_own_deck_choose':
+        case 'reveal_own_deck_choose':
         case 'look_at_opponent_deck':
+        case 'look_at_opponent_deck_choose':
         case 'reveal_opponent_deck':
+        case 'reveal_opponent_deck_choose':
         case 'discard_opponent_deck':
+        case 'discard_opponent_deck_choose':
         case 'reserve_opponent_deck':
           // Modal-driven or opponent-required — GoldfishCanvas intercepts, or
           // the effect is multiplayer-only. No-op here. (look_at_own_deck_choose

--- a/app/play/components/MultiplayerCanvas.tsx
+++ b/app/play/components/MultiplayerCanvas.tsx
@@ -2109,6 +2109,35 @@ export default function MultiplayerCanvas({ gameId, onLoadDeck, undoStack, onSea
         if (source) gameState.logLookAtTop(n, source.cardName, ability.position);
         return;
       }
+      if (ability?.type === 'reveal_own_deck_choose') {
+        // Public counterpart of look_at_own_deck_choose — same peek modal the
+        // fixed-count reveal_own_deck uses, so the opponent sees it too.
+        const n = Math.min(count, ability.maxCount);
+        setPeekState({
+          position: ability.position,
+          count: n,
+          cardIds: sampleDeckCardIds(ability.position, n),
+          source: { cardName: source!.cardName },
+        });
+        return;
+      }
+      if (
+        ability?.type === 'look_at_opponent_deck_choose'
+        || ability?.type === 'reveal_opponent_deck_choose'
+        || ability?.type === 'discard_opponent_deck_choose'
+      ) {
+        // Same opponent-consent flow as the fixed-count variants — the request
+        // payload already carries an arbitrary count, so the only difference is
+        // where the number comes from.
+        const n = Math.min(count, ability.maxCount);
+        const verb =
+          ability.type === 'look_at_opponent_deck_choose' ? 'look'
+          : ability.type === 'reveal_opponent_deck_choose' ? 'reveal'
+          : 'discard';
+        const action = `${verb}_deck_${ability.position}`;
+        requestOpponentAction(action, JSON.stringify({ count: n }));
+        return;
+      }
       gameState.executeCardAbilityWithCount(sourceInstanceId, abilityIndex, count);
     },
     beginCountPrompt: (req) => setCountPrompt(req),

--- a/app/shared/components/CardContextMenu.tsx
+++ b/app/shared/components/CardContextMenu.tsx
@@ -306,13 +306,28 @@ export function CardContextMenu({ card: initialCard, x, y, actions, onClose, onE
                       },
                       onCancel: () => {},
                     });
-                  } else if (ability.type === 'look_at_own_deck_choose') {
+                  } else if (
+                    ability.type === 'look_at_own_deck_choose'
+                    || ability.type === 'reveal_own_deck_choose'
+                    || ability.type === 'look_at_opponent_deck_choose'
+                    || ability.type === 'reveal_opponent_deck_choose'
+                    || ability.type === 'discard_opponent_deck_choose'
+                  ) {
+                    // All five player-chosen-count abilities share one prompt;
+                    // the canvas decides what to do with the number (local peek
+                    // vs opponent-consent request) when it comes back.
+                    const verb =
+                      ability.type.startsWith('look') ? 'Look at'
+                      : ability.type.startsWith('reveal') ? 'Reveal'
+                      : 'Discard';
+                    const whose = ability.type.includes('opponent') ? "opponent's deck" : 'deck';
+                    const where = ability.position === 'random' ? 'X random' : `${ability.position} X`;
                     actions.beginCountPrompt?.({
-                      title: `Look at ${ability.position === 'random' ? 'X random' : `${ability.position} X`} cards of deck (limit ${ability.maxCount})`,
+                      title: `${verb} ${where} cards of ${whose} (limit ${ability.maxCount})`,
                       cardName: card.cardName,
                       defaultCount: ability.defaultCount,
                       maxCount: ability.maxCount,
-                      confirmVerb: 'Look at',
+                      confirmVerb: verb,
                       onConfirm: (count) => {
                         actions.executeCardAbilityWithCount?.(card.instanceId, index, count);
                       },

--- a/lib/cards/__tests__/cardAbilities.test.ts
+++ b/lib/cards/__tests__/cardAbilities.test.ts
@@ -374,6 +374,47 @@ describe('hasUsableAbilityInZone', () => {
   });
 });
 
+describe('player-chosen-count (*_choose) abilities', () => {
+  const CHOOSE_TYPES = [
+    'look_at_own_deck_choose',
+    'reveal_own_deck_choose',
+    'look_at_opponent_deck_choose',
+    'reveal_opponent_deck_choose',
+    'discard_opponent_deck_choose',
+  ];
+  const chooseEntries = Object.entries(CARD_ABILITIES).flatMap(([name, abilities]) =>
+    abilities
+      .filter((a) => CHOOSE_TYPES.includes(a.type))
+      .map((a) => [name, a] as [string, typeof a & { defaultCount: number; maxCount: number }]),
+  );
+
+  it('covers every card that has one', () => {
+    expect(chooseEntries.length).toBeGreaterThan(0);
+  });
+
+  // The count prompt seeds itself with defaultCount and clamps to maxCount, so a
+  // default above the cap would open the dialog already past its own limit.
+  it('never seeds a default above its own cap', () => {
+    const bad = chooseEntries
+      .filter(([, a]) => a.defaultCount > a.maxCount)
+      .map(([name, a]) => `${name}: default ${a.defaultCount} > max ${a.maxCount}`);
+    expect(bad).toEqual([]);
+  });
+
+  it('has a positive, finite cap', () => {
+    const bad = chooseEntries
+      .filter(([, a]) => !Number.isInteger(a.maxCount) || a.maxCount < 1)
+      .map(([name, a]) => `${name}: maxCount ${a.maxCount}`);
+    expect(bad).toEqual([]);
+  });
+
+  it('renders a label ending in an ellipsis, marking it as prompting for input', () => {
+    for (const [name, a] of chooseEntries) {
+      expect(abilityLabel(a), name).toMatch(/…$/);
+    }
+  });
+});
+
 describe('getEffectiveAbilities', () => {
   it('returns base abilities when not imitating', () => {
     const out = getEffectiveAbilities({

--- a/lib/cards/cardAbilities.ts
+++ b/lib/cards/cardAbilities.ts
@@ -44,6 +44,18 @@ export type CardAbility = AbilityBase & (
   // defaultCount and capped at maxCount; like look_at_own_deck it's modal-driven
   // client-side (intercepted in the canvas, never routed through the reducer).
   | { type: 'look_at_own_deck_choose'; position: 'top' | 'bottom' | 'random'; defaultCount: number; maxCount: number }
+  // The remaining three cells of the choose grid (own/opponent × look/reveal,
+  // plus discard). Cards printing "top X" where X is a board-state count you
+  // control — "X = # of your Armor of God Enhancements" — with a printed or
+  // card-pool-derived cap. All four choose types are dispatched CLIENT-side
+  // like look_at_own_deck_choose: the menu opens a count prompt, then the
+  // canvas either opens the peek locally (own deck) or forwards the chosen
+  // count through the existing opponent-consent flow, whose request payload
+  // already carries an arbitrary count. No reducer is involved.
+  | { type: 'reveal_own_deck_choose'; position: 'top' | 'bottom' | 'random'; defaultCount: number; maxCount: number }
+  | { type: 'look_at_opponent_deck_choose'; position: 'top' | 'bottom' | 'random'; defaultCount: number; maxCount: number }
+  | { type: 'reveal_opponent_deck_choose'; position: 'top' | 'bottom' | 'random'; defaultCount: number; maxCount: number }
+  | { type: 'discard_opponent_deck_choose'; position: 'top' | 'bottom' | 'random'; defaultCount: number; maxCount: number }
   | { type: 'look_at_opponent_deck'; position: 'top' | 'bottom' | 'random'; count: number }
   | { type: 'reveal_opponent_deck'; position: 'top' | 'bottom' | 'random'; count: number }
   | { type: 'discard_opponent_deck'; position: 'top' | 'bottom' | 'random'; count: number }
@@ -434,6 +446,27 @@ export const CARD_ABILITIES: Record<string, CardAbility[]> = {
   'Everlasting Beings':                                  [{ type: 'resurrect_heroes' }],
   'Raising of the Saints (Wa)':                          [{ type: 'resurrect_heroes' }],
   'Valley of Dry Bones':                                 [{ type: 'resurrect_heroes' }],
+
+  // ---------------------------------------------------------------------------
+  // Player-chosen count — opponent-facing and reveal variants
+  //
+  // Only cards whose ceiling is printed on the card ("limit N") or enforced by
+  // the engine (Outsiders: X = cards in your hand, bounded by HAND_LIMIT).
+  // Cards whose X needs a card-pool census — Michal, Aaron's Staff, Egyptian
+  // Treasures, Claudia, Eve (FoM) — are deliberately left out until someone
+  // rules on the ceiling: a guessed maxCount silently truncates the effect.
+  //
+  // Angel of Revelation reveals "each player's deck", so it gets one entry per
+  // deck rather than a combined shape.
+  // ---------------------------------------------------------------------------
+  'The Seventy Elders':                                  [{ type: 'reveal_opponent_deck_choose', position: 'top', defaultCount: 3, maxCount: 7 }],
+  'Wash Basin':                                          [{ type: 'reveal_opponent_deck_choose', position: 'bottom', defaultCount: 2, maxCount: 2 }],
+  'the gods of Egypt [IR]':                              [{ type: 'discard_opponent_deck_choose', position: 'top', defaultCount: 3, maxCount: 5 }],
+  'Sabbath Breaker [Gray/Pale Green]':                   [{ type: 'look_at_opponent_deck_choose', position: 'top', defaultCount: 3, maxCount: 6 }],
+  'Angel of Revelation (RoJ)':                           [{ type: 'reveal_own_deck_choose', position: 'top', defaultCount: 3, maxCount: 7 }, { type: 'reveal_opponent_deck_choose', position: 'top', defaultCount: 3, maxCount: 7 }],
+  'Angel of Revelation (RoJ AB)':                        [{ type: 'reveal_own_deck_choose', position: 'top', defaultCount: 3, maxCount: 7 }, { type: 'reveal_opponent_deck_choose', position: 'top', defaultCount: 3, maxCount: 7 }],
+  'Outsiders (Gray/Pale Green) (RoJ)':                   [{ type: 'look_at_opponent_deck_choose', position: 'top', defaultCount: 5, maxCount: 16 }],
+  'Outsiders (Gray/Pale Green) (RoJ AB)':                [{ type: 'look_at_opponent_deck_choose', position: 'top', defaultCount: 5, maxCount: 16 }],
 };
 
 /**
@@ -747,6 +780,22 @@ export function abilityLabel(a: CardAbility): string {
     case 'look_at_own_deck_choose': {
       const where = a.position === 'random' ? 'X random' : `${a.position} X`;
       return `Look at ${where} cards of deck…`;
+    }
+    case 'reveal_own_deck_choose': {
+      const where = a.position === 'random' ? 'X random' : `${a.position} X`;
+      return `Reveal ${where} cards of deck…`;
+    }
+    case 'look_at_opponent_deck_choose': {
+      const where = a.position === 'random' ? 'X random' : `${a.position} X`;
+      return `Look at ${where} cards of opponent's deck…`;
+    }
+    case 'reveal_opponent_deck_choose': {
+      const where = a.position === 'random' ? 'X random' : `${a.position} X`;
+      return `Reveal ${where} cards of opponent's deck…`;
+    }
+    case 'discard_opponent_deck_choose': {
+      const where = a.position === 'random' ? 'X random' : `${a.position} X`;
+      return `Discard ${where} cards of opponent's deck…`;
     }
     case 'look_at_opponent_deck': {
       const where = a.position === 'random' ? `${a.count} random` : `${a.position} ${a.count}`;

--- a/spacetimedb/src/cardAbilities.ts
+++ b/spacetimedb/src/cardAbilities.ts
@@ -48,6 +48,18 @@ export type CardAbility = AbilityBase & (
   // defaultCount and capped at maxCount; like look_at_own_deck it's modal-driven
   // client-side (intercepted in the canvas, never routed through the reducer).
   | { type: 'look_at_own_deck_choose'; position: 'top' | 'bottom' | 'random'; defaultCount: number; maxCount: number }
+  // The remaining three cells of the choose grid (own/opponent × look/reveal,
+  // plus discard). Cards printing "top X" where X is a board-state count you
+  // control — "X = # of your Armor of God Enhancements" — with a printed or
+  // card-pool-derived cap. All four choose types are dispatched CLIENT-side
+  // like look_at_own_deck_choose: the menu opens a count prompt, then the
+  // canvas either opens the peek locally (own deck) or forwards the chosen
+  // count through the existing opponent-consent flow, whose request payload
+  // already carries an arbitrary count. No reducer is involved.
+  | { type: 'reveal_own_deck_choose'; position: 'top' | 'bottom' | 'random'; defaultCount: number; maxCount: number }
+  | { type: 'look_at_opponent_deck_choose'; position: 'top' | 'bottom' | 'random'; defaultCount: number; maxCount: number }
+  | { type: 'reveal_opponent_deck_choose'; position: 'top' | 'bottom' | 'random'; defaultCount: number; maxCount: number }
+  | { type: 'discard_opponent_deck_choose'; position: 'top' | 'bottom' | 'random'; defaultCount: number; maxCount: number }
   | { type: 'look_at_opponent_deck'; position: 'top' | 'bottom' | 'random'; count: number }
   | { type: 'reveal_opponent_deck'; position: 'top' | 'bottom' | 'random'; count: number }
   | { type: 'discard_opponent_deck'; position: 'top' | 'bottom' | 'random'; count: number }
@@ -428,6 +440,27 @@ export const CARD_ABILITIES: Record<string, CardAbility[]> = {
   'Everlasting Beings':                                  [{ type: 'resurrect_heroes' }],
   'Raising of the Saints (Wa)':                          [{ type: 'resurrect_heroes' }],
   'Valley of Dry Bones':                                 [{ type: 'resurrect_heroes' }],
+
+  // ---------------------------------------------------------------------------
+  // Player-chosen count — opponent-facing and reveal variants
+  //
+  // Only cards whose ceiling is printed on the card ("limit N") or enforced by
+  // the engine (Outsiders: X = cards in your hand, bounded by HAND_LIMIT).
+  // Cards whose X needs a card-pool census — Michal, Aaron's Staff, Egyptian
+  // Treasures, Claudia, Eve (FoM) — are deliberately left out until someone
+  // rules on the ceiling: a guessed maxCount silently truncates the effect.
+  //
+  // Angel of Revelation reveals "each player's deck", so it gets one entry per
+  // deck rather than a combined shape.
+  // ---------------------------------------------------------------------------
+  'The Seventy Elders':                                  [{ type: 'reveal_opponent_deck_choose', position: 'top', defaultCount: 3, maxCount: 7 }],
+  'Wash Basin':                                          [{ type: 'reveal_opponent_deck_choose', position: 'bottom', defaultCount: 2, maxCount: 2 }],
+  'the gods of Egypt [IR]':                              [{ type: 'discard_opponent_deck_choose', position: 'top', defaultCount: 3, maxCount: 5 }],
+  'Sabbath Breaker [Gray/Pale Green]':                   [{ type: 'look_at_opponent_deck_choose', position: 'top', defaultCount: 3, maxCount: 6 }],
+  'Angel of Revelation (RoJ)':                           [{ type: 'reveal_own_deck_choose', position: 'top', defaultCount: 3, maxCount: 7 }, { type: 'reveal_opponent_deck_choose', position: 'top', defaultCount: 3, maxCount: 7 }],
+  'Angel of Revelation (RoJ AB)':                        [{ type: 'reveal_own_deck_choose', position: 'top', defaultCount: 3, maxCount: 7 }, { type: 'reveal_opponent_deck_choose', position: 'top', defaultCount: 3, maxCount: 7 }],
+  'Outsiders (Gray/Pale Green) (RoJ)':                   [{ type: 'look_at_opponent_deck_choose', position: 'top', defaultCount: 5, maxCount: 16 }],
+  'Outsiders (Gray/Pale Green) (RoJ AB)':                [{ type: 'look_at_opponent_deck_choose', position: 'top', defaultCount: 5, maxCount: 16 }],
 };
 
 export function getAbilitiesForCard(identifier: string): CardAbility[] {

--- a/spacetimedb/src/index.ts
+++ b/spacetimedb/src/index.ts
@@ -4779,6 +4779,14 @@ export const execute_card_ability = spacetimedb.reducer(
         throw new SenderError('look_at_own_deck is dispatched by the client, not this reducer');
       case 'look_at_own_deck_choose':
         throw new SenderError('look_at_own_deck_choose is dispatched by the client, not this reducer');
+      case 'reveal_own_deck_choose':
+        throw new SenderError('reveal_own_deck_choose is dispatched by the client, not this reducer');
+      case 'look_at_opponent_deck_choose':
+        throw new SenderError('look_at_opponent_deck_choose is dispatched by the client, not this reducer');
+      case 'reveal_opponent_deck_choose':
+        throw new SenderError('reveal_opponent_deck_choose is dispatched by the client, not this reducer');
+      case 'discard_opponent_deck_choose':
+        throw new SenderError('discard_opponent_deck_choose is dispatched by the client, not this reducer');
       case 'look_at_opponent_deck':
         throw new SenderError('look_at_opponent_deck is dispatched by the client, not this reducer');
       case 'reveal_opponent_deck':


### PR DESCRIPTION
> **Stacked on #298** — base is `feat/ability-full-pool-audit`, so the diff shows only tranche 3. Merge #298 first.

Completes the `*_choose` grid. The registry has had `look_at_own_deck_choose` since Angel of the Harvest, but none of its siblings — so a card printing *"reveal the top X (limit 7) cards of a deck"* had no shape to map onto and got dropped from the last two tranches.

**Four independent audit slices** (CoW+RoJ, TPC+Women, Israel's Rebellion, Prophecies of Christ) asked for these same missing cells without being able to see each other. That convergence is what makes this worth building as a type rather than a one-off `custom` reducer.

Adds `reveal_own_deck_choose`, `look_at_opponent_deck_choose`, `reveal_opponent_deck_choose`, `discard_opponent_deck_choose`.

## No new reducer, no schema change, no bindings

All four are dispatched **client-side**, exactly like `look_at_own_deck_choose`:

- The context menu opens **one shared count prompt** for all five choose types, deriving the verb and target from the ability type instead of repeating the block.
- The canvas then either opens the peek locally (own deck) or forwards the chosen number through the existing opponent-consent flow.

The key observation that makes the opponent-facing variants nearly free: `requestOpponentAction(action, JSON.stringify({ count }))` **already carried an arbitrary count**. The fixed-count types just happen to pass `ability.count`. So the choose variants are the same path with the number coming from the prompt instead of the card — no new action strings, no server work.

| Surface | Behaviour |
|---|---|
| Multiplayer | own-deck → local peek; opponent-deck → existing consent flow with the chosen count |
| Goldfish | own-deck look/reveal collapse to one modal (as the fixed-count pair already does); opponent variants no-op — there's no opponent |
| Server | four types added to the union + an explicit `SenderError` each, matching every other client-dispatched ability. Unreachable in practice, but keeps the switch exhaustive |

## Cards registered (8)

Only where the ceiling is **defensible**:

| Card | Ability | Cap from |
|---|---|---|
| `The Seventy Elders` | `reveal_opponent_deck_choose` top | printed "limit 7" |
| `Wash Basin` | `reveal_opponent_deck_choose` bottom | printed "limit 2" |
| `the gods of Egypt [IR]` | `discard_opponent_deck_choose` top | printed "limit 5" |
| `Sabbath Breaker [Gray/Pale Green]` | `look_at_opponent_deck_choose` top | printed "limit 6" |
| `Angel of Revelation (RoJ)` + `(RoJ AB)` | `reveal_own_deck_choose` **and** `reveal_opponent_deck_choose` | printed "limit 7" |
| `Outsiders (Gray/Pale Green) (RoJ)` + `(RoJ AB)` | `look_at_opponent_deck_choose` top | engine `HAND_LIMIT` = 16 |

`Angel of Revelation` reveals *"each player's deck"*, so it gets one entry per deck rather than a combined shape — two menu items.

`Wash Basin` is the card that was pulled from #296 and rejected again during #298's verification, both times for the same reason: its "bottom X (limit 2)" is a variable the fixed-count entry would have overstated. It now has the shape it always needed.

## Deliberately not registered

`Michal`, `Aaron's Staff`, `Egyptian Treasures`, `Claudia`, `Eve (FoM)`. Their X needs a card-pool census with **no printed cap to check it against** — and a guessed `maxCount` silently truncates the effect rather than failing loudly. Same reason 8 `look_at_own_deck_choose` cards were held in #298. These want a human ruling, not a better guess.

## Tests

Four new cases covering the family as a whole, so future additions are guarded automatically:

- it is non-empty (guards against the other assertions passing vacuously)
- no entry seeds a `defaultCount` above its own `maxCount` — that would open the prompt already past its cap
- every cap is a positive integer
- every label ends in an ellipsis, so the menu marks it as prompting for input

## Verification

- Full suite: **1989 passed**, 0 failed
- `cardAbilities` suite **54/54**, including the lib↔spacetimedb parity deep-equality check
- `tsc --noEmit`: no errors in any of the 8 touched files (the 7 remaining are pre-existing in `forge-anon-leak.test.ts` / `playDecksAuthorize.test.ts`)
- All 8 cards confirmed to render their menu labels, including Angel of Revelation's two

## Publishing

The module's `CARD_ABILITIES` union and dispatch switch changed, but since none of these types ever reach the server, a republish is **not required** for the feature to work — the new `SenderError` cases are defensive only. Worth folding into the next publish for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)