### PR TITLE
chore(nav): point host resources at the 2026 Host Guide

### DIFF
--- a/components/top-nav.tsx
+++ b/components/top-nav.tsx
@@ -163,16 +163,21 @@ const TopNav: React.FC = () => {
     { href: "https://landofredemption.com/wp-content/uploads/2025/11/Paragon-Format-Lost-Souls-BW-v1.pdf", label: "Lost Souls (B&W)" },
   ];
 
+  // Host files live on cactusgamedesign.com/downloads. As of the 2026 Host Guide
+  // there are two applications — with prize pack support, or promos only at a
+  // lower fee — so they get distinct labels instead of two "Hosting Application"
+  // rows.
   const hostResources = [
-    { href: "https://landofredemption.com/wp-content/uploads/2025/03/Redemption_Host_Guide_2025.pdf", label: "Hosting Guide" },
-    { href: "https://landofredemption.com/wp-content/uploads/2025/05/Redemption-Tournament-Host-Application-2025-1.pdf", label: "Hosting Application" },
-    { href: "https://landofredemption.com/wp-content/uploads/2025/11/Redemption-Tournament-Host-Application-2025-08.pdf", label: "Hosting Application" },
-    { href: "https://landofredemption.com/wp-content/uploads/2025/03/host_sign_in_sheets.pdf", label: "Sign In Sheet" },
+    { href: "https://www.cactusgamedesign.com/wp-content/uploads/2026/08/Redemption_Host_Guide_2026-1.pdf", label: "Hosting Guide" },
+    { href: "https://www.cactusgamedesign.com/wp-content/uploads/2026/08/host_instructions.pdf", label: "Host Instructions" },
+    { href: "https://www.cactusgamedesign.com/wp-content/uploads/2026/08/Redemption-Tournament-Host-Application-2027_With_Prize_Pack_Support.pdf", label: "Hosting Application (with Prize Packs)" },
+    { href: "https://www.cactusgamedesign.com/wp-content/uploads/2026/08/Redemption-Tournament-Host-Application-2027_WITHOUT_Prize_Pack_Support.pdf", label: "Hosting Application (Promos Only)" },
+    { href: "https://www.cactusgamedesign.com/wp-content/uploads/2026/08/host_sign_in_sheets-1.pdf", label: "Sign In Sheet" },
     { href: "https://landofredemption.com/wp-content/uploads/2026/07/t1_deck_check_v2.pdf", label: "T1 Deck Check Sheet" },
     { href: "https://landofredemption.com/wp-content/uploads/2025/03/Reserve-List-T1.pdf", label: "T1 Reserve List" },
     { href: "https://landofredemption.com/wp-content/uploads/2026/07/t2_deck_check_v2.pdf", label: "T2 Deck Check Sheet" },
     { href: "https://landofredemption.com/wp-content/uploads/2026/07/T2-Reserve-list.pdf", label: "T2 Reserve List" },
-    { href: "https://landofredemption.com/wp-content/uploads/2025/03/host_winners_list.pdf", label: "Winners Form" },
+    { href: "https://www.cactusgamedesign.com/wp-content/uploads/2026/08/host_winners_list-2.pdf", label: "Winners Form" },
   ];
 
   return (


### PR DESCRIPTION
Cactus published the **2026 Tournament Host Guide** (v26.0.0, published 8/13/2026) and moved the host files to [cactusgamedesign.com/downloads](https://www.cactusgamedesign.com/downloads/). Our Host Resources menu still pointed at the 2025 guide and at two applications that were both labeled "Hosting Application".

The old URLs all still return 200 — they just serve last year's documents, so this was silently handing hosts stale rules.

### Changes
| Item | Before | After |
|---|---|---|
| Hosting Guide | 2025 guide (landofredemption) | 2026 guide v26.0.0 |
| Hosting Application ×2 | two rows, same label, 2025 | 2027 **with Prize Packs** / **Promos Only** |
| Host Instructions | not linked | added |
| Sign In Sheet | 2025/03 | 2026/08 (content differs) |
| Winners Form | 2025/03 | 2026/08 (content differs) |

Left alone: T1/T2 deck check sheets, T1 reserve list, and the T2 reserve list — the T2 file on Cactus is byte-identical (`md5 c1266d3a…`) to the one we already link.

Every new URL verified `200` via `curl -sI -L`.

### Why the two applications now differ
The 2026 guide adds a lower-cost path for hosts: *"Tournament application without prize pack support. This has lower fees since prize packs are not included. Both applications include participation promos."* Labeling both rows identically hid that choice.

### Not in this PR
- The **Seasonal** level replacing Local/District (separate PR — touches the tier picker and the listings calendar)
- **Deck Building Rules 2.0**, also published 8/13/2026 — we still link v1.3 in three places. It has a new "Format Options and Ban Lists" section and wants a real 1.3→2.0 diff before flipping the link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)