### PR TITLE
feat(deckbuilder): the Banned filter follows the deck's format

### DIFF
--- a/app/decklist/card-search/ModalWithClose.tsx
+++ b/app/decklist/card-search/ModalWithClose.tsx
@@ -10,6 +10,7 @@ import { useIsAdmin } from "../../../hooks/useIsAdmin";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { createRuling, updateRuling, deleteRuling } from "../../admin/rulings/actions";
 import { DuplicateCards, DuplicateCardsMobile } from "./components/DuplicateCards";
+import type { FormatId } from "@/lib/formats";
 import type { Card } from "./utils";
 import type { DeckZone } from "./types/deck";
 
@@ -531,6 +532,7 @@ export default function ModalWithClose({
   getCardQuantity,
   activeDeckTab = "main", // Default to main if not provided
   legalityFilter = null,
+  legalityFormat = "Limited",
   allCards,
   collectionQuantities = null,
   onAdjustCollection = null,
@@ -547,6 +549,8 @@ export default function ModalWithClose({
   activeDeckTab?: string;
   /** Current legality filter for duplicate cards. null = show all. */
   legalityFilter?: string | null;
+  /** Format the deck is being built in — decides what "Banned" means. */
+  legalityFormat?: FormatId;
   /** Full unfiltered card list for legality checking of duplicates */
   allCards?: Card[];
   /** Owned quantities keyed by `name|set|imgFile`. null = collection unavailable (signed out). */
@@ -1374,6 +1378,7 @@ export default function ModalWithClose({
                   visibleCards={visibleCards}
                   allCards={allCards}
                   legalityFilter={legalityFilter}
+                  legalityFormat={legalityFormat}
                   onNavigate={(card) => setModalCard(card)}
                 />
               )}

--- a/app/decklist/card-search/client.tsx
+++ b/app/decklist/card-search/client.tsx
@@ -18,7 +18,7 @@ import { DeckBuilderConfig, PUBLIC_BUILDER_CONFIG, BuilderConfigProvider } from 
 import { readStickyFilters, writeStickyFilters, type AltArtMode } from "./stickyFilters";
 import { hasAbReprint } from "@/lib/cards/lookup";
 import { compareCardsDefault } from "@/lib/cards/defaultSort";
-import { normalizeFormat, PARAGON_EXCLUDED_SETS } from "@/lib/formats";
+import { isBannedInFormat, normalizeFormat, PARAGON_EXCLUDED_SETS } from "@/lib/formats";
 import { useDeckState } from "./hooks/useDeckState";
 import { useDeckCheck } from "./hooks/useDeckCheck";
 import { useCardImageUrl } from "./hooks/useCardImageUrl";
@@ -1033,7 +1033,10 @@ export default function CardSearchClient({
         .filter((c) => {
           if (legalityMode === 'Unlimited') return true;
           if (legalityMode === 'Limited') return c.legality === 'Rotation';
-          if (legalityMode === 'Banned') return c.legality === 'Banned';
+          // Banned is answered per format, not by the card's own flag: DBR 2.0
+          // gave each category its own ban list, so what counts as banned
+          // depends on the deck being built.
+          if (legalityMode === 'Banned') return isBannedInFormat(c, normalizeFormat(deck.format));
           if (legalityMode === 'Scrolls') return c.legality !== 'Rotation' && c.legality !== 'Banned';
           if (legalityMode === 'Paragon') {
             // Paragon format: exclude Lost Souls (not allowed in Paragon)
@@ -1694,6 +1697,7 @@ export default function CardSearchClient({
           getCardQuantity={getCardQuantity}
           activeDeckTab={activeDeckTab}
           legalityFilter={legalityMode}
+          legalityFormat={normalizeFormat(deck.format)}
           allCards={cards}
           collectionQuantities={collectionAvailable ? collectionQuantities : null}
           onAdjustCollection={collectionAvailable ? adjustCollectionQuantity : null}

--- a/app/decklist/card-search/components/DuplicateCards.tsx
+++ b/app/decklist/card-search/components/DuplicateCards.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import type { DuplicateSibling } from '@/lib/duplicateCards';
 import type { Card } from '../utils';
-import { PARAGON_EXCLUDED_SETS } from '@/lib/formats';
+import { isBannedInFormat, PARAGON_EXCLUDED_SETS, type FormatId } from '@/lib/formats';
 
 interface DuplicateCardsProps {
   siblings: DuplicateSibling[];
@@ -13,6 +13,8 @@ interface DuplicateCardsProps {
   onNavigate?: (card: Card) => void;
   /** Current legality mode — siblings not matching this are dimmed. null = show all */
   legalityFilter?: string | null;
+  /** Format the deck is being built in — decides what "Banned" means */
+  legalityFormat?: FormatId;
   /** Full card list (unfiltered) for legality checking */
   allCards?: Card[];
   /** Callback for hover preview on desktop */
@@ -23,10 +25,11 @@ interface DuplicateCardsProps {
  * Check if a card passes a legality filter.
  * Mirrors the logic in client.tsx lines 795-842.
  */
-function passesLegalityFilter(card: Card, mode: string): boolean {
+function passesLegalityFilter(card: Card, mode: string, format: FormatId): boolean {
   if (mode === 'Unlimited') return true;
   if (mode === 'Limited') return card.legality === 'Rotation';
-  if (mode === 'Banned') return card.legality === 'Banned';
+  // Per-format since DBR 2.0 — see isBannedInFormat.
+  if (mode === 'Banned') return isBannedInFormat(card, format);
   if (mode === 'Scrolls') return card.legality !== 'Rotation' && card.legality !== 'Banned';
   if (mode === 'Paragon') {
     if (card.type.toLowerCase().includes('lost soul')) return false;
@@ -103,6 +106,7 @@ export function DuplicateCards({
   visibleCards,
   onNavigate,
   legalityFilter,
+  legalityFormat = 'Limited',
   allCards,
   onHoverSibling,
 }: DuplicateCardsProps) {
@@ -127,7 +131,7 @@ export function DuplicateCards({
       let passesLegality = true;
       if (legalityFilter && matchedCards.length > 0) {
         passesLegality = matchedCards.some((c) =>
-          passesLegalityFilter(c, legalityFilter)
+          passesLegalityFilter(c, legalityFilter, legalityFormat)
         );
       }
       if (legalityFilter && matchedCards.length === 0) {
@@ -147,7 +151,7 @@ export function DuplicateCards({
         passesLegality,
       };
     });
-  }, [siblings, allCardsIndex, visibleCardsIndex, legalityFilter]);
+  }, [siblings, allCardsIndex, visibleCardsIndex, legalityFilter, legalityFormat]);
 
   // Filter out siblings that don't pass legality when a filter is active
   const displaySiblings = legalityFilter

--- a/lib/__tests__/formats.test.ts
+++ b/lib/__tests__/formats.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeFormat, normalizeTournamentFormat, FORMATS, FORMAT_IDS, PARAGON_EXCLUDED_SETS } from '../formats';
+import { normalizeFormat, normalizeTournamentFormat, FORMATS, FORMAT_IDS, isBannedInFormat, PARAGON_EXCLUDED_SETS } from '../formats';
 import { CARDS } from '../cards/lookup';
 import { matchesBanListEntry } from '@/utils/deckcheck/rules';
 
@@ -74,6 +74,27 @@ describe('ban list entries match real card rows', () => {
   it.each(ALL_BAN_ENTRIES)('$format: $entry.note matches at least one row in CARDS', ({ entry }) => {
     const matches = CARDS.filter((card) => matchesBanListEntry(card, entry));
     expect(matches.length).toBeGreaterThan(0);
+  });
+});
+
+// What the card browser's "Banned" chip asks. Since DBR 2.0 the answer depends
+// on the format, so the same card gives different answers.
+describe('isBannedInFormat', () => {
+  const cardRow = (name: string) => {
+    const row = CARDS.find((c) => c.name === name);
+    expect(row, `no card row named "${name}"`).toBeDefined();
+    return row!;
+  };
+
+  it.each([
+    ['Daniel (CoW)', { Limited: true, Unlimited: true, T2: true, Paragon: false }],
+    ['Lost Soul "Imitate" [III John 1:11]', { Limited: true, Unlimited: false, T2: true, Paragon: false }],
+    ['Harvest Time (GoC)', { Limited: false, Unlimited: false, T2: true, Paragon: false }],
+    ['Ephesian Widow', { Limited: false, Unlimited: false, T2: false, Paragon: false }],
+  ] as const)('%s', (name, expected) => {
+    for (const id of FORMAT_IDS) {
+      expect(isBannedInFormat(cardRow(name), id), `${name} in ${id}`).toBe(expected[id]);
+    }
   });
 });
 

--- a/lib/formats.ts
+++ b/lib/formats.ts
@@ -82,6 +82,43 @@ export const FORMATS: Record<FormatId, FormatDef> = {
 export const FORMAT_IDS: FormatId[] = ['Limited', 'Unlimited', 'T2', 'Paragon'];
 
 /**
+ * Predicate satisfied by both ResolvedCard (deckcheck) and CardData (raw card
+ * database) — the 3 fields a ban-list entry can match on.
+ */
+export type BanMatchable = { name: string; set: string; reference: string };
+
+/**
+ * Match a card against a single ban-list entry. Reference entries (covering
+ * all printings of a scripture reference) match on card.reference alone;
+ * name+set entries match name AND set case-insensitively with EXACT
+ * equality — no startsWith/canonicalName fuzzing, since each entry is keyed
+ * directly to a real row in the card database (see the regression guard in
+ * lib/__tests__/formats.test.ts).
+ */
+export function matchesBanListEntry(
+  card: BanMatchable,
+  entry: BannedCardDef
+): boolean {
+  if (entry.reference !== undefined) {
+    return card.reference === entry.reference;
+  }
+  return (
+    card.name.toLowerCase() === entry.name.toLowerCase() &&
+    card.set.toLowerCase() === (entry.set ?? '').toLowerCase()
+  );
+}
+
+/**
+ * Is this card banned in the given format? Since DBR 2.0 the answer depends on
+ * the format — the Imitate Lost Soul is banned in Limited and T2 but legal in
+ * Unlimited, Harvest Time only in T2 — so the card browser has to ask per
+ * format rather than reading the card's own legality flag.
+ */
+export function isBannedInFormat(card: BanMatchable, id: FormatId): boolean {
+  return FORMATS[id].banList.some((entry) => matchesBanListEntry(card, entry));
+}
+
+/**
  * Map any historical or current format string to a canonical FormatId.
  * Precedence is load-bearing: paragon → type 2 → unlimited/classic → Limited.
  * ('Classic' was the old name for the all-cards pool.) Unlike the matchmaking

--- a/utils/deckcheck/rules.ts
+++ b/utils/deckcheck/rules.ts
@@ -1,5 +1,5 @@
 import { ResolvedCard, DeckCheckIssue, CardGroup } from "./types";
-import { FormatDef, BannedCardDef, PARAGON_EXCLUDED_SETS } from "@/lib/formats";
+import { FormatDef, PARAGON_EXCLUDED_SETS, matchesBanListEntry } from "@/lib/formats";
 
 // ---------------------------------------------------------------------------
 // Helper predicates
@@ -858,32 +858,11 @@ export function checkSitesCitiesLimit(
   return issues;
 }
 
-/**
- * Predicate satisfied by both ResolvedCard (deckcheck) and CardData (raw card
- * database) — the 3 fields a ban-list entry can match on.
- */
-type BanMatchable = Pick<ResolvedCard, "name" | "set" | "reference">;
-
-/**
- * Match a card against a single ban-list entry. Reference entries (covering
- * all printings of a scripture reference) match on card.reference alone;
- * name+set entries match name AND set case-insensitively with EXACT
- * equality — no startsWith/canonicalName fuzzing, since each entry is keyed
- * directly to a real row in the card database (see the regression guard in
- * lib/__tests__/formats.test.ts).
- */
-export function matchesBanListEntry(
-  card: BanMatchable,
-  entry: BannedCardDef
-): boolean {
-  if (entry.reference !== undefined) {
-    return card.reference === entry.reference;
-  }
-  return (
-    card.name.toLowerCase() === entry.name.toLowerCase() &&
-    card.set.toLowerCase() === (entry.set ?? "").toLowerCase()
-  );
-}
+// The matcher moved to lib/formats.ts so the card browser can ask "is this
+// card banned in the format I'm building?" without importing the deck-check
+// rules engine. Re-exported here: this has been its public home since the
+// format restructure, and callers (and tests) still import it from here.
+export { matchesBanListEntry };
 
 /**
  * Rule: banned-card — every card is checked against the format's explicit


### PR DESCRIPTION
Follows #305. Now that each category has its own ban list, "banned" isn't a property of a card any more — it depends on what you're building. The browser's **Banned** chip still read the card data's global `legality` flag, so it showed the same set whether you were building Limited, Unlimited or T2.

The pool chips already follow the deck format — `handleDeckFormatChange` syncs `legalityMode` to Paragon/Unlimited/Limited when you switch. Banned was the one mode left behind.

### What you see now
| Building | Banned chip shows |
|---|---|
| Limited | Daniel ×2, Endless Treasures, Imitate LS ×2, Mourn and Weep, Foretelling Angel |
| Unlimited | Daniel ×2 — nothing else is banned there |
| T2 | Limited's seven, plus Harvest Time ×2 |
| Paragon | nothing — Paragon governs its pool with excluded sets, not a ban list |

### Shape
`matchesBanListEntry` moves from [rules.ts](utils/deckcheck/rules.ts) to [lib/formats.ts](lib/formats.ts), beside the lists it reads, so the card browser can ask the question without importing the deck-check rules engine into the client bundle. `rules.ts` re-exports it — that's been its public home since the format restructure and existing callers/tests still import from there.

The new `isBannedInFormat(card, format)` is used in two places: the card grid, and the duplicate-printing strip in the card modal, which dims siblings by the same filter and needed the format threaded through `ModalWithClose`.

### Worth a look
- **Paragon now shows an empty Banned list.** Starker than before, but more correct — the cards it used to list aren't specially banned in Paragon, they're excluded by set. If the empty state reads as broken, the fix is hiding the chip when `banList` is empty, which needs the format in `FilterGrid`.
- **The chip label still just says "Banned"** with no hint that it's format-scoped. Adding "Banned in Limited" means another prop into `FilterGrid`; happy to do it if you want the signal.
- `DuplicateCardsMobile` never receives `legalityFilter` at its call site, so its sibling dimming is inert on mobile — pre-existing, untouched here.

### Verification
- `npx vitest run` — 2014 passed, 80 skipped (added a table test asserting the four cards give different answers per format)
- `npx tsc --noEmit` — clean on touched files (10 pre-existing, unrelated forge test errors)

### Still open from your list
**Type 1 Teams Limited** — Burial (GoC) and High Places (LoC) have nowhere to live until Teams is a real `FormatDef`. Worth noting DBR 2.0 gives Teams its own *construction* rule too, not just a ban list: "All Lost Souls are considered meek for Teams play." So it's a genuine format, not a ban-list overlay on Limited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)