### PR TITLE
feat(tracker): Seasonal replaces the Local and District levels

### DIFF
--- a/app/tournaments/tournaments-client.tsx
+++ b/app/tournaments/tournaments-client.tsx
@@ -55,6 +55,13 @@ function toDateKey(dateStr: string): string {
   return dateStr; // already YYYY-MM-DD
 }
 
+// Seasonal replaced Local and District in the 2026 Host Guide, but listings
+// sanctioned under the old levels are still on the calendar — they share the
+// Seasonal color rather than keeping a retired one of their own.
+function isSeasonal(t: string): boolean {
+  return t.includes("seasonal") || t.includes("district") || t.includes("local");
+}
+
 function getTypeBadgeClasses(type: string | null): string {
   const t = (type || "").toLowerCase();
   if (t.includes("regional") || t.includes("national")) {
@@ -63,7 +70,7 @@ function getTypeBadgeClasses(type: string | null): string {
   if (t.includes("state")) {
     return "bg-primary/10 text-primary";
   }
-  if (t.includes("district")) {
+  if (isSeasonal(t)) {
     return "bg-blue-500/15 text-blue-700 dark:text-blue-400";
   }
   return "bg-muted text-muted-foreground";
@@ -77,7 +84,7 @@ function getTypeDotColor(type: string | null): string {
   if (t.includes("state")) {
     return "bg-primary";
   }
-  if (t.includes("district")) {
+  if (isSeasonal(t)) {
     return "bg-blue-500";
   }
   return "bg-muted-foreground/50";
@@ -527,20 +534,16 @@ function CalendarView({
       {/* Legend */}
       <div className="flex items-center gap-4 mt-3 text-[10px] text-muted-foreground">
         <div className="flex items-center gap-1">
+          <span className="w-1.5 h-1.5 rounded-full bg-blue-500" />
+          Seasonal
+        </div>
+        <div className="flex items-center gap-1">
           <span className="w-1.5 h-1.5 rounded-full bg-primary" />
           State
         </div>
         <div className="flex items-center gap-1">
-          <span className="w-1.5 h-1.5 rounded-full bg-blue-500" />
-          District
-        </div>
-        <div className="flex items-center gap-1">
           <span className="w-1.5 h-1.5 rounded-full bg-amber-500" />
           Regional
-        </div>
-        <div className="flex items-center gap-1">
-          <span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/50" />
-          Local
         </div>
       </div>
 

--- a/lib/listings/parse.ts
+++ b/lib/listings/parse.ts
@@ -10,7 +10,7 @@ IMPORTANT RULES:
 - For multi-day events, set both start_date and end_date
 - Confidence is 0-1: use 1.0 for clearly parsed listings, lower for ambiguous ones
 - For formats, extract each game format and its entry fee separately
-- title should be "{City}, {State} {Tournament Type}" (e.g., "Arcadia, CA Local (Open)")
+- title should be "{City}, {State} {Tournament Type}" (e.g., "Arcadia, CA Seasonal")
 - If a field is not present, use null
 - Return ONLY valid JSON, no markdown fences or explanation
 
@@ -18,7 +18,7 @@ OUTPUT SCHEMA (JSON array):
 [
   {
     "title": "string",
-    "tournament_type": "string | null (e.g., 'Local (Open)', 'District', 'State')",
+    "tournament_type": "string | null (e.g., 'Seasonal', 'State', 'Regional', 'National'; older listings may say 'Local (Open)', 'Local (Closed)' or 'District' — copy whatever the page shows, do not translate it)",
     "start_date": "YYYY-MM-DD",
     "end_date": "YYYY-MM-DD | null",
     "start_time": "string | null (e.g., '10:00 AM')",

--- a/supabase/migrations/090_refresh_tournament_tier_comment.sql
+++ b/supabase/migrations/090_refresh_tournament_tier_comment.sql
@@ -1,0 +1,8 @@
+-- Comment-only. 085 enumerated the six levels that existed when the column was
+-- added; the 2026 Host Guide (v26.0.0) collapsed Local (Open), Local (Closed)
+-- and District into Seasonal, leaving four. The column stays free text — old
+-- rows keep the level they were sanctioned under, and normalizeTier still
+-- resolves the retired names for listings that predate the change.
+
+comment on column public.tournaments.tier is
+  'Sanctioning tier: Seasonal | State | Regional | National. Rows created before the 2026 Host Guide may hold the retired Local (Open) | Local (Closed) | District. Null = unspecified. Canonical list in utils/tournament/tiers.ts.';

--- a/utils/tournament/__tests__/eventType.test.ts
+++ b/utils/tournament/__tests__/eventType.test.ts
@@ -29,15 +29,16 @@ describe("normalizeTier", () => {
     expect(normalizeTier("Redemption National")).toBe("National");
   });
 
-  it("keeps the open/closed distinction on Local", () => {
-    expect(normalizeTier("Local (Open)")).toBe("Local (Open)");
-    expect(normalizeTier("Local (Closed)")).toBe("Local (Closed)");
-    expect(normalizeTier("local")).toBe("Local (Open)");
+  it("maps the levels the 2026 guide retired onto Seasonal", () => {
+    expect(normalizeTier("Local (Open)")).toBe("Seasonal");
+    expect(normalizeTier("Local (Closed)")).toBe("Seasonal");
+    expect(normalizeTier("local")).toBe("Seasonal");
+    expect(normalizeTier("District")).toBe("Seasonal");
   });
 
   it("passes through the plain tiers", () => {
     expect(normalizeTier("State")).toBe("State");
-    expect(normalizeTier("District")).toBe("District");
+    expect(normalizeTier("Seasonal")).toBe("Seasonal");
   });
 
   it("returns null rather than guessing on unknown or empty input", () => {
@@ -129,10 +130,10 @@ describe("renameForEventType", () => {
   it("rebuilds from created_at when the name is free-form", () => {
     const out = renameForEventType(
       "Friday Night Redemption",
-      { tier: "Local (Open)", category: "Type 2", city: null, state: null },
+      { tier: "Seasonal", category: "Type 2", city: null, state: null },
       UNLIMITED.created_at
     );
-    expect(out).toMatch(/^\w{3} \d{1,2}, \d{4} Local \(Open\) Type 2 Tournament$/);
+    expect(out).toMatch(/^\w{3} \d{1,2}, \d{4} Seasonal Type 2 Tournament$/);
   });
 
   it("applies the location when falling back on a free-form name", () => {

--- a/utils/tournament/tiers.ts
+++ b/utils/tournament/tiers.ts
@@ -1,12 +1,12 @@
 // A tournament's sanctioning tier, orthogonal to its category/format: a
-// Regional and a Local can both be Type 1 Unlimited. Mirrors the vocabulary the
-// public listings already use (tournament_listings.tournament_type), so an
+// Regional and a Seasonal can both be Type 1 Unlimited. Mirrors the vocabulary
+// the public listings already use (tournament_listings.tournament_type), so an
 // event hosted from a listing inherits the tier the listing advertised.
 
+// The 2026 Host Guide (v26.0.0, published 8/13/2026) replaced Local (Open),
+// Local (Closed) and District with a single Seasonal level, leaving four.
 export const TOURNAMENT_TIERS = [
-  "Local (Open)",
-  "Local (Closed)",
-  "District",
+  "Seasonal",
   "State",
   "Regional",
   "National",
@@ -20,14 +20,18 @@ export type TournamentTier = (typeof TOURNAMENT_TIERS)[number];
  * Tournament", "Midwest Regional" — that all collapse to their base tier.
  * Returns null for anything unrecognized so an odd listing leaves the tier
  * unset rather than guessing.
+ *
+ * Cactus's feed still advertises events sanctioned under the retired levels,
+ * so "Local (Open)", "Local (Closed)" and "District" keep resolving — onto
+ * Seasonal, the level that replaced them.
  */
 export function normalizeTier(raw: string | null | undefined): TournamentTier | null {
   const t = (raw ?? "").toLowerCase().trim();
   if (!t) return null;
   if (t.includes("national")) return "National";
   if (t.includes("regional")) return "Regional";
-  if (t.includes("district")) return "District";
   if (t.includes("state")) return "State";
-  if (t.includes("local")) return t.includes("closed") ? "Local (Closed)" : "Local (Open)";
+  if (t.includes("seasonal") || t.includes("district") || t.includes("local"))
+    return "Seasonal";
   return null;
 }


### PR DESCRIPTION
The [2026 Tournament Host Guide](https://www.cactusgamedesign.com/wp-content/uploads/2026/08/Redemption_Host_Guide_2026-1.pdf) (v26.0.0, published 8/13/2026) collapsed **Local (Open)**, **Local (Closed)** and **District** into a single **Seasonal** level:

> There are four *levels* of tournaments: Seasonal, State, Regional and National.

Our tier picker still offered all six, so a host creating an event today could sanction it at a level that no longer exists — and that level goes into the frozen tournament name.

### Changes
- **[tiers.ts](utils/tournament/tiers.ts)** — `TOURNAMENT_TIERS` is now `Seasonal | State | Regional | National`. Both pickers ([create modal](components/ui/tournament-form-modal.tsx#L208), [Tournament Settings](components/ui/TournamentSettings.tsx#L388)) map over the constant, so they pick this up for free.
- **`normalizeTier` still resolves the retired strings**, onto Seasonal. This matters: Cactus's feed is mid-transition — 41 of the live listings are still `Local (Open)` (24), `District` (10) or `Local (Closed)` (7). Hosting from one of those listings has to inherit a level that's still in the picker, or the tier silently drops.
- **Listings calendar** — Seasonal takes the blue that District had; Local and District share it rather than each keeping a swatch for a retired level. Legend is now Seasonal / State / Regional, in level order.
- **Scraper prompt** — learns the new vocabulary, and is explicitly told to copy whatever the page shows rather than translate it, so a listing that says "District" is still recorded as "District". The normalizer does the collapsing at read time, not the parser at write time.
- **Migration 090** — comment-only refresh of the `tier` column comment, which enumerated the old six. No DDL, no data change.

### No data migration
`tournaments.tier` is free text with no CHECK constraint (`085_add_tournament_tier.sql`), so nothing rejects the old values. Exactly one production tournament has a tier of `Local (Open)`; it keeps it, since its frozen name already reads that way and rewriting the column alone would make name and column disagree (`renameForEventType` only rebuilds the name when someone saves Settings).

### Verification
- `npx vitest run utils/tournament/__tests__/eventType.test.ts` — 28 passed (tests updated: retired levels now assert they map to Seasonal)
- `npx tsc --noEmit` — no errors in any touched file (10 pre-existing errors elsewhere, all in unrelated forge test files, present on `main` too)
- An adversarial review pass separately confirmed the four-level claim against the guide text, re-counted the 41 legacy listings in prod, and verified no CHECK/enum/index/RLS depends on the literals.

### Deliberately not renamed
`District` also appears as a **card rarity** in `lib/cards/generated/cardData.json` and in card names like `Raiders' Camp [2025 - District]`, and `Seasonal` is already a promo set-year token. This PR touches only tournament-level code — no global find/replace.

### Follow-ups not in this PR
- `suggestNumberOfRounds` still cites the 2024 guide; the 2026 chart tops out at 65+ → 7 rounds (we return 8 above 128) and has a separate multi-player chart (3-5→1, 6-16→2, 17-64→3, 65+→4) we don't model.
- Deck lists are now required at State/Regional/National and only encouraged at Seasonal — `requireDecklistsDefault` keys on category alone.
- The RNRS points page still models `local` and `district` levels with point values Cactus no longer publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)