### PR TITLE
fix(play): anchor the deck context menu on the cursor

### DIFF
--- a/app/shared/components/DeckContextMenu.tsx
+++ b/app/shared/components/DeckContextMenu.tsx
@@ -13,6 +13,7 @@ import {
   hoverEnter,
   hoverLeave,
 } from './SubMenuActionRow';
+import { anchorContextMenu } from './contextMenuPosition';
 
 interface DeckContextMenuProps {
   x: number;
@@ -173,9 +174,19 @@ export function DeckContextMenu({
   const [activeSubmenu, setActiveSubmenu] = useState<string | null>(null);
   const submenuCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const MENU_WIDTH = 200;
-  const rightAligned = x + MENU_WIDTH > window.innerWidth;
-  const menuLeft = rightAligned ? Math.max(0, x - MENU_WIDTH) : x;
+  // Measure the rendered menu, then anchor it on the cursor. Measuring matters:
+  // the menu's height changes with the Draw X expander and the opponent-deck
+  // variant, and a guessed height is what used to pin the menu to a fixed line.
+  const [pos, setPos] = useState<{ left: number; top: number; ready: boolean }>({ left: x, top: y, ready: false });
+  useLayoutEffect(() => {
+    const menu = menuRef.current;
+    if (!menu) return;
+    const { width, height } = menu.getBoundingClientRect();
+    const { left, top } = anchorContextMenu(x, y, { width, height }, { width: window.innerWidth, height: window.innerHeight });
+    setPos({ left, top, ready: true });
+    // Re-measure when Draw X expands: the taller menu keeps the same anchor if
+    // it still fits, and only lifts if the expander pushed it off the bottom.
+  }, [x, y, showDrawX]);
 
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
@@ -200,8 +211,8 @@ export function DeckContextMenu({
       onContextMenu={(e) => e.preventDefault()}
       style={{
         position: 'fixed',
-        left: menuLeft,
-        top: Math.min(y, window.innerHeight - 300),
+        left: pos.left,
+        top: pos.top,
         background: 'var(--gf-bg)',
         border: '1px solid var(--gf-border)',
         borderRadius: 6,
@@ -209,6 +220,7 @@ export function DeckContextMenu({
         zIndex: 900,
         boxShadow: '0 8px 24px rgba(0,0,0,0.6)',
         whiteSpace: 'nowrap',
+        visibility: pos.ready ? 'visible' : 'hidden',
       }}
     >
       <button style={ITEM_STYLE} onClick={onSearchDeck} onMouseEnter={hoverEnter} onMouseLeave={hoverLeave}>

--- a/app/shared/components/__tests__/contextMenuPosition.test.ts
+++ b/app/shared/components/__tests__/contextMenuPosition.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { anchorContextMenu } from '../contextMenuPosition';
+
+/** Roughly the deck menu: 7 rows + 2 separators + padding. */
+const MENU = { width: 200, height: 210 };
+const MARGIN = 8;
+
+describe('anchorContextMenu', () => {
+  it('anchors at the cursor when the menu fits', () => {
+    const pos = anchorContextMenu(400, 300, MENU, { width: 1512, height: 945 });
+    expect(pos).toEqual({ left: 400, top: 300 });
+  });
+
+  it('tracks the cursor 1:1 across the deck pile on a short viewport', () => {
+    // Regression: the deck pile spans clientY 475..564 on a 1440x780 window.
+    // The old `Math.min(y, innerHeight - 300)` clamp pinned that entire band to
+    // top 480 — a 2px spread over 89px of cursor travel. The bottom 2px still
+    // clamp here (a 210px menu genuinely cannot fit below y=562 in a 780px
+    // window), but the other 87px track the cursor exactly.
+    const viewport = { width: 1440, height: 780 };
+    const top = (y: number) => anchorContextMenu(950, y, MENU, viewport).top;
+    expect(top(475)).toBe(475);
+    expect(top(520)).toBe(520);
+    expect(top(562)).toBe(562);
+    expect(top(564)).toBe(562);
+  });
+
+  it('nudges up by only the overflow, not to a fixed line', () => {
+    const pos = anchorContextMenu(400, 700, MENU, { width: 1440, height: 780 });
+    expect(pos.top).toBe(780 - MENU.height - MARGIN);
+  });
+
+  it('flips left of the cursor when the menu would overflow the right edge', () => {
+    const pos = anchorContextMenu(1380, 300, MENU, { width: 1440, height: 780 });
+    expect(pos.left).toBe(1380 - MENU.width);
+  });
+
+  it('keeps the menu on screen when it is taller than the viewport', () => {
+    const pos = anchorContextMenu(100, 200, { width: 200, height: 900 }, { width: 1440, height: 780 });
+    expect(pos.top).toBe(MARGIN);
+  });
+
+  it('does not push the menu off the left edge when flipping', () => {
+    const pos = anchorContextMenu(40, 300, { width: 200, height: 100 }, { width: 300, height: 780 });
+    expect(pos.left).toBeGreaterThanOrEqual(MARGIN);
+  });
+});

--- a/app/shared/components/contextMenuPosition.ts
+++ b/app/shared/components/contextMenuPosition.ts
@@ -1,0 +1,41 @@
+/** Gap kept between the menu and the viewport edge. */
+export const MENU_MARGIN = 8;
+
+export interface MenuSize {
+  width: number;
+  height: number;
+}
+
+/**
+ * Place a context menu so its top-left corner sits at the cursor.
+ *
+ * Vertically the menu is only nudged up by however much it would overrun the
+ * bottom edge — never to a fixed line. The sidebar piles sit low on the board,
+ * so a fixed clamp (the old `Math.min(y, innerHeight - 300)`) swallowed the
+ * entire pile's worth of cursor movement and left the menu looking bolted in
+ * place. Nudging only on real overflow keeps the menu tracking the cursor 1:1
+ * everywhere it fits, which is everywhere the piles actually are.
+ *
+ * Horizontally it flips to the left of the cursor instead, since a menu
+ * anchored past the right edge would otherwise be squeezed against it.
+ *
+ * `menu` must be the *measured* size — the bug this replaces came from
+ * guessing a height that was ~90px too large.
+ */
+export function anchorContextMenu(
+  x: number,
+  y: number,
+  menu: MenuSize,
+  viewport: MenuSize,
+  margin = MENU_MARGIN,
+): { left: number; top: number } {
+  const onScreen = (pos: number, size: number, extent: number) =>
+    Math.max(margin, Math.min(pos, Math.max(margin, extent - size - margin)));
+
+  const flipped = x + menu.width > viewport.width - margin ? x - menu.width : x;
+
+  return {
+    left: onScreen(flipped, menu.width, viewport.width),
+    top: onScreen(y, menu.height, viewport.height),
+  };
+}


### PR DESCRIPTION
## The bug

> I right clicked my deck and the search deck needs to be lower down on the cursor. Like I right clicked at pixel A and the search deck needs to be next to pixel A, but it looks like no matter where I right click my deck the right click menu is in a static place... which makes muscle memory for interacting with the deck annoying.

## Root cause

`DeckContextMenu` positioned itself with:

```ts
top: Math.min(y, window.innerHeight - 300)
```

`300` is a hardcoded guess at the menu's height. The deck pile sits low in the right sidebar, so on common window heights that clamp is active across the *whole pile* — the cursor's `y` is discarded and every right-click lands the menu in the same place.

The click coordinates were never the problem. Both call sites in `MultiplayerCanvas` (the zone rect and the sidebar pile group) pass `e.evt.clientX/clientY` correctly.

Measuring the real deck rect from `calculateMultiplayerLayout` and running it through the old math shows how far the collapse goes:

| Window | Deck pile clientY span | Menu-top spread (before) | After |
|---|---|---|---|
| 1440×780 | 475–564 (89px) | **2px** | 87px |
| 1512×860 | 522–620 (98px) | 35px | 98px |
| 1512×945 | 571–680 (109px) | 71px | 109px |
| 2560×1330 | 787–938 (151px) | 145px | 151px |

## The fix

New `anchorContextMenu()` helper: measure the rendered menu, anchor its top-left on the cursor, and nudge it up only by however much it would actually overrun the bottom edge. The menu's real height is ~210px, not 300 — that 90px error alone accounts for most of the collapse.

Two judgment calls worth review:

- **Nudge, don't flip.** The first attempt flipped the menu above the cursor on overflow (standard OS behavior), but that jumped the menu 171px partway down the pile — a worse muscle-memory problem than the one being fixed. With the measured height, nudging never engages over the deck pile on any viewport ≥860px tall. Horizontal still flips left near the right edge, as it did before.
- **The bottom ~2px of the pile still clamps on a 780px-tall window.** A 210px menu genuinely cannot fit below y=562 there.

Also re-measures when the Draw X expander opens, so the taller menu keeps its anchor if it still fits.

## Not in scope

The identical fixed-line clamp exists in `ReserveContextMenu` (`-300/-100`), `LorContextMenu` (`-100`), `ZoneContextMenu` (`-200`), `HandContextMenu` (`-300`) and `OpponentZoneContextMenu` (`-60`). Reserve is the most likely next complaint — it's in the same sidebar row as the deck, at identical y. Each is a ~4-line change to use the new helper; left out to keep this scoped to the reported bug.

## Verification

- 6 new unit tests for `anchorContextMenu`, including a regression case pinned to the real deck-pile geometry on a 1440×780 window
- Full suite green: 1991 passed / 156 files, on top of current `main`
- `tsc --noEmit` clean on the touched files
- **Not** driven in a live game — the numbers above are computed from the layout module, not observed in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)