### PR TITLE
fix(deckcheck): Type 1 is singleton, not 3 copies of vanilla cards

### DIFF
--- a/utils/deckcheck/__tests__/rules.test.ts
+++ b/utils/deckcheck/__tests__/rules.test.ts
@@ -1318,7 +1318,37 @@ describe("Rule: checkSpecialAbilityLimit (t1-quantity-special-ability)", () => {
 });
 
 describe("Rule: checkVanillaLimit (t1-quantity-vanilla)", () => {
-  it("passes for 3 copies of vanilla single-brigade Hero", () => {
+  it("passes for 1 copy of vanilla single-brigade Hero", () => {
+    const card = makeCard({
+      name: "Vanilla Hero",
+      type: "Hero",
+      brigade: "Blue",
+      specialAbility: "",
+      quantity: 1,
+    });
+    const groups = [makeGroup("Vanilla Hero", [card])];
+    expect(checkVanillaLimit([], [], groups)).toHaveLength(0);
+  });
+
+  it("fails for 2 copies of vanilla single-brigade Hero", () => {
+    const card = makeCard({
+      name: "Vanilla Hero",
+      type: "Hero",
+      brigade: "Blue",
+      specialAbility: "",
+      quantity: 2,
+    });
+    const groups = [makeGroup("Vanilla Hero", [card])];
+    const issues = checkVanillaLimit([], [], groups);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].rule).toBe("t1-quantity-vanilla");
+    expect(issues[0].message).toContain("max 1 copy");
+    expect(issues[0].message).toContain("found 2");
+  });
+
+  // 3 copies were legal under Deck Building Rules 1.3 — the exact case the
+  // checker used to wave through and 2.0 makes illegal.
+  it("fails for 3 copies, the allowance 1.3 used to grant", () => {
     const card = makeCard({
       name: "Vanilla Hero",
       type: "Hero",
@@ -1327,23 +1357,7 @@ describe("Rule: checkVanillaLimit (t1-quantity-vanilla)", () => {
       quantity: 3,
     });
     const groups = [makeGroup("Vanilla Hero", [card])];
-    expect(checkVanillaLimit([], [], groups)).toHaveLength(0);
-  });
-
-  it("fails for 4 copies of vanilla single-brigade Hero", () => {
-    const card = makeCard({
-      name: "Vanilla Hero",
-      type: "Hero",
-      brigade: "Blue",
-      specialAbility: "",
-      quantity: 4,
-    });
-    const groups = [makeGroup("Vanilla Hero", [card])];
-    const issues = checkVanillaLimit([], [], groups);
-    expect(issues).toHaveLength(1);
-    expect(issues[0].rule).toBe("t1-quantity-vanilla");
-    expect(issues[0].message).toContain("max 3");
-    expect(issues[0].message).toContain("found 4");
+    expect(checkVanillaLimit([], [], groups)).toHaveLength(1);
   });
 
   it("applies to Evil Characters", () => {

--- a/utils/deckcheck/rules.ts
+++ b/utils/deckcheck/rules.ts
@@ -787,7 +787,14 @@ export function checkCharacterAliasLimit(
 
 /**
  * Rule: t1-quantity-vanilla — Vanilla single-brigade Heroes, Evil Characters,
- * and Enhancements are limited to 3 copies each.
+ * and Enhancements are limited to 1 copy each.
+ *
+ * Deck Construction & Format Specific Rules 2.0 (8/13/2026) made Type 1
+ * singleton: "All other cards have a maximum of 1 of each in a deck", with only
+ * meek Lost Souls exempt. That retired the 3-copy allowance these cards had
+ * under Deck Building Rules 1.3. Paragon shares this check and agrees — Paragon
+ * Format Rules 1.2 p.3: "You may not include more than 1 copy of any card in
+ * your deck."
  */
 export function checkVanillaLimit(
   _mainDeckCards: ResolvedCard[],
@@ -809,11 +816,11 @@ export function checkVanillaLimit(
     if (vanillaCards.length === 0) continue;
 
     const totalQty = vanillaCards.reduce((sum, c) => sum + c.quantity, 0);
-    if (totalQty > 3) {
+    if (totalQty > 1) {
       issues.push({
         type: "error",
         rule: "t1-quantity-vanilla",
-        message: `"${group.canonicalName}" (vanilla, single-brigade) — max 3 copies allowed, found ${totalQty}.`,
+        message: `"${group.canonicalName}" — max 1 copy allowed, found ${totalQty}.`,
         cards: [group.canonicalName],
       });
     }


### PR DESCRIPTION
[Deck Construction & Format Specific Rules 2.0](https://www.cactusgamedesign.com/wp-content/uploads/2026/08/Deck_Building_Rules_2.0-1.pdf) (published 8/13/2026, the successor to Deck Building Rules 1.3) made Type 1 singleton:

> Meek (no special ability) Lost Souls do not have a maximum number of copies in a deck… **All other cards have a maximum of 1 of each in a deck.**

1.3 had granted an exception — "Maximum of 3 of each in a deck: Heroes, Evil Characters and Enhancements that do not have a special ability and have one brigade at face value" — and [`checkVanillaLimit`](utils/deckcheck/rules.ts#L788) still implemented it verbatim. **The deck checker has been passing decks that are now illegal**, both in the deckbuilder's legality panel and on generated deck-check sheets.

### The change
`totalQty > 3` → `totalQty > 1`, plus the message and the rule's doc comment. That's the whole behavioral diff.

The rest of Type 1's copy ladder already lands on 1 without help:
- multi-brigade cards — `checkMultiBrigadeLimit` caps at 1 outright
- special-ability cards — `checkSpecialAbilityLimit` uses `getMaxPerFifty(size, 1)`, and with Type 1 capped at 70 cards the multiplier is always 1
- Dominants, special-ability Lost Souls, and the named exceptions (Faithful Witness, Legion, Angry Mob, Locust from the Pit) keep their own rules, untouched

### Both callers want this
`checkVanillaLimit` runs in `validateT1Rules` (Limited + Unlimited) and in the Paragon validator. Paragon reaches the same rule from its own document — [Paragon Format Rules 1.2](https://landofredemption.com/wp-content/uploads/2026/07/Redemption-Paragon-Format-Rules.pdf) p.3: *"You may not include more than 1 copy of any card in your deck."* So Paragon decks were being under-validated too, and this corrects both.

### Expected fallout
Decks built under 1.3 that lean on 2–3 copies of a vanilla Hero/EC/Enhancement will now show an error in the legality panel. That's the point — those decks are no longer legal — but it will look like a regression to anyone who saved such a deck before today.

### Known gap, unchanged by this PR
The rule still only covers types whose lowercased name is exactly `hero` / `evil character` / `enhancement`. A vanilla single-brigade card of any other type (a Site, say) has no quantity rule at all — true under 1.3 as well, and 2.0's blanket "all other cards" would close it. Left alone deliberately: `e2e/qr-join.spec.ts` documents and depends on that gap for deck seeding, so closing it is its own change.

### Verification
- `npx vitest run utils/deckcheck` — 304 passed (the 3-copy test flipped to assert 3 copies now fail; added a 2-copy case)
- `npx vitest run` — 1996 passed, 80 skipped, no new failures
- `npx tsc --noEmit` — no errors in touched files (10 pre-existing, unrelated forge test files, present on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)