### PR TITLE
feat(formats): per-category ban lists from Deck Building Rules 2.0

### DIFF
--- a/lib/__tests__/formats.test.ts
+++ b/lib/__tests__/formats.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeFormat, normalizeTournamentFormat, FORMATS, PARAGON_EXCLUDED_SETS } from '../formats';
+import { normalizeFormat, normalizeTournamentFormat, FORMATS, FORMAT_IDS, PARAGON_EXCLUDED_SETS } from '../formats';
 import { CARDS } from '../cards/lookup';
 import { matchesBanListEntry } from '@/utils/deckcheck/rules';
 
@@ -37,10 +37,19 @@ describe('FORMATS registry', () => {
     expect(FORMATS.Limited.reserveMax).toBe(10);
     expect(FORMATS.Unlimited.pool).toBe('all');
   });
-  it('only Limited has a populated ban list; Unlimited/T2/Paragon stay empty by design', () => {
-    expect(FORMATS.Limited.banList.length).toBe(8);
-    expect(FORMATS.Unlimited.banList).toEqual([]);
-    expect(FORMATS.T2.banList).toEqual([]);
+  it('carries a ban list per category, per DBR 2.0', () => {
+    expect(FORMATS.Limited.banList.length).toBe(7);
+    // "In Unlimited play, all cards are legal" — except Daniel, both printings.
+    expect(FORMATS.Unlimited.banList.map((e) => e.name)).toEqual([
+      'Daniel (CoW)',
+      'Daniel (CoW AB)',
+    ]);
+    // T2 is Limited's list plus Harvest Time (both printings).
+    expect(FORMATS.T2.banList.length).toBe(FORMATS.Limited.banList.length + 2);
+    for (const entry of FORMATS.Limited.banList) {
+      expect(FORMATS.T2.banList).toContainEqual(entry);
+    }
+    // Paragon governs its pool with excluded sets, not a ban list.
     expect(FORMATS.Paragon.banList).toEqual([]);
   });
   it('paragon excluded sets carried over', () => {
@@ -50,34 +59,89 @@ describe('FORMATS registry', () => {
 });
 
 // ===========================================================================
-// Regression guard: every Limited banList entry must match a REAL row in the
-// generated card database. This is the direct lesson from the old dead
-// BANNED_CARDS list (deleted in Task 2), whose entries keyed on full set
-// names that never appeared in ResolvedCard.set (TSV codes) and so matched
-// nothing. If this test ever fails, the ban list has drifted from the actual
-// card data — fix the entry, don't loosen the matcher.
+// Regression guard: every banList entry must match a REAL row in the generated
+// card database. This is the direct lesson from the old dead BANNED_CARDS list
+// (deleted in Task 2), whose entries keyed on full set names that never
+// appeared in ResolvedCard.set (TSV codes) and so matched nothing. If this
+// test ever fails, the ban list has drifted from the actual card data — fix
+// the entry, don't loosen the matcher.
 // ===========================================================================
-describe('FORMATS.Limited.banList matches real card rows', () => {
-  it.each(FORMATS.Limited.banList)('$note matches at least one row in CARDS', (entry) => {
+const ALL_BAN_ENTRIES = FORMAT_IDS.flatMap((id) =>
+  FORMATS[id].banList.map((entry) => ({ format: id, entry })),
+);
+
+describe('ban list entries match real card rows', () => {
+  it.each(ALL_BAN_ENTRIES)('$format: $entry.note matches at least one row in CARDS', ({ entry }) => {
     const matches = CARDS.filter((card) => matchesBanListEntry(card, entry));
     expect(matches.length).toBeGreaterThan(0);
   });
+});
 
-  it('the reference entry matches both Lost Souls printings (Two Liner and Three Liner)', () => {
-    const refEntry = FORMATS.Limited.banList.find((e) => e.reference === 'Proverbs 22:14');
-    expect(refEntry).toBeDefined();
-    const matches = CARDS.filter((card) => matchesBanListEntry(card, refEntry!));
-    const names = matches.map((c) => c.name);
-    expect(names).toContain('Lost Souls (Two Liner)');
-    expect(names).toContain('Lost Souls (Three Liner)');
+// ===========================================================================
+// DBR 2.0 decoupled the ban lists from the card data's legality flag. These
+// guard the four cases where the two now disagree — each one is a card the
+// app would rule on wrongly if an entry were dropped.
+// ===========================================================================
+describe('DBR 2.0 bans that the legality flag does not cover', () => {
+  const bannedIn = (id: (typeof FORMAT_IDS)[number], name: string) =>
+    FORMATS[id].banList.some((entry) => entry.name === name);
+
+  it('bans the Imitate Lost Soul in Limited and T2, though both printings are Rotation-legal', () => {
+    const printings = CARDS.filter((c) => c.name.startsWith('Lost Soul "Imitate" [III John 1:11]'));
+    expect(printings.length).toBe(2);
+    for (const card of printings) {
+      expect(card.legality).toBe('Rotation');
+      expect(FORMATS.Limited.banList.some((e) => matchesBanListEntry(card, e))).toBe(true);
+      expect(FORMATS.T2.banList.some((e) => matchesBanListEntry(card, e))).toBe(true);
+      // Unlimited bans Daniel only.
+      expect(FORMATS.Unlimited.banList.some((e) => matchesBanListEntry(card, e))).toBe(false);
+    }
   });
 
-  it('covers exactly the 9 known Banned-legality rows (7 name+set + 2 via reference)', () => {
-    const bannedRows = CARDS.filter((c) => c.legality === 'Banned');
-    expect(bannedRows.length).toBe(9);
-    for (const row of bannedRows) {
-      const matched = FORMATS.Limited.banList.some((entry) => matchesBanListEntry(row, entry));
-      expect(matched, `expected a banList entry to match "${row.name}" (${row.set})`).toBe(true);
+  it('bans Harvest Time in T2 only, not in Limited', () => {
+    expect(bannedIn('T2', 'Harvest Time (GoC)')).toBe(true);
+    expect(bannedIn('Limited', 'Harvest Time (GoC)')).toBe(false);
+    // Imitating Evil shares III John 1:11 and the "Harvest" Lost Soul shares
+    // John 4:35 — reference matching would sweep them in, so neither list may
+    // use it.
+    const harvestSoul = CARDS.find((c) => c.name === 'Lost Soul "Harvest" [John 4:35]');
+    expect(harvestSoul).toBeDefined();
+    expect(FORMATS.T2.banList.some((e) => matchesBanListEntry(harvestSoul!, e))).toBe(false);
+    const imitatingEvil = CARDS.find((c) => c.name === 'Imitating Evil (RoJ)');
+    expect(imitatingEvil).toBeDefined();
+    expect(FORMATS.Limited.banList.some((e) => matchesBanListEntry(imitatingEvil!, e))).toBe(false);
+  });
+
+  it('bans Daniel in Unlimited, where the all-cards pool would otherwise allow it', () => {
+    const daniel = CARDS.find((c) => c.name === 'Daniel (CoW)');
+    expect(daniel).toBeDefined();
+    expect(FORMATS.Unlimited.pool).toBe('all');
+    expect(FORMATS.Unlimited.banList.some((e) => matchesBanListEntry(daniel!, e))).toBe(true);
+  });
+
+  it('leaves Ephesian Widow unbanned everywhere and in the Limited pool', () => {
+    const widow = CARDS.find((c) => c.name === 'Ephesian Widow');
+    expect(widow).toBeDefined();
+    // Unbanned by 2.0; the lookup layer's legality override is what actually
+    // puts it back in the rotation pool (upstream data still says Banned).
+    expect(widow!.legality).toBe('Rotation');
+    for (const id of FORMAT_IDS) {
+      expect(FORMATS[id].banList.some((e) => matchesBanListEntry(widow!, e))).toBe(false);
+    }
+  });
+
+  it('keeps Samuel (RoA) and the Proverbs 22:14 souls out via the pool, not the ban list', () => {
+    const rows = CARDS.filter((c) =>
+      ['Samuel (RoA)', 'Lost Souls (Two Liner)', 'Lost Souls (Three Liner)'].includes(c.name),
+    );
+    expect(rows.length).toBe(3);
+    for (const row of rows) {
+      // Still flagged in the card data, so the rotation pool test excludes
+      // them from Limited/T2 — but no longer named on any ban list.
+      expect(row.legality).toBe('Banned');
+      for (const id of FORMAT_IDS) {
+        expect(FORMATS[id].banList.some((e) => matchesBanListEntry(row, e))).toBe(false);
+      }
     }
   });
 });

--- a/lib/cards/lookup.ts
+++ b/lib/cards/lookup.ts
@@ -34,7 +34,25 @@ const CARD_BY_NAME_SET = new Map<string, CardData>();
 const CARD_BY_NAME = new Map<string, CardData>();
 const CARD_BY_NAME_LOWER = new Map<string, CardData>();
 
+// Card-data errata, keyed `name|set`. Deck Construction & Format Specific
+// Rules 2.0 (8/13/2026) unbanned Ephesian Widow, but the generated data still
+// carries the pre-2.0 flag from upstream (set "TPC [Ban]", legality "Banned"),
+// and legality !== 'Rotation' is exactly what keeps a card out of the Limited
+// and T2 pools — so without this the card stays unplayable no matter what the
+// ban lists say. It lives here rather than in the generated artifact so it
+// survives `make update-cards`; delete the entry once upstream re-flags it.
+//
+// Only cards whose pool membership actually changed belong here. Samuel (RoA)
+// and the Proverbs 22:14 Lost Souls were unbanned too, but they are
+// old-format printings that were never in the Limited/T2 pool to begin with,
+// so their legality flag is not what excludes them.
+const LEGALITY_OVERRIDES: Readonly<Record<string, string>> = {
+  'Ephesian Widow|TPC [Ban]': 'Rotation',
+};
+
 for (const card of CARDS) {
+  const override = LEGALITY_OVERRIDES[`${card.name}|${card.set}`];
+  if (override !== undefined) card.legality = override;
   CARD_BY_KEY.set(`${card.name}|${card.set}|${card.imgFile}`, card);
   CARD_BY_NAME_SET.set(`${card.name}|${card.set}`, card);
   CARD_BY_NAME.set(card.name, card);

--- a/lib/formats.ts
+++ b/lib/formats.ts
@@ -29,26 +29,53 @@ export interface FormatDef {
 // Limited/T2 pool test; Paragon's excluded sets cover the rest. banList adds
 // explicit, print-specific bans on top of that (see BannedCardDef).
 //
-// The 9 legality:'Banned' printings below are Limited's explicit ban list.
-// Unlimited, T2, and Paragon deliberately leave banList EMPTY: Unlimited is
-// wild-west by decision (spec §1), and T2/Paragon already exclude these same
-// printings via the pool-legality rotation/excluded-set test — an
-// intentional asymmetry with Limited, not an oversight.
-const LIMITED_BAN_LIST: BannedCardDef[] = [
+// Ban lists follow Deck Construction & Format Specific Rules 2.0 (published
+// 8/13/2026), which replaced 1.3's single global list with one per category.
+// Two things that changed here:
+//
+//   - Unlimited and T2 are no longer empty. "In Unlimited play, all cards are
+//     legal" except Daniel, and T2's list is Limited's plus Harvest Time.
+//   - The lists no longer mirror the card data's legality:'Banned' flag.
+//     Some banned cards are Rotation-legal printings that only an explicit
+//     entry stops (the Imitate Lost Soul, Harvest Time), and some
+//     legality:'Banned' rows are no longer banned anywhere — Samuel (RoA)
+//     and the Proverbs 22:14 Lost Souls are simply old-format cards outside
+//     the Limited/T2 pool, which the pool test already handles.
+//
+// Entries match on name+set, or on reference to catch every printing. Prefer
+// name+set unless the verse belongs to one card only: III John 1:11 is shared
+// with Imitating Evil and John 4:35 with the "Harvest" Lost Soul, so those
+// list their printings individually.
+
+// Banned in every constructed category.
+const DANIEL_COW: BannedCardDef[] = [
   { name: 'Daniel (CoW)', set: 'CoW [Ban]', note: 'Daniel (Cloud of Witnesses)' },
   { name: 'Daniel (CoW AB)', set: 'CoW (AB)', note: 'Daniel (Cloud of Witnesses, AB)' },
-  { name: 'Endless Treasures (Banned)', set: 'PoC [Ban]', note: 'Endless Treasures (Prophecies of Christ)' },
-  { name: 'Ephesian Widow', set: 'TPC [Ban]', note: 'Ephesian Widow (Persecuted Church)' },
+];
+
+// Type 1 Limited ban list.
+const LIMITED_BAN_LIST: BannedCardDef[] = [
+  ...DANIEL_COW,
+  { name: 'Endless Treasures (Banned)', set: 'PoC [Ban]', note: 'Endless Treasures with the draw ability (Prophecies of Christ) — the errata printing stays legal' },
+  { name: 'Lost Soul "Imitate" [III John 1:11]', set: 'RoJ', note: 'Lost Soul "Imitate" (Revelation of John)' },
+  { name: 'Lost Soul "Imitate" [III John 1:11]  [AB - RoJ]', set: 'RoJ (AB)', note: 'Lost Soul "Imitate" (Revelation of John, AB)' },
   { name: 'Mourn and Weep', set: 'PoC [Ban]', note: 'Mourn and Weep (Prophecies of Christ)' },
-  { name: 'Samuel (RoA)', set: 'RoA [Ban]', note: 'Samuel (Rock of Ages)' },
   { name: 'The Foretelling Angel (PC)', set: 'TPC', note: 'The Foretelling Angel (Persecuted Church)' },
-  { reference: 'Proverbs 22:14', name: 'Lost Soul', note: 'Lost Soul "Proverbs 22:14" (all printings)' },
+];
+
+// Type 2 Limited ban list: Type 1's, plus Harvest Time. The Fundraiser
+// printing carries the same name and the same ability text as the Gospel of
+// Christ one, so the ban covers both.
+const T2_BAN_LIST: BannedCardDef[] = [
+  ...LIMITED_BAN_LIST,
+  { name: 'Harvest Time (GoC)', set: 'GoC', note: 'Harvest Time (Gospel of Christ)' },
+  { name: 'Harvest Time [Fundraiser]', set: 'Fund', note: 'Harvest Time (Gospel of Christ, fundraiser printing)' },
 ];
 
 export const FORMATS: Record<FormatId, FormatDef> = {
   Limited:   { id: 'Limited',   label: 'Limited',   badge: 'L',  family: 'T1',      main: { min: 50,  max: 70 },  reserveMax: 10, pool: 'rotation', banList: LIMITED_BAN_LIST },
-  Unlimited: { id: 'Unlimited', label: 'Unlimited', badge: 'U',  family: 'T1',      main: { min: 50,  max: 70 },  reserveMax: 10, pool: 'all',      banList: [] },
-  T2:        { id: 'T2',        label: 'T2',        badge: 'T2', family: 'T2',      main: { min: 100, max: 140 }, reserveMax: 20, pool: 'rotation', banList: [] },
+  Unlimited: { id: 'Unlimited', label: 'Unlimited', badge: 'U',  family: 'T1',      main: { min: 50,  max: 70 },  reserveMax: 10, pool: 'all',      banList: DANIEL_COW },
+  T2:        { id: 'T2',        label: 'T2',        badge: 'T2', family: 'T2',      main: { min: 100, max: 140 }, reserveMax: 20, pool: 'rotation', banList: T2_BAN_LIST },
   Paragon:   { id: 'Paragon',   label: 'Paragon',   badge: 'P',  family: 'Paragon', main: { min: 40,  max: 40 },  reserveMax: 10, pool: 'paragon',  banList: [] },
 };
 

--- a/utils/deckcheck/__tests__/rules-t2.test.ts
+++ b/utils/deckcheck/__tests__/rules-t2.test.ts
@@ -1154,7 +1154,9 @@ describe("checkGoodEvilBalance", () => {
 // (T2's banList is deliberately empty; see lib/formats.ts).
 // ===========================================================================
 
-describe("banned-card in T2 (unchanged pool-legality behavior)", () => {
+// DBR 2.0 gave T2 its own ban list, so these cards are now named outright
+// rather than falling through to the pool test.
+describe("banned-card in T2", () => {
   const daniel = makeCard({
     name: "Daniel (CoW)",
     set: "CoW [Ban]",
@@ -1163,19 +1165,37 @@ describe("banned-card in T2 (unchanged pool-legality behavior)", () => {
     type: "Hero",
   });
 
-  it("checkFormatBanList is a no-op (empty banList) and checkPoolLegality still fires", () => {
-    expect(checkFormatBanList(FORMATS.T2, [daniel], [])).toEqual([]);
-    const poolIssues = checkPoolLegality(FORMATS.T2, [daniel], []);
-    expect(poolIssues.some((i) => i.rule === "pool-legality")).toBe(true);
+  // Rotation-legal, so the pool test can't catch it — only the ban list can.
+  const harvestTime = makeCard({
+    name: "Harvest Time (GoC)",
+    set: "GoC",
+    legality: "Rotation",
+    officialSet: "Gospel of Christ",
+    type: "Good Enhancement",
   });
 
-  it("is wired into validateT2Rules as a no-op — only pool-legality reports this card", () => {
+  it("reports Daniel as banned-card, and pool-legality yields to it", () => {
+    const banIssues = checkFormatBanList(FORMATS.T2, [daniel], []);
+    expect(banIssues).toHaveLength(1);
+    expect(banIssues[0].message).toBe('"Daniel (CoW)" (CoW [Ban]) is banned in T2.');
+    expect(checkPoolLegality(FORMATS.T2, [daniel], [])).toEqual([]);
+  });
+
+  it("catches Harvest Time, which is Rotation-legal and banned in T2 only", () => {
+    const banIssues = checkFormatBanList(FORMATS.T2, [harvestTime], []);
+    expect(banIssues).toHaveLength(1);
+    expect(banIssues[0].rule).toBe("banned-card");
+    expect(checkFormatBanList(FORMATS.Limited, [harvestTime], [])).toEqual([]);
+    expect(checkPoolLegality(FORMATS.Limited, [harvestTime], [])).toEqual([]);
+  });
+
+  it("is wired into validateT2Rules", () => {
     const mainDeck = makeValidMainDeck(100, [daniel]);
     const cardGroups = [makeGroup("Daniel (CoW)", [daniel])];
     const issues = validateT2Rules(FORMATS.T2, mainDeck, [], cardGroups);
     const danielIssues = issues.filter((i) => i.cards?.includes("Daniel (CoW)"));
-    expect(danielIssues.every((i) => i.rule !== "banned-card")).toBe(true);
-    expect(danielIssues.some((i) => i.rule === "pool-legality")).toBe(true);
+    expect(danielIssues.some((i) => i.rule === "banned-card")).toBe(true);
+    expect(danielIssues.every((i) => i.rule !== "pool-legality")).toBe(true);
   });
 });
 

--- a/utils/deckcheck/__tests__/rules.test.ts
+++ b/utils/deckcheck/__tests__/rules.test.ts
@@ -2342,18 +2342,26 @@ describe("banned-card (checkFormatBanList)", () => {
     expect(poolIssues).toEqual([]);
   });
 
-  it("does not flag the same card in Unlimited (empty ban list, all-cards pool)", () => {
-    expect(checkFormatBanList(FORMATS.Unlimited, [daniel], [])).toEqual([]);
+  // Daniel is the one card DBR 2.0 bans in Unlimited, where every other card
+  // is legal and the pool test never runs.
+  it("flags the same card in Unlimited, which bans Daniel and nothing else", () => {
+    const issues = checkFormatBanList(FORMATS.Unlimited, [daniel], []);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toBe('"Daniel (CoW)" (CoW [Ban]) is banned in Unlimited.');
     expect(checkPoolLegality(FORMATS.Unlimited, [daniel], [])).toEqual([]);
   });
 
-  it("in T2, falls through to pool-legality (unchanged behavior) with no banned-card", () => {
-    expect(checkFormatBanList(FORMATS.T2, [daniel], [])).toEqual([]);
-    const poolIssues = checkPoolLegality(FORMATS.T2, [daniel], []);
-    expect(poolIssues.some((i) => i.rule === "pool-legality")).toBe(true);
+  it("in T2, reports banned-card and lets pool-legality stand down", () => {
+    const issues = checkFormatBanList(FORMATS.T2, [daniel], []);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].rule).toBe("banned-card");
+    expect(checkPoolLegality(FORMATS.T2, [daniel], [])).toEqual([]);
   });
 
-  it("matches the reference entry for both Lost Souls (Two Liner) and (Three Liner) in Limited", () => {
+  // The Proverbs 22:14 souls came off every ban list in DBR 2.0. They stay out
+  // of Limited because they are old-format prints outside the pool, which is
+  // the pool test's job, not the ban list's.
+  it("no longer bans the Proverbs 22:14 Lost Souls, leaving them to pool-legality", () => {
     const twoLiner = makeCard({
       name: "Lost Souls (Two Liner)",
       set: "Main [Ban]",
@@ -2370,9 +2378,12 @@ describe("banned-card (checkFormatBanList)", () => {
       type: "Lost Soul",
       reference: "Proverbs 22:14",
     });
-    const issues = checkFormatBanList(FORMATS.Limited, [twoLiner, threeLiner], []);
-    expect(issues).toHaveLength(2);
-    expect(issues.every((i) => i.rule === "banned-card")).toBe(true);
+    expect(checkFormatBanList(FORMATS.Limited, [twoLiner, threeLiner], [])).toEqual([]);
+    const poolIssues = checkPoolLegality(FORMATS.Limited, [twoLiner, threeLiner], []);
+    expect(poolIssues).toHaveLength(2);
+    expect(poolIssues.every((i) => i.rule === "pool-legality")).toBe(true);
+    // Legal in Unlimited now — nothing there bans them.
+    expect(checkFormatBanList(FORMATS.Unlimited, [twoLiner, threeLiner], [])).toEqual([]);
   });
 
   it("skips quantity-0 and card-not-found stub cards", () => {


### PR DESCRIPTION
[DBR 2.0](https://www.cactusgamedesign.com/wp-content/uploads/2026/08/Deck_Building_Rules_2.0-1.pdf) (8/13/2026) replaced 1.3's single global ban list with **one list per category**. `checkFormatBanList` was already def-driven, so this is mostly data — but four cards were being ruled on wrongly, and two of them are playable in the app right now.

### What the app gets wrong today

| Card | Card data says | Today | After |
|---|---|---|---|
| Lost Soul "Imitate" [III John 1:11] (both printings) | `Rotation` | **legal** in Limited + T2 | banned in Limited + T2, legal in Unlimited |
| Harvest Time (GoC + Fundraiser) | `Rotation` | **legal** in T2 | banned in T2 only |
| Daniel (CoW + AB) | `Banned` | **legal in Unlimited** (empty ban list) | banned in Unlimited |
| Ephesian Widow | `Banned` | illegal everywhere | legal everywhere |

The first two are the sharp end: they're Rotation-legal printings, so the pool test can't catch them — only an explicit entry can.

### The unban needed more than deleting a line
Removing Ephesian Widow from the list does nothing on its own. `checkPoolLegality` requires `legality === 'Rotation'`, and upstream card data still carries the pre-2.0 flag (`set: "TPC [Ban]", legality: "Banned"`), so the card stays unplayable. [lookup.ts](lib/cards/lookup.ts) gains a small errata map applied where the lookup tables are built — deliberately not in the generated artifact, so it survives `make update-cards`. **Delete the entry once upstream re-flags the card.**

Samuel (RoA) and the Proverbs 22:14 Lost Souls were unbanned too but need no override: they're old-format printings the pool test excludes on its own, and 2.0 makes them legal in Unlimited — which they now are, since Unlimited's pool is `all` and they're off every list.

### Judgment calls worth a second opinion
- **Fundraiser printings.** Cactus names "Harvest Time (Gospel of Christ)", but `Harvest Time [Fundraiser]` has the same name and *byte-identical ability text*, so I banned both. If Cactus means the GoC printing alone, drop one line.
- **Reference vs name+set matching.** Neither new ban can use reference matching: III John 1:11 is shared with Imitating Evil, John 4:35 with the "Harvest" Lost Soul. Both list their printings individually, and a test guards against a future entry sweeping the wrong card in.

### Tests
The old suite asserted the ban list *mirrors* the card data's `Banned` flag ("covers exactly the 9 known Banned-legality rows"). 2.0 decouples them, so that's replaced by guards on the five cases where the two now disagree. The "every entry matches a real card row" typo guard is kept and widened to all four formats.

- `npx vitest run` — 2009 passed, 80 skipped, 0 failures (5 tests updated: they encoded the empty-Unlimited/T2 design)
- `npx tsc --noEmit` — clean on touched files (10 pre-existing, unrelated)

### Not in this PR
**Type 1 Teams Limited** (adds Burial (GoC) and High Places (LoC)) has nowhere to live — Teams isn't a `FormatDef`, it maps to Limited. That's the next piece, along with making the deckbuilder's **Banned** filter chip read the active deck's format instead of the global `legality` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)